### PR TITLE
Store the file edit backup file in `/tmp`

### DIFF
--- a/openhands/runtime/plugins/agent_skills/file_ops/file_ops.py
+++ b/openhands/runtime/plugins/agent_skills/file_ops/file_ops.py
@@ -512,9 +512,11 @@ def _edit_file_impl(
         if enable_auto_lint:
             # BACKUP the original file
             original_file_backup_path = os.path.join(
+                '/tmp',
                 os.path.dirname(file_name),
                 f'.backup.{os.path.basename(file_name)}',
             )
+            os.makedirs(os.path.dirname(original_file_backup_path), exist_ok=True)
             with open(original_file_backup_path, 'w') as f:
                 f.writelines(lines)
 

--- a/openhands/runtime/plugins/agent_skills/file_ops/file_ops.py
+++ b/openhands/runtime/plugins/agent_skills/file_ops/file_ops.py
@@ -511,96 +511,96 @@ def _edit_file_impl(
         # because the env var will be set AFTER the agentskills is imported
         if enable_auto_lint:
             # BACKUP the original file
-            original_file_backup_path = os.path.join(
-                '/tmp',
-                os.path.dirname(file_name),
-                f'.backup.{os.path.basename(file_name)}',
-            )
-            os.makedirs(os.path.dirname(original_file_backup_path), exist_ok=True)
-            with open(original_file_backup_path, 'w') as f:
-                f.writelines(lines)
-
-            lint_error, first_error_line = _lint_file(file_name)
-
-            # Select the errors caused by the modification
-            def extract_last_part(line):
-                parts = line.split(':')
-                if len(parts) > 1:
-                    return parts[-1].strip()
-                return line.strip()
-
-            def subtract_strings(str1, str2) -> str:
-                lines1 = str1.splitlines()
-                lines2 = str2.splitlines()
-
-                last_parts1 = [extract_last_part(line) for line in lines1]
-
-                remaining_lines = [
-                    line
-                    for line in lines2
-                    if extract_last_part(line) not in last_parts1
-                ]
-
-                result = '\n'.join(remaining_lines)
-                return result
-
-            if original_lint_error and lint_error:
-                lint_error = subtract_strings(original_lint_error, lint_error)
-                if lint_error == '':
-                    lint_error = None
-                    first_error_line = None
-
-            if lint_error is not None:
-                if first_error_line is not None:
-                    show_line = int(first_error_line)
-                elif is_append:
-                    # original end-of-file
-                    show_line = len(lines)
-                # insert OR edit WILL provide meaningful line numbers
-                elif start is not None and end is not None:
-                    show_line = int((start + end) / 2)
-                else:
-                    raise ValueError('Invalid state. This should never happen.')
-
-                ret_str += LINTER_ERROR_MSG
-                ret_str += lint_error + '\n'
-
-                editor_lines = n_added_lines + 20
-                sep = '-' * 49 + '\n'
-                ret_str += (
-                    f'[This is how your edit would have looked if applied]\n{sep}'
+            with tempfile.TemporaryDirectory() as temp_dir:
+                original_file_backup_path = os.path.join(
+                    temp_dir,
+                    f'.backup.{os.path.basename(file_name)}',
                 )
-                ret_str += (
-                    _print_window(file_name, show_line, editor_lines, return_str=True)
-                    + '\n'
-                )
-                ret_str += f'{sep}\n'
+                with open(original_file_backup_path, 'w') as f:
+                    f.writelines(lines)
 
-                ret_str += '[This is the original code before your edit]\n'
-                ret_str += sep
-                ret_str += (
-                    _print_window(
-                        original_file_backup_path,
-                        show_line,
-                        editor_lines,
-                        return_str=True,
+                lint_error, first_error_line = _lint_file(file_name)
+
+                # Select the errors caused by the modification
+                def extract_last_part(line):
+                    parts = line.split(':')
+                    if len(parts) > 1:
+                        return parts[-1].strip()
+                    return line.strip()
+
+                def subtract_strings(str1, str2) -> str:
+                    lines1 = str1.splitlines()
+                    lines2 = str2.splitlines()
+
+                    last_parts1 = [extract_last_part(line) for line in lines1]
+
+                    remaining_lines = [
+                        line
+                        for line in lines2
+                        if extract_last_part(line) not in last_parts1
+                    ]
+
+                    result = '\n'.join(remaining_lines)
+                    return result
+
+                if original_lint_error and lint_error:
+                    lint_error = subtract_strings(original_lint_error, lint_error)
+                    if lint_error == '':
+                        lint_error = None
+                        first_error_line = None
+
+                if lint_error is not None:
+                    if first_error_line is not None:
+                        show_line = int(first_error_line)
+                    elif is_append:
+                        # original end-of-file
+                        show_line = len(lines)
+                    # insert OR edit WILL provide meaningful line numbers
+                    elif start is not None and end is not None:
+                        show_line = int((start + end) / 2)
+                    else:
+                        raise ValueError('Invalid state. This should never happen.')
+
+                    ret_str += LINTER_ERROR_MSG
+                    ret_str += lint_error + '\n'
+
+                    editor_lines = n_added_lines + 20
+                    sep = '-' * 49 + '\n'
+                    ret_str += (
+                        f'[This is how your edit would have looked if applied]\n{sep}'
                     )
-                    + '\n'
-                )
-                ret_str += sep
-                ret_str += (
-                    'Your changes have NOT been applied. Please fix your edit command and try again.\n'
-                    'You either need to 1) Specify the correct start/end line arguments or 2) Correct your edit code.\n'
-                    'DO NOT re-run the same failed edit command. Running it again will lead to the same error.'
-                )
+                    ret_str += (
+                        _print_window(
+                            file_name, show_line, editor_lines, return_str=True
+                        )
+                        + '\n'
+                    )
+                    ret_str += f'{sep}\n'
 
-                # recover the original file
-                with open(original_file_backup_path) as fin, open(
-                    file_name, 'w'
-                ) as fout:
-                    fout.write(fin.read())
-                os.remove(original_file_backup_path)
-                return ret_str
+                    ret_str += '[This is the original code before your edit]\n'
+                    ret_str += sep
+                    ret_str += (
+                        _print_window(
+                            original_file_backup_path,
+                            show_line,
+                            editor_lines,
+                            return_str=True,
+                        )
+                        + '\n'
+                    )
+                    ret_str += sep
+                    ret_str += (
+                        'Your changes have NOT been applied. Please fix your edit command and try again.\n'
+                        'You either need to 1) Specify the correct start/end line arguments or 2) Correct your edit code.\n'
+                        'DO NOT re-run the same failed edit command. Running it again will lead to the same error.'
+                    )
+
+                    # recover the original file
+                    with open(original_file_backup_path) as fin, open(
+                        file_name, 'w'
+                    ) as fout:
+                        fout.write(fin.read())
+                    return ret_str
 
     except FileNotFoundError as e:
         ret_str += f'File not found: {e}\n'


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Existing agentskills' editing store backup file in the same directory, which sometimes messes up the `git patch` produced for SWE-Bench evaluation (not in terms of accuracy, but in terms of size).

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR stores those tmp file under `/tmp` instead of the same directory.

---
**Link of any specific issues this addresses**
