### PR TITLE
[eval] log evaluating warnings directly to console

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -378,18 +378,24 @@ def reset_logger_for_multiprocessing(
     # Remove all existing handlers from logger
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
-    # add back the console handler to print ONE line
-    logger.addHandler(get_console_handler())
+
+    # add console handler to print ONE line
+    console_handler = get_console_handler(
+        log_level=logging.INFO, extra_info=f'Instance {instance_id}'
+    )
+    logger.addHandler(console_handler)
     logger.info(
         f'Starting evaluation for instance {instance_id}.\n'
         f'Hint: run "tail -f {log_file}" to see live logs in a separate shell'
     )
-    # Remove all existing handlers from logger
-    for handler in logger.handlers[:]:
-        logger.removeHandler(handler)
+    # Only log WARNING or higher to console
+    console_handler.setLevel(logging.WARNING)
+
+    # Log INFO and above to file
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     file_handler = logging.FileHandler(log_file)
     file_handler.setFormatter(
         logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     )
+    file_handler.setLevel(logging.INFO)
     logger.addHandler(file_handler)

--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -380,8 +380,11 @@ def reset_logger_for_multiprocessing(
         logger.removeHandler(handler)
 
     # add console handler to print ONE line
-    console_handler = get_console_handler(
-        log_level=logging.INFO, extra_info=f'Instance {instance_id}'
+    console_handler = get_console_handler(log_level=logging.INFO)
+    console_handler.setFormatter(
+        logging.Formatter(
+            f'Instance {instance_id} - ' + '%(asctime)s - %(levelname)s - %(message)s'
+        )
     )
     logger.addHandler(console_handler)
     logger.info(

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -117,11 +117,14 @@ class SensitiveDataFilter(logging.Filter):
         return True
 
 
-def get_console_handler(log_level=logging.INFO):
+def get_console_handler(log_level=logging.INFO, extra_info: str | None = None):
     """Returns a console handler for logging."""
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
-    console_handler.setFormatter(console_formatter)
+    formatter_str = '%(asctime)s - %(levelname)s - %(message)s'
+    if extra_info:
+        formatter_str = f'{extra_info} - ' + formatter_str
+    console_handler.setFormatter(logging.Formatter(formatter_str))
     return console_handler
 
 

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -117,14 +117,11 @@ class SensitiveDataFilter(logging.Filter):
         return True
 
 
-def get_console_handler(log_level=logging.INFO, extra_info: str | None = None):
+def get_console_handler(log_level=logging.INFO):
     """Returns a console handler for logging."""
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
-    formatter_str = '%(asctime)s - %(levelname)s - %(message)s'
-    if extra_info:
-        formatter_str = f'{extra_info} - ' + formatter_str
-    console_handler.setFormatter(logging.Formatter(formatter_str))
+    console_handler.setFormatter(console_formatter)
     return console_handler
 
 

--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -59,7 +59,7 @@ class RemoteRuntime(Runtime):
         self.config = config
         if self.config.sandbox.api_hostname == 'localhost':
             self.config.sandbox.api_hostname = 'api.all-hands.dev/v0/runtime'
-            logger.warning(
+            logger.info(
                 'Using localhost as the API hostname is not supported in the RemoteRuntime. Please set a proper hostname.\n'
                 'Setting it to default value: api.all-hands.dev/v0/runtime'
             )


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Sometimes, if you run an evaluation using RemoteRuntime with too many processes, the LLM will throw rate limit warnings/errors, which only get logged to the file. It makes it hard to figure out whether that error is a rate-limit warning or a fatal LLM error (e.g., the LLM was down - it happened yesterday, and it took me quite some time to find out and recover the eval).

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- When run in multi-processing, this PR log WARNING and above directly to the console, and add a prefix of `instance_id` to help figure out which instance is having an issue.

---
**Link of any specific issues this addresses**
