### PR TITLE
ChatMessage: get timestamp out of direct view

### DIFF
--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -60,6 +60,10 @@ function ChatMessage({
     }
   };
 
+  const copyButtonTitle = message.timestamp
+    ? `${t(I18nKey.CHAT_INTERFACE$TOOLTIP_COPY_MESSAGE)} - ${formatTimestamp(message.timestamp)}`
+    : t(I18nKey.CHAT_INTERFACE$TOOLTIP_COPY_MESSAGE);
+
   return (
     <article
       data-testid="article"
@@ -78,7 +82,8 @@ function ChatMessage({
           data-testid="copy-button"
           onClick={copyToClipboard}
           className="absolute top-1 right-1 p-1 bg-neutral-600 rounded hover:bg-neutral-700"
-          aria-label={t(I18nKey.CHAT_INTERFACE$TOOLTIP_COPY_MESSAGE)}
+          aria-label={copyButtonTitle}
+          title={copyButtonTitle}
           type="button"
         >
           {isCopy ? <FaClipboardCheck /> : <FaClipboard />}
@@ -99,9 +104,6 @@ function ChatMessage({
           ))}
         </div>
       )}
-      <div className="text-xs text-neutral-400 mt-2">
-        {formatTimestamp(message.timestamp)}
-      </div>
       {isLastMessage &&
         message.sender === "assistant" &&
         awaitingUserConfirmation && <ConfirmationButtons />}


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Make the timestamp less visible by moving it to the hover-hint of the copy button.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Followup to #3869 
First attempt to make it less obtrusive was to use it as the chat bubble's title, but that had the annoying effect of constantly showing when e.g. using the mouse to select any text.
Now it'll just be appended to the hint of the copy button and doesn't take any room away.