### PR TITLE
[eval] Use `imap_unorderd` for parallizing evaluation

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -328,21 +328,15 @@ def run_evaluation(
     try:
         if use_multiprocessing:
             with mp.Pool(num_workers) as pool:
-                results = [
-                    pool.apply_async(
-                        _process_instance_wrapper,
-                        args=(
-                            process_instance_func,
-                            instance,
-                            metadata,
-                            True,
-                            max_retries,
-                        ),
-                    )
-                    for _, instance in dataset.iterrows()
-                ]
+                results = pool.imap_unordered(
+                    lambda args: _process_instance_wrapper(*args),
+                    [
+                        (process_instance_func, instance, metadata, True, max_retries)
+                        for _, instance in dataset.iterrows()
+                    ],
+                )
                 for result in results:
-                    update_progress(result.get(), pbar, output_fp)
+                    update_progress(result, pbar, output_fp)
         else:
             for _, instance in dataset.iterrows():
                 result = _process_instance_wrapper(


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Follow-up of https://github.com/All-Hands-AI/OpenHands/pull/4025. This is probably the 10th attempt to fix this multiprocessing.


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Use `imap_unordered` instead of `pool.apply_async`, so results that are finished will be returned immediately, and we don't need to wait for the "first task" to finish (it happens when using `pool.apply_async`).

---
**Link of any specific issues this addresses**
