### PR TITLE
Fix step count out-of-sync bug when delegated agent fails

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -365,10 +365,14 @@ class AgentController:
                 f'[Agent Controller {self.id}] Delegate state: {delegate_state}'
             )
             if delegate_state == AgentState.ERROR:
+                # update iteration that shall be shared across agents
+                self.state.iteration = self.delegate.state.iteration
+
                 # close the delegate upon error
                 await self.delegate.close()
                 self.delegate = None
                 self.delegateAction = None
+
                 await self.report_error('Delegator agent encounters an error')
                 return
             delegate_done = delegate_state in (AgentState.FINISHED, AgentState.REJECTED)


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fix a global step count out-of-sync bug when delegated agent fails

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Reported by @tobitege 
![image](https://github.com/user-attachments/assets/de4567ef-5449-4ff3-b904-930205de99c9)


---
**Link of any specific issues this addresses**

Fixes https://openhands-ai.slack.com/archives/C078L0FUGUX/p1725133898782779
