### PR TITLE
Allow the Agent to run uniittests for verification.

### DIFF
--- a/evaluation/aider_bench/helper.py
+++ b/evaluation/aider_bench/helper.py
@@ -6,6 +6,7 @@ INSTRUCTIONS_ADDENDUM = """
 Use the above instructions to modify the supplied files: {signature_file}
 Don't change the names of existing functions or classes, as they may be referenced from other code like unit tests, etc.
 
+Use the test_file: {test_file}, to verify the correctness of your solution. DO NOT EDIT the test file.
 Only use standard python libraries, don't suggest installing any packages.
 """
 

--- a/evaluation/aider_bench/run_infer.py
+++ b/evaluation/aider_bench/run_infer.py
@@ -85,6 +85,13 @@ async def initialize_runtime(
             file_path,
             '/workspace',
         )
+        file_path = os.path.join(tmpdir, f'{instance.instance_name}_test.py')
+        with open(file_path, 'w') as f:
+            f.write(instance.test)
+        await runtime.copy_to(
+            file_path,
+            '/workspace',
+        )
     logger.info(f"{'-' * 50} END Runtime Initialization Fn {'-' * 50}")
 
 
@@ -101,6 +108,7 @@ async def complete_runtime(
     logger.info(f"{'-' * 50} BEGIN Runtime Completion Fn {'-' * 50}")
     obs: CmdOutputObservation
 
+    # Rewriting the test file to ignore any changes Agent may have made.
     script_name = f'{instance.instance_name}_test.py'
     with tempfile.TemporaryDirectory() as tmpdir:
         file_path = os.path.join(tmpdir, script_name)
@@ -155,6 +163,7 @@ async def process_instance(
     instruction = instance.instruction
     instruction += INSTRUCTIONS_ADDENDUM.format(
         signature_file=f'{instance.instance_name}.py',
+        test_file=f'{instance.instance_name}_test.py',
     )
     instruction += (
         'IMPORTANT: You should ONLY interact with the environment provided '
@@ -254,7 +263,7 @@ if __name__ == '__main__':
 
     instances = prepare_dataset(
         aider_bench_tests, output_file, args.eval_n_limit, eval_ids=eval_ids
-    )
+    )[124:]
 
     asyncio.run(
         run_evaluation(


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Allowing the Agent to run unittests for a given instance allows it to identify and fix trivial issues. This significantly improves perfomance on the benchmark.

Using Claude-3.5-sonnet,
Passed 115 tests, failed 18 tests, resolve rate = 86.47%