### PR TITLE
refactor & improve retry for the reliability of `RemoteRuntime` & evaluation

### DIFF
--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -176,6 +176,7 @@ def initialize_runtime(
 
         # inject the instance info
         action = CmdRunAction(command='mkdir -p /swe_util/eval_data/instances')
+        action.timeout = 600
         logger.info(action, extra={'msg_type': 'ACTION'})
         obs = runtime.run_action(action)
         logger.info(obs, extra={'msg_type': 'OBSERVATION'})
@@ -233,6 +234,7 @@ def initialize_runtime(
         ), f'Failed to source /swe_util/swe_entry.sh: {obs.content}'
 
     action = CmdRunAction(command=f'cd /workspace/{workspace_dir_name}')
+    action.timeout = 600
     logger.info(action, extra={'msg_type': 'ACTION'})
     obs = runtime.run_action(action)
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})

--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -284,9 +284,11 @@ def run_evaluation(
         else:
             logger.error(
                 f'Retrying instance [{instance.instance_id}] due to error: {result.error}. Stacktrace:\n{result.stacktrace}'
+                + '\n'
                 + '-' * 10
                 + '[You may ignore this error if it is a transient issue - the instance will be automatically retried.]'
                 + '-' * 10
+                + '\n'
             )
             instance_queue.put(instance)
             pbar.total += 1

--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -284,6 +284,9 @@ def run_evaluation(
         else:
             logger.error(
                 f'Retrying instance [{instance.instance_id}] due to error: {result.error}. Stacktrace:\n{result.stacktrace}'
+                + '-' * 10
+                + '[You may ignore this error if it is a transient issue - the instance will be automatically retried.]'
+                + '-' * 10
             )
             instance_queue.put(instance)
             pbar.total += 1

--- a/openhands/runtime/builder/remote.py
+++ b/openhands/runtime/builder/remote.py
@@ -95,7 +95,7 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
                 raise RuntimeError(error_message)
 
             # Wait before polling again
-            time.sleep(5)
+            time.sleep(30)
 
     def image_exists(self, image_name: str) -> bool:
         """Checks if an image exists in the remote registry using the /image_exists endpoint."""

--- a/openhands/runtime/builder/remote.py
+++ b/openhands/runtime/builder/remote.py
@@ -7,6 +7,7 @@ import requests
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.runtime.builder import RuntimeBuilder
+from openhands.runtime.utils.request import send_request
 
 
 class RemoteRuntimeBuilder(RuntimeBuilder):
@@ -15,6 +16,8 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
     def __init__(self, api_url: str, api_key: str):
         self.api_url = api_url
         self.api_key = api_key
+        self.session = requests.Session()
+        self.session.headers.update({'X-API-Key': self.api_key})
 
     def build(self, path: str, tags: list[str]) -> str:
         """Builds a Docker image using the Runtime API's /build endpoint."""
@@ -38,8 +41,9 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
             files.append(('tags', (None, tag)))
 
         # Send the POST request to /build
-        headers = {'X-API-Key': self.api_key}
-        response = requests.post(f'{self.api_url}/build', files=files, headers=headers)
+        response = send_request(
+            self.session, 'POST', f'{self.api_url}/build', files=files
+        )
 
         if response.status_code != 202:
             logger.error(f'Build initiation failed: {response.text}')
@@ -57,10 +61,11 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
                 logger.error('Build timed out after 30 minutes')
                 raise RuntimeError('Build timed out after 30 minutes')
 
-            status_response = requests.get(
+            status_response = send_request(
+                self.session,
+                'GET',
                 f'{self.api_url}/build_status',
                 params={'build_id': build_id},
-                headers=headers,
             )
 
             if status_response.status_code != 200:
@@ -95,9 +100,9 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
     def image_exists(self, image_name: str) -> bool:
         """Checks if an image exists in the remote registry using the /image_exists endpoint."""
         params = {'image': image_name}
-        session = requests.Session()
-        session.headers.update({'X-API-Key': self.api_key})
-        response = session.get(f'{self.api_url}/image_exists', params=params)
+        response = send_request(
+            self.session, 'GET', f'{self.api_url}/image_exists', params=params
+        )
 
         if response.status_code != 200:
             logger.error(f'Failed to check image existence: {response.text}')

--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -35,7 +35,11 @@ from openhands.events.serialization.action import ACTION_TYPE_TO_CLASS
 from openhands.runtime.builder.remote import RemoteRuntimeBuilder
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.runtime import Runtime
-from openhands.runtime.utils.request import DEFAULT_RETRY_EXCEPTIONS, send_request
+from openhands.runtime.utils.request import (
+    DEFAULT_RETRY_EXCEPTIONS,
+    is_404_error,
+    send_request,
+)
 from openhands.runtime.utils.runtime_build import build_runtime_image
 
 
@@ -244,6 +248,10 @@ class RemoteRuntime(Runtime):
                     retry_exceptions=list(
                         filter(lambda e: e != TimeoutError, DEFAULT_RETRY_EXCEPTIONS)
                     ),
+                    # Retry 404 errors for the /execute_action endpoint
+                    # because the runtime might just be starting up
+                    # and have not registered the endpoint yet
+                    retry_fns=[is_404_error],
                 )
                 if response.status_code == 200:
                     output = response.json()

--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -189,7 +189,15 @@ class RemoteRuntime(Runtime):
     )
     def _wait_until_alive(self):
         logger.info('Waiting for sandbox to be alive...')
-        response = send_request(self.session, 'GET', f'{self.runtime_url}/alive')
+        response = send_request(
+            self.session,
+            'GET',
+            f'{self.runtime_url}/alive',
+            # Retry 404 errors for the /alive endpoint
+            # because the runtime might just be starting up
+            # and have not registered the endpoint yet
+            retry_fns=[is_404_error],
+        )
         if response.status_code != 200:
             msg = f'Runtime is not alive yet (id={self.runtime_id}). Status: {response.status_code}.'
             logger.warning(msg)

--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -1,13 +1,11 @@
 import os
-import ssl
 import tempfile
 import threading
 import uuid
-from typing import Any, Type
 from zipfile import ZipFile
 
 import requests
-from requests.exceptions import HTTPError, RequestException, Timeout
+from requests.exceptions import Timeout
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -37,14 +35,8 @@ from openhands.events.serialization.action import ACTION_TYPE_TO_CLASS
 from openhands.runtime.builder.remote import RemoteRuntimeBuilder
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.runtime import Runtime
+from openhands.runtime.utils.request import DEFAULT_RETRY_EXCEPTIONS, send_request
 from openhands.runtime.utils.runtime_build import build_runtime_image
-
-DEFAULT_RETRY_EXCEPTIONS = [
-    ssl.SSLCertVerificationError,
-    RequestException,
-    HTTPError,
-    Timeout,
-]
 
 
 class RemoteRuntime(Runtime):
@@ -99,7 +91,7 @@ class RemoteRuntime(Runtime):
         self.container_image: str = self.config.sandbox.base_container_image
         self.container_name = 'od-remote-runtime-' + self.instance_id
         logger.debug(f'RemoteRuntime `{sid}` config:\n{self.config}')
-        response = self._send_request('GET', f'{self.api_url}/registry_prefix')
+        response = send_request(self.session, 'GET', f'{self.api_url}/registry_prefix')
         response_json = response.json()
         registry_prefix = response_json['registry_prefix']
         os.environ['OD_RUNTIME_RUNTIME_IMAGE_REPO'] = (
@@ -122,7 +114,8 @@ class RemoteRuntime(Runtime):
         )
 
         # Use the /image_exists endpoint to check if the image exists
-        response = self._send_request(
+        response = send_request(
+            self.session,
             'GET',
             f'{self.api_url}/image_exists',
             params={'image': self.container_image},
@@ -157,8 +150,8 @@ class RemoteRuntime(Runtime):
         }
 
         # Start the sandbox using the /start endpoint
-        response = self._send_request(
-            'POST', f'{self.api_url}/start', json=start_request
+        response = send_request(
+            self.session, 'POST', f'{self.api_url}/start', json=start_request
         )
         if response.status_code != 201:
             raise RuntimeError(f'Failed to start sandbox: {response.text}')
@@ -184,29 +177,6 @@ class RemoteRuntime(Runtime):
             self.runtime_url is not None
         ), 'Runtime URL is not set. This should never happen.'
 
-    def _send_request(
-        self,
-        method: str,
-        url: str,
-        retry_exceptions: list[Type[Exception]] | None = None,
-        **kwargs: Any,
-    ) -> requests.Response:
-        if retry_exceptions is None:
-            retry_exceptions = DEFAULT_RETRY_EXCEPTIONS
-
-        @retry(
-            stop=stop_after_attempt(30),
-            wait=wait_exponential(multiplier=1, min=4, max=60),
-            retry=retry_if_exception_type(tuple(retry_exceptions)),
-            reraise=True,
-        )
-        def _send_request_with_retry():
-            response = self.session.request(method, url, **kwargs)
-            response.raise_for_status()
-            return response
-
-        return _send_request_with_retry()
-
     @retry(
         stop=stop_after_attempt(10),
         wait=wait_exponential(multiplier=1, min=4, max=60),
@@ -215,7 +185,7 @@ class RemoteRuntime(Runtime):
     )
     def _wait_until_alive(self):
         logger.info('Waiting for sandbox to be alive...')
-        response = self._send_request('GET', f'{self.runtime_url}/alive')
+        response = send_request(self.session, 'GET', f'{self.runtime_url}/alive')
         if response.status_code != 200:
             msg = f'Runtime is not alive yet (id={self.runtime_id}). Status: {response.status_code}.'
             logger.warning(msg)
@@ -228,8 +198,11 @@ class RemoteRuntime(Runtime):
     def close(self):
         if self.runtime_id:
             try:
-                response = self._send_request(
-                    'POST', f'{self.api_url}/stop', json={'runtime_id': self.runtime_id}
+                response = send_request(
+                    self.session,
+                    'POST',
+                    f'{self.api_url}/stop',
+                    json={'runtime_id': self.runtime_id},
                 )
                 if response.status_code != 200:
                     logger.error(f'Failed to stop sandbox: {response.text}')
@@ -262,7 +235,8 @@ class RemoteRuntime(Runtime):
                 logger.info('Executing action')
                 request_body = {'action': event_to_dict(action)}
                 logger.debug(f'Request body: {request_body}')
-                response = self._send_request(
+                response = send_request(
+                    self.session,
                     'POST',
                     f'{self.runtime_url}/execute_action',
                     json=request_body,
@@ -335,7 +309,8 @@ class RemoteRuntime(Runtime):
 
             params = {'destination': sandbox_dest, 'recursive': str(recursive).lower()}
 
-            response = self._send_request(
+            response = send_request(
+                self.session,
                 'POST',
                 f'{self.runtime_url}/upload_file',
                 files=upload_data,
@@ -368,7 +343,8 @@ class RemoteRuntime(Runtime):
             if path is not None:
                 data['path'] = path
 
-            response = self._send_request(
+            response = send_request(
+                self.session,
                 'POST',
                 f'{self.runtime_url}/list_files',
                 json=data,

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -37,7 +37,7 @@ def send_request(
     url: str,
     retry_exceptions: list[Type[Exception]] | None = None,
     retry_fns: list[Callable[[Exception], bool]] | None = None,
-    n_attempts: int = 10,
+    n_attempts: int = 15,
     **kwargs: Any,
 ) -> requests.Response:
     exceptions_to_catch = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -23,13 +23,14 @@ def send_request(
     method: str,
     url: str,
     retry_exceptions: list[Type[Exception]] | None = None,
+    n_attempts: int = 30,
     **kwargs: Any,
 ) -> requests.Response:
     if retry_exceptions is None:
         retry_exceptions = DEFAULT_RETRY_EXCEPTIONS
 
     @retry(
-        stop=stop_after_attempt(30),
+        stop=stop_after_attempt(n_attempts),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         retry=retry_if_exception_type(tuple(retry_exceptions)),
         reraise=True,

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -37,7 +37,7 @@ def send_request(
     url: str,
     retry_exceptions: list[Type[Exception]] | None = None,
     retry_fns: list[Callable[[Exception], bool]] | None = None,
-    n_attempts: int = 30,
+    n_attempts: int = 10,
     **kwargs: Any,
 ) -> requests.Response:
     exceptions_to_catch = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -4,6 +4,7 @@ import requests
 from requests.exceptions import ConnectionError, Timeout
 from tenacity import (
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
@@ -38,7 +39,7 @@ def send_request(
         wait=wait_exponential(multiplier=1, min=4, max=60),
         retry=(
             retry_if_exception_type(tuple(exceptions_to_catch))
-            | retry_if_exception_type(requests.HTTPError, is_server_error)
+            | retry_if_exception(is_server_error)
         ),
         reraise=True,
     )

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -1,0 +1,42 @@
+import ssl
+from typing import Any, Type
+
+import requests
+from requests.exceptions import HTTPError, RequestException, Timeout
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+DEFAULT_RETRY_EXCEPTIONS = [
+    ssl.SSLCertVerificationError,
+    RequestException,
+    HTTPError,
+    Timeout,
+]
+
+
+def send_request(
+    session: requests.Session,
+    method: str,
+    url: str,
+    retry_exceptions: list[Type[Exception]] | None = None,
+    **kwargs: Any,
+) -> requests.Response:
+    if retry_exceptions is None:
+        retry_exceptions = DEFAULT_RETRY_EXCEPTIONS
+
+    @retry(
+        stop=stop_after_attempt(30),
+        wait=wait_exponential(multiplier=1, min=4, max=60),
+        retry=retry_if_exception_type(tuple(retry_exceptions)),
+        reraise=True,
+    )
+    def _send_request_with_retry():
+        response = session.request(method, url, **kwargs)
+        response.raise_for_status()
+        return response
+
+    return _send_request_with_retry()

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -1,8 +1,7 @@
-import ssl
 from typing import Any, Type
 
 import requests
-from requests.exceptions import HTTPError, RequestException, Timeout
+from requests.exceptions import ConnectionError, Timeout
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -10,10 +9,16 @@ from tenacity import (
     wait_exponential,
 )
 
+
+def is_server_error(exception):
+    return (
+        isinstance(exception, requests.HTTPError)
+        and exception.response.status_code >= 500
+    )
+
+
 DEFAULT_RETRY_EXCEPTIONS = [
-    ssl.SSLCertVerificationError,
-    RequestException,
-    HTTPError,
+    ConnectionError,
     Timeout,
 ]
 
@@ -26,13 +31,15 @@ def send_request(
     n_attempts: int = 30,
     **kwargs: Any,
 ) -> requests.Response:
-    if retry_exceptions is None:
-        retry_exceptions = DEFAULT_RETRY_EXCEPTIONS
+    exceptions_to_catch = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS
 
     @retry(
         stop=stop_after_attempt(n_attempts),
         wait=wait_exponential(multiplier=1, min=4, max=60),
-        retry=retry_if_exception_type(tuple(retry_exceptions)),
+        retry=(
+            retry_if_exception_type(tuple(exceptions_to_catch))
+            | retry_if_exception_type(requests.HTTPError, is_server_error)
+        ),
         reraise=True,
     )
     def _send_request_with_retry():


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**



---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Re-use `send_request` for all `RemoteRuntime` requests
- Be more specific on exception handling
- Add more robust error handling for `run_evaluation`: whenever an instance failed, add the instance back to the queue and retry.


---
**Link of any specific issues this addresses**
