### PR TITLE
Fix queue length on Mac

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -267,7 +267,7 @@ def run_evaluation(
     for _, instance in dataset.iterrows():
         instance_queue.put(instance)
 
-    total_instances = instance_queue.qsize()
+    total_instances = len(dataset)
     pbar = tqdm(total=total_instances, desc='Instances processed')
     output_fp = open(output_file, 'a')
 


### PR DESCRIPTION
**CHANGELOG**
Fix for method in SWE-bench unsupported on Mac

---
```
ERROR:root:  File "/Users/enyst/repos/odie/evaluation/swe_bench/run_infer.py", line 477, in <module>
    run_evaluation(
  "/Users/enyst/repos/odie/evaluation/utils/shared.py", line 270, in run_evaluation
    total_instances = instance_queue.qsize()
                  "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 126, in qsize
       return self._maxsize - self._sem._semlock._get_value()

ERROR:root:<class 'NotImplementedError'>:
```


---
**Link of any specific issues this addresses**
