### PR TITLE
Fix: uvicorn reloading when python files in workspace change, & started section for debugging instructions for developers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ build-frontend:
 # Start backend
 start-backend:
 	@echo "$(YELLOW)Starting backend...$(RESET)"
-	@poetry run uvicorn openhands.server.listen:app --host $(BACKEND_HOST) --port $(BACKEND_PORT) --reload --reload-exclude "workspace/*"
+	@poetry run uvicorn openhands.server.listen:app --host $(BACKEND_HOST) --port $(BACKEND_PORT) --reload --reload-exclude "$(shell pwd)/workspace"
 
 # Start frontend
 start-frontend:

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -1,6 +1,6 @@
 # Debugging
 
-The following is intended as a primer on debugging OpenHands for development purposes.
+The following is intended as a primer on debugging OpenHands for Development purposes.
 
 ## Server / VSCode
 
@@ -26,6 +26,8 @@ runs inside docker):
             "args": [
                 "openhands.server.listen:app",
                 "--reload",
+                "--reload-include",
+                "openhands/*",
                 "--port",
                 "3000"
             ],

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -2,11 +2,19 @@
 
 The following is intended as a primer on debugging OpenHands for Development purposes.
 
+## Uvicorn Hates Your Workspace Directory
+
+Uvicorn currently *ALWAYS* adds the current working directory to the list of reload directories, regardless of what
+is specified in `reload-dir`. The `--exclude-list` / `--include-list` directives does not reliably filter out files
+based on a directory. (They could if you could specify an absolute path, but uvicorn does not allow this.)
+So the only real option for now is to make sure your workspace directory is *OUTSIDE* the openhands directory.
+Otherwise every time you modify a python file in a subdirectory of your workspace directory, uvicorn will 
+blast your session and create a new one. (I tried many combinations of `workspace/*` / `**/workspace/**` before giving up)
+
 ## Server / VSCode
 
 The following `launch.json` will allow debugging the agent, controller and server elements, but not the sandbox (Which
-runs inside docker). It will ignore changes in the `workspace/` directory (So updates to files here will
-not cause uvicorn to reload - unfortunately this means that this file must exist before starting your server):
+runs inside docker):
 
 ```
 {
@@ -27,10 +35,6 @@ not cause uvicorn to reload - unfortunately this means that this file must exist
             "args": [
                 "openhands.server.listen:app",
                 "--reload",
-                "--reload-exclude",
-                "workspace/*",
-                "--reload-exclude",
-                "**/workspace/**/*.py",
                 "--port",
                 "3000"
             ],

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -2,22 +2,9 @@
 
 The following is intended as a primer on debugging OpenHands for Development purposes.
 
-## Uvicorn Hates Your Workspace Directory
-
-Uvicorn currently *ALWAYS* adds the current working directory to the list of reload directories, regardless of what
-is specified in `reload-dir`. (Their docs are inaccurate at the moment too!). The `--exclude-list` / `--include-list` 
-directives do not reliably filter out files based on a directory. (They could if you could specify an absolute path,
-but uvicorn does not allow this.)
-
-So the only real option for now is to make sure your workspace directory is *OUTSIDE* the openhands directory. (e.g.:
-update the following in your `config.toml` : `workspace_base = "../workspace"`) Otherwise every time you modify a python
-file in a subdirectory of your workspace directory, uvicorn will blast your session and create a new one. (I tried
-many combinations of `workspace/*` / `**/workspace/**` before giving up)
-
 ## Server / VSCode
 
-The following `launch.json` will allow debugging the agent, controller and server elements, but not the sandbox (Which
-runs inside docker):
+The following `launch.json` will allow debugging the agent, controller and server elements, but not the sandbox (Which runs inside docker). It will ignore any changes inside the `workspace/` directory:
 
 ```
 {
@@ -38,8 +25,29 @@ runs inside docker):
             "args": [
                 "openhands.server.listen:app",
                 "--reload",
+                "--reload-exclude",
+                "${workspaceFolder}/workspace",
                 "--port",
                 "3000"
+            ],
+            "justMyCode": false
+        },
+        {
+            "name": "D: CodeAct",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "openhands.core.main",
+            "args": [
+                "-t",
+                "Ask me what your task is.",
+                "-d",
+                "/home/user/workspace",
+                "-c",
+                "CodeActAgent",
+                "-l",
+                "llm.o1",
+                "-n",
+                "prompts"
             ],
             "justMyCode": false
         }

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -31,26 +31,41 @@ The following `launch.json` will allow debugging the agent, controller and serve
                 "3000"
             ],
             "justMyCode": false
-        },
-        {
-            "name": "D: CodeAct",
-            "type": "debugpy",
-            "request": "launch",
-            "module": "openhands.core.main",
-            "args": [
-                "-t",
-                "Ask me what your task is.",
-                "-d",
-                "/home/user/workspace",
-                "-c",
-                "CodeActAgent",
-                "-l",
-                "llm.o1",
-                "-n",
-                "prompts"
-            ],
-            "justMyCode": false
         }
     ]
 }
 ```
+
+More specific debugging configurations which include more parameters may be specified:
+
+```
+    ...
+    {
+      "name": "Debug CodeAct",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "openhands.core.main",
+      "args": [
+        "-t",
+        "Ask me what your task is.",
+        "-d",
+        "${workspaceFolder}/workspace",
+        "-c",
+        "CodeActAgent",
+        "-l",
+        "llm.o1",
+        "-n",
+        "prompts"
+      ],
+      "justMyCode": false
+    }
+    ...
+```
+
+Values in the snippet above can be updated such that:
+
+    * *t*: the task
+    * *d*: the openhands workspace directory
+    * *c*: the agent
+    * *l*: the LLM config (pre-defined in config.toml)
+    * *n*: session name (e.g. eventstream name)

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -1,0 +1,36 @@
+# Debugging
+
+The following is intended as a primer on debugging OpenHands for Development purposes.
+
+## Server / VSCode
+
+The following `launch.json` will allow debugging the agent, controller and server elements, but not the sandbox (Which
+runs inside docker):
+
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "OpenHands CLI",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "openhands.core.cli",
+            "justMyCode": false
+        },
+        {
+            "name": "OpenHands WebApp",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "openhands.server.listen:app",
+                "--reload",
+                "--port",
+                "3000"
+            ],
+            "justMyCode": false
+        }
+    ]
+}
+```

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -5,11 +5,14 @@ The following is intended as a primer on debugging OpenHands for Development pur
 ## Uvicorn Hates Your Workspace Directory
 
 Uvicorn currently *ALWAYS* adds the current working directory to the list of reload directories, regardless of what
-is specified in `reload-dir`. The `--exclude-list` / `--include-list` directives does not reliably filter out files
-based on a directory. (They could if you could specify an absolute path, but uvicorn does not allow this.)
-So the only real option for now is to make sure your workspace directory is *OUTSIDE* the openhands directory.
-Otherwise every time you modify a python file in a subdirectory of your workspace directory, uvicorn will 
-blast your session and create a new one. (I tried many combinations of `workspace/*` / `**/workspace/**` before giving up)
+is specified in `reload-dir`. (Their docs are inaccurate at the moment too!). The `--exclude-list` / `--include-list` 
+directives do not reliably filter out files based on a directory. (They could if you could specify an absolute path,
+but uvicorn does not allow this.)
+
+So the only real option for now is to make sure your workspace directory is *OUTSIDE* the openhands directory. (e.g.:
+update the following in your `config.toml` : `workspace_base = "../workspace"`) Otherwise every time you modify a python
+file in a subdirectory of your workspace directory, uvicorn will blast your session and create a new one. (I tried
+many combinations of `workspace/*` / `**/workspace/**` before giving up)
 
 ## Server / VSCode
 

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -1,6 +1,6 @@
 # Debugging
 
-The following is intended as a primer on debugging OpenHands for Development purposes.
+The following is intended as a primer on debugging OpenHands for development purposes.
 
 ## Server / VSCode
 

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -5,7 +5,7 @@ The following is intended as a primer on debugging OpenHands for Development pur
 ## Server / VSCode
 
 The following `launch.json` will allow debugging the agent, controller and server elements, but not the sandbox (Which
-runs inside docker). It will watch for changes in the `openhands` directory (So updates to files in your workspace will
+runs inside docker). It will ignore changes in the `workspace/` directory (So updates to files here will
 not cause uvicorn to reload):
 
 ```
@@ -27,8 +27,8 @@ not cause uvicorn to reload):
             "args": [
                 "openhands.server.listen:app",
                 "--reload",
-                "--reload-include",
-                "openhands",
+                "--reload-exclude",
+                "workspace/*",
                 "--port",
                 "3000"
             ],

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -5,7 +5,8 @@ The following is intended as a primer on debugging OpenHands for Development pur
 ## Server / VSCode
 
 The following `launch.json` will allow debugging the agent, controller and server elements, but not the sandbox (Which
-runs inside docker):
+runs inside docker). It will watch for changes in the `openhands` directory (So updates to files in your workspace will
+not cause uvicorn to reload):
 
 ```
 {
@@ -26,7 +27,7 @@ runs inside docker):
             "args": [
                 "openhands.server.listen:app",
                 "--reload",
-                "--reload-dir",
+                "--reload-include",
                 "openhands",
                 "--port",
                 "3000"

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -6,7 +6,7 @@ The following is intended as a primer on debugging OpenHands for Development pur
 
 The following `launch.json` will allow debugging the agent, controller and server elements, but not the sandbox (Which
 runs inside docker). It will ignore changes in the `workspace/` directory (So updates to files here will
-not cause uvicorn to reload):
+not cause uvicorn to reload - unfortunately this means that this file must exist before starting your server):
 
 ```
 {
@@ -29,6 +29,8 @@ not cause uvicorn to reload):
                 "--reload",
                 "--reload-exclude",
                 "workspace/*",
+                "--reload-exclude",
+                "**/workspace/**/*.py",
                 "--port",
                 "3000"
             ],

--- a/docs/modules/usage/how-to/debugging.md
+++ b/docs/modules/usage/how-to/debugging.md
@@ -26,8 +26,8 @@ runs inside docker):
             "args": [
                 "openhands.server.listen:app",
                 "--reload",
-                "--reload-include",
-                "openhands/*",
+                "--reload-dir",
+                "openhands",
                 "--port",
                 "3000"
             ],

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -83,6 +83,10 @@ const sidebars: SidebarsConfig = {
         {
           type: 'doc',
           id: 'usage/how-to/openshift-example',
+        },
+        {
+          type: 'doc',
+          id: 'usage/how-to/debugging',
         }
       ]
     },


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

* Uvicorn no longer reloads when python files in the workspace director change if you use the make file.
* Added documentation section for debugging OpenHands. The initial section includes instructions for VSCode.

---

Uvicorn `reload-exclude` must be an absolute path if it is a directory. Pattern matches will not work.