### PR TITLE
Add Anthropic Models to Cache Prompt

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -39,8 +39,6 @@ __all__ = ['LLM']
 message_separator = '\n\n----------\n\n'
 
 cache_prompting_supported_models = [
-    'anthropic/claude-3-5-sonnet-20240620',
-    'anthropic/claude-3-haiku-20240307',
     'claude-3-5-sonnet-20240620',
     'claude-3-haiku-20240307',
 ]
@@ -480,9 +478,8 @@ class LLM:
         Returns:
             boolean: True if prompt caching is active for the given model.
         """
-        return (
-            self.config.caching_prompt is True
-            and self.config.model in cache_prompting_supported_models
+        return self.config.caching_prompt is True and any(
+            model in self.config.model for model in cache_prompting_supported_models
         )
 
     def _post_completion(self, response) -> None:

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -39,6 +39,8 @@ __all__ = ['LLM']
 message_separator = '\n\n----------\n\n'
 
 cache_prompting_supported_models = [
+    'anthropic/claude-3-5-sonnet-20240620',
+    'anthropic/claude-3-haiku-20240307',
     'claude-3-5-sonnet-20240620',
     'claude-3-haiku-20240307',
 ]


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**
Adds support for Anthropic models with 'anthropic/' prefix in cache prompting.

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**
This pull request addresses an issue where Anthropic models with the 'anthropic/' prefix were not being correctly identified for cache prompting support. The changes include:

1. Added two new entries to the `cache_prompting_supported_models` list:
   - 'anthropic/claude-3-5-sonnet-20240620'
   - 'anthropic/claude-3-haiku-20240307'

2. Retained the existing entries without the 'anthropic/' prefix to maintain backwards compatibility:
   - 'claude-3-5-sonnet-20240620'
   - 'claude-3-haiku-20240307'

This change ensures that the cache prompting feature correctly supports Anthropic models regardless of whether they are referenced with or without the 'anthropic/' prefix. This dual-entry approach allows for flexibility in model naming conventions while maintaining support for existing configurations.

The decision to keep both prefixed and non-prefixed versions was made to:
1. Support users who may be using the models with the 'anthropic/' prefix in their configurations.
2. Maintain compatibility for users who are already using the non-prefixed versions.

---

**Link of any specific issues this addresses**
Fixes https://github.com/All-Hands-AI/OpenHands/issues/3774: Incorrect identification of Anthropic models in prompt cache supported models