### PR TITLE
Regression fixes: LLM logging; client readiness (EventStreamRuntime)

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -192,32 +192,8 @@ class LLM:
             else:
                 messages = args[1] if len(args) > 1 else []
 
-            # log the prompt
-            debug_message = ''
-            for message in messages:
-                debug_str = ''  # helper to prevent empty messages
-                content = message['content']
-
-                if isinstance(content, list):
-                    for element in content:
-                        if isinstance(element, dict):
-                            if 'text' in element:
-                                debug_str = element['text'].strip()
-                            elif (
-                                self.vision_is_active()
-                                and 'image_url' in element
-                                and 'url' in element['image_url']
-                            ):
-                                debug_str = element['image_url']['url']
-                            else:
-                                debug_str = str(element)
-                        else:
-                            debug_str = str(element)
-                else:
-                    debug_str = str(content)
-
-                if debug_str:
-                    debug_message += message_separator + debug_str
+            # this serves to prevent empty messages and logging the messages
+            debug_message = self._get_debug_message(messages)
 
             if self.is_caching_prompt_active():
                 # Anthropic-specific prompt caching
@@ -276,36 +252,16 @@ class LLM:
             if 'messages' in kwargs:
                 messages = kwargs['messages']
             else:
-                messages = args[1]
+                messages = args[1] if len(args) > 1 else []
 
-            # log the prompt
-            debug_message = ''
-            for message in messages:
-                content = message['content']
-
-                if isinstance(content, list):
-                    for element in content:
-                        if isinstance(element, dict):
-                            if 'text' in element:
-                                debug_str = element['text']
-                            elif (
-                                self.vision_is_active()
-                                and 'image_url' in element
-                                and 'url' in element['image_url']
-                            ):
-                                debug_str = element['image_url']['url']
-                            else:
-                                debug_str = str(element)
-                        else:
-                            debug_str = str(element)
-
-                        debug_message += message_separator + debug_str
-                else:
-                    debug_str = str(content)
-
-                debug_message += message_separator + debug_str
-
-            llm_prompt_logger.debug(debug_message)
+            # this serves to prevent empty messages and logging the messages
+            debug_message = self._get_debug_message(messages)
+            if debug_message:
+                llm_prompt_logger.debug(debug_message)
+                resp = completion_unwrapped(*args, **kwargs)
+            else:
+                logger.debug('No completion messages!')
+                resp = {'choices': [{'message': {'content': ''}}]}
 
             async def check_stopped():
                 while True:
@@ -370,7 +326,7 @@ class LLM:
             if 'messages' in kwargs:
                 messages = kwargs['messages']
             else:
-                messages = args[1]
+                messages = args[1] if len(args) > 1 else []
 
             # log the prompt
             debug_message = ''
@@ -421,6 +377,38 @@ class LLM:
 
         self._async_completion = async_completion_wrapper  # type: ignore
         self._async_streaming_completion = async_acompletion_stream_wrapper  # type: ignore
+
+    def _get_debug_message(self, messages):
+        if not messages:
+            return ''
+
+        messages = messages if isinstance(messages, list) else [messages]
+        return message_separator.join(
+            self._format_message_content(msg) for msg in messages if msg['content']
+        )
+
+    def _format_message_content(self, message):
+        content = message['content']
+        if isinstance(content, list):
+            return self._format_list_content(content)
+        return str(content)
+
+    def _format_list_content(self, content_list):
+        return '\n'.join(
+            self._format_content_element(element) for element in content_list
+        )
+
+    def _format_content_element(self, element):
+        if isinstance(element, dict):
+            if 'text' in element:
+                return element['text']
+            if (
+                self.vision_is_active()
+                and 'image_url' in element
+                and 'url' in element['image_url']
+            ):
+                return element['image_url']['url']
+        return str(element)
 
     async def _call_acompletion(self, *args, **kwargs):
         return await litellm.acompletion(*args, **kwargs)

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -256,12 +256,6 @@ class LLM:
 
             # this serves to prevent empty messages and logging the messages
             debug_message = self._get_debug_message(messages)
