### PR TITLE
[runtime] do not keep rebuilding from generic image

### DIFF
--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -356,10 +356,16 @@ def _build_sandbox_image(
     target_image_hash_name = f'{target_image_repo}:{target_image_hash_tag}'
     target_image_generic_name = f'{target_image_repo}:{target_image_tag}'
 
+    tags_to_add = [target_image_hash_name]
+
+    # Only add the generic tag if the image does not exist
+    # so it does not get overwritten & only points to the earliest version
+    # to avoid "too many layers" after many re-builds
+    if not runtime_builder.image_exists(target_image_generic_name):
+        tags_to_add.append(target_image_generic_name)
+
     try:
-        image_name = runtime_builder.build(
-            path=docker_folder, tags=[target_image_hash_name, target_image_generic_name]
-        )
+        image_name = runtime_builder.build(path=docker_folder, tags=tags_to_add)
         if not image_name:
             raise RuntimeError(f'Build failed for image {target_image_hash_name}')
     except Exception as e:


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Previously, whenever a new runtime image is built, we tag them with the newest generic tag. For example:

```
Base image = python:bookworm

# 1st time to build runtime image
FROM python:bookworm
tag=<hash_for_this_build>,oh_v0.9.4_image_python_tag_3.11-bookworm

# 2nd time: we will re-use the image `oh_v0.9.4_image_python_tag_3.11-bookworm` to speed up build
FROM oh_v0.9.4_image_python_tag_3.11-bookworm
tag=<hash_for_this_build>,oh_v0.9.4_image_python_tag_3.11-bookworm

# 3rd time: we will re-use the image `oh_v0.9.4_image_python_tag_3.11-bookworm` to speed up build
FROM oh_v0.9.4_image_python_tag_3.11-bookworm
tag=<hash_for_this_build>,oh_v0.9.4_image_python_tag_3.11-bookworm

...
```

`oh_v0.9.4_image_python_tag_3.11-bookworm` tag will be keep updated with the latest runtime image. The issue is, as we build more and more images, the layers of the latest runtime will KEEP INCREASING!

I ran into an issue of runtime image building during eval:
```
step 2/5 : RUN if [ -d /openhands/code ]; then rm -rf /openhands/code; fi
 ---> Running in 98341753bf97
max depth exceeded
```
And claude suggests: The error "max depth exceeded" typically occurs when there are too many nested layers in a Docker image. This can happen if you have many RUN commands or if you're **using a base image that already has many layers.**

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR aims to fix this issue by only tagging a runtime image with the generic tag (e.g., `oh_v0.9.4_image_python_tag_3.11-bookworm`) when it does not exist. This way, we always use the first generic image to speed up re-build, which should resolve this too many layer issue. 

It will look like this
```
Base image = python:bookworm

# 1st time to build runtime image
FROM python:bookworm
tag=<hash_for_this_build>,oh_v0.9.4_image_python_tag_3.11-bookworm

# 2nd time: we will re-use the image `oh_v0.9.4_image_python_tag_3.11-bookworm` to speed up build
FROM oh_v0.9.4_image_python_tag_3.11-bookworm
tag=<hash_for_this_build> # <- NO GENERIC TAG NOW

# 3rd time: we will re-use the image `oh_v0.9.4_image_python_tag_3.11-bookworm` to speed up build
FROM oh_v0.9.4_image_python_tag_3.11-bookworm
tag=<hash_for_this_build> # <- NO GENERIC TAG NOW

...
```

---
**Link of any specific issues this addresses**
