### PR TITLE
Make drop_params default in llm_config

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -64,7 +64,7 @@ class LLMConfig:
     input_cost_per_token: float | None = None
     output_cost_per_token: float | None = None
     ollama_base_url: str | None = None
-    drop_params: bool | None = None
+    drop_params: bool = True
     disable_vision: bool | None = None
     caching_prompt: bool = False
     log_completions: bool = False

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -132,9 +132,6 @@ class LLM:
                 ):
                     self.config.max_output_tokens = self.model_info['max_tokens']
 
-        if self.config.drop_params:
-            litellm.drop_params = self.config.drop_params
-
         # This only seems to work with Google as the provider, not with OpenRouter!
         gemini_safety_settings = (
             [
@@ -170,6 +167,7 @@ class LLM:
             timeout=self.config.timeout,
             temperature=self.config.temperature,
             top_p=self.config.top_p,
+            drop_params=self.config.drop_params,
             **(
                 {'safety_settings': gemini_safety_settings}
                 if gemini_safety_settings is not None
@@ -298,7 +296,7 @@ class LLM:
             timeout=self.config.timeout,
             temperature=self.config.temperature,
             top_p=self.config.top_p,
-            drop_params=True,
+            drop_params=self.config.drop_params,
             **(
                 {'safety_settings': gemini_safety_settings}
                 if gemini_safety_settings is not None


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**
Make drop_params default to improve compatibility with LMs including OpenAI o1.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The use of `drop_params` in our `llm.py` code was inconsistent, it always dropped params for async completion, and followed system defaults for synchronous completions.

This PR makes behavior consistent:
1. Always drop params by default
2. Always follow the configuration values
3. Never mess with global litellm parameters

---
**Link of any specific issues this addresses**
Fixes https://github.com/All-Hands-AI/OpenHands/issues/4005