### PR TITLE
Remove param from docstring that does not exist in the append_file 

### DIFF
--- a/openhands/runtime/plugins/agent_skills/file_ops/file_ops.py
+++ b/openhands/runtime/plugins/agent_skills/file_ops/file_ops.py
@@ -786,7 +786,6 @@ def append_file(file_name: str, content: str) -> None:
 
     Args:
         file_name: str: The name of the file to edit.
-        line_number: int: The line number (starting from 1) to insert the content after.
         content: str: The content to insert.
     """
     ret_str = _edit_file_impl(

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_001.log
@@ -117,7 +117,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
@@ -117,7 +117,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_001.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_002.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_003.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_004.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_edits/prompt_005.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_001.log
@@ -117,7 +117,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_002.log
@@ -117,7 +117,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython/prompt_003.log
@@ -117,7 +117,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_001.log
@@ -116,7 +116,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_002.log
@@ -116,7 +116,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_003.log
@@ -116,7 +116,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_ipython_module/prompt_004.log
@@ -116,7 +116,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_001.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_002.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_003.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_004.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_005.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_006.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_006.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_007.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_007.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_008.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_008.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_009.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_simple_task_rejection/prompt_009.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_001.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_002.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_003.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_write_simple_script/prompt_004.log
@@ -121,7 +121,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_001.log
@@ -105,7 +105,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_browse_internet/prompt_002.log
@@ -105,7 +105,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_001.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_002.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_003.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_004.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_edits/prompt_005.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_001.log
@@ -105,7 +105,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_002.log
@@ -105,7 +105,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython/prompt_003.log
@@ -105,7 +105,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_001.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_002.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_003.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_ipython_module/prompt_004.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_simple_task_rejection/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_simple_task_rejection/prompt_001.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_simple_task_rejection/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_simple_task_rejection/prompt_002.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_simple_task_rejection/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_simple_task_rejection/prompt_003.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_001.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_001.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_002.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_003.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:

--- a/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActSWEAgent/test_write_simple_script/prompt_004.log
@@ -109,7 +109,6 @@ append_file(file_name: str, content: str) -> None:
     It appends text `content` to the end of the specified file, ideal after a `create_file`!
     Args:
     file_name: str: The name of the file to edit.
-    line_number: int: The line number (starting from 1) to insert the content after.
     content: str: The content to insert.
 
 search_dir(search_term: str, dir_path: str = './') -> None:


### PR DESCRIPTION

**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**
There was a wrong param in the docstring of the append_file docstring in the file_ops.py file



---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
There was a wrong param in the docstring of the append_file docstring in the file_ops.py file



---
**Link of any specific issues this addresses**
