### PR TITLE
Update FeedbackModal to fix URL and remove password link

### DIFF
--- a/frontend/src/components/modals/feedback/FeedbackModal.tsx
+++ b/frontend/src/components/modals/feedback/FeedbackModal.tsx
@@ -16,7 +16,7 @@ const isEmailValid = (email: string) => {
   return emailRegex.test(email);
 };
 
-const VIEWER_PAGE = "https://www.all-hands.dev/share-openhands";
+const VIEWER_PAGE = "https://www.all-hands.dev/share";
 const FEEDBACK_VERSION = "1.0";
 
 interface FeedbackModalProps {
@@ -103,7 +103,7 @@ function FeedbackModal({
       localStorage.setItem("feedback-email", email); // store email in local storage
       if (response.statusCode === 200) {
         const { message, feedback_id: feedbackId, password } = response.body;
-        const link = `${VIEWER_PAGE}?share_id=${feedbackId}&password=${password}`;
+        const link = `${VIEWER_PAGE}?share_id=${feedbackId}`;
         shareFeedbackToast(message, link, password);
       } else {
         toast.error(


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This PR updates feedbackmodal to fix two things:
1. It fixes the link from `share-openhands` to `share` as that's the link on the new version of the All Hands AI web site.
2. It removes the password from the link. The password should be kept private, and if the password is included in the link, people might accidentally share it with others.
