### PR TITLE
Make the publish PyPi manual to fit current release process

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,9 +1,14 @@
-name: Release workflow
+# Publishes the OpenHands PyPi package
+name: Publish PyPi Package
 
+# Triggered manually
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: true
+        default: ''
 
 jobs:
   release:


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Make the publish PyPi manual to fit current release process

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This workflow currently gets automatically kicked off by a tagged run. However, this doesn't fit our current release process. Making it manual for now until we can automate it

---
**Link of any specific issues this addresses**
