### PR TITLE
add (placeholder) workflow for regenerating the integration tests

### DIFF
--- a/.github/workflows/regenerate_integration_tests.yml
+++ b/.github/workflows/regenerate_integration_tests.yml
@@ -1,0 +1,25 @@
+
+name: Regenerate Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Add newline to README
+      run: echo "" >> README.md
+
+    - name: Commit changes
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add README.md
+        git commit -m "Add newline to README"
+        git push

--- a/.github/workflows/regenerate_integration_tests.yml
+++ b/.github/workflows/regenerate_integration_tests.yml
@@ -14,12 +14,13 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Add newline to README
-      run: echo "" >> README.md
+      # TODO: change this to regenerate the tests once this workflow is verified as working
+      run: echo "hello world" >> README.md
 
     - name: Commit changes
       run: |
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-        git add README.md
-        git commit -m "Add newline to README"
+        git add .
+        git commit -m "Regenerate integration tests"
         git push


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

I really struggle to run the integration tests locally. This script would allow us to run them inside of a GitHub action

Most likely we will need to set an LLM_API_KEY as well.



---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

For now, this just makes a minor change to README.md, so I can check the logic of the workflow. But it needs to be checked into main before I can run it manually to test it.

Once it's verified working, I will follow up with another PR that actually gets it to regenerate

---
**Link of any specific issues this addresses**
