### PR TITLE
agent_controller: in PAUSED state reduce delegate logspam from delegate

### DIFF
--- a/agenthub/browsing_agent/prompt.py
+++ b/agenthub/browsing_agent/prompt.py
@@ -57,7 +57,7 @@ class Flags:
 
     @classmethod
     def from_dict(self, flags_dict):
-        """Helper for JSON serializble requirement."""
+        """Helper for JSON serializable requirement."""
         if isinstance(flags_dict, Flags):
             return flags_dict
 

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -383,7 +383,10 @@ class AgentController:
 
         if self.delegate is not None:
             assert self.delegate != self
-            await self._delegate_step()
+            if self.delegate.get_agent_state() == AgentState.PAUSED:
+                await asyncio.sleep(1)
+            else:
+                await self._delegate_step()
             return
 
         logger.info(
@@ -458,7 +461,7 @@ class AgentController:
             self.delegate = None
             self.delegateAction = None
 
-            await self.report_error('Delegator agent encounters an error')
+            await self.report_error('Delegator agent encountered an error')
         elif delegate_state in (AgentState.FINISHED, AgentState.REJECTED):
             logger.info(
                 f'[Agent Controller {self.id}] Delegate agent has finished execution'


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

agent_controller: if delegate is in PAUSED state reduce logspam

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

@enyst this change is aimed to reduce logspam, similar to the fact, that the normal agent doesn't create log entries unless RUNNING.
What do you think?

Ok, also fixed 2 typos along the way.