### PR TITLE
(fix) revert enabling litellm verbose mode from testing

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -92,8 +92,6 @@ class LLM:
             RateLimitError,
         )
 
-        litellm.set_verbose = True
-
         # Set the max tokens in an LM-specific way if not set
         if self.config.max_input_tokens is None:
             if (


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Forgot to remove litellm verbose mode from earlier PR

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Just one line removed in llm.py.