### PR TITLE
(WIP) Dockerfile.j2: split RUN's; remove ",o+rw" from chmod

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -63,11 +63,13 @@ RUN \
     /openhands/miniforge3/bin/mamba run -n base poetry config virtualenvs.path /openhands/poetry && \
     /openhands/miniforge3/bin/mamba run -n base poetry env use python3.11 && \
     # Install project dependencies
-    /openhands/miniforge3/bin/mamba run -n base poetry install --only main,runtime --no-interaction --no-root && \
+    /openhands/miniforge3/bin/mamba run -n base poetry install --only main,runtime --no-interaction --no-root
+RUN \
     # Update and install additional tools
     apt-get update && \
     /openhands/miniforge3/bin/mamba run -n base poetry run pip install playwright && \
-    /openhands/miniforge3/bin/mamba run -n base poetry run playwright install --with-deps chromium && \
+    /openhands/miniforge3/bin/mamba run -n base poetry run playwright install --with-deps chromium
+RUN \
     # Set environment variables
     export OH_INTERPRETER_PATH=$(/openhands/miniforge3/bin/mamba run -n base poetry run python -c "import sys; print(sys.executable)") && \
     export OH_VENV_PATH=$(/openhands/miniforge3/bin/mamba run -n base poetry env info --path) && \
@@ -77,7 +79,7 @@ RUN \
     /openhands/miniforge3/bin/mamba run -n base poetry cache clear --all . && \
     # Set permissions
     {% if not skip_init %}chmod -R g+rws /openhands/poetry && {% endif %} \
-    mkdir -p /openhands/workspace && chmod -R g+rws,o+rw /openhands/workspace && \
+    mkdir -p /openhands/workspace && chmod -R g+rws /openhands/workspace && \
     # Clean up
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     /openhands/miniforge3/bin/mamba clean --all

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -60,8 +60,10 @@ COPY ./code /openhands/code
 WORKDIR /openhands/code
 RUN \
     # Configure Poetry and create virtual environment
-    /openhands/miniforge3/bin/mamba run -n base poetry config virtualenvs.path /openhands/poetry && \
-    /openhands/miniforge3/bin/mamba run -n base poetry env use python3.11 && \
+    /openhands/miniforge3/bin/mamba run -n base poetry config virtualenvs.path /openhands/poetry
+RUN \
+    /openhands/miniforge3/bin/mamba run -n base poetry env use python3.11
+RUN \
     # Install project dependencies
     /openhands/miniforge3/bin/mamba run -n base poetry install --only main,runtime --no-interaction --no-root
 RUN \


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Testing if changes to template remedy the hanging of image builds, especially arm64

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- `Dockerfile.j2`: split up single, big `RUN` command into several which should make it easier to trace at which steps the image builds may hang for a long time (> 1h)
- removed `,o+rw` from command `chmod -R g+rws,o+rw` as this _may_ no longer be needed

---
**Link of any specific issues this addresses**
