### PR TITLE
(feat) runtime: in _wait_until_alive upon start wait for client to have initialized too

### DIFF
--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -187,7 +187,7 @@ def get_runtime_image_repo_and_tag(base_image: str) -> tuple[str, str]:
 
     if RUNTIME_IMAGE_REPO in base_image:
         logger.info(
-            f'The provided image [{base_image}] is a already a valid runtime image.\n'
+            f'The provided image [{base_image}] is already a valid runtime image.\n'
             f'Will try to reuse it as is.'
         )
 


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

EventStreamRuntime will wait for runtime client to be initialized once, for up to 10s. 

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The runtime starts the client and should wait for its full initialization before resuming normal processing.
This will only be done once and only for up to 10 seconds so to not get stuck.

@xingyaoww Let me know what you think about this approach.