### PR TITLE
(fix) Update logs after run_action (EventStreamRuntime)

### DIFF
--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -426,7 +426,6 @@ class EventStreamRuntime(Runtime):
                     output = response.json()
                     obs = observation_from_dict(output)
                     obs._cause = action.id  # type: ignore[attr-defined]
-                    return obs
                 else:
                     error_message = response.text
                     logger.error(f'Error from server: {error_message}')
@@ -437,6 +436,8 @@ class EventStreamRuntime(Runtime):
             except Exception as e:
                 logger.error(f'Error during command execution: {e}')
                 obs = ErrorObservation(f'Command execution failed: {str(e)}')
+            # Refresh docker logs
+            self._wait_until_alive()
             return obs
 
     def run(self, action: CmdRunAction) -> Observation:


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

No longer defer container logs after runtime `run_action` (EventStreamRuntime)

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

- the container logs were not directly updated after a `run_command` in the `EventStreamRuntime`
- this caused a "lagging" of logs showing in dev terminal


Issue is easy to reproduce:
- in `File Explorer` click different files (which can be displayed in the Code Editor) 
- observe that their content appears on the _next_ click in the terminal's docker logs, not immediately after

---

**Link of any specific issues this addresses**
