### PR TITLE
Redesign settings modal

### DIFF
--- a/frontend/src/components/modals/base-modal/BaseModal.tsx
+++ b/frontend/src/components/modals/base-modal/BaseModal.tsx
@@ -58,7 +58,7 @@ function BaseModal({
             <ModalBody className={bodyClassName}>{children}</ModalBody>
 
             {actions && actions.length > 0 && (
-              <ModalFooter className="flex-col flex justify-start p-0">
+              <ModalFooter className="flex-row flex justify-start p-0">
                 <FooterContent actions={actions} closeModal={closeModal} />
               </ModalFooter>
             )}

--- a/frontend/src/components/modals/base-modal/BaseModal.tsx
+++ b/frontend/src/components/modals/base-modal/BaseModal.tsx
@@ -39,7 +39,6 @@ function BaseModal({
       data-testid={testID}
       isOpen={isOpen}
       onOpenChange={onOpenChange}
-      title={title}
       isDismissable={isDismissable}
       backdrop="blur"
       hideCloseButton
@@ -51,7 +50,7 @@ function BaseModal({
           <>
             {title && (
               <ModalHeader className="flex flex-col p-0">
-                <HeaderContent title={title} subtitle={subtitle} />
+                <HeaderContent maintitle={title} subtitle={subtitle} />
               </ModalHeader>
             )}
 

--- a/frontend/src/components/modals/base-modal/HeaderContent.tsx
+++ b/frontend/src/components/modals/base-modal/HeaderContent.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
 interface HeaderContentProps {
-  title: string;
+  maintitle: string;
   subtitle?: string;
 }
 
 export function HeaderContent({
-  title,
+  maintitle: maintitle,
   subtitle = undefined,
 }: HeaderContentProps) {
   return (
     <>
-      <h3>{title}</h3>
+      <h3>{maintitle}</h3>
       {subtitle && (
         <span className="text-neutral-400 text-sm font-light">{subtitle}</span>
       )}

--- a/frontend/src/components/modals/settings/ModelSelector.tsx
+++ b/frontend/src/components/modals/settings/ModelSelector.tsx
@@ -61,10 +61,10 @@ export function ModelSelector({
 
   return (
     <div data-testid="model-selector" className="flex flex-col gap-2">
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-row gap-3">
         <Autocomplete
           isDisabled={isDisabled}
-          label="Provider"
+          label="LLM Provider"
           placeholder="Select a provider"
           isClearable={false}
           onSelectionChange={(e) => {
@@ -95,7 +95,7 @@ export function ModelSelector({
         </Autocomplete>
 
         <Autocomplete
-          label="Model"
+          label="LLM Model"
           placeholder="Select a model"
           onSelectionChange={(e) => {
             if (e?.toString()) handleChangeModel(e.toString());

--- a/frontend/src/components/modals/settings/ModelSelector.tsx
+++ b/frontend/src/components/modals/settings/ModelSelector.tsx
@@ -61,10 +61,6 @@ export function ModelSelector({
 
   return (
     <div data-testid="model-selector" className="flex flex-col gap-2">
-      <span className="text-center italic text-gray-500" data-testid="model-id">
-        {litellmId?.replace("other", "") || "No model selected"}
-      </span>
-
       <div className="flex flex-col gap-3">
         <Autocomplete
           isDisabled={isDisabled}

--- a/frontend/src/components/modals/settings/SettingsForm.test.tsx
+++ b/frontend/src/components/modals/settings/SettingsForm.test.tsx
@@ -21,8 +21,6 @@ const renderSettingsForm = (settings?: Settings) => {
       settings={
         settings || {
           LLM_MODEL: "gpt-4o",
-          CUSTOM_LLM_MODEL: "",
-          USING_CUSTOM_MODEL: false,
           AGENT: "agent1",
           LANGUAGE: "en",
           LLM_API_KEY: "sk-...",
@@ -71,8 +69,6 @@ describe("SettingsForm", () => {
   it("should display the existing values if they are present", () => {
     renderSettingsForm({
       LLM_MODEL: "gpt-3.5-turbo",
-      CUSTOM_LLM_MODEL: "",
-      USING_CUSTOM_MODEL: false,
       AGENT: "agent2",
       LANGUAGE: "es",
       LLM_API_KEY: "sk-...",
@@ -100,8 +96,6 @@ describe("SettingsForm", () => {
       <SettingsForm
         settings={{
           LLM_MODEL: "gpt-4o",
-          CUSTOM_LLM_MODEL: "",
-          USING_CUSTOM_MODEL: false,
           AGENT: "agent1",
           LANGUAGE: "en",
           LLM_API_KEY: "sk-...",
@@ -230,8 +224,6 @@ describe("SettingsForm", () => {
         <SettingsForm
           settings={{
             LLM_MODEL: "gpt-4o",
-            CUSTOM_LLM_MODEL: "CUSTOM_MODEL",
-            USING_CUSTOM_MODEL: true,
             AGENT: "agent1",
             LANGUAGE: "en",
             LLM_API_KEY: "sk-...",

--- a/frontend/src/components/modals/settings/SettingsForm.tsx
+++ b/frontend/src/components/modals/settings/SettingsForm.tsx
@@ -43,32 +43,20 @@ function SettingsForm({
 }: SettingsFormProps) {
   const { t } = useTranslation();
   const { isOpen: isVisible, onOpenChange: onVisibleChange } = useDisclosure();
-  const [isAgentSelectEnabled, setIsAgentSelectEnabled] = React.useState(false);
-  const [usingCustomModel, setUsingCustomModel] = React.useState(
-    settings.USING_CUSTOM_MODEL,
-  );
-
-  const changeModelType = (type: "custom" | "default") => {
-    if (type === "custom") {
-      setUsingCustomModel(true);
-      onModelTypeChange("custom");
-    } else {
-      setUsingCustomModel(false);
-      onModelTypeChange("default");
-    }
-  };
+  const advancedAlreadyInUse = settings.USING_CUSTOM_MODEL || !!settings.SECURITY_ANALYZER || !!settings.CONFIRMATION_MODE;
+  const [enableAdvanced, setEnableAdvanced] = React.useState(advancedAlreadyInUse);
 
   return (
     <>
       <Switch
-        data-testid="custom-model-toggle"
-        aria-checked={usingCustomModel}
-        isSelected={usingCustomModel}
-        onValueChange={(value) => changeModelType(value ? "custom" : "default")}
+        data-testid="advanced-options-toggle"
+        aria-checked={enableAdvanced}
+        isSelected={enableAdvanced}
+        onValueChange={(value) => setEnableAdvanced(value)}
       >
-        Use custom model
+        Advanced Options
       </Switch>
-      {usingCustomModel && (
+      {enableAdvanced && (
         <Input
           data-testid="custom-model-input"
           label="Custom Model"
@@ -76,7 +64,7 @@ function SettingsForm({
           defaultValue={settings.CUSTOM_LLM_MODEL}
         />
       )}
-      {!usingCustomModel && (
+      {!enableAdvanced && (
         <ModelSelector
           isDisabled={disabled}
           models={organizeModelsAndProviders(models)}
@@ -117,24 +105,14 @@ function SettingsForm({
         tooltip={t(I18nKey.SETTINGS$LANGUAGE_TOOLTIP)}
         disabled={disabled}
       />
-      <AutocompleteCombobox
+      {enableAdvanced && (<AutocompleteCombobox
         ariaLabel="agent"
         items={agents.map((agent) => ({ value: agent, label: agent }))}
         defaultKey={settings.AGENT}
         onChange={onAgentChange}
         tooltip={t(I18nKey.SETTINGS$AGENT_TOOLTIP)}
-        disabled={disabled || !isAgentSelectEnabled}
-      />
-      <Switch
-        defaultSelected={false}
-        isSelected={isAgentSelectEnabled}
-        onValueChange={setIsAgentSelectEnabled}
-        aria-label="enableagentselect"
-        data-testid="enableagentselect"
-      >
-        {t(I18nKey.SETTINGS$AGENT_SELECT_ENABLED)}
-      </Switch>
-      <AutocompleteCombobox
+      />)}
+      {enableAdvanced && (<AutocompleteCombobox
         ariaLabel="securityanalyzer"
         items={securityAnalyzers.map((securityAnalyzer) => ({
           value: securityAnalyzer,
@@ -144,8 +122,8 @@ function SettingsForm({
         onChange={onSecurityAnalyzerChange}
         tooltip={t(I18nKey.SETTINGS$SECURITY_ANALYZER)}
         disabled={disabled}
-      />
-      <Switch
+      />)}
+      {enableAdvanced && (<Switch
         aria-label="confirmationmode"
         data-testid="confirmationmode"
         defaultSelected={
@@ -162,7 +140,7 @@ function SettingsForm({
         >
           {t(I18nKey.SETTINGS$CONFIRMATION_MODE)}
         </Tooltip>
-      </Switch>
+      </Switch>)}
     </>
   );
 }

--- a/frontend/src/components/modals/settings/SettingsForm.tsx
+++ b/frontend/src/components/modals/settings/SettingsForm.tsx
@@ -17,8 +17,6 @@ interface SettingsFormProps {
   disabled: boolean;
 
   onModelChange: (model: string) => void;
-  onCustomModelChange: (model: string) => void;
-  onModelTypeChange: (type: "custom" | "default") => void;
   onAPIKeyChange: (apiKey: string) => void;
   onAgentChange: (agent: string) => void;
   onLanguageChange: (language: string) => void;
@@ -33,8 +31,6 @@ function SettingsForm({
   securityAnalyzers,
   disabled,
   onModelChange,
-  onCustomModelChange,
-  onModelTypeChange,
   onAPIKeyChange,
   onAgentChange,
   onLanguageChange,
@@ -43,7 +39,8 @@ function SettingsForm({
 }: SettingsFormProps) {
   const { t } = useTranslation();
   const { isOpen: isVisible, onOpenChange: onVisibleChange } = useDisclosure();
-  const advancedAlreadyInUse = settings.USING_CUSTOM_MODEL || !!settings.SECURITY_ANALYZER || !!settings.CONFIRMATION_MODE;
+  const advancedAlreadyInUse = !!settings.SECURITY_ANALYZER || !!settings.CONFIRMATION_MODE;
+  // TODO: || model is not in the list
   const [enableAdvanced, setEnableAdvanced] = React.useState(advancedAlreadyInUse);
 
   return (
@@ -60,8 +57,8 @@ function SettingsForm({
         <Input
           data-testid="custom-model-input"
           label="Custom Model"
-          onValueChange={onCustomModelChange}
-          defaultValue={settings.CUSTOM_LLM_MODEL}
+          onValueChange={onModelChange}
+          defaultValue={settings.LLM_MODEL}
         />
       )}
       {!enableAdvanced && (

--- a/frontend/src/components/modals/settings/SettingsModal.test.tsx
+++ b/frontend/src/components/modals/settings/SettingsModal.test.tsx
@@ -24,8 +24,6 @@ vi.mock("#/services/settings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#/services/settings")>()),
   getSettings: vi.fn().mockReturnValue({
     LLM_MODEL: "gpt-4o",
-    CUSTOM_LLM_MODEL: "",
-    USING_CUSTOM_MODEL: false,
     AGENT: "CodeActAgent",
     LANGUAGE: "en",
     LLM_API_KEY: "sk-...",
@@ -34,8 +32,6 @@ vi.mock("#/services/settings", async (importOriginal) => ({
   }),
   getDefaultSettings: vi.fn().mockReturnValue({
     LLM_MODEL: "gpt-4o",
-    CUSTOM_LLM_MODEL: "",
-    USING_CUSTOM_MODEL: false,
     AGENT: "CodeActAgent",
     LANGUAGE: "en",
     LLM_API_KEY: "",
@@ -115,8 +111,6 @@ describe("SettingsModal", () => {
   describe("onHandleSave", () => {
     const initialSettings: Settings = {
       LLM_MODEL: "gpt-4o",
-      CUSTOM_LLM_MODEL: "",
-      USING_CUSTOM_MODEL: false,
       AGENT: "CodeActAgent",
       LANGUAGE: "en",
       LLM_API_KEY: "sk-...",

--- a/frontend/src/components/modals/settings/SettingsModal.tsx
+++ b/frontend/src/components/modals/settings/SettingsModal.tsx
@@ -83,20 +83,6 @@ function SettingsModal({ isOpen, onOpenChange }: SettingsProps) {
     }));
   };
 
-  const handleCustomModelChange = (model: string) => {
-    setSettings((prev) => ({
-      ...prev,
-      CUSTOM_LLM_MODEL: model,
-    }));
-  };
-
-  const handleModelTypeChange = (type: "custom" | "default") => {
-    setSettings((prev) => ({
-      ...prev,
-      USING_CUSTOM_MODEL: type === "custom",
-    }));
-  };
-
   const handleAgentChange = (agent: string) => {
     setSettings((prev) => ({ ...prev, AGENT: agent }));
   };
@@ -205,8 +191,6 @@ function SettingsModal({ isOpen, onOpenChange }: SettingsProps) {
           agents={agents}
           securityAnalyzers={securityAnalyzers}
           onModelChange={handleModelChange}
-          onCustomModelChange={handleCustomModelChange}
-          onModelTypeChange={handleModelTypeChange}
           onAgentChange={handleAgentChange}
           onLanguageChange={handleLanguageChange}
           onAPIKeyChange={handleAPIKeyChange}

--- a/frontend/src/components/modals/settings/SettingsModal.tsx
+++ b/frontend/src/components/modals/settings/SettingsModal.tsx
@@ -122,16 +122,6 @@ function SettingsModal({ isOpen, onOpenChange }: SettingsProps) {
     i18next.changeLanguage(settings.LANGUAGE);
     Session.startNewSession();
 
-    const sensitiveKeys = ["LLM_API_KEY"];
-
-    Object.entries(updatedSettings).forEach(([key, value]) => {
-      if (!sensitiveKeys.includes(key)) {
-        toast.settingsChanged(`${key} set to "${value}"`);
-      } else {
-        toast.settingsChanged(`${key} has been updated securely.`);
-      }
-    });
-
     localStorage.setItem(
       `API_KEY_${settings.LLM_MODEL || models[0]}`,
       settings.LLM_API_KEY,

--- a/frontend/src/components/modals/settings/SettingsModal.tsx
+++ b/frontend/src/components/modals/settings/SettingsModal.tsx
@@ -128,7 +128,7 @@ function SettingsModal({ isOpen, onOpenChange }: SettingsProps) {
     );
   };
 
-  let subtitle = t(I18nKey.CONFIGURATION$MODAL_SUB_TITLE);
+  let subtitle = "";
   if (loading) {
     subtitle = t(I18nKey.CONFIGURATION$AGENT_LOADING);
   } else if (agentIsRunning) {

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -250,18 +250,6 @@
     "fr": "Configuration",
     "tr": "Konfigürasyon"
   },
-  "CONFIGURATION$MODAL_SUB_TITLE": {
-    "en": "Adjust settings to your liking",
-    "zh-CN": "根据您的喜好调整设置",
-    "de": "Passen Sie die Einstellungen nach Ihren Wünschen an ",
-    "ko-KR": "원하는 대로 설정 조정",
-    "no": "Juster innstillinger etter dine ønsker ",
-    "zh-TW": "調整設定以符合您的喜好",
-    "it": "Regola le impostazioni in base alle tue preferenze",
-    "pt": "Ajuste as configurações de acordo com sua preferência",
-    "es": "Ajusta la configuración a tu gusto",
-    "tr": "Ayarları isteğinize göre ayarlayın"
-  },
   "CONFIGURATION$MODEL_SELECT_LABEL": {
     "en": "Model",
     "zh-CN": "模型",

--- a/frontend/src/services/session.test.ts
+++ b/frontend/src/services/session.test.ts
@@ -19,8 +19,6 @@ describe("startNewSession", () => {
   it("Should start a new session with the current settings", () => {
     const settings: Settings = {
       LLM_MODEL: "llm_value",
-      CUSTOM_LLM_MODEL: "",
-      USING_CUSTOM_MODEL: false,
       AGENT: "agent_value",
       LANGUAGE: "language_value",
       LLM_API_KEY: "sk-...",
@@ -43,8 +41,6 @@ describe("startNewSession", () => {
   it("should start with the custom llm if set", () => {
     const settings: Settings = {
       LLM_MODEL: "llm_value",
-      CUSTOM_LLM_MODEL: "custom_llm_value",
-      USING_CUSTOM_MODEL: true,
       AGENT: "agent_value",
       LANGUAGE: "language_value",
       LLM_API_KEY: "sk-...",

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -50,9 +50,6 @@ class Session {
       action: ActionType.INIT,
       args: {
         ...settings,
-        LLM_MODEL: settings.USING_CUSTOM_MODEL
-          ? settings.CUSTOM_LLM_MODEL
-          : settings.LLM_MODEL,
       },
     };
     const eventString = JSON.stringify(event);

--- a/frontend/src/services/settings.test.ts
+++ b/frontend/src/services/settings.test.ts
@@ -30,8 +30,6 @@ describe("getSettings", () => {
 
     expect(settings).toEqual({
       LLM_MODEL: "llm_value",
-      CUSTOM_LLM_MODEL: "custom_llm_value",
-      USING_CUSTOM_MODEL: true,
       AGENT: "agent_value",
       LANGUAGE: "language_value",
       LLM_API_KEY: "api_key",
@@ -55,8 +53,6 @@ describe("getSettings", () => {
 
     expect(settings).toEqual({
       LLM_MODEL: DEFAULT_SETTINGS.LLM_MODEL,
-      CUSTOM_LLM_MODEL: "",
-      USING_CUSTOM_MODEL: DEFAULT_SETTINGS.USING_CUSTOM_MODEL,
       AGENT: DEFAULT_SETTINGS.AGENT,
       LANGUAGE: DEFAULT_SETTINGS.LANGUAGE,
       LLM_API_KEY: "",
@@ -70,8 +66,6 @@ describe("saveSettings", () => {
   it("should save the settings", () => {
     const settings: Settings = {
       LLM_MODEL: "llm_value",
-      CUSTOM_LLM_MODEL: "custom_llm_value",
-      USING_CUSTOM_MODEL: true,
       AGENT: "agent_value",
       LANGUAGE: "language_value",
       LLM_API_KEY: "some_key",
@@ -82,14 +76,6 @@ describe("saveSettings", () => {
     saveSettings(settings);
 
     expect(localStorage.setItem).toHaveBeenCalledWith("LLM_MODEL", "llm_value");
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      "CUSTOM_LLM_MODEL",
-      "custom_llm_value",
-    );
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      "USING_CUSTOM_MODEL",
-      "true",
-    );
     expect(localStorage.setItem).toHaveBeenCalledWith("AGENT", "agent_value");
     expect(localStorage.setItem).toHaveBeenCalledWith(
       "LANGUAGE",
@@ -149,8 +135,6 @@ describe("getSettingsDifference", () => {
   it("should return updated settings", () => {
     const settings = {
       LLM_MODEL: "new_llm_value",
-      CUSTOM_LLM_MODEL: "custom_llm_value",
-      USING_CUSTOM_MODEL: true,
       AGENT: "new_agent_value",
       LANGUAGE: "language_value",
     };
@@ -158,7 +142,6 @@ describe("getSettingsDifference", () => {
     const updatedSettings = getSettingsDifference(settings);
 
     expect(updatedSettings).toEqual({
-      USING_CUSTOM_MODEL: true,
       LLM_MODEL: "new_llm_value",
       AGENT: "new_agent_value",
     });

--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -1,9 +1,7 @@
-const LATEST_SETTINGS_VERSION = 1;
+const LATEST_SETTINGS_VERSION = 2;
 
 export type Settings = {
   LLM_MODEL: string;
-  CUSTOM_LLM_MODEL: string;
-  USING_CUSTOM_MODEL: boolean;
   AGENT: string;
   LANGUAGE: string;
   LLM_API_KEY: string;
@@ -15,8 +13,6 @@ type SettingsInput = Settings[keyof Settings];
 
 export const DEFAULT_SETTINGS: Settings = {
   LLM_MODEL: "openai/gpt-4o",
-  CUSTOM_LLM_MODEL: "",
-  USING_CUSTOM_MODEL: false,
   AGENT: "CodeActAgent",
   LANGUAGE: "en",
   LLM_API_KEY: "",
@@ -46,6 +42,14 @@ export const maybeMigrateSettings = () => {
   if (currentVersion < 1) {
     localStorage.setItem("AGENT", DEFAULT_SETTINGS.AGENT);
   }
+  if (currentVersion < 2) {
+    const customModel = localStorage.getItem("CUSTOM_LLM_MODEL");
+    if (customModel) {
+      localStorage.setItem("LLM_MODEL", customModel);
+    }
+    localStorage.removeItem("CUSTOM_LLM_MODEL");
+    localStorage.removeItem("USING_CUSTOM_MODEL");
+  }
 };
 
 /**
@@ -58,9 +62,6 @@ export const getDefaultSettings = (): Settings => DEFAULT_SETTINGS;
  */
 export const getSettings = (): Settings => {
   const model = localStorage.getItem("LLM_MODEL");
-  const customModel = localStorage.getItem("CUSTOM_LLM_MODEL");
-  const usingCustomModel =
-    localStorage.getItem("USING_CUSTOM_MODEL") === "true";
   const agent = localStorage.getItem("AGENT");
   const language = localStorage.getItem("LANGUAGE");
   const apiKey = localStorage.getItem("LLM_API_KEY");
@@ -69,8 +70,6 @@ export const getSettings = (): Settings => {
 
   return {
     LLM_MODEL: model || DEFAULT_SETTINGS.LLM_MODEL,
-    CUSTOM_LLM_MODEL: customModel || DEFAULT_SETTINGS.CUSTOM_LLM_MODEL,
-    USING_CUSTOM_MODEL: usingCustomModel || DEFAULT_SETTINGS.USING_CUSTOM_MODEL,
     AGENT: agent || DEFAULT_SETTINGS.AGENT,
     LANGUAGE: language || DEFAULT_SETTINGS.LANGUAGE,
     LLM_API_KEY: apiKey || DEFAULT_SETTINGS.LLM_API_KEY,


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

The settings modal has progressively grown and is very intimidating for new users.


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

* Hide all advanced stuff under "advanced options"
* Consolidate a few things on single rows
* Fix `title` attributes
* Remove toasts on settings update

Before:
<img width="452" alt="Screenshot 2024-09-05 at 3 27 44 PM" src="https://github.com/user-attachments/assets/19f71afa-be53-48f9-bc53-0e79d7fdb3f4">

After:
<img width="461" alt="Screenshot 2024-09-05 at 3 27 49 PM" src="https://github.com/user-attachments/assets/b64a4378-1b10-4e05-9141-1d7ae095661d">

After with advanced:
<img width="491" alt="Screenshot 2024-09-05 at 3 27 52 PM" src="https://github.com/user-attachments/assets/97768b3f-aa13-4c54-a549-38e03f2e3e13">



---
**Link of any specific issues this addresses**
