### PR TITLE
Fix wrong doc url

### DIFF
--- a/docs/modules/usage/how-to/custom-sandbox-guide.md
+++ b/docs/modules/usage/how-to/custom-sandbox-guide.md
@@ -86,7 +86,7 @@ Congratulations!
 
 ## Technical Explanation
 
-Please refer to [custom docker image section of the runtime documentation](https://docs.all-hands.dev/modules/usage/runtime#advanced-how-openhands-builds-and-maintains-od-runtime-images) for more details.
+Please refer to [custom docker image section of the runtime documentation](https://docs.all-hands.dev/modules/usage/architecture/runtime#advanced-how-openhands-builds-and-maintains-od-runtime-images) for more details.
 
 ## Troubleshooting / Errors
 

--- a/openhands/README.md
+++ b/openhands/README.md
@@ -49,4 +49,4 @@ flowchart LR
 
 ## Runtime
 
-Please refer to the [documentation](https://docs.all-hands.dev/modules/usage/runtime) to learn more about `Runtime`.
+Please refer to the [documentation](https://docs.all-hands.dev/modules/usage/architecture/runtime) to learn more about `Runtime`.

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -216,7 +216,7 @@ def build_runtime_image(
     Returns:
     - str: <image_repo>:<MD5 hash>. Where MD5 hash is the hash of the docker build folder
 
-    See https://docs.all-hands.dev/modules/usage/runtime for more details.
+    See https://docs.all-hands.dev/modules/usage/architecture/runtime for more details.
     """
     # Calculate the hash for the docker build folder (source code and Dockerfile)
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

this link in README and comment is wrong: https://docs.all-hands.dev/modules/usage/runtime , it should be: https://docs.all-hands.dev/modules/usage/architecture/runtime

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Other references**
