### PR TITLE
[agent, WIP] File edit using diff format based on Raj's #3777

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -38,7 +38,7 @@ from openhands.utils.prompt import PromptManager
 
 
 class CodeActAgent(Agent):
-    VERSION = '1.9'
+    VERSION = '1.10'
     """
     The Code Act Agent is a minimalist agent.
     The agent works by passing the model a list of action-observation pairs and prompting the model to take the next step.

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -13,12 +13,14 @@ from openhands.events.action import (
     AgentDelegateAction,
     AgentFinishAction,
     CmdRunAction,
+    FileEditAction,
     IPythonRunCellAction,
     MessageAction,
 )
 from openhands.events.observation import (
     AgentDelegateObservation,
     CmdOutputObservation,
+    FileEditObservation,
     IPythonRunCellObservation,
     UserRejectObservation,
 )
@@ -104,6 +106,8 @@ class CodeActAgent(Agent):
             return f'{action.thought}\n<execute_ipython>\n{action.code}\n</execute_ipython>'
         elif isinstance(action, AgentDelegateAction):
             return f'{action.thought}\n<execute_browse>\n{action.inputs["task"]}\n</execute_browse>'
+        elif isinstance(action, FileEditAction):
+            return f'{action.thought}\n<execute_edit>\n{action.diff_block}\n</execute_edit>'
         elif isinstance(action, MessageAction):
             return action.content
         elif isinstance(action, AgentFinishAction) and action.source == 'agent':
@@ -113,6 +117,7 @@ class CodeActAgent(Agent):
     def get_action_message(self, action: Action) -> Message | None:
         if (
             isinstance(action, AgentDelegateAction)
+            or isinstance(action, FileEditAction)
             or isinstance(action, CmdRunAction)
             or isinstance(action, IPythonRunCellAction)
             or isinstance(action, MessageAction)
@@ -153,6 +158,9 @@ class CodeActAgent(Agent):
             text = '\n'.join(splitted)
             text = truncate_content(text, max_message_chars)
             return Message(role='user', content=[TextContent(text=text)])
+        elif isinstance(obs, FileEditObservation):
+            text = obs_prefix + truncate_content(obs.content, max_message_chars)
+            return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, AgentDelegateObservation):
             text = obs_prefix + truncate_content(
                 obs.outputs['content'] if 'content' in obs.outputs else '',
@@ -164,7 +172,7 @@ class CodeActAgent(Agent):
             text += '\n[Error occurred in processing last action]'
             return Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, UserRejectObservation):
-            text = 'OBSERVATION:\n' + truncate_content(obs.content, max_message_chars)
+            text = obs_prefix + truncate_content(obs.content, max_message_chars)
             text += '\n[Last action has been rejected by the user]'
             return Message(role='user', content=[TextContent(text=text)])
         else:
@@ -187,6 +195,7 @@ class CodeActAgent(Agent):
         - CmdRunAction(command) - bash command to run
         - IPythonRunCellAction(code) - IPython code to run
         - AgentDelegateAction(agent, inputs) - delegate action for (sub)task
+        - FileEditAction(diff_block) - Search/Replace block to edit.
         - MessageAction(content) - Message action to run (e.g. ask for clarification)
         - AgentFinishAction() - end the interaction
         """
@@ -203,6 +212,7 @@ class CodeActAgent(Agent):
                 '</execute_ipython>',
                 '</execute_bash>',
                 '</execute_browse>',
+                '</execute_edit>',
             ],
         }
 

--- a/agenthub/codeact_agent/system_prompt.j2
+++ b/agenthub/codeact_agent/system_prompt.j2
@@ -23,7 +23,7 @@ Or <execute_browse> Tell me what is in http://example.com </execute_browse>.
 {% set EDIT_DIFF_PREFIX %}
 The assistant can edit files with <execute_edit> and </execute_edit>. Each change must be described with a SEARCH/REPLACE block.
 Every SEARCH section must EXACTLY MATCH the existing file content, character for character, including all comments, docstrings, etc. SEARCH/REPLACE blocks will replace all matching occurrences. Include enough lines to make the SEARCH blocks uniquely match the lines to change.