-            if debug_message:
-                llm_prompt_logger.debug(debug_message)
-                resp = completion_unwrapped(*args, **kwargs)
-            else:
-                logger.debug('No completion messages!')
-                resp = {'choices': [{'message': {'content': ''}}]}
 
             async def check_stopped():
                 while True:
@@ -277,7 +271,12 @@ class LLM:
 
             try:
                 # Directly call and await litellm_acompletion
-                resp = await async_completion_unwrapped(*args, **kwargs)
+                if debug_message:
+                    llm_prompt_logger.debug(debug_message)
+                    resp = await async_completion_unwrapped(*args, **kwargs)
+                else:
+                    logger.debug('No completion messages!')
+                    resp = {'choices': [{'message': {'content': ''}}]}
 
                 # skip if messages is empty (thus debug_message is empty)
                 if debug_message:

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -212,11 +212,11 @@ class LLM:
 
             # log the response
             message_back = resp['choices'][0]['message']['content']
+            if message_back:
+                llm_response_logger.debug(message_back)
 
-            llm_response_logger.debug(message_back)
-
-            # post-process to log costs
-            self._post_completion(resp)
+                # post-process to log costs
+                self._post_completion(resp)
 
             return resp
 

--- a/openhands/runtime/client/client.py
+++ b/openhands/runtime/client/client.py
@@ -115,6 +115,7 @@ class RuntimeClient:
             logger.info(f'AgentSkills initialized: {obs}')
 
         await self._init_bash_commands()
+        logger.info('Runtime client initialized.')
 
     def _init_user(self, username: str, user_id: int) -> None:
         """Create user if not exists."""
@@ -515,7 +516,6 @@ if __name__ == '__main__':
             browsergym_eval_env=args.browsergym_eval_env,
         )
         await client.ainit()
-        logger.info('Runtime client initialized.')
         yield
         # Clean up & release the resources
         client.close()
@@ -721,6 +721,8 @@ if __name__ == '__main__':
         except Exception as e:
             logger.error(f'Error listing files: {e}', exc_info=True)
             return []
+
+    logger.info('Runtime client initialized.')
 
     logger.info(f'Starting action execution API on port {args.port}')
     run(app, host='0.0.0.0', port=args.port)

--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -277,7 +277,7 @@ class EventStreamRuntime(Runtime):
 
         if not self.log_buffer.client_ready:
             attempts = 0
-            while not self.log_buffer.client_ready and attempts < 10:
+            while not self.log_buffer.client_ready and attempts < 5:
                 attempts += 1
                 time.sleep(1)
                 logs = self.log_buffer.get_and_clear()

