### PR TITLE
Add docs for Groq and for OpenAI proxies

### DIFF
--- a/docs/modules/usage/llms/groq.md
+++ b/docs/modules/usage/llms/groq.md
@@ -1,0 +1,19 @@
+# Running LLMs on Groq
+
+OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their full documentation on using Groq as provider [here](https://docs.litellm.ai/docs/providers/groq). When running OpenHands, it's simpler: you only need to set the options below.
+
+## Configuration
+
+You'll need to set the following in the OpenHands UI through the Settings:
+* `LLM Provider` to `Groq`
+* `LLM Model` to the model you will be using
+* `API key` to your Groq API key. To find or create your Groq API Key, [see **here**](https://console.groq.com/keys).
+
+Visit [here](https://console.groq.com/docs/models) to see the list of models that Groq hosts.
+
+## Using Groq as an OpenAI-Compatible Endpoint
+
+The Groq endpoint for chat completion is [mostly OpenAI-compatible](https://console.groq.com/docs/openai). Therefore, if you wish, you can access Groq models as you would access any OpenAI-compatible endpoint. You can toggle `Advanced Options` and set the following:
+* `Custom Model` to the prefix `openai/` + the model you will be using, e.g. `openai/llama3-8b-8192`
+* `API Key` to your Groq API key
+* `Base URL` to `https://api.groq.com/openai/v1`

--- a/docs/modules/usage/llms/groq.md
+++ b/docs/modules/usage/llms/groq.md
@@ -1,10 +1,10 @@
 # Running LLMs on Groq
 
-OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their full documentation on using Groq as provider [here](https://docs.litellm.ai/docs/providers/groq). When running OpenHands, it's simpler: you only need to set the options below.
+OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their full documentation on using Groq as provider [here](https://docs.litellm.ai/docs/providers/groq). With OpenHands, it's simpler: please see the configuration below.
 
 ## Configuration
 
-You'll need to set the following in the OpenHands UI through the Settings:
+When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings:
 * `LLM Provider` to `Groq`
 * `LLM Model` to the model you will be using
 * `API key` to your Groq API key. To find or create your Groq API Key, [see **here**](https://console.groq.com/keys).

--- a/docs/modules/usage/llms/groq.md
+++ b/docs/modules/usage/llms/groq.md
@@ -1,6 +1,6 @@
 # Running LLMs on Groq
 
-OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their full documentation on using Groq as provider [here](https://docs.litellm.ai/docs/providers/groq). With OpenHands, it's simpler: please see the configuration below.
+OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their full documentation on using Groq as provider [here](https://docs.litellm.ai/docs/providers/groq).
 
 ## Configuration
 

--- a/docs/modules/usage/llms/openai-llms.md
+++ b/docs/modules/usage/llms/openai-llms.md
@@ -15,7 +15,7 @@ If the model is not in the list, toggle `Advanced Options`, and enter it in `Cus
 
 Just as for OpenAI Chat completions, we use LiteLLM for OpenAI-compatible endpoints. You can find their full documentation on this topic [here](https://docs.litellm.ai/docs/providers/openai_compatible).
 
-## Using an OpenAI proxy
+## Using an OpenAI Proxy
 
 If you're using an OpenAI proxy, you'll need to toggle `Advanced Options` in the OpenHands Settings, and set the following:
 * `Custom Model` to the model you will be using, e.g. `openai/gpt-4o` or `openai/&lt;proxy_prefix&gt;/&lt;model_name&gt;`

--- a/docs/modules/usage/llms/openai-llms.md
+++ b/docs/modules/usage/llms/openai-llms.md
@@ -14,3 +14,10 @@ If the model is not in the list, toggle `Advanced Options`, and enter it in `Cus
 ## Using OpenAI-Compatible Endpoints
 
 Just as for OpenAI Chat completions, we use LiteLLM for OpenAI-compatible endpoints. You can find their full documentation on this topic [here](https://docs.litellm.ai/docs/providers/openai_compatible).
+
+## Using an OpenAI proxy
+
+If you're using an OpenAI proxy, you'll need to toggle `Advanced Options` in the OpenHands Settings, and set the following:
+* `Custom Model` to the model you will be using, e.g. `openai/gpt-4o` or `openai/&lt;proxy_prefix&gt;/&lt;model_name&gt;`
+* `API Key` to your API key.
+* `Base URL` to the URL of your OpenAI proxy.

--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -426,7 +426,6 @@ class EventStreamRuntime(Runtime):
                     output = response.json()
                     obs = observation_from_dict(output)
                     obs._cause = action.id  # type: ignore[attr-defined]
-                    return obs
                 else:
                     error_message = response.text
                     logger.error(f'Error from server: {error_message}')
@@ -437,6 +436,8 @@ class EventStreamRuntime(Runtime):
             except Exception as e:
                 logger.error(f'Error during command execution: {e}')
                 obs = ErrorObservation(f'Command execution failed: {str(e)}')
+            # Refresh docker logs
+            self._wait_until_alive()
             return obs
 
     def run(self, action: CmdRunAction) -> Observation:

--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -426,6 +426,7 @@ class EventStreamRuntime(Runtime):
                     output = response.json()
                     obs = observation_from_dict(output)
                     obs._cause = action.id  # type: ignore[attr-defined]
+                    return obs
                 else:
                     error_message = response.text
                     logger.error(f'Error from server: {error_message}')
@@ -436,8 +437,6 @@ class EventStreamRuntime(Runtime):
             except Exception as e:
                 logger.error(f'Error during command execution: {e}')
                 obs = ErrorObservation(f'Command execution failed: {str(e)}')
-            # Refresh docker logs
-            self._wait_until_alive()
             return obs
 
     def run(self, action: CmdRunAction) -> Observation:


### PR DESCRIPTION
**CHANGELOG**

Just some docs, so we have clear cases what works:
- using provider groq
- using openai proxies

---

@mamoodi TBH Groq is a little strange to add along the other "llms", since it has no models of its own, it just serves [a number of models](https://console.groq.com/docs/models) - presumably to showcase how fast their chips are. But maybe it's better to have a few notes documented than be unsure how it works?
