### PR TITLE
(fix) regression in fork artifact upload in ghcr_runtime

### DIFF
--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -98,7 +98,7 @@ jobs:
           outputs: type=docker,dest=/tmp/runtime-${{ matrix.base_image.tag }}.tar
           context: containers/runtime
       - name: Upload runtime image for fork
-        if: github.event.pull_request.head.repo.fork != true
+        if: github.event.pull_request.head.repo.fork
         uses: actions/upload-artifact@v4
         with:
           name: runtime-${{ matrix.base_image.tag }}


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fix  regression in fork artifact upload in `ghcr_runtime` workflow.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Missed to remove a `!=` in a fork-related condition to upload artifact after image build.