-Keep SEARCH/REPLACE blocks concise. Break large SEARCH/REPLACE blocks into a series of smaller blocks that each change a small portion of the file.
+Keep SEARCH/REPLACE blocks as concise as possible. Break large SEARCH/REPLACE blocks into a series of smaller blocks that each change a small portion of the file.
 To move code within a file, use 2 SEARCH/REPLACE blocks: 1 to delete it from its current location, 1 to insert it in the new location.
 If you want to put code in a new file, use a SEARCH/REPLACE block with: a new file path, an empty `SEARCH` section and the new file's contents in the `REPLACE` section.
 

--- a/agenthub/codeact_agent/system_prompt.j2
+++ b/agenthub/codeact_agent/system_prompt.j2
@@ -20,21 +20,43 @@ The assistant can browse the Internet with <execute_browse> and </execute_browse
 For example, <execute_browse> Tell me the usa's president using google search </execute_browse>.
 Or <execute_browse> Tell me what is in http://example.com </execute_browse>.
 {% endset %}
+{% set EDIT_DIFF_PREFIX %}
+The assistant can edit files with <execute_edit> and </execute_edit>. Each change must be described with a SEARCH/REPLACE block.
+Every SEARCH section must EXACTLY MATCH the existing file content, character for character, including all comments, docstrings, etc. SEARCH/REPLACE blocks will replace all matching occurrences. Include enough lines to make the SEARCH blocks uniquely match the lines to change.
+Keep SEARCH/REPLACE blocks concise. Break large SEARCH/REPLACE blocks into a series of smaller blocks that each change a small portion of the file.
+To move code within a file, use 2 SEARCH/REPLACE blocks: 1 to delete it from its current location, 1 to insert it in the new location.
+If you want to put code in a new file, use a SEARCH/REPLACE block with: a new file path, an empty `SEARCH` section and the new file's contents in the `REPLACE` section.
+
+Every SEARCH/REPLACE block must use this format:
+1. The FULL file path alone on a line, verbatim. No bold asterisks, no quotes around it, no escaping of characters, etc.
+2. The start of search block: <<<<<<< SEARCH
+3. A contiguous chunk of lines to search for in the existing source code
+4. The dividing line: =======
+5. The lines to replace into the source code
+6. The end of the replace block: >>>>>>> REPLACE
+
+For example,
+<execute_edit>
+demo.py
+<<<<<<< SEARCH
+    print("hello")
+=======
+    print("goodbye")
+>>>>>>> REPLACE
+</execute_edit>
+
+{% endset %}
 {% set PIP_INSTALL_PREFIX %}
 The assistant can install Python packages using the %pip magic command in an IPython environment by using the following syntax: <execute_ipython> %pip install [package needed] </execute_ipython> and should always import packages and define variables before starting to use them.
 {% endset %}
-{% set SYSTEM_PREFIX = MINIMAL_SYSTEM_PREFIX + BROWSING_PREFIX + PIP_INSTALL_PREFIX %}
+{% set SYSTEM_PREFIX = MINIMAL_SYSTEM_PREFIX + BROWSING_PREFIX + EDIT_DIFF_PREFIX + PIP_INSTALL_PREFIX %}
 {% set COMMAND_DOCS %}
 Apart from the standard Python library, the assistant can also use the following functions (already imported) in <execute_ipython> environment:
 {{ agent_skills_docs }}
 IMPORTANT:
 - `open_file` only returns the first 100 lines of the file by default! The assistant MUST use `scroll_down` repeatedly to read the full file BEFORE making edits!
-- The assistant shall adhere to THE `edit_file_by_replace`, `append_file` and `insert_content_at_line` FUNCTIONS REQUIRING PROPER INDENTATION. If the assistant would like to add the line '        print(x)', it must fully write the line out, with all leading spaces before the code!
 - Indentation is important and code that is not indented correctly will fail and require fixing before it can be run.
 - Any code issued should be less than 50 lines to avoid context being cut off!
-- After EVERY `create_file` the method `append_file` shall be used to write the FIRST content!
-- For `edit_file_by_replace` NEVER provide empty parameters!
-- For `edit_file_by_replace` the file must be read fully before any replacements!
 {% endset %}
 {% set SYSTEM_SUFFIX %}
 Responses should be concise.

