### PR TITLE
docs: Update steps for running integration tests in a local environment

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -51,8 +51,11 @@ of agents with real LLMs are stored under `mock/AgentName/TestName` folders.
 
 ## Run Integration Tests
 
-Take a look at `ghcr.yml` (in the `.github/workflow` folder) to learn
-how integration tests are launched in a CI environment.
+[ghcr_runtime.yml](../../.github/workflows/ghcr_runtime.yml) runs integration tests in a CI environment.
+
+Note: If you are using docker desktop make sure that your version is up to date and "Enable host networking"
+is checked (Under settings -> Resources -> Network ). Otherwise the integration tests may hang with the
+message `Getting container logs...` repeated ad infinitum.
 
 You can run:
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -53,7 +53,7 @@ of agents with real LLMs are stored under `mock/AgentName/TestName` folders.
 
 [ghcr_runtime.yml](../../.github/workflows/ghcr_runtime.yml) runs integration tests in a CI environment.
 
-Note: If you are using docker desktop make sure that your version is up to date and "Enable host networking"
+*Note:* If you are using docker desktop make sure that your version is up to date and "Enable Host Networking"
 is checked (Under settings -> Resources -> Network ). Otherwise the integration tests may hang with the
 message `Getting container logs...` repeated ad infinitum.
 


### PR DESCRIPTION
Documentation update alerting the user to an additional required step when running integration tests locally.
