### PR TITLE
Indicate browser as experimental so user is aware it may not be fully stable

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -197,17 +197,17 @@
   },
   "WORKSPACE$BROWSER_TAB_LABEL": {
     "en": "Browser (Experimental)",
-    "zh-CN": "浏览器",
-    "de": "Browser",
-    "ko-KR": "브라우저",
-    "no": "Nettleser",
-    "zh-TW": "瀏覽器",
-    "it": "Browser",
-    "pt": "Navegador",
-    "es": "Navegador",
-    "ar": "المتصفح",
-    "fr": "Navigateur",
-    "tr": "Tarayıcı"
+    "zh-CN": "浏览器（实验性）",
+    "de": "Browser (Experimentell)",
+    "ko-KR": "브라우저 (실험적)",
+    "no": "Nettleser (Eksperimentell)",
+    "zh-TW": "瀏覽器 (實驗性)",
+    "it": "Browser (Sperimentale)",
+    "pt": "Navegador (Experimental)",
+    "es": "Navegador (Experimental)",
+    "ar": "المتصفح (تجريبي)",
+    "fr": "Navigateur (Expérimental)",
+    "tr": "Tarayıcı (Deneysel)"
   },
   "CONFIGURATION$OPENHANDS_WORKSPACE_DIRECTORY_INPUT_LABEL": {
     "en": "OpenHands Workspace directory",

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -196,7 +196,7 @@
     "es": "Editor de código"
   },
   "WORKSPACE$BROWSER_TAB_LABEL": {
-    "en": "Browser",
+    "en": "Browser (Experimental)",
     "zh-CN": "浏览器",
     "de": "Browser",
     "ko-KR": "브라우저",


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Indicate browser as experimental so user is aware it may not be fully stable

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The browser agent may not be fully stable. Running prompts may or may not work. Sometimes OpenHands can get into a permanently stuck state if the browser agent goes into a loop and will require a full restart. As such, putting a label on the browser tab to indicate experimental status until this becomes more stable.

---
**Link of any specific issues this addresses**
