### PR TITLE
Fix init order with threading

### DIFF
--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -51,11 +51,11 @@ class LogBuffer:
 
         self.buffer: list[str] = []
         self.lock = threading.Lock()
+        self._stop_event = threading.Event()
         self.log_generator = container.logs(stream=True, follow=True)
         self.log_stream_thread = threading.Thread(target=self.stream_logs)
         self.log_stream_thread.daemon = True
         self.log_stream_thread.start()
-        self._stop_event = threading.Event()
 
     def append(self, log_line: str):
         with self.lock:


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

The init method was starting a thread before it finished initializing instance vars, and on some systems the thread accesses an instance var before it's set.

---
**Link of any specific issues this addresses**
Fix https://github.com/All-Hands-AI/OpenHands/issues/2651