--- a/agenthub/codeact_agent/user_prompt.j2
+++ b/agenthub/codeact_agent/user_prompt.j2
@@ -4,21 +4,7 @@
 USER: Create a list of numbers from 1 to 10, and display them in a web page at port 5000.
 
 ASSISTANT:
-Sure! Let me create a Python file `app.py`:
-<execute_ipython>
-create_file('app.py')
-</execute_ipython>
-
-USER:
-OBSERVATION:
-[File: /workspace/app.py (1 lines total)]
-(this is the beginning of the file)
-1|
-(this is the end of the file)
-[File app.py created.]
-
-ASSISTANT:
-Now I will write the Python code for starting a web server and save it to the file `app.py`:
+Sure! Let me write the Python code for starting a web server and save it to a new Python file `app.py`:
 <execute_edit>
 app.py
 <<<<<<< SEARCH

--- a/agenthub/codeact_agent/user_prompt.j2
+++ b/agenthub/codeact_agent/user_prompt.j2
@@ -19,8 +19,11 @@ OBSERVATION:
 
 ASSISTANT:
 Now I will write the Python code for starting a web server and save it to the file `app.py`:
-<execute_ipython>
-EDITED_CODE="""from flask import Flask
+<execute_edit>
+app.py
+<<<<<<< SEARCH
+=======
+from flask import Flask
 app = Flask(__name__)
 
 @app.route('/')
@@ -29,30 +32,14 @@ def index():
     return str(numbers)
 
 if __name__ == '__main__':
-    app.run(port=5000)"""
+    app.run(port=5000)
+>>>>>>> REPLACE
+</execute_edit>
 
-insert_content_at_line(
-  'app.py',
-  1,
-  EDITED_CODE,
-)
-</execute_ipython>
 
 USER:
 OBSERVATION:
-(this is the beginning of the file)
-1|from flask import Flask
-2|app = Flask(__name__)
-3|
-4|@app.route('/')
-5|def index():
-6|    numbers = list(range(1, 11))
-7|    return str(numbers)
-8|
-9|if __name__ == '__main__':
-10|    app.run(port=5000)
-(this is the end of the file)
-[File updated (edited at line 1). Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.]
+I edited the file app.py.
 
 ASSISTANT:
 I have created a Python file `app.py` that will display a list of numbers from 1 to 10 when you run it. Let me run the Python file for you:
@@ -177,13 +164,14 @@ USER:
 
 ASSISTANT:
 I should edit the file to display the numbers in a table format. I should include correct indentation. Let me update the file:
-<execute_ipython>
-edit_file_by_replace(
-  'app.py',
-  to_replace="    return str(numbers)",
-  new_content="    return '<table>' + ''.join([f'<tr><td>{i}</td></tr>' for i in numbers]) + '</table>'",
-)
-</execute_ipython>
+<execute_edit>
+app.py
+<<<<<<< SEARCH
+    return str(numbers)
+=======
+    return '<table>' + ''.join([f'<tr><td>{i}</td></tr>' for i in numbers]) + '</table>'
+>>>>>>> REPLACE
+</execute_edit>
 
 USER:
 Observation:

--- a/agenthub/codeact_agent/user_prompt.j2
+++ b/agenthub/codeact_agent/user_prompt.j2
@@ -39,7 +39,10 @@ if __name__ == '__main__':
 
 USER:
 OBSERVATION:
-I edited the file app.py.
+I updated the file app.py by
+appending:
+from flask import Flask
+app = Flask(__name__)
 
 ASSISTANT:
 I have created a Python file `app.py` that will display a list of numbers from 1 to 10 when you run it. Let me run the Python file for you:
@@ -175,20 +178,11 @@ app.py
 
 USER:
 Observation:
