### PR TITLE
Fix for regression

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -119,8 +119,6 @@ class AgentController:
 
     async def close(self):
         """Closes the agent controller, canceling any ongoing tasks and unsubscribing from the event stream."""
-        if self.agent_task is not None:
-            self.agent_task.cancel()
         await self.set_agent_state_to(AgentState.STOPPED)
         self.event_stream.unsubscribe(EventStreamSubscriber.AGENT_CONTROLLER)
 

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -32,6 +32,7 @@ class AgentSession:
     runtime: Runtime | None = None
     security_analyzer: SecurityAnalyzer | None = None
     _closed: bool = False
+    loop: asyncio.AbstractEventLoop
 
     def __init__(self, sid: str, file_store: FileStore):
         """Initializes a new instance of the Session class
@@ -44,6 +45,7 @@ class AgentSession:
         self.sid = sid
         self.event_stream = EventStream(sid, file_store)
         self.file_store = file_store
+        self.loop = asyncio.new_event_loop()
 
     async def start(
         self,
@@ -71,7 +73,6 @@ class AgentSession:
                 'Session already started. You need to close this session and start a new one.'
             )
 
-        self.loop = asyncio.new_event_loop()
         self.thread = Thread(target=self._run, daemon=True)
         self.thread.start()
 


### PR DESCRIPTION
**Fix for regression when cancelling tasks.**



---
Tasks are not cancelled using `task.cancel` - closing the runtime cancels them.
