### PR TITLE
Fix broken cli

### DIFF
--- a/openhands/core/cli.py
+++ b/openhands/core/cli.py
@@ -74,6 +74,7 @@ def get_parser() -> argparse.ArgumentParser:
         action='version',
         version=f'{__version__}',
         help='Show the version number and exit',
+        default=None,
     )
 
     return parser


### PR DESCRIPTION
Cli was broken by a merge about 7 hours ago. This fixes it (The arg parser creates a namespace without a version attribute if none is specified - by adding a default value we make sure this is always created)

e.g.:
```
poetry run python -m openhands.core.cli

ERROR:root:  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/tofarr/dev/all-hands/OpenHands/openhands/core/cli.py", line 161, in <module>
    loop.run_until_complete(main())
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/tofarr/dev/all-hands/OpenHands/openhands/core/cli.py", line 88, in main
    if args.version:
       ^^^^^^^^^^^^

ERROR:root:<class 'AttributeError'>: 'Namespace' object has no attribute 'version'
```