### PR TITLE
[Fix] Metrics should be updated when agent reaches max iterations.

### DIFF
--- a/evaluation/aider_bench/run_infer.py
+++ b/evaluation/aider_bench/run_infer.py
@@ -120,11 +120,15 @@ async def complete_runtime(
     obs = await runtime.run_action(action)
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
 
+    exit_code = 1
+    if isinstance(obs, CmdOutputObservation):
+        exit_code = obs.exit_code
+
     logger.info(f"{'-' * 50} END Runtime Completion Fn {'-' * 50}")
 
     return {
         'test_output': obs.content,
-        'exit_code': obs.exit_code,
+        'exit_code': exit_code,
     }
 
 

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -220,6 +220,8 @@ class AgentController:
                 logger.info(event, extra={'msg_type': 'OBSERVATION'})
             elif isinstance(event, ErrorObservation):
                 logger.info(event, extra={'msg_type': 'OBSERVATION'})
+                if self.state.agent_state == AgentState.ERROR:
+                    self.state.metrics.merge(self.state.local_metrics)
 
     def reset_task(self):
         """Resets the agent's task."""


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
Accumulated cost is 0.0 when agent times out.


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Update metrics with local_metrics when Agent reached ERROR state.


---
**Other references**
