### PR TITLE
(fix) actions.ts: restored handleAssistantMessage handling order

### DIFF
--- a/frontend/src/components/AgentStatusBar.tsx
+++ b/frontend/src/components/AgentStatusBar.tsx
@@ -94,13 +94,13 @@ function AgentStatusBar() {
   const [statusMessage, setStatusMessage] = React.useState<string>("");
 
   React.useEffect(() => {
-    const trimmedCustomMessage = curStatusMessage.message.trim();
+    const trimmedCustomMessage = curStatusMessage.status.trim();
     if (trimmedCustomMessage) {
       setStatusMessage(t(trimmedCustomMessage));
     } else {
       setStatusMessage(AgentStatusMap[curAgentState].message);
     }
-  }, [curAgentState, curStatusMessage.message]);
+  }, [curAgentState, curStatusMessage.status]);
 
   return (
     <div className="flex flex-col items-center">

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -160,9 +160,9 @@ export function handleAssistantMessage(data: string | SocketMessage) {
 
   if ("action" in socketMessage) {
     handleActionMessage(socketMessage);
-  } else if ("observation" in socketMessage) {
-    handleObservationMessage(socketMessage);
   } else if ("message" in socketMessage) {
     handleStatusMessage(socketMessage);
+  } else {
+    handleObservationMessage(socketMessage);
   }
 }

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -140,11 +140,11 @@ export function handleActionMessage(message: ActionMessage) {
 }
 
 export function handleStatusMessage(message: StatusMessage) {
-  const msg = message.message == null ? "" : message.message.trim();
+  const msg = message.status == null ? "" : message.status.trim();
   store.dispatch(
     setCurStatusMessage({
       ...message,
-      message: msg,
+      status: msg,
     }),
   );
 }
@@ -160,7 +160,7 @@ export function handleAssistantMessage(data: string | SocketMessage) {
 
   if ("action" in socketMessage) {
     handleActionMessage(socketMessage);
-  } else if ("message" in socketMessage) {
+  } else if ("status" in socketMessage) {
     handleStatusMessage(socketMessage);
   } else {
     handleObservationMessage(socketMessage);

--- a/frontend/src/state/statusSlice.ts
+++ b/frontend/src/state/statusSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { StatusMessage } from "#/types/Message";
 
 const initialStatusMessage: StatusMessage = {
-  message: "",
+  status: "",
   is_error: false,
 };
 

--- a/frontend/src/types/Message.tsx
+++ b/frontend/src/types/Message.tsx
@@ -38,5 +38,5 @@ export interface StatusMessage {
   is_error: boolean;
 
   // A status message to display to the user
-  message: string;
+  status: string;
 }

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -119,7 +119,7 @@ class AgentController:
 
     async def close(self):
         """Closes the agent controller, canceling any ongoing tasks and unsubscribing from the event stream."""
-        if self.agent_task is not None:
+        if self.agent_task is not None and hasattr(self.agent_task, 'cancel'):
             self.agent_task.cancel()
         await self.set_agent_state_to(AgentState.STOPPED)
         self.event_stream.unsubscribe(EventStreamSubscriber.AGENT_CONTROLLER)

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -1,5 +1,4 @@
 import asyncio
-
 from threading import Thread
 from typing import Callable, Optional
 
@@ -75,10 +74,20 @@ class AgentSession:
         self.thread = Thread(target=self._run, daemon=True)
         self.thread.start()
 
-        coro = self._start(runtime_name, config, agent, max_iterations, max_budget_per_task, agent_to_llm_config, agent_configs, status_message_callback)
-        asyncio.run_coroutine_threadsafe(coro, self.loop) # type: ignore
+        coro = self._start(
+            runtime_name,
+            config,
+            agent,
+            max_iterations,
+            max_budget_per_task,
+            agent_to_llm_config,
+            agent_configs,
+            status_message_callback,
+        )
+        asyncio.run_coroutine_threadsafe(coro, self.loop)  # type: ignore
 
-    async def _start(self,
+    async def _start(
+        self,
         runtime_name: str,
         config: AppConfig,
         agent: Agent,
@@ -102,8 +111,8 @@ class AgentSession:
             ChangeAgentStateAction(AgentState.INIT), EventSource.USER
         )
         if self.controller:
-            self.controller.agent_task = self.controller.start_step_loop()   
-            await self.controller.agent_task # type: ignore
+            self.controller.agent_task = self.controller.start_step_loop()
+            await self.controller.agent_task  # type: ignore
 
     def _run(self):
         asyncio.set_event_loop(self.loop)

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -187,6 +187,10 @@ class Session:
         """Sends a message to the client."""
         return await self.send({'message': message})
 
+    async def send_status_message(self, message: str) -> bool:
+        """Sends a status message to the client."""
+        return await self.send({'status': message})
+
     def update_connection(self, ws: WebSocket):
         self.websocket = ws
         self.is_alive = True
@@ -202,4 +206,4 @@ class Session:
     def queue_status_message(self, message: str):
         """Queues a status message to be sent asynchronously."""
         # Ensure the coroutine runs in the main event loop
-        asyncio.run_coroutine_threadsafe(self.send_message(message), self.loop)
+        asyncio.run_coroutine_threadsafe(self.send_status_message(message), self.loop)


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

In actions.ts: restored handleAssistantMessage the order of handling messages

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Fixes #4073 

- changed in StatusMessage in frontend the attribute "message" to "status" so that it is distinct from the other 2 types
- In `actions.ts` (frontend file) the order of statements in `handleAssistantMessage` was "restored" so
that `handleObservationMessage` comes last.
- That method is, in spite of its name - potentially acting as a "catch all", even if there's no
"observation" in it, due to its default case.  🤔 

This order was last changed in #3771 

---
**Link of any specific issues this addresses**
