### PR TITLE
(fix) backend: only push app/runtime images on merge to main, not PR's

### DIFF
--- a/.github/workflows/ghcr_app.yml
+++ b/.github/workflows/ghcr_app.yml
@@ -58,4 +58,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and export image
         id: build
-        run: ./containers/build.sh openhands ${{ github.repository_owner }} --push
+        run: |
+          # Only if the push is to the main branch or a manual trigger, push the image to ghcr.io
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ./containers/build.sh openhands ${{ github.repository_owner }} --push
+          else
+            ./containers/build.sh openhands ${{ github.repository_owner }}
+          fi

--- a/.github/workflows/ghcr_app.yml
+++ b/.github/workflows/ghcr_app.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ghcr_app.yml
+++ b/.github/workflows/ghcr_app.yml
@@ -60,7 +60,7 @@ jobs:
         id: build
         run: |
           # Only if the push is to the main branch or a manual trigger, push the image to ghcr.io
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             ./containers/build.sh openhands ${{ github.repository_owner }} --push
           else
             ./containers/build.sh openhands ${{ github.repository_owner }}

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -75,11 +75,7 @@ jobs:
         id: build
         run: |
           suffix=$(echo "${{ matrix.base_image }}" | cut -d ':' -f 1 | cut -d '/' -f 1)
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            ./containers/build.sh runtime ${{ github.repository_owner }} --push $suffix
-          else
-            ./containers/build.sh runtime ${{ github.repository_owner }} $suffix
-          fi
+          ./containers/build.sh runtime ${{ github.repository_owner }} --push $suffix
 
   # Run unit tests with the EventStream runtime Docker images
   test_runtime:

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -75,7 +75,11 @@ jobs:
         id: build
         run: |
           suffix=$(echo "${{ matrix.base_image }}" | cut -d ':' -f 1 | cut -d '/' -f 1)
-          ./containers/build.sh runtime ${{ github.repository_owner }} --push $suffix
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            ./containers/build.sh runtime ${{ github.repository_owner }} --push $suffix
+          else
+            ./containers/build.sh runtime ${{ github.repository_owner }} $suffix
+          fi
 
   # Run unit tests with the EventStream runtime Docker images
   test_runtime:

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
     strategy:
       matrix:
         base_image: ['nikolaik/python-nodejs:python3.11-nodejs22', 'python:3.11-bookworm', 'node:22-bookworm']

--- a/containers/README.md
+++ b/containers/README.md
@@ -10,3 +10,74 @@ by the `ghcr.yml` workflow.
 docker build -f containers/app/Dockerfile -t openhands .
 docker build -f containers/sandbox/Dockerfile -t sandbox .
 ```
+
+Here's a simplified README explaining the `build.sh` script, focusing on the Docker commands:
+
+## build.sh Script README
+
+This script automates the process of building and optionally pushing Docker images for the OpenHands project.
+
+### What does this script do?
+
+1. Sets up image names, tags, and build configurations.
+2. Determines which tags to use based on Git information and user input.
+3. Builds a Docker image using `docker buildx build` with various optimizations.
+
+### Key Docker Commands Explained
+
+The main Docker command used is `docker buildx build`. Here's what it does in simple terms:
+
+1. **Building for multiple platforms**:
+
+   ```sh
+   --platform linux/amd64,linux/arm64
+   ```
+
+   This builds the image for both Intel/AMD and ARM-based computers.
+
+2. **Tagging the image**:
+
+   ```sh
+   -t $DOCKER_REPOSITORY:$tag
+   ```
+
+   This gives the image one or more names (tags) for easy reference.
+
+3. **Caching for faster builds**:
+
+   ```sh
+   --cache-from=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag
+   ```
+
+   This uses previously built parts of the image to speed up the build process.
+
+4. **Pushing to a registry** (if requested):
+
+   ```sh
+   --push
+   ```
+
+   This uploads the built image to a central storage (registry) for others to use.
+
+5. **Specifying the build context**:
+
+   ```sh
+   "$DOCKER_BASE_DIR"
+   ```
+
+   This tells Docker where to find the files needed for building the image.
+
+### How to use the script
+
+Run the script with these arguments:
+
+```sh
+./build.sh <image_name> <org_name> [--push] [tag_suffix]
+```
+
+- `<image_name>`: The name of the image to build (e.g., "openhands", "runtime")
+- `<org_name>`: Your organization name
+- `--push`: (Optional) If included, pushes the image to the registry
+- `[tag_suffix]`: (Optional) Adds a suffix to the image tags
+
+The script handles the complexities of building, tagging, and optionally pushing Docker images, making it easier for developers to manage the build process.


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Only push generated images to repository on merge to main branch, not PR's, to prevent errors - until this issue gets resolved on either repo and/or ghcr level.

Also expanded the `containers/README.md` file with info on the `build.sh` script.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Changes 2 workflows `ghcr_app.yml` and `ghcr_runtime.yml` to only use the `--push` flag when merging to `main`.

---
**Other references**

Currently PR's run into this error on app/runtime push:
```
> exporting to image:
------
ERROR: failed to solve: failed to push ghcr.io/all-hands-ai/openhands:d0eccd7: unexpected status from POST request to https://ghcr.io/v2/all-hands-ai/openhands/blobs/uploads/: 403 Forbidden
```