### PR TITLE
Enabling of unittests in aider benchmark should be optional.

### DIFF
--- a/evaluation/aider_bench/README.md
+++ b/evaluation/aider_bench/README.md
@@ -32,6 +32,11 @@ development environment and LLM.
 - `eval_ids`, e.g. `"1,3,10"`, limits the evaluation to instances with the
     given IDs (comma separated).
 
+There are also following optional environment variables you can set:
+```
+export USE_UNIT_TESTS=true # if you want to allow the Agent to verify correctness using unittests. Default to false.
+```
+
 Following is the basic command to start the evaluation.
 
 You can update the arguments in the script

--- a/evaluation/aider_bench/helper.py
+++ b/evaluation/aider_bench/helper.py
@@ -6,7 +6,6 @@ INSTRUCTIONS_ADDENDUM = """
 Use the above instructions to modify the supplied files: {signature_file}
 Don't change the names of existing functions or classes, as they may be referenced from other code like unit tests, etc.
 
-Use the test_file: {test_file}, to verify the correctness of your solution. DO NOT EDIT the test file.
 Only use standard python libraries, don't suggest installing any packages.
 """
 

--- a/evaluation/aider_bench/scripts/run_infer.sh
+++ b/evaluation/aider_bench/scripts/run_infer.sh
@@ -35,6 +35,12 @@ COMMAND="export PYTHONPATH=evaluation/aider_bench:\$PYTHONPATH && poetry run pyt
   --eval-num-workers $NUM_WORKERS \
   --eval-note $AGENT_VERSION"
 
+# Default to NOT use unit tests.
+if [ -z "$USE_UNIT_TESTS" ]; then
+  export USE_UNIT_TESTS=false
+fi
+echo "USE_UNIT_TESTS: $USE_UNIT_TESTS"
+
 if [ -n "$EVAL_LIMIT" ]; then
   echo "EVAL_LIMIT: $EVAL_LIMIT"
   COMMAND="$COMMAND --eval-n-limit $EVAL_LIMIT"


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Allow the Aider Benchmark to be run in 2 modes - with/without the Agent having the ability to use unittests to influence its editing accuracy.
