### PR TITLE
fix Hyperbolic / Qwen message format

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -680,5 +680,12 @@ class LLM:
 
     def format_messages_for_llm(self, messages: Message | list[Message]) -> list[dict]:
         if isinstance(messages, Message):
-            return [messages.model_dump()]
+            messages = [messages]
+
+        # set flags to know how to serialize the messages
+        for message in messages:
+            message.cache_enabled = self.is_caching_prompt_active()
+            message.vision_enabled = self.vision_is_active()
+
+        # let pydantic handle the serialization
         return [message.model_dump() for message in messages]

--- a/tests/unit/test_message_serialization.py
+++ b/tests/unit/test_message_serialization.py
@@ -83,3 +83,34 @@ def test_message_with_only_text_content_and_vision_disabled():
 
     assert serialized_message == expected_serialized_message
     assert message.contains_image is False
+
+
+def test_message_with_mixed_content_and_vision_disabled():
+    # Create a message with both text and image content
+    text_content1 = TextContent(text='This is a text message')
+    image_content1 = ImageContent(
+        image_urls=['http://example.com/image1.png', 'http://example.com/image2.png']
+    )
+    text_content2 = TextContent(text='This is another text message')
+    image_content2 = ImageContent(
+        image_urls=['http://example.com/image3.png', 'http://example.com/image4.png']
+    )
+
+    # Initialize Message with vision disabled
+    message = Message(
+        role='user',
+        content=[text_content1, image_content1, text_content2, image_content2],
+        vision_enabled=False,
+    )
+    serialized_message = message.serialize_model()
+
+    # Expected serialization ignores images and concatenates text
+    expected_serialized_message = {
+        'role': 'user',
+        'content': 'This is a text message\nThis is another text message',
+    }
+
+    # Assert serialized message matches expectation
+    assert serialized_message == expected_serialized_message
+    # Assert that images exist in the original message
+    assert message.contains_image

--- a/tests/unit/test_message_serialization.py
+++ b/tests/unit/test_message_serialization.py
@@ -1,7 +1,7 @@
 from openhands.core.message import ImageContent, Message, TextContent
 
 
-def test_message_serialization():
+def test_message_with_vision_enabled():
     text_content1 = TextContent(text='This is a text message')
     image_content1 = ImageContent(
         image_urls=['http://example.com/image1.png', 'http://example.com/image2.png']
@@ -14,6 +14,7 @@ def test_message_serialization():
     message = Message(
         role='user',
         content=[text_content1, image_content1, text_content2, image_content2],
+        vision_enabled=True,
     )
     serialized_message = message.serialize_model()
 
@@ -45,11 +46,13 @@ def test_message_serialization():
     assert message.contains_image is True
 
 
-def test_message_with_only_text_content():
+def test_message_with_only_text_content_and_vision_enabled():
     text_content1 = TextContent(text='This is a text message')
     text_content2 = TextContent(text='This is another text message')
 
-    message = Message(role='user', content=[text_content1, text_content2])
+    message = Message(
+        role='user', content=[text_content1, text_content2], vision_enabled=True
+    )
     serialized_message = message.serialize_model()
 
     expected_serialized_message = {
@@ -58,6 +61,24 @@ def test_message_with_only_text_content():
             {'type': 'text', 'text': 'This is a text message'},
             {'type': 'text', 'text': 'This is another text message'},
         ],
+    }
+
+    assert serialized_message == expected_serialized_message
+    assert message.contains_image is False
+
+
+def test_message_with_only_text_content_and_vision_disabled():
+    text_content1 = TextContent(text='This is a text message')
+    text_content2 = TextContent(text='This is another text message')
+
+    message = Message(
+        role='user', content=[text_content1, text_content2], vision_enabled=False
+    )
+    serialized_message = message.serialize_model()
+
+    expected_serialized_message = {
+        'role': 'user',
+        'content': 'This is a text message\nThis is another text message',
     }
 
     assert serialized_message == expected_serialized_message


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**
Fix Qwen non-vision expected message format.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This addresses a regression from https://github.com/All-Hands-AI/OpenHands/pull/3832: Hyperbolic supports both vision and non-vision formats, but separately, each for the respective LLM. If the LLM doesn't have vision enabled, the API returns 400 for `role=user` messages in vision-like format. So the compromise that PR 3832 tried to make doesn't work.

This PR proposes to support the two formats for now with flags for the type of format: `vision_enabled` and `cache_enabled`. It continues to use Pydantic serialization mechanism, restructured a bit. The flag is set per Message.

---
**Link of any specific issues this addresses**
https://github.com/All-Hands-AI/OpenHands/issues/4004