### PR TITLE
Tightened up the logic on retries.

### DIFF
--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -6,7 +6,7 @@ from tenacity import (
     retry,
     retry_if_exception,
     retry_if_exception_type,
-    stop_after_attempt,
+    stop_after_delay,
     wait_exponential,
 )
 
@@ -31,13 +31,14 @@ DEFAULT_RETRY_EXCEPTIONS = [
 ]
 
 
+# Find the timeout....
 def send_request(
     session: requests.Session,
     method: str,
     url: str,
     retry_exceptions: list[Type[Exception]] | None = None,
     retry_fns: list[Callable[[Exception], bool]] | None = None,
-    n_attempts: int = 15,
+    timeout: int = 150,
     **kwargs: Any,
 ) -> requests.Response:
     exceptions_to_catch = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS
@@ -49,7 +50,7 @@ def send_request(
             retry_condition |= retry_if_exception(fn)
 
     @retry(
-        stop=stop_after_attempt(n_attempts),
+        stop=stop_after_delay(timeout),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         retry=retry_condition,
         reraise=True,


### PR DESCRIPTION
## Requests retry for a very long time when an endoint fails at insand:

* 15 retries with an exponential backoff starting at 4 seconds and ending at 50 seconds == almost 10 minutes.
* This does not include any time the http requests take to run - and these can have a timeout of a few minutes by default depending on the type of error involved.

This changes the number of retries to a set time period of 2 minutes. (If the request does not succeed in 2 minutes, the user has probably long since lost interest and tried to cancel it.

## Speaking of which...

This is not handled by this PR, but the timeout actually locks up the server. For example:
Here is output of me trying to `cmd+c` the server at 11:37:16...
<img width="650" alt="image" src="https://github.com/user-attachments/assets/bc3d0746-f6c2-4670-a0e1-445a043c2e18">

But the server did not actually die until 11:39:20
<img width="545" alt="image" src="https://github.com/user-attachments/assets/80d2f1de-a84b-40f6-9397-b53290f60c18">

I will am working on a subsequent PR to address the lock up.