### PR TITLE
add url info in browsing observation

### DIFF
--- a/agenthub/browsing_agent/browsing_agent.py
+++ b/agenthub/browsing_agent/browsing_agent.py
@@ -65,9 +65,14 @@ In order to accomplish my goal I need to send the information asked back to the 
 """
 
 
-def get_prompt(error_prefix: str, cur_axtree_txt: str, prev_action_str: str) -> str:
+def get_prompt(
+    error_prefix: str, cur_url: str, cur_axtree_txt: str, prev_action_str: str
+) -> str:
     prompt = f"""\
 {error_prefix}
+
+# Current Page URL:
+{cur_url}
 
 # Current Accessibility Tree:
 {cur_axtree_txt}
@@ -139,6 +144,7 @@ class BrowsingAgent(Agent):
         """
         messages: list[Message] = []
         prev_actions = []
+        cur_url = ''
         cur_axtree_txt = ''
         error_prefix = ''
         last_obs = None
@@ -179,6 +185,9 @@ class BrowsingAgent(Agent):
                 self.error_accumulator += 1
                 if self.error_accumulator > 5:
                     return MessageAction('Too many errors encountered. Task failed.')
+
+            cur_url = last_obs.url
+
             try:
                 cur_axtree_txt = flatten_axtree_to_str(
                     last_obs.axtree_object,
@@ -204,7 +213,7 @@ class BrowsingAgent(Agent):
 
         messages.append(Message(role='system', content=[TextContent(text=system_msg)]))
 
-        prompt = get_prompt(error_prefix, cur_axtree_txt, prev_action_str)
+        prompt = get_prompt(error_prefix, cur_url, cur_axtree_txt, prev_action_str)
         messages.append(Message(role='user', content=[TextContent(text=prompt)]))
 
         flat_messages = self.llm.format_messages_for_llm(messages)


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Add URL information to Browsing Observation to help with browser agents

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

#3813 