### PR TITLE
Update state.last_error when agent failed due to LLM API failure

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -220,7 +220,8 @@ class CodeActAgent(Agent):
             logger.error(f'{e}')
             error_message = '{}: {}'.format(type(e).__name__, str(e).split('\n')[0])
             return AgentFinishAction(
-                thought=f'Agent encountered an error while processing the last action.\nError: {error_message}\nPlease try again.'
+                thought=f'Agent encountered an error while processing the last action.\nError: {error_message}\nPlease try again.',
+                error=error_message,
             )
 
         return self.action_parser.parse(response)

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -200,6 +200,8 @@ class AgentController:
         elif isinstance(action, AgentFinishAction):
             self.state.outputs = action.outputs
             self.state.metrics.merge(self.state.local_metrics)
+            if action.error:
+                self.state.last_error = action.error
             await self.set_agent_state_to(AgentState.FINISHED)
         elif isinstance(action, AgentRejectAction):
             self.state.outputs = action.outputs

--- a/openhands/events/action/agent.py
+++ b/openhands/events/action/agent.py
@@ -45,6 +45,7 @@ class AgentFinishAction(Action):
 
     outputs: dict[str, Any] = field(default_factory=dict)
     thought: str = ''
+    error: str = ''
     action: str = ActionType.FINISH
 
     @property


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

This is mainly for evaluation. Previously, an evaluation instance may silently fail because it can return `AgentFinishAction` but didn't actually set the `state.last_error`, so it is not easy to figure out whether an instance fails due to agent quality, or it is just due to LLM API issue.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR adds an additional field `error` to `AgentFinishAction` to track these error messages, and update it to `state.last_error` when detected a not empty `.error`.


---
**Link of any specific issues this addresses**
