### PR TITLE
fix: models cut off in Settings UI (#3900)

### DIFF
--- a/frontend/src/components/modals/settings/ModelSelector.tsx
+++ b/frontend/src/components/modals/settings/ModelSelector.tsx
@@ -112,7 +112,7 @@ export function ModelSelector({
             {models[selectedProvider || ""]?.models
               .filter((model) => VERIFIED_MODELS.includes(model))
               .map((model) => (
-                <AutocompleteItem key={model} value={model}>
+                <AutocompleteItem key={model} value={model} title={model}>
                   {model}
                 </AutocompleteItem>
               ))}
@@ -121,7 +121,7 @@ export function ModelSelector({
             {models[selectedProvider || ""]?.models
               .filter((model) => !VERIFIED_MODELS.includes(model))
               .map((model) => (
-                <AutocompleteItem key={model} value={model}>
+                <AutocompleteItem key={model} value={model} title={model}>
                   {model}
                 </AutocompleteItem>
               ))}


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

This PR fixes an issue where model names are cut off in the Settings UI, improving the user experience by displaying the full model name on hover. The tooltip ensures that longer model names are fully visible without affecting the layout.


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
This PR introduces a tooltip that appears when hovering over truncated model names in the autocomplete dropdown. It ensures that models with long names are not cut off, providing clarity to the user. The tooltip is added without affecting the existing UI design, maintaining consistency with the overall structure.



---
**Link of any specific issues this addresses**
Fixes #3900


