### PR TITLE
(fix) Aider bench: logname fix; improve test calling instruction

### DIFF
--- a/evaluation/aider_bench/run_infer.py
+++ b/evaluation/aider_bench/run_infer.py
@@ -177,9 +177,10 @@ def process_instance(
         signature_file=f'{instance.instance_name}.py',
     )
     if USE_UNIT_TESTS:
+        print(f'\nInstruction to run test_file: {instance.instance_name}_test.py\n')
         instruction += (
-            f'Use the test_file: {instance.instance_name}_test.py, to verify '
-            'the correctness of your solution. DO NOT EDIT the test file.\n\n'
+            f'Use `python -m unittest {instance.instance_name}_test.py` to run the test_file '
+            'and verify the correctness of your solution. DO NOT EDIT the test file.\n\n'
         )
 
     instruction += (

--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -139,13 +139,14 @@ def make_metadata(
     details: dict[str, Any] | None = None,
 ) -> EvalMetadata:
     model_name = llm_config.model.split('/')[-1]
+    model_path = model_name.replace(':', '_')
     eval_note = f'_N_{eval_note}' if eval_note else ''
 
     eval_output_path = os.path.join(
         eval_output_dir,
         dataset_name,
         agent_class,
-        f'{model_name}_maxiter_{max_iterations}{eval_note}',
+        f'{model_path}_maxiter_{max_iterations}{eval_note}',
     )
 
     pathlib.Path(eval_output_path).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fixes potential logfile name if model has `:` character in it. Improve instruction on how to call the (optional) test case to prevent timeouts.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Any colon `:` in a model name, like `nousresearch/hermes-3-llama-3.1-405b:extended` prevents logging to file as there won't be a folder created.
- If the use of the unit test is enabled (env var option), the LLM's have all different ideas on _how_ to _execute_ that test, which often resulted in timeouts. The instruction to the LLM has been improved to use the same format as the bench would use itself,
e.g. `python -m unittest {instance.instance_name}_test.py`