### PR TITLE
hotfix(frontend): Clear base URL when advanced options is unselected

### DIFF
--- a/frontend/src/components/modals/settings/SettingsForm.tsx
+++ b/frontend/src/components/modals/settings/SettingsForm.tsx
@@ -52,13 +52,19 @@ function SettingsForm({
   const [enableAdvanced, setEnableAdvanced] =
     React.useState(advancedAlreadyInUse);
 
+  const handleAdvancedChange = (value: boolean) => {
+    setEnableAdvanced(value);
+    // Reset the base URL if the user disables advanced options
+    if (!value) onBaseURLChange("");
+  };
+
   return (
     <>
       <Switch
         data-testid="advanced-options-toggle"
         aria-checked={enableAdvanced}
         isSelected={enableAdvanced}
-        onValueChange={(value) => setEnableAdvanced(value)}
+        onValueChange={handleAdvancedChange}
       >
         Advanced Options
       </Switch>


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**
Clear the base URL when unselecting the advanced options switch


---
**TODO**
- [ ] ~~Fix set/unset bug:~~
  > Enable Advanced Options
  > Set Base URL
  > Remove Base URL



---
**Link of any specific issues this addresses**
Resolves #4013
