### PR TITLE
(test) enhance conftest to lessen false positives in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,7 +52,7 @@ def filter_out_symbols(input):
 
     # mask the specific part in a poetry path
     input = re.sub(
-        r'(/opendevin/poetry/opendevin-)[a-zA-Z0-9-]+(-py3\.\d+/bin/python)',
+        r'(/open[a-z]{5}/poetry/open[a-z]{5}-)[a-zA-Z0-9-]+(-py3\.\d+/bin/python)',
         r'\1[DUMMY_STRING]\2',
         input,
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,6 +50,13 @@ def filter_out_symbols(input):
     # openhands@379c7fce40b4:/workspace $
     input = re.sub(r'(openhands|root)@.*(:/.*)', r'\1[DUMMY_HOSTNAME]\2', input)
 
+    # mask the specific part in a poetry path
+    input = re.sub(
+        r'(/opendevin/poetry/opendevin-)[a-zA-Z0-9-]+(-py3\.\d+/bin/python)',
+        r'\1[DUMMY_STRING]\2',
+        input,
+    )
+
     # handle size param
     input = re.sub(r' size=\d+ ', ' size=[DUMMY_SIZE] ', input)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,6 +50,9 @@ def filter_out_symbols(input):
     # openhands@379c7fce40b4:/workspace $
     input = re.sub(r'(openhands|root)@.*(:/.*)', r'\1[DUMMY_HOSTNAME]\2', input)
 
+    # handle size param
+    input = re.sub(r' size=\d+ ', ' size=[DUMMY_SIZE] ', input)
+
     # handle sha256 hashes
     # sha256=4ecf8be428f55981e2a188f510ba5f9022bed88f5fb404d7d949f44382201e3d
     input = re.sub(r'sha256=[a-z0-9]+', 'sha256=[DUMMY_HASH]', input)


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Enhanced main integration test `conftest.py` to prevent errors on non-deterministic, textual differences:
- mask any `size=xxx` parameter
- mask specific parts in a poetry path

Some tests get results back from e.g. bash commands like `pip install` that then contain non-deterministic content, which differs from our mock files.
This frequently lead to headaches 😔 to keep the mock files "fixed".

---
**Other references**

Example 1:
```
filename=PyMsgBox-1.0.9-py3-none-any.whl size=7407 sha256=aca10c2c34795d92bcf85b43c34a0f7eb39d1cf3a4edf8f69f65ed206619ae51
```

Example 2:
```
 -     '/opendevin/poetry/opendevin-w8YlaYp7-py3.11/bin/python]',
  ?            ^^^^             ^^^^ ^^^^ ^^^
  +     '/openhands/poetry/openhands-5O4_aCHf-py3.11/bin/python]',
  ?           +++ ^            +++ ^ ^^^^ ^^^
```