### PR TITLE
LLM hotfix: safety_settings need to be in kwargs

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 import warnings
 from functools import partial
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 from openhands.core.config import LLMConfig
 
@@ -122,7 +122,7 @@ class LLM:
         if self.config.drop_params:
             litellm.drop_params = self.config.drop_params
 
-        completion_kwargs: Dict[str, Any] = {
+        completion_kwargs: dict[str, Any] = {
             'model': self.config.model,
             'api_key': self.config.api_key,
             'base_url': self.config.base_url,
@@ -252,7 +252,7 @@ class LLM:
         self._completion = wrapper  # type: ignore
 
         # Update for _async_completion
-        async_completion_kwargs: Dict[str, Any] = {
+        async_completion_kwargs: dict[str, Any] = {
             'model': self.config.model,
             'api_key': self.config.api_key,
             'base_url': self.config.base_url,

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -347,9 +347,6 @@ class LLM:
         )
         async def async_acompletion_stream_wrapper(*args, **kwargs):
             """Async wrapper for the litellm acompletion with streaming function."""
-            # Merge async_completion_kwargs with the provided kwargs
-            merged_kwargs = {**async_completion_kwargs, **kwargs}
-
             # some callers might just send the messages directly
             if 'messages' in kwargs:
                 messages = kwargs['messages']
@@ -364,7 +361,7 @@ class LLM:
 
             try:
                 # Directly call and await litellm_acompletion
-                resp = await async_completion_unwrapped(*args, **merged_kwargs)
+                resp = await async_completion_unwrapped(*args, **kwargs)
 
                 # For streaming we iterate over the chunks
                 async for chunk in resp:
@@ -404,6 +401,7 @@ class LLM:
                     await asyncio.sleep(0.1)
 
         self._async_completion = async_completion_wrapper  # type: ignore
+
         self._async_streaming_completion = async_acompletion_stream_wrapper  # type: ignore
 
     def _get_debug_message(self, messages):


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

LLM hotfix: safety_settings for Gemini need to be in kwargs

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Fixes #3925 