### PR TITLE
(fix) prevent 500 server error on a just removed folder when listing files

### DIFF
--- a/openhands/runtime/client/client.py
+++ b/openhands/runtime/client/client.py
@@ -605,10 +605,8 @@ if __name__ == '__main__':
             full_path = os.path.join(client.initial_pwd, path)
 
         if not os.path.exists(full_path):
-            return JSONResponse(
-                content={'error': f'Directory {full_path} does not exist'},
-                status_code=400,
-            )
+            # if user just removed a folder, prevent server error 500 in UI
+            return []
 
         try:
             # Check if the directory exists


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

If a folder in the workspace is being removed (in the actual filesystem, outside of OpenHands) and then in the UI the "Refresh" icon on the file explorer is clicked, an error "500 internal server error" will appear in the UI. This PR prevents this.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Instead of returning a 400 error from the runtime client back in case a folder no longer exists, this should just return an empty list and not error about it, which is confusing in the UI.

---
**Other references**
