### PR TITLE
doc updates for headless / cli mode

### DIFF
--- a/docs/modules/usage/how-to/headless-mode.md
+++ b/docs/modules/usage/how-to/headless-mode.md
@@ -48,7 +48,7 @@ docker run -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app-$(date +%Y%m%d%H%M%S) \
-    ghcr.io/all-hands-ai/openhands:0.9 \ # TODO: pin a version here
+    ghcr.io/all-hands-ai/openhands:0.9 \
     poetry run python -m openhands.core.main \
     -t "Write a bash script that prints Hello World"
 ```
@@ -76,6 +76,6 @@ docker run -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app-$(date +%Y%m%d%H%M%S) \
-    ghcr.io/all-hands-ai/openhands:0.9 \ # TODO: pin a version here
+    ghcr.io/all-hands-ai/openhands:0.9 \
     poetry run python -m openhands.core.cli
 ```

--- a/docs/modules/usage/how-to/headless-mode.md
+++ b/docs/modules/usage/how-to/headless-mode.md
@@ -6,7 +6,7 @@ to automate tasks with OpenHands. There are 2 main modes of operation:
 * **Headless** : Designed for use with scripts
 * **CLI** : Designed for interactive use via a console
 
-As with other modes, the environment is configurable via environment variables or by saving values into [config.toml](https://github.com/All-Hands-AI/OpenHands/blob/main/config.toml.template) 
+As with other modes, the environment is configurable via environment variables or by saving values into [config.toml](https://github.com/All-Hands-AI/OpenHands/blob/main/config.template.toml) 
 
 ## With Python
 To run OpenHands in headless mode with Python,

--- a/docs/modules/usage/how-to/headless-mode.md
+++ b/docs/modules/usage/how-to/headless-mode.md
@@ -1,18 +1,29 @@
 # Running in Headless Mode
 
 You can run OpenHands via a CLI, without starting the web application. This makes it easy
-to automate tasks with OpenHands.
+to automate tasks with OpenHands. There are 2 main modes of operation:
+
+* **Headless** : Designed for use with scripts
+* **CLI** : Designed for interactive use via a console
 
 ## With Python
 To run OpenHands in headless mode with Python,
 [follow the Development setup instructions](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md),
 and then run:
 
+### Headless
 ```bash
 poetry run python -m openhands.core.main -t "write a bash script that prints hi"
 ```
 
-## With Docker
+### CLI
+```bash
+poetry run python -m openhands.core.cli
+
+How can I help? >> write a bash script that prints hi
+```
+
+## Headless With Docker
 To run OpenHands in headless mode with Docker, run:
 
 ```bash
@@ -35,7 +46,34 @@ docker run -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app-$(date +%Y%m%d%H%M%S) \
-    ghcr.io/all-hands-ai/openhands:main \ # TODO: pin a version here
-    python -m openhands.core.main \
+    ghcr.io/all-hands-ai/openhands:0.9 \ # TODO: pin a version here
+    poetry run python -m openhands.core.main \
     -t "Write a bash script that prints Hello World"
+```
+
+## CLI With Docker
+To run OpenHands in cli mode with Docker, run:
+
+```bash
+# Set WORKSPACE_BASE to the directory you want OpenHands to edit
+WORKSPACE_BASE=$(pwd)/workspace
+
+# Set LLM_API_KEY to an API key, e.g. for OpenAI or Anthropic
+LLM_API_KEY="abcde"
+
+# Set LLM_MODEL to the model you want to use
+LLM_MODEL="gpt-4o"
+
+docker run -it \
+    --pull=always \
+    -e SANDBOX_USER_ID=$(id -u) \
+    -e WORKSPACE_MOUNT_PATH=$WORKSPACE_BASE \
+    -e LLM_API_KEY=$LLM_API_KEY \
+    -e LLM_MODEL=$LLM_MODEL \
+    -v $WORKSPACE_BASE:/opt/workspace_base \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    --add-host host.docker.internal:host-gateway \
+    --name openhands-app-$(date +%Y%m%d%H%M%S) \
+    ghcr.io/all-hands-ai/openhands:0.9 \ # TODO: pin a version here
+    poetry run python -m openhands.core.cli
 ```

--- a/docs/modules/usage/how-to/headless-mode.md
+++ b/docs/modules/usage/how-to/headless-mode.md
@@ -11,12 +11,12 @@ To run OpenHands in headless mode with Python,
 [follow the Development setup instructions](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md),
 and then run:
 
-### Headless
+### Headless with Python
 ```bash
 poetry run python -m openhands.core.main -t "write a bash script that prints hi"
 ```
 
-### CLI
+### CLI with Python
 ```bash
 poetry run python -m openhands.core.cli
 

--- a/docs/modules/usage/how-to/headless-mode.md
+++ b/docs/modules/usage/how-to/headless-mode.md
@@ -1,10 +1,12 @@
-# Running in Headless Mode
+# Running in Headless / CLI Mode
 
 You can run OpenHands via a CLI, without starting the web application. This makes it easy
 to automate tasks with OpenHands. There are 2 main modes of operation:
 
 * **Headless** : Designed for use with scripts
 * **CLI** : Designed for interactive use via a console
+
+As with other modes, the environment is configurable via environment variables or by saving values into [config.toml](https://github.com/All-Hands-AI/OpenHands/blob/main/config.toml.template) 
 
 ## With Python
 To run OpenHands in headless mode with Python,


### PR DESCRIPTION
This is indented to address https://github.com/All-Hands-AI/OpenHands/issues/3703

* CLI mode was undocumented, so this adds documentation for it.
* The commands in the documentation didn't work. (Fixed `poetry run python` vs `python`)
