### PR TITLE
(fix) confirmation mode bugfix for the EventStreamRuntime

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -17,6 +17,7 @@ from openhands.events.observation import (
     AgentDelegateObservation,
     CmdOutputObservation,
     IPythonRunCellObservation,
+    UserRejectObservation,
 )
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.observation.observation import Observation
@@ -152,6 +153,10 @@ class CodeActAgent(Agent):
         elif isinstance(obs, ErrorObservation):
             text = 'OBSERVATION:\n' + truncate_content(obs.content, max_message_chars)
             text += '\n[Error occurred in processing last action]'
+            return Message(role='user', content=[TextContent(text=text)])
+        elif isinstance(obs, UserRejectObservation):
+            text = 'OBSERVATION:\n' + truncate_content(obs.content, max_message_chars)
+            text += '\n[Last action has been rejected by the user]'
             return Message(role='user', content=[TextContent(text=text)])
         else:
             # If an observation message is not returned, it will cause an error

--- a/openhands/events/observation/reject.py
+++ b/openhands/events/observation/reject.py
@@ -6,7 +6,7 @@ from openhands.events.observation.observation import Observation
 
 @dataclass
 class UserRejectObservation(Observation):
-    """This data class represents the result of a successful action."""
+    """This data class represents the result of a rejected action."""
 
     observation: str = ObservationType.USER_REJECTED
 


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fixes the bug noticed in https://github.com/All-Hands-AI/OpenHands/issues/3684 which appears because new `EventStreamRuntime` did not have handling confirmation mode options during running of the actions.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

PR implements checking of confirmation mode for `EventStreamRuntime` with the same conditions that were used in `Runtime`: https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/runtime/runtime.py#L128 

---
**Link of any specific issues this addresses**
Resolves #3684