### PR TITLE
(enh) add test_python_version to test_bash.py runtime tests

### DIFF
--- a/tests/runtime/test_bash.py
+++ b/tests/runtime/test_bash.py
@@ -456,3 +456,17 @@ def test_git_operation(box_class):
         assert obs.exit_code == 0
     finally:
         _close_test_runtime(runtime)
+
+
+def test_python_version(temp_dir, box_class, run_as_openhands):
+    runtime = _load_runtime(temp_dir, box_class, run_as_openhands)
+    try:
+        obs = runtime.run_action(CmdRunAction(command='python --version'))
+
+        assert isinstance(
+            obs, CmdOutputObservation
+        ), 'The observation should be a CmdOutputObservation.'
+        assert obs.exit_code == 0, 'The exit code should be 0.'
+        assert 'Python 3' in obs.content, 'The output should contain "Python 3".'
+    finally:
+        _close_test_runtime(runtime)


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Add `test_python_version` for runtime image `bash` tests to confirm python

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Related to #4095 - this adds a simple bash test after the issue is resolved, see result below.

---
**Link of any specific issues this addresses**


![grafik](https://github.com/user-attachments/assets/59030904-e119-40d0-8ba9-466cb2ebe0bf)
