### PR TITLE
(enh) StuckDetector: fix+enhance syntax error loop detection

### DIFF
--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -241,8 +241,6 @@ class TestStuckDetector:
         ipython_observation_4._cause = ipython_action_4._id
         event_stream.add_event(ipython_observation_4, EventSource.USER)
 
-        # stuck_detector.state.history.set_event_stream(event_stream)
-
         last_observations = [
             ipython_observation_1,
             ipython_observation_2,
@@ -314,8 +312,10 @@ class TestStuckDetector:
         event_stream.add_event(ipython_observation_4, EventSource.USER)
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck() is False
-            mock_warning.assert_not_called()
+            assert stuck_detector.is_stuck() is True
+            mock_warning.assert_called_once_with(
+                'Action, IPythonRunCellObservation loop detected'
+            )
 
     def test_is_stuck_repeating_action_observation_pattern(
         self, stuck_detector: StuckDetector, event_stream: EventStream


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Detection of one type of syntax error was broken. Expanded to 4 types of syntax errors.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

There was only one type of syntax error in the stuck detection, like `unterminated string literal`.
However, this was broken as the detection only checked a limited range of characters for it.

Instead, the detection was expanded to the last 4 lines of the observation.
In recent enhancements there were potentially 2 lines added for interpreter and prompt,
making the check basically skip the detection each time.

List of detected errors is now a list:
```py
    SYNTAX_ERROR_MESSAGES = [
        'SyntaxError: unterminated string literal (detected at line',
        'SyntaxError: invalid syntax. Perhaps you forgot a comma?',
        'SyntaxError: incomplete input',
        "E999 SyntaxError: unmatched ')'",
    ]
```

The added errors is a distinct collection from 98 occurences in a bench that I ran.
