### PR TITLE
Change PR template to enforce a simple description for CHANGELOG

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
+**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**
 
 
 
@@ -8,4 +8,4 @@
 
 
 ---
-**Other references**
+**Link of any specific issues this addresses**


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

In an effort to make better CHANGELOGs going forward, we are changing the PR template. 
Maintainers must always make sure that the simple explanation used for CHANGELOG is filled out.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Other references**
