### PR TITLE
Fail the Runtime tests check if the previous jobs were cancelled or failed

### DIFF
--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -215,7 +215,6 @@ jobs:
         run: make install-python-dependencies
       - name: Run integration tests
         run: |
-          exit 1
           image_name=ghcr.io/${{ github.repository_owner }}/runtime:${{ github.sha }}-${{ matrix.base_image }}
           image_name=$(echo $image_name | tr '[:upper:]' '[:lower:]')
 

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -237,7 +237,7 @@ jobs:
     needs: [test_runtime, runtime_integration_tests_on_linux]
     steps:
       - name: All tests passed
-        if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && contains(needs.*.result, 'cancelled') }}
+        if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: echo "All runtime tests have passed successfully!"
       # If the prerequisite jobs failed, run this step so this job fails
       - name: Tests failed

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -215,6 +215,7 @@ jobs:
         run: make install-python-dependencies
       - name: Run integration tests
         run: |
+          exit 1
           image_name=ghcr.io/${{ github.repository_owner }}/runtime:${{ github.sha }}-${{ matrix.base_image }}
           image_name=$(echo $image_name | tr '[:upper:]' '[:lower:]')
 

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -237,11 +237,11 @@ jobs:
     needs: [test_runtime, runtime_integration_tests_on_linux]
     steps:
       - name: All tests passed
-        if: ${{ !contains(needs.*.result, 'failure') }}
+        if: ${{ !cancelled() || !contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: echo "All runtime tests have passed successfully!"
       # If the prerequisite jobs failed, run this step so this job fails
       - name: Tests failed
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
           echo "Some tests have failed!"
           exit 1

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -236,11 +236,11 @@ jobs:
     needs: [test_runtime, runtime_integration_tests_on_linux]
     steps:
       - name: All tests passed
-        if: ${{ !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'failure') }}
+        if: ${{ !contains(needs.*.result, 'failure') }}
         run: echo "All runtime tests have passed successfully!"
-      # If the prerequisite jobs were cancelled or failed, run this step so this job fails
+      # If the prerequisite jobs failed, run this step so this job fails
       - name: Tests failed
-        if: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') }}
         run: |
           echo "Some tests have failed!"
           exit 1

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -237,7 +237,7 @@ jobs:
     needs: [test_runtime, runtime_integration_tests_on_linux]
     steps:
       - name: All tests passed
-        if: ${{ !cancelled() || !contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && contains(needs.*.result, 'cancelled') }}
         run: echo "All runtime tests have passed successfully!"
       # If the prerequisite jobs failed, run this step so this job fails
       - name: Tests failed

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -236,4 +236,11 @@ jobs:
     needs: [test_runtime, runtime_integration_tests_on_linux]
     steps:
       - name: All tests passed
+        if: ${{ !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'failure') }}
         run: echo "All runtime tests have passed successfully!"
+      # If the prerequisite jobs were cancelled or failed, run this step so this job fails
+      - name: Tests failed
+        if: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+        run: |
+          echo "Some tests have failed!"
+          exit 1

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -230,18 +230,26 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # Checks that all runtime tests have passed
-  all_runtime_tests_passed:
+  # The two following jobs (named identically) are to check whether all the runtime tests have passed as the
+  # "All Runtime Tests Passed" is a required job for PRs to merge
+  # Due to this bug: https://github.com/actions/runner/issues/2566, we want to create a job that runs when the
+  # prerequisites have been cancelled or failed so merging is disallowed, otherwise Github considers "skipped" as "success"
+  runtime_tests_check_success:
     name: All Runtime Tests Passed
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-latest
     needs: [test_runtime, runtime_integration_tests_on_linux]
     steps:
       - name: All tests passed
-        if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: echo "All runtime tests have passed successfully!"
-      # If the prerequisite jobs failed, run this step so this job fails
-      - name: Tests failed
-        if: ${{ cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
+  runtime_tests_check_fail:
+    name: All Runtime Tests Passed
+    if: ${{ cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+    runs-on: ubuntu-latest
+    needs: [test_runtime, runtime_integration_tests_on_linux]
+    steps:
+      - name: Some tests failed
         run: |
-          echo "Some tests have failed!"
+          echo "Some runtime tests failed or were cancelled"
           exit 1


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fail the Runtime tests check if the previous jobs were cancelled or failed

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

If the required tests fail or get cancelled, the last check is skipped which gets treated as success and PRs are able to merge.

---
**Link of any specific issues this addresses**
