### PR TITLE
(fix) CodeActAgent: use `content` of AgentDelegateObservation

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -153,9 +153,7 @@ class CodeActAgent(Agent):
             text = truncate_content(text, max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, AgentDelegateObservation):
-            if isinstance(obs.outputs, dict) and 'content' in obs.outputs:
-                obs.outputs = obs.outputs['content']
-            text = obs_prefix + truncate_content(str(obs.outputs), max_message_chars)
+            text = obs_prefix + truncate_content(obs.outputs['content'] if 'content' in obs.outputs else ''), max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, ErrorObservation):
             text = obs_prefix + truncate_content(obs.content, max_message_chars)

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -153,7 +153,10 @@ class CodeActAgent(Agent):
             text = truncate_content(text, max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, AgentDelegateObservation):
-            text = obs_prefix + truncate_content(obs.outputs['content'] if 'content' in obs.outputs else '', max_message_chars)
+            text = obs_prefix + truncate_content(
+                obs.outputs['content'] if 'content' in obs.outputs else '',
+                max_message_chars,
+            )
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, ErrorObservation):
             text = obs_prefix + truncate_content(obs.content, max_message_chars)

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -153,6 +153,8 @@ class CodeActAgent(Agent):
             text = truncate_content(text, max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, AgentDelegateObservation):
+            if isinstance(obs.outputs, dict) and 'content' in obs.outputs:
+                obs.outputs = obs.outputs['content']
             text = obs_prefix + truncate_content(str(obs.outputs), max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, ErrorObservation):

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -153,7 +153,7 @@ class CodeActAgent(Agent):
             text = truncate_content(text, max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, AgentDelegateObservation):
-            text = obs_prefix + truncate_content(obs.outputs['content'] if 'content' in obs.outputs else ''), max_message_chars)
+            text = obs_prefix + truncate_content(obs.outputs['content'] if 'content' in obs.outputs else '', max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, ErrorObservation):
             text = obs_prefix + truncate_content(obs.content, max_message_chars)

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_001.log
@@ -402,7 +402,13 @@ The server is running on port 5000 with PID 126. You can access the list of numb
 
 
 NOW, LET'S START!
+
+----------
+
 Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me for confirmation at any point.
+
+----------
+
 
 
 ENVIRONMENT REMINDER: You have 19 turns left to complete the task. When finished reply with <finish></finish>.

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
@@ -402,6 +402,9 @@ The server is running on port 5000 with PID 126. You can access the list of numb
 
 
 NOW, LET'S START!
+
+----------
+
 Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me for confirmation at any point.
 
 ----------
@@ -414,7 +417,10 @@ Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me fo
 ----------
 
 OBSERVATION:
-{'content': 'The answer to life, the universe, and everything has been revealed: OpenHands is all you need!'}
+The answer to life, the universe, and everything has been revealed: OpenHands is all you need!
+
+----------
+
 
 
 ENVIRONMENT REMINDER: You have 13 turns left to complete the task. When finished reply with <finish></finish>.


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fix content retrieval from AgentDelegateObservation in CodeActAgent

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

In `get_observation_message` the handling of an `AgentDelegateObservation` needs to retrieve the `content` attribute of obs.outputs,
which is a dict.

I wonder if we need to do similar for AgentFinishAction for delegats where a dict with e.g. `summary` is coming back etc.?

Fixes #3969 

CC @ryanhoangt 
