### PR TITLE
(fix) test_is_stuck.py to not fail (regression)

### DIFF
--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -75,12 +75,12 @@ class TestStuckDetector:
     def _impl_unterminated_string_error_events(
         self, event_stream: EventStream, random_line: bool
     ):
-        for _ in range(4):
+        for i in range(4):
             ipython_action = IPythonRunCellAction(code='print("hello')
             event_stream.add_event(ipython_action, EventSource.AGENT)
-            line_number = str(random.randint(1, 10)) if random_line else '1'
+            line_number = i * 10 if random_line else '1'
             ipython_observation = IPythonRunCellObservation(
-                content=f'print("hello\n       ^\nSyntaxError: unterminated string literal (detected at line {line_number})'
+                content=f'print("  Cell In[1], line {line_number}\nhello\n       ^\nSyntaxError: unterminated string literal (detected at line {line_number})'
                 + jupyter_line_1
                 + jupyter_line_2,
                 code='print("hello',


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fixes #3628 which causes a fail in unit test `test_is_stuck.py` occasionally 

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

One test data generation method didn't generate random enough data.

---
**Link of any specific issues this addresses**

Example GitHub action fail log:
https://github.com/All-Hands-AI/OpenHands/actions/runs/10625323277/job/29455090006
