### PR TITLE
chore: parser fix for deepseek

### DIFF
--- a/agenthub/codeact_agent/action_parser.py
+++ b/agenthub/codeact_agent/action_parser.py
@@ -40,6 +40,10 @@ class CodeActResponseParser(ResponseParser):
         if action is None:
             return ''
         for lang in ['bash', 'ipython', 'browse']:
+            # special handling for DeepSeek: it has stop-word bug and returns </execute_ipython instead of </execute_ipython>
+            if f'</execute_{lang}' in action and f'</execute_{lang}>' not in action:
+                action = action.replace(f'</execute_{lang}', f'</execute_{lang}>')
+
             if f'<execute_{lang}>' in action and f'</execute_{lang}>' not in action:
                 action += f'</execute_{lang}>'
         return action


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Deepseek-coder/chat would consistently produce `</execute_XXX` instead of `</execute_XXX>`, which makes OpenHands completely unusable.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Add an if to handle this type of missing tag specifically.

---
**Link of any specific issues this addresses**