-[File: /workspace/app.py (10 lines total after edit)]
-(this is the beginning of the file)
-1|from flask import Flask
-2|app = Flask(__name__)
-3|
-4|@app.route('/')
-5|def index():
-6|    numbers = list(range(1, 11))
-7|    return '<table>' + ''.join([f'<tr><td>{i}</td></tr>' for i in numbers]) + '</table>'
-8|
-9|if __name__ == '__main__':
-10|    app.run(port=5000)
-(this is the end of the file)
-[File updated (edited at line 7). Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.]
+I updated the file app.py by
+replacing:
+    return str(numbers)
+with:
+    return '<table>' + ''.join([f'<tr><td>{i}</td></tr>' for i in numbers]) + '</table>'
 
 ASSISTANT:
 Running the updated file:

--- a/evaluation/aider_bench/run_infer.py
+++ b/evaluation/aider_bench/run_infer.py
@@ -256,6 +256,7 @@ def process_instance(
 if __name__ == '__main__':
     args = parse_arguments()
     dataset = load_dataset('RajMaheshwari/Exercism-Python')
+    dataset = dataset.shuffle(seed=42)
     aider_bench_tests = dataset['train'].to_pandas()
 
     llm_config = None

--- a/openhands/core/schema/action.py
+++ b/openhands/core/schema/action.py
@@ -24,6 +24,10 @@ class ActionTypeSchema(BaseModel):
     """Writes the content to a file.
     """
 
+    EDIT: str = Field(default='edit')
+    """Edits the content of a file.
+    """
+
     RUN: str = Field(default='run')
     """Runs a command.
     """

--- a/openhands/core/schema/observation.py
+++ b/openhands/core/schema/observation.py
@@ -10,6 +10,10 @@ class ObservationTypeSchema(BaseModel):
 
     WRITE: str = Field(default='write')
 
+    EDIT: str = Field(default='edit')
+    """The edited file
+    """
+
     BROWSE: str = Field(default='browse')
     """The HTML content of a URL
     """

--- a/openhands/events/action/__init__.py
+++ b/openhands/events/action/__init__.py
@@ -9,7 +9,11 @@ from openhands.events.action.agent import (
 from openhands.events.action.browse import BrowseInteractiveAction, BrowseURLAction
 from openhands.events.action.commands import CmdRunAction, IPythonRunCellAction
 from openhands.events.action.empty import NullAction
-from openhands.events.action.files import FileReadAction, FileWriteAction
+from openhands.events.action.files import (
+    FileEditAction,
+    FileReadAction,
+    FileWriteAction,
+)
 from openhands.events.action.message import MessageAction
 from openhands.events.action.tasks import AddTaskAction, ModifyTaskAction
 
@@ -21,6 +25,7 @@ __all__ = [
     'BrowseInteractiveAction',
     'FileReadAction',
     'FileWriteAction',
+    'FileEditAction',
     'AgentFinishAction',
     'AgentRejectAction',
     'AgentDelegateAction',

--- a/openhands/events/action/files.py
+++ b/openhands/events/action/files.py
@@ -39,3 +39,23 @@ class FileWriteAction(Action):
     @property
     def message(self) -> str:
         return f'Writing file: {self.path}'
+
+
+@dataclass
+class FileEditAction(Action):
+    diff_block: str
+    thought: str = ''
+    action: str = ActionType.EDIT
+    runnable: ClassVar[bool] = True
+    security_risk: ActionSecurityRisk | None = None
+
+    def __str__(self) -> str:
+        ret = '**EditFileAction**\n'
+        if self.thought:
+            ret += f'THOUGHT: {self.thought}\n'
+        ret += f'DIFF BLOCK:\n{self.diff_block}\n'
+        return ret
+
+    @property
+    def message(self) -> str:
+        return f'Edit Diff block: {self.diff_block}'

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -7,7 +7,11 @@ from openhands.events.observation.commands import (
 from openhands.events.observation.delegate import AgentDelegateObservation
 from openhands.events.observation.empty import NullObservation
 from openhands.events.observation.error import ErrorObservation
-from openhands.events.observation.files import FileReadObservation, FileWriteObservation
+from openhands.events.observation.files import (
+    FileEditObservation,
+    FileReadObservation,
+    FileWriteObservation,
+)
 from openhands.events.observation.observation import Observation
 from openhands.events.observation.reject import UserRejectObservation
 from openhands.events.observation.success import SuccessObservation
@@ -20,6 +24,7 @@ __all__ = [
     'BrowserOutputObservation',
     'FileReadObservation',
     'FileWriteObservation',
+    'FileEditObservation',
     'ErrorObservation',
     'AgentStateChangedObservation',
     'AgentDelegateObservation',

--- a/openhands/events/observation/files.py
+++ b/openhands/events/observation/files.py
@@ -26,3 +26,30 @@ class FileWriteObservation(Observation):
     @property
     def message(self) -> str:
         return f'I wrote to the file {self.path}.'
+
+
+@dataclass
+class FileEditObservation(Observation):
+    """This data class represents a file edit operation"""
+
+    path: str
+    search_block: str
+    replace_block: str
+    observation: str = ObservationType.EDIT
+
+    @property
+    def message(self) -> str:
+        if self.search_block:
+            return (
+                f'I updated the file {self.path} by \n'
+                f'replacing:\n {self.search_block}\n'
+                f'with:\n {self.replace_block}\n'
+            )
+        else:
+            return (
+                f'I updated the file {self.path} by \n'
+                f'appending:\n {self.replace_block}\n'
+            )
+
+    def __str__(self) -> str:
+        return f'**FileEditObservation**\n' f'DIFF BLOCK: {self.content}\n'

--- a/openhands/events/serialization/action.py
+++ b/openhands/events/serialization/action.py
@@ -12,7 +12,11 @@ from openhands.events.action.commands import (
     IPythonRunCellAction,
 )
 from openhands.events.action.empty import NullAction
-from openhands.events.action.files import FileReadAction, FileWriteAction
+from openhands.events.action.files import (
+    FileEditAction,
+    FileReadAction,
+    FileWriteAction,
+)
 from openhands.events.action.message import MessageAction
 from openhands.events.action.tasks import AddTaskAction, ModifyTaskAction
 
@@ -24,6 +28,7 @@ actions = (
     BrowseInteractiveAction,
     FileReadAction,
     FileWriteAction,
+    FileEditAction,
     AgentFinishAction,
     AgentRejectAction,
     AgentDelegateAction,

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -7,7 +7,11 @@ from openhands.events.observation.commands import (
 from openhands.events.observation.delegate import AgentDelegateObservation
 from openhands.events.observation.empty import NullObservation
 from openhands.events.observation.error import ErrorObservation
-from openhands.events.observation.files import FileReadObservation, FileWriteObservation
+from openhands.events.observation.files import (
+    FileEditObservation,
+    FileReadObservation,
+    FileWriteObservation,
+)
 from openhands.events.observation.observation import Observation
 from openhands.events.observation.reject import UserRejectObservation
 from openhands.events.observation.success import SuccessObservation
@@ -19,6 +23,7 @@ observations = (
     BrowserOutputObservation,
     FileReadObservation,
     FileWriteObservation,
+    FileEditObservation,
     AgentDelegateObservation,
     SuccessObservation,
     ErrorObservation,

--- a/openhands/runtime/client/client.py
+++ b/openhands/runtime/client/client.py
@@ -523,9 +523,16 @@ class RuntimeClient:
             f'(.*)\n{HEAD}(.*)\n{DIVIDER}(.*)\n{TAIL}', action.diff_block, re.DOTALL
         )
         if not diff_blocks or len(diff_blocks.groups()) < 3:
-            return ErrorObservation(
-                'Could not resolve diff block into search/replace blocks.'
-            )
+            found_head = re.search(f'{HEAD}', action.diff_block) is not None
+            found_divider = re.search(f'{DIVIDER}', action.diff_block) is not None
+            found_tail = re.search(f'{TAIL}', action.diff_block) is not None
+
+            error_msg = 'Could not resolve diff block into search/replace blocks.'
+            if found_head and (not found_tail):
+                error_msg = 'The diff block got cut off because it is too long. Try breaking it into smaller SEARCH/REPLACE blocks.'
+            elif found_head and found_tail and (not found_divider):
+                error_msg = 'Could not find the divider between SEARCH/REPLACE blocks.'
+            return ErrorObservation(error_msg)
 
         path = diff_blocks.group(1)
         search_block = diff_blocks.group(2)

--- a/openhands/runtime/client/client.py
+++ b/openhands/runtime/client/client.py
@@ -26,6 +26,7 @@ from openhands.events.action import (
     BrowseInteractiveAction,
     BrowseURLAction,
     CmdRunAction,
+    FileEditAction,
     FileReadAction,
     FileWriteAction,
     IPythonRunCellAction,
@@ -33,6 +34,7 @@ from openhands.events.action import (
 from openhands.events.observation import (
     CmdOutputObservation,
     ErrorObservation,
+    FileEditObservation,
     FileReadObservation,
     FileWriteObservation,
     IPythonRunCellObservation,
@@ -45,6 +47,10 @@ from openhands.runtime.plugins import (
     ALL_PLUGINS,
     JupyterPlugin,
     Plugin,
+)
+from openhands.runtime.plugins.agent_skills.file_ops import (
+    append_file,
+    edit_file_by_replace,
 )
 from openhands.runtime.utils import split_bash_commands
 from openhands.runtime.utils.files import insert_lines, read_lines
@@ -59,6 +65,10 @@ INIT_COMMANDS = [
     'git config --global user.name "openhands" && git config --global user.email "openhands@all-hands.dev" && alias git="git --no-pager"',
 ]
 SOFT_TIMEOUT_SECONDS = 5
+
+HEAD = '<<<<<<< SEARCH'
+DIVIDER = '======='
+TAIL = '>>>>>>> REPLACE'
 
 
 class RuntimeClient:
@@ -506,6 +516,39 @@ class RuntimeClient:
         except PermissionError:
             return ErrorObservation(f'Malformed paths not permitted: {filepath}')
         return FileWriteObservation(content='', path=filepath)
+
+    async def edit(self, action: FileEditAction) -> Observation:
+        diff_blocks = re.search(
+            f'(.*){HEAD}(.*){DIVIDER}(.*){TAIL}', action.diff_block, re.DOTALL
+        )
+        if not diff_blocks or len(diff_blocks.groups()) < 3:
+            return ErrorObservation(
+                'Could not resolve diff block into search/replace blocks.'
+            )
+
+        path = diff_blocks.group(1).strip()
+        search_block = diff_blocks.group(2).strip()
+        replace_block = diff_blocks.group(3).strip()
+
+        working_dir = self._get_working_directory()
+        filepath = self._resolve_path(path, working_dir)
+        if not search_block:
+            append_file(
+                file_name=filepath,
+                content=replace_block,
+            )
+        else:
+            edit_file_by_replace(
+                file_name=filepath,
+                to_replace=search_block,
+                new_content=replace_block,
+            )
+        return FileEditObservation(
+            content=action.diff_block,
+            path=filepath,
+            search_block=search_block,
+            replace_block=replace_block,
+        )
 
     async def browse(self, action: BrowseURLAction) -> Observation:
         return await browse(action, self.browser)

--- a/openhands/runtime/client/client.py
+++ b/openhands/runtime/client/client.py
@@ -519,7 +519,7 @@ class RuntimeClient:
 
     async def edit(self, action: FileEditAction) -> Observation:
         diff_blocks = re.search(
-            f'(.*){HEAD}(.*){DIVIDER}(.*){TAIL}', action.diff_block, re.DOTALL
+            f'(.*){HEAD}\n(.*)\n{DIVIDER}\n(.*)\n{TAIL}', action.diff_block, re.DOTALL
         )
         if not diff_blocks or len(diff_blocks.groups()) < 3:
             return ErrorObservation(
@@ -527,8 +527,8 @@ class RuntimeClient:
             )
 
         path = diff_blocks.group(1).strip()
-        search_block = diff_blocks.group(2).strip()
-        replace_block = diff_blocks.group(3).strip()
+        search_block = diff_blocks.group(2)
+        replace_block = diff_blocks.group(3)
 
         working_dir = self._get_working_directory()
         filepath = self._resolve_path(path, working_dir)

--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -16,6 +16,7 @@ from openhands.events.action import (
     BrowseInteractiveAction,
     BrowseURLAction,
     CmdRunAction,
+    FileEditAction,
     FileReadAction,
     FileWriteAction,
     IPythonRunCellAction,
@@ -437,6 +438,9 @@ class EventStreamRuntime(Runtime):
         return self.run_action(action)
 
     def write(self, action: FileWriteAction) -> Observation:
+        return self.run_action(action)
+
+    def edit(self, action: FileEditAction) -> Observation:
         return self.run_action(action)
 
     def browse(self, action: BrowseURLAction) -> Observation:

--- a/openhands/runtime/plugins/agent_skills/agentskills.py
+++ b/openhands/runtime/plugins/agent_skills/agentskills.py
@@ -10,9 +10,17 @@ import_functions(
     module=file_reader, function_names=file_reader.__all__, target_globals=globals()
 )
 __all__ = file_ops.__all__ + file_reader.__all__
+__except__ = [
+    'edit_file_by_replace',
+    'insert_content_at_line',
+    'append_file',
+]  ## DISABLED TEMPORARILY.
 
 DOCUMENTATION = ''
 for func_name in __all__:
+    if func_name in __except__:
+        continue
+
     func = globals()[func_name]
 
     cur_doc = func.__doc__

--- a/openhands/runtime/plugins/agent_skills/agentskills.py
+++ b/openhands/runtime/plugins/agent_skills/agentskills.py
@@ -11,6 +11,7 @@ import_functions(
 )
 __all__ = file_ops.__all__ + file_reader.__all__
 __except__ = [
+    'create_file',
     'edit_file_by_replace',
     'insert_content_at_line',
     'append_file',

--- a/openhands/runtime/plugins/agent_skills/file_ops/__init__.py
+++ b/openhands/runtime/plugins/agent_skills/file_ops/__init__.py
@@ -6,6 +6,7 @@ import_functions(
 )
 __all__ = file_ops.__all__
 
+create_file = file_ops.create_file
 append_file = file_ops.append_file
 edit_file_by_replace = file_ops.edit_file_by_replace
 insert_content_at_line = file_ops.insert_content_at_line

--- a/openhands/runtime/plugins/agent_skills/file_ops/__init__.py
+++ b/openhands/runtime/plugins/agent_skills/file_ops/__init__.py
@@ -5,3 +5,7 @@ import_functions(
     module=file_ops, function_names=file_ops.__all__, target_globals=globals()
 )
 __all__ = file_ops.__all__
+
+append_file = file_ops.append_file
+edit_file_by_replace = file_ops.edit_file_by_replace
+insert_content_at_line = file_ops.insert_content_at_line

--- a/openhands/runtime/runtime.py
+++ b/openhands/runtime/runtime.py
@@ -13,6 +13,7 @@ from openhands.events.action import (
     BrowseInteractiveAction,
     BrowseURLAction,
     CmdRunAction,
+    FileEditAction,
     FileReadAction,
     FileWriteAction,
     IPythonRunCellAction,
@@ -174,6 +175,10 @@ class Runtime:
 
     @abstractmethod
     def write(self, action: FileWriteAction) -> Observation:
+        pass
+
+    @abstractmethod
+    def edit(self, action: FileEditAction) -> Observation:
         pass
 
     @abstractmethod


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

This is a WIP experimentation/code refactor of #3777 using most utilities I've implemented in #3985.
This PR is created so i don't need to push directly to #3777 to disrupt Raj's workflow & create merge conflict monsters 🤣.


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Original from @RajWorking's PR:

> **Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG** We want to switch from our current agenskills style (similar to https://aider.chat/docs/benchmarks.html#diff-func) to Aider's diff block (https://aider.chat/docs/benchmarks.html#diff) and how that would improve the editing performance.
> 
> **Give a summary of what the PR does, explaining any non-trivial design decisions**
> 
> This PR adds a new EditAction, with logic to parse these output in diff format in the CodeActParser (translating the diff into EditAction). The EditAction is then executed inside the runtime (for now, we simply parse the diff format into search and replace blocks and manually call the existing agentskills to perform the edit)
> 
> We use the <execute_edit> tags to enclose the diff format. For example,
> 
> ```
> <execute_edit>
> demo.py
> <<<<<<< SEARCH
>     print("hello")
> =======
>     print("goodbye")
> >>>>>>> REPLACE
> </execute_edit>
> ```
> 
> **Link of any specific issues this addresses** #3650


---
**Link of any specific issues this addresses**
