### PR TITLE
Set runtime container image so it doesn't need to be rebuilt

### DIFF
--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -145,8 +145,7 @@ jobs:
         run: make install-python-dependencies
       - name: Run runtime tests
         run: |
-          # We install pytest-xdist in order to run tests across CPUs. However, tests start to fail when we run
-          # then across more than 2 CPUs for some reason
+          # We install pytest-xdist in order to run tests across CPUs
           poetry run pip install pytest-xdist
 
           # Install to be able to retry on failures for flaky tests
@@ -161,7 +160,7 @@ jobs:
           SANDBOX_RUNTIME_CONTAINER_IMAGE=$image_name \
           TEST_IN_CI=true \
           RUN_AS_OPENHANDS=false \
-          poetry run pytest -n 3 --reruns 1 --reruns-delay 3 --cov=agenthub --cov=openhands --cov-report=xml -s ./tests/runtime
+          poetry run pytest -n 3 -raR --reruns 1 --reruns-delay 3 --cov=agenthub --cov=openhands --cov-report=xml -s ./tests/runtime
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:
@@ -207,8 +206,7 @@ jobs:
         run: make install-python-dependencies
       - name: Run runtime tests
         run: |
-          # We install pytest-xdist in order to run tests across CPUs. However, tests start to fail when we run
-          # then across more than 2 CPUs for some reason
+          # We install pytest-xdist in order to run tests across CPUs
           poetry run pip install pytest-xdist
 
           # Install to be able to retry on failures for flaky tests
@@ -220,10 +218,10 @@ jobs:
           SKIP_CONTAINER_LOGS=true \
           TEST_RUNTIME=eventstream \
           SANDBOX_USER_ID=$(id -u) \
-          SANDBOX_BASE_CONTAINER_IMAGE=$image_name \
+          SANDBOX_RUNTIME_CONTAINER_IMAGE=$image_name \
           TEST_IN_CI=true \
           RUN_AS_OPENHANDS=true \
-          poetry run pytest -n 3 --reruns 1 --reruns-delay 3 --cov=agenthub --cov=openhands --cov-report=xml -s ./tests/runtime
+          poetry run pytest -n 3 -raR --reruns 1 --reruns-delay 3 --cov=agenthub --cov=openhands --cov-report=xml -s ./tests/runtime
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:
@@ -275,7 +273,7 @@ jobs:
 
           TEST_RUNTIME=eventstream \
           SANDBOX_USER_ID=$(id -u) \
-          SANDBOX_BASE_CONTAINER_IMAGE=$image_name \
+          SANDBOX_RUNTIME_CONTAINER_IMAGE=$image_name \
           TEST_IN_CI=true \
           TEST_ONLY=true \
           ./tests/integration/regenerate.sh

--- a/.github/workflows/ghcr_runtime.yml
+++ b/.github/workflows/ghcr_runtime.yml
@@ -158,7 +158,7 @@ jobs:
           SKIP_CONTAINER_LOGS=true \
           TEST_RUNTIME=eventstream \
           SANDBOX_USER_ID=$(id -u) \
-          SANDBOX_BASE_CONTAINER_IMAGE=$image_name \
+          SANDBOX_RUNTIME_CONTAINER_IMAGE=$image_name \
           TEST_IN_CI=true \
           RUN_AS_OPENHANDS=false \
           poetry run pytest -n 3 --reruns 1 --reruns-delay 3 --cov=agenthub --cov=openhands --cov-report=xml -s ./tests/runtime

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -243,6 +243,7 @@ def _load_runtime(
 
     if base_container_image is not None:
         config.sandbox.base_container_image = base_container_image
+        config.sandbox.runtime_container_image = None
 
     file_store = get_file_store(config.file_store, config.file_store_path)
     event_stream = EventStream(sid, file_store)


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Set runtime container image so it doesn't need to be rebuilt

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We already build the runtime images, so we can just use it in the tests
Tested on fork version too just in case: https://github.com/All-Hands-AI/OpenHands/pull/4036

---
**Link of any specific issues this addresses**