--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -47,6 +47,9 @@ class LogBuffer:
     """
 
     def __init__(self, container: docker.models.containers.Container):
+        self.client_ready = False
+        self.init_msg = 'Runtime client initialized.'
+
         self.buffer: list[str] = []
         self.lock = threading.Lock()
         self.log_generator = container.logs(stream=True, follow=True)
@@ -77,9 +80,12 @@ class LogBuffer:
                 if self._stop_event.is_set():
                     break
                 if log_line:
-                    self.append(log_line.decode('utf-8').rstrip())
+                    decoded_line = log_line.decode('utf-8').rstrip()
+                    self.append(decoded_line)
+                    if self.init_msg in decoded_line:
+                        self.client_ready = True
         except Exception as e:
-            logger.error(f'Error in stream_logs: {e}')
+            logger.error(f'Error streaming docker logs: {e}')
 
     def __del__(self):
         if self.log_stream_thread.is_alive():
@@ -129,7 +135,6 @@ class EventStreamRuntime(Runtime):
 
         # Buffer for container logs
         self.log_buffer: LogBuffer | None = None
-        self.startup_done = False
 
         if self.config.sandbox.runtime_extra_deps:
             logger.info(
@@ -249,7 +254,6 @@ class EventStreamRuntime(Runtime):
         reraise=(ConnectionRefusedError,),
     )
     def _wait_until_alive(self):
-        init_msg = 'Runtime client initialized.'
         logger.debug('Getting container logs...')
 
         # Print and clear the log buffer
@@ -257,26 +261,23 @@ class EventStreamRuntime(Runtime):
             self.log_buffer is not None
         ), 'Log buffer is expected to be initialized when container is started'
 
-        # Always process logs, regardless of startup_done status
+        # Always process logs, regardless of client_ready status
         logs = self.log_buffer.get_and_clear()
         if logs:
             formatted_logs = '\n'.join([f'    |{log}' for log in logs])
             logger.info(
                 '\n'
-                + '-' * 30
+                + '-' * 35
                 + 'Container logs:'
-                + '-' * 30
+                + '-' * 35
                 + f'\n{formatted_logs}'
                 + '\n'
-                + '-' * 90
+                + '-' * 80
             )
-            # Check for initialization message even if startup_done is True
-            if any(init_msg in log for log in logs):
-                self.startup_done = True
 
-        if not self.startup_done:
+        if not self.log_buffer.client_ready:
             attempts = 0
-            while not self.startup_done and attempts < 10:
+            while not self.log_buffer.client_ready and attempts < 10:
                 attempts += 1
                 time.sleep(1)
                 logs = self.log_buffer.get_and_clear()
@@ -284,16 +285,13 @@ class EventStreamRuntime(Runtime):
                     formatted_logs = '\n'.join([f'    |{log}' for log in logs])
                     logger.info(
                         '\n'
-                        + '-' * 30
+                        + '-' * 35
                         + 'Container logs:'
-                        + '-' * 30
+                        + '-' * 35
                         + f'\n{formatted_logs}'
                         + '\n'
-                        + '-' * 90
+                        + '-' * 80
                     )
-                    if any(init_msg in log for log in logs):
-                        self.startup_done = True
-                        break
 
         response = self.session.get(f'{self.api_url}/alive')
         if response.status_code == 200:

--- a/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/prompt_001.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 # Instructions
 Review the current state of the page and all other information to find the best
 possible next action to accomplish your goal. Your answer will be interpreted
@@ -108,7 +104,6 @@ click('51')
 click('48', button='middle', modifiers=['Shift'])
 Multiple actions are meant to be executed sequentially without any feedback from the page.
 Don't execute multiple actions at once if you need feedback from the page.
-
 
 
 

--- a/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/prompt_002.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 # Instructions
 Review the current state of the page and all other information to find the best
 possible next action to accomplish your goal. Your answer will be interpreted
@@ -108,7 +104,6 @@ click('51')
 click('48', button='middle', modifiers=['Shift'])
 Multiple actions are meant to be executed sequentially without any feedback from the page.
 Don't execute multiple actions at once if you need feedback from the page.
-
 
 
 

--- a/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/prompt_003.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 # Instructions
 Review the current state of the page and all other information to find the best
 possible next action to accomplish your goal. Your answer will be interpreted
@@ -108,7 +104,6 @@ click('51')
 click('48', button='middle', modifiers=['Shift'])
 Multiple actions are meant to be executed sequentially without any feedback from the page.
 Don't execute multiple actions at once if you need feedback from the page.
-
 
 
 

--- a/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/response_001.log
+++ b/tests/integration/mock/eventstream_runtime/BrowsingAgent/test_browse_internet/response_001.log
@@ -1,4 +1,3 @@
 To accomplish the goal of browsing localhost:8000 and finding the ultimate answer to life, I need to first navigate to the specified URL.
 
-```
-goto("http://localhost:8000"
+```goto("http://localhost:8000"

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_002.log
@@ -1,14 +1,10 @@
-
-
-----------
-
 # Instructions
 Review the current state of the page and all other information to find the best
 possible next action to accomplish your goal. Your answer will be interpreted
 and executed by a program, make sure to follow the formatting instructions.
 
 # Goal:
-Certainly! I'll browse localhost:8000 and retrieve the ultimate answer to life for you.. I should start with: Get the content on "http://localhost:8000"
+. I should start with: Get the content on "http://localhost:8000"
 
 # Action Space
 
@@ -108,7 +104,6 @@ click('51')
 click('48', button='middle', modifiers=['Shift'])
 Multiple actions are meant to be executed sequentially without any feedback from the page.
 Don't execute multiple actions at once if you need feedback from the page.
-
 
 
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_003.log
@@ -1,14 +1,10 @@
-
-
-----------
-
 # Instructions
 Review the current state of the page and all other information to find the best
 possible next action to accomplish your goal. Your answer will be interpreted
 and executed by a program, make sure to follow the formatting instructions.
 
 # Goal:
-Certainly! I'll browse localhost:8000 and retrieve the ultimate answer to life for you.. I should start with: Get the content on "http://localhost:8000"
+. I should start with: Get the content on "http://localhost:8000"
 
 # Action Space
 
@@ -108,7 +104,6 @@ click('51')
 click('48', button='middle', modifiers=['Shift'])
 Multiple actions are meant to be executed sequentially without any feedback from the page.
 Don't execute multiple actions at once if you need feedback from the page.
-
 
 
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_004.log
@@ -1,14 +1,10 @@
-
-
-----------
-
 # Instructions
 Review the current state of the page and all other information to find the best
 possible next action to accomplish your goal. Your answer will be interpreted
 and executed by a program, make sure to follow the formatting instructions.
 
 # Goal:
-Certainly! I'll browse localhost:8000 and retrieve the ultimate answer to life for you.. I should start with: Get the content on "http://localhost:8000"
+. I should start with: Get the content on "http://localhost:8000"
 
 # Action Space
 
@@ -108,7 +104,6 @@ click('51')
 click('48', button='middle', modifiers=['Shift'])
 Multiple actions are meant to be executed sequentially without any feedback from the page.
 Don't execute multiple actions at once if you need feedback from the page.
-
 
 
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed answers to the user's questions.
 The assistant can use a Python environment with <execute_ipython>, e.g.:
 <execute_ipython>
@@ -174,7 +170,6 @@ If the assistant is finished with the task you MUST include <finish></finish> in
 IMPORTANT: Execute code using <execute_ipython>, <execute_bash>, or <execute_browse> whenever possible.
 The assistant should utilize full file paths and the `pwd` command to prevent path-related errors.
 The assistant must avoid apologies and thanks in its responses.
-
 
 ----------
 
@@ -404,19 +399,17 @@ The server is running on port 5000 with PID 126. You can access the list of numb
 NOW, LET'S START!
 Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me for confirmation at any point.
 
-
 ----------
 
 
 <execute_browse>
-Certainly! I'll browse localhost:8000 and retrieve the ultimate answer to life for you.. I should start with: Get the content on "http://localhost:8000"
+. I should start with: Get the content on "http://localhost:8000"
 </execute_browse>
-
 
 ----------
 
 OBSERVATION:
-{'content': 'The ultimate answer to life, the universe, and everything is: OpenHands is all you need!'}
+{'content': 'The answer to life, the universe, and everything has been revealed: OpenHands is all you need!'}
 
 
 ENVIRONMENT REMINDER: You have 13 turns left to complete the task. When finished reply with <finish></finish>.

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_001.log
@@ -1,4 +1,2 @@
-Certainly! I'll browse localhost:8000 and retrieve the ultimate answer to life for you.
-
 <execute_browse>
 Get the content on "http://localhost:8000"

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_002.log
@@ -1,5 +1,5 @@
-To accomplish our goal of retrieving the ultimate answer to life from localhost:8000, I need to start by accessing the content on that page. Here's my thought process and action:
+To accomplish my goal of getting the content on "http://localhost:8000", I need to use the goto action to navigate to that URL. Here's the action with my chain of thought:
 
-In order to accomplish my goal, I need to navigate to the specified URL using the goto action.
+In order to accomplish my goal of accessing the content on "http://localhost:8000", I need to navigate to that URL using the goto action.
 
 ```goto("http://localhost:8000"

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_003.log
@@ -1,6 +1,5 @@
-To accomplish our goal of retrieving the ultimate answer to life, we need to click on the "Click me" button. The button has a bid of 10, so we should click on it.
+To accomplish the goal of revealing the answer, I need to click on the "Click me" button. The button has a bid of 10.
 
 Here's the action I'll take:
 
-In order to accomplish my goal, I need to click on the button with bid 10
 ```click("10"

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_004.log
@@ -1,6 +1,12 @@
-Based on the current Accessibility Tree and the previous actions taken, it appears that we have already successfully navigated to the webpage and clicked the button to reveal the answer. The answer is now visible on the page.
+Based on the current state of the page and the previous actions taken, it appears that we have already accomplished the goal. Let's analyze the situation:
 
-To accomplish our goal of retrieving the ultimate answer to life, I will now send this information to the user:
+1. We started by navigating to "http://localhost:8000" using the `goto` action.
+2. We then clicked on the button with bid "10" using the `click` action.
+3. The current Accessibility Tree shows that the answer has been revealed: "The answer is OpenHands is all you need!"
 
-```
-send_msg_to_user("The ultimate answer to life, the universe, and everything is: OpenHands is all you need!"
+Since the goal was to get the content on the page and reveal the answer, we have successfully completed the task. There's no need for any further actions.
+
+However, to formally conclude and report our findings to the user, we should send a message summarizing what we've discovered. Here's the action I propose:
+
+In order to report our findings to the user, I will send a message with the revealed answer.
+```send_msg_to_user("The answer to life, the universe, and everything has been revealed: OpenHands is all you need!"

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/response_005.log
@@ -1,7 +1,1 @@
-Based on the content retrieved from localhost:8000, I can provide you with the ultimate answer to life:
-
-The ultimate answer to life, the universe, and everything is: OpenHands is all you need!
-
-This appears to be the answer provided by the server at localhost:8000. It's a playful reference to Douglas Adams' "The Hitchhiker's Guide to the Galaxy," where the answer to life, the universe, and everything is famously 42. In this case, it's been customized to highlight "OpenHands."
-
 <finish></finish>

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_001.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed answers to the user's questions.
 The assistant can use a Python environment with <execute_ipython>, e.g.:
 <execute_ipython>
@@ -174,7 +170,6 @@ If the assistant is finished with the task you MUST include <finish></finish> in
 IMPORTANT: Execute code using <execute_ipython>, <execute_bash>, or <execute_browse> whenever possible.
 The assistant should utilize full file paths and the `pwd` command to prevent path-related errors.
 The assistant must avoid apologies and thanks in its responses.
-
 
 ----------
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_002.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed answers to the user's questions.
 The assistant can use a Python environment with <execute_ipython>, e.g.:
 <execute_ipython>
@@ -174,7 +170,6 @@ If the assistant is finished with the task you MUST include <finish></finish> in
 IMPORTANT: Execute code using <execute_ipython>, <execute_bash>, or <execute_browse> whenever possible.
 The assistant should utilize full file paths and the `pwd` command to prevent path-related errors.
 The assistant must avoid apologies and thanks in its responses.
-
 
 ----------
 
@@ -404,29 +399,19 @@ The server is running on port 5000 with PID 126. You can access the list of numb
 NOW, LET'S START!
 Use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'. Do not ask me for confirmation at any point.
 
-
 ----------
 
-Certainly! I'll use Jupyter IPython to create a text file containing 'hello world' in the specified location.
+Certainly! I'll use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'.
 <execute_ipython>
-create_file('/workspace/test.txt')
-append_file('/workspace/test.txt', 'hello world')
+with open('/workspace/test.txt', 'w') as f:
+    f.write('hello world')
+print("File created successfully.")
 </execute_ipython>
-
 
 ----------
 
 OBSERVATION:
-[File: /workspace/test.txt (1 lines total)]
-(this is the beginning of the file)
-1|
-(this is the end of the file)
-[File /workspace/test.txt created.]
-[File: /workspace/test.txt (1 lines total after edit)]
-(this is the beginning of the file)
-1|hello world
-(this is the end of the file)
-[File updated (edited at line 1). Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.]
+File created successfully.
 [Jupyter current working directory: /workspace]
 [Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_002.log
@@ -406,7 +406,7 @@ Use Jupyter IPython to write a text file containing 'hello world' to '/workspace
 
 ----------
 
-Certainly! I'll use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'.
+Certainly! I'll use Jupyter IPython to create a text file containing 'hello world' in the specified location.
 <execute_ipython>
 create_file('/workspace/test.txt')
 </execute_ipython>

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_003.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed answers to the user's questions.
 The assistant can use a Python environment with <execute_ipython>, e.g.:
 <execute_ipython>

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_003.log
@@ -397,7 +397,39 @@ The server is running on port 5000 with PID 126. You can access the list of numb
 
 
 NOW, LET'S START!
-Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me for confirmation at any point.
+Use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'. Do not ask me for confirmation at any point.
+
+----------
+
+Certainly! I'll use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'.
+<execute_ipython>
+with open('/workspace/test.txt', 'w') as f:
+    f.write('hello world')
+print("File created successfully.")
+</execute_ipython>
+
+----------
+
+OBSERVATION:
+File created successfully.
+[Jupyter current working directory: /workspace]
+[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
+
+----------
+
+Great! The file has been created successfully. Let's verify its contents:
+<execute_ipython>
+with open('/workspace/test.txt', 'r') as f:
+    content = f.read()
+print(f"Content of /workspace/test.txt: {content}")
+</execute_ipython>
+
+----------
+
+OBSERVATION:
+Content of /workspace/test.txt: hello world
+[Jupyter current working directory: /workspace]
+[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
 
 
-ENVIRONMENT REMINDER: You have 19 turns left to complete the task. When finished reply with <finish></finish>.
+ENVIRONMENT REMINDER: You have 17 turns left to complete the task. When finished reply with <finish></finish>.

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_001.log
@@ -1,5 +1,6 @@
-Certainly! I'll use Jupyter IPython to create a text file containing 'hello world' in the specified location.
+Certainly! I'll use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'.
 
 <execute_ipython>
-create_file('/workspace/test.txt')
-append_file('/workspace/test.txt', 'hello world')
+with open('/workspace/test.txt', 'w') as f:
+    f.write('hello world')
+print("File created successfully.")

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_001.log
@@ -1,4 +1,4 @@
-Certainly! I'll use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'.
+Certainly! I'll use Jupyter IPython to create a text file containing 'hello world' in the specified location.
 
 <execute_ipython>
 create_file('/workspace/test.txt')

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_002.log
@@ -1,3 +1,6 @@
-The task has been completed successfully. The file '/workspace/test.txt' has been created and contains the text 'hello world'.
+Great! The file has been created successfully. Let's verify its contents:
 
-<finish></finish>
+<execute_ipython>
+with open('/workspace/test.txt', 'r') as f:
+    content = f.read()
+print(f"Content of /workspace/test.txt: {content}")

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/response_003.log
@@ -1,0 +1,3 @@
+The task has been completed successfully. We have created a text file at '/workspace/test.txt' containing the text 'hello world', and we have verified its contents. There are no further actions required for this task.
+
+<finish></finish>

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_001.log
@@ -584,38 +584,6 @@ exit
 
 
 NOW, LET'S START!
-Use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'. Do not ask me for confirmation at any point.
+Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me for confirmation at any point.
 
-----------
-
-Certainly! I'll use Jupyter IPython to create a text file containing 'hello world' at '/workspace/test.txt'. Here's how we'll do it:
-<execute_ipython>
-with open('/workspace/test.txt', 'w') as f:
-    f.write('hello world')
-print("File created successfully.")
-</execute_ipython>
-
-----------
-
-OBSERVATION:
-File created successfully.
-[Jupyter current working directory: /workspace]
-[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
-
-----------
-
-Great! The file has been created successfully. Let's verify its contents to make sure everything is correct:
-<execute_ipython>
-with open('/workspace/test.txt', 'r') as f:
-    content = f.read()
-print(f"Contents of /workspace/test.txt: {content}")
-</execute_ipython>
-
-----------
-
-OBSERVATION:
-Contents of /workspace/test.txt: hello world
-[Jupyter current working directory: /workspace]
-[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
-
-ENVIRONMENT REMINDER: You have 17 turns left to complete the task. When finished reply with <finish></finish>.
+ENVIRONMENT REMINDER: You have 19 turns left to complete the task. When finished reply with <finish></finish>.

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_002.log
@@ -584,38 +584,87 @@ exit
 
 
 NOW, LET'S START!
-Use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'. Do not ask me for confirmation at any point.
+Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me for confirmation at any point.
 
 ----------
 
-Certainly! I'll use Jupyter IPython to create a text file containing 'hello world' at '/workspace/test.txt'. Here's how we'll do it:
-<execute_ipython>
-with open('/workspace/test.txt', 'w') as f:
-    f.write('hello world')
-print("File created successfully.")
-</execute_ipython>
 
-----------
-
-OBSERVATION:
-File created successfully.
-[Jupyter current working directory: /workspace]
-[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
-
-----------
-
-Great! The file has been created successfully. Let's verify its contents to make sure everything is correct:
-<execute_ipython>
-with open('/workspace/test.txt', 'r') as f:
-    content = f.read()
-print(f"Contents of /workspace/test.txt: {content}")
-</execute_ipython>
+<execute_bash>
+curl -s localhost:8000
+</execute_bash>
 
 ----------
 
 OBSERVATION:
-Contents of /workspace/test.txt: hello world
-[Jupyter current working directory: /workspace]
-[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>The Ultimate Answer</title>
+    <style>
+        body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background: linear-gradient(to right, #1e3c72, #2a5298);
+            color: #fff;
+            font-family: 'Arial', sans-serif;
+            text-align: center;
+        }
+        .container {
+            text-align: center;
+            padding: 20px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 10px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+        }
+        h1 {
+            font-size: 36px;
+            margin-bottom: 20px;
+        }
+        p {
+            font-size: 18px;
+            margin-bottom: 30px;
+        }
+        #showButton {
+            padding: 10px 20px;
+            font-size: 16px;
+            color: #1e3c72;
+            background: #fff;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            transition: background 0.3s ease;
+        }
+        #showButton:hover {
+            background: #f0f0f0;
+        }
+        #result {
+            margin-top: 20px;
+            font-size: 24px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>The Ultimate Answer</h1>
+        <p>Click the button to reveal the answer to life, the universe, and everything.</p>
+        <button id="showButton">Click me</button>
+        <div id="result"></div>
+    </div>
+    <script>
+        document.getElementById('showButton').addEventListener('click', function() {
+            document.getElementById('result').innerText = 'The answer is OpenHands is all you need!';
+        });
+    </script>
+</body>
+</html>
 
-ENVIRONMENT REMINDER: You have 17 turns left to complete the task. When finished reply with <finish></finish>.
+[Python Interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.11/bin/python]
+openhands@docker-desktop:/workspace $
+[Command -1 finished with exit code 0]
+
+ENVIRONMENT REMINDER: You have 18 turns left to complete the task. When finished reply with <finish></finish>.

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/response_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/response_001.log
@@ -1,0 +1,2 @@
+<execute_bash>
+curl -s localhost:8000

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/response_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/response_002.log
@@ -1,0 +1,1 @@
+The ultimate answer to life, the universe, and everything is **OpenHands is all you need!**

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_001.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.
 The assistant can interact with an interactive Python (Jupyter Notebook) environment and receive the corresponding output when needed. The code should be enclosed using "<execute_ipython>" tag, for example:
 <execute_ipython>
@@ -155,7 +151,6 @@ Please note that THE `edit_file` FUNCTION REQUIRES PROPER INDENTATION. If the as
 The assistant's response should be concise.
 The assistant should include ONLY ONE <execute_ipython> or <execute_bash> in every one of the responses, unless the assistant is finished with the task or need more input or action from the user in order to proceed.
 IMPORTANT: Whenever possible, execute the code for the user using <execute_ipython> or <execute_bash> instead of providing it.
-
 
 
 ----------

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_002.log
@@ -1,7 +1,3 @@
-
-
-----------
-
 A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.
 The assistant can interact with an interactive Python (Jupyter Notebook) environment and receive the corresponding output when needed. The code should be enclosed using "<execute_ipython>" tag, for example:
 <execute_ipython>
@@ -155,7 +151,6 @@ Please note that THE `edit_file` FUNCTION REQUIRES PROPER INDENTATION. If the as
 The assistant's response should be concise.
 The assistant should include ONLY ONE <execute_ipython> or <execute_bash> in every one of the responses, unless the assistant is finished with the task or need more input or action from the user in order to proceed.
 IMPORTANT: Whenever possible, execute the code for the user using <execute_ipython> or <execute_bash> instead of providing it.
-
 
 
 ----------
@@ -591,7 +586,6 @@ exit
 NOW, LET'S START!
 Use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'. Do not ask me for confirmation at any point.
 
-
 ----------
 
 Certainly! I'll use Jupyter IPython to create a text file containing 'hello world' at '/workspace/test.txt'. Here's how we'll do it:
@@ -600,7 +594,6 @@ with open('/workspace/test.txt', 'w') as f:
     f.write('hello world')
 print("File created successfully.")
 </execute_ipython>
-
 
 ----------
 

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/response_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/response_002.log
@@ -3,4 +3,4 @@ Great! The file has been created successfully. Let's verify its contents to make
 <execute_ipython>
 with open('/workspace/test.txt', 'r') as f:
     content = f.read()
-print(f"File contents: {content}")
+print(f"Contents of /workspace/test.txt: {content}")

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/response_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/response_003.log
@@ -1,3 +1,3 @@
-Excellent! We have successfully created the file '/workspace/test.txt' with the content 'hello world' and verified its contents. The task is now complete.
+Excellent! We have successfully created the file '/workspace/test.txt' and verified that it contains the text 'hello world'. The task is now complete.
 
 <finish></finish>


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fix logging of LLM messages (if enabled) and client readiness detection in EventStreamRuntime

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Unfortunately a recent PR of mine broke the logging of LLM messages to file, which caused integration test mock files to miss the user prompt for some agents+test combos.
  EDIT: ~~Newer PR's since then started to fail.~~ The regeneration of integration mock files for PR's was problematic.
- For the `EventStreamRuntime` the client readiness detection was moved to the actual `LogBuffer` class. In some situations, depending on timing, OH could've gotten stuck on getting docker container logs. This detection was added to prevent premature sending of commands before the client was fully initialized (a container is signaled as ready several seconds before that).
- Several integration test mock files were regenerated for this PR.

---

**Link of any specific issues this addresses**
#3665 