### PR TITLE
change top_p default value to 1.0

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -204,7 +204,7 @@ class CodeActAgent(Agent):
                 '</execute_bash>',
                 '</execute_browse>',
             ],
-            'temperature': 0.0,
+            'temperature': self.llm.config.temperature,
         }
 
         if self.llm.is_caching_prompt_active():

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -204,7 +204,6 @@ class CodeActAgent(Agent):
                 '</execute_bash>',
                 '</execute_browse>',
             ],
-            'temperature': self.llm.config.temperature,
         }
 
         if self.llm.is_caching_prompt_active():

--- a/config.template.toml
+++ b/config.template.toml
@@ -153,13 +153,13 @@ model = "gpt-4o"
 #ollama_base_url = ""
 
 # Temperature for the API
-#temperature = 0.0
+#temperature = 1.0
 
 # Timeout for the API
 #timeout = 0
 
 # Top p for the API
-#top_p = 0.5
+#top_p = 1.0
 
 # If model is vision capable, this option allows to disable image processing (useful for cost reduction).
 #disable_vision = true

--- a/config.template.toml
+++ b/config.template.toml
@@ -153,7 +153,7 @@ model = "gpt-4o"
 #ollama_base_url = ""
 
 # Temperature for the API
-#temperature = 1.0
+#temperature = 0.0
 
 # Timeout for the API
 #timeout = 0

--- a/openhands/core/config.py
+++ b/openhands/core/config.py
@@ -71,7 +71,7 @@ class LLMConfig:
     retry_max_wait: int = 120
     timeout: int | None = None
     max_message_chars: int = 10_000  # maximum number of characters in an observation's content when sent to the llm
-    temperature: float = 1.0
+    temperature: float = 0.0
     top_p: float = 1.0
     custom_llm_provider: str | None = None
     max_input_tokens: int | None = None

--- a/openhands/core/config.py
+++ b/openhands/core/config.py
@@ -71,8 +71,8 @@ class LLMConfig:
     retry_max_wait: int = 120
     timeout: int | None = None
     max_message_chars: int = 10_000  # maximum number of characters in an observation's content when sent to the llm
-    temperature: float = 0
-    top_p: float = 0.5
+    temperature: float = 1.0
+    top_p: float = 1.0
     custom_llm_provider: str | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Just realize we have 0.5 as the default top_p value - i figure we'd better set this to a more standard default (e.g., following OpenAI's [setting](https://platform.openai.com/docs/api-reference/chat/create))?

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Set top P and temperature to default 1.0.

---
**Link of any specific issues this addresses**
