### PR TITLE
[eval] yet another eval fixes on multi-processing

### DIFF
--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -218,7 +218,7 @@ def initialize_runtime(
         assert obs.exit_code == 0
 
         action = CmdRunAction(command='source /swe_util/instance_swe_entry.sh')
-        action.timeout = 600
+        action.timeout = 1800
         logger.info(action, extra={'msg_type': 'ACTION'})
         obs = runtime.run_action(action)
         logger.info(obs, extra={'msg_type': 'OBSERVATION'})


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

In https://github.com/All-Hands-AI/OpenHands/pull/3846, we introduce the ability to add a failed instance back to the `instance_queue` for future retry. But the original implementation has a bug: when running for a while, it will stuck there forever. I investigated the reason, it seems it is blocked by `queue.get()`.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- This PR (hopefully) fixes the multi-processing logic so that the `executor.submit` loop continues to run whenever (1) the instance queue is not empty OR (2) there's an unfinished process (future) running (bc it may add a new instance to the queue).
- nit: Increased timeout for `/swe_util/instance_swe_entry.sh` bc i found there's issue with 600 sec timeout in some cases.


---
**Link of any specific issues this addresses**
