### PR TITLE
fix hash equivalance verification ci for fork

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -71,11 +71,11 @@ jobs:
       - name: Build and push app image
         if: "!github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh openhands ${{ github.repository_owner }} --push
+          ./containers/build.sh -i openhands -o ${{ github.repository_owner }} --push
       - name: Build app image
         if: "github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh openhands image ${{ github.repository_owner }}
+          ./containers/build.sh -i openhands -o ${{ github.repository_owner }} --load
       - name: Get hash in App Image
         id: get_hash_in_app_image
         run: |
@@ -154,7 +154,7 @@ jobs:
       - name: Build and push runtime image ${{ matrix.base_image.image }}
         if: github.event.pull_request.head.repo.fork != true
         run: |
-          ./containers/build.sh runtime ${{ github.repository_owner }} --push ${{ matrix.base_image.tag }}
+          ./containers/build.sh -i runtime -o ${{ github.repository_owner }} --push -t ${{ matrix.base_image.tag }}
       # Forked repos can't push to GHCR, so we need to upload the image as an artifact
       - name: Build runtime image ${{ matrix.base_image.image }} for fork
         if: github.event.pull_request.head.repo.fork

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build app image
         if: "github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh openhands image ${{ github.repository_owner }}
+          ./containers/build.sh openhands ${{ github.repository_owner }}
       - name: Get hash in App Image
         id: get_hash_in_app_image
         run: |

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -71,11 +71,11 @@ jobs:
       - name: Build and push app image
         if: "!github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh openhands ${{ github.repository_owner }} --push
+          ./containers/build.sh -i openhands -o ${{ github.repository_owner }} --push
       - name: Build app image
         if: "github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh openhands ${{ github.repository_owner }}
+          ./containers/build.sh -i openhands -o ${{ github.repository_owner }} --load
       - name: Get hash in App Image
         id: get_hash_in_app_image
         run: |
@@ -154,7 +154,7 @@ jobs:
       - name: Build and push runtime image ${{ matrix.base_image.image }}
         if: github.event.pull_request.head.repo.fork != true
         run: |
-          ./containers/build.sh runtime ${{ github.repository_owner }} --push ${{ matrix.base_image.tag }}
+          ./containers/build.sh -i runtime -o ${{ github.repository_owner }} --push -t ${{ matrix.base_image.tag }}
       # Forked repos can't push to GHCR, so we need to upload the image as an artifact
       - name: Build runtime image ${{ matrix.base_image.image }} for fork
         if: github.event.pull_request.head.repo.fork

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -71,11 +71,11 @@ jobs:
       - name: Build and push app image
         if: "!github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh -i openhands -o ${{ github.repository_owner }} --push
+          ./containers/build.sh openhands ${{ github.repository_owner }} --push
       - name: Build app image
         if: "github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh -i openhands -o ${{ github.repository_owner }} --load
+          ./containers/build.sh openhands image ${{ github.repository_owner }}
       - name: Get hash in App Image
         id: get_hash_in_app_image
         run: |
@@ -154,7 +154,7 @@ jobs:
       - name: Build and push runtime image ${{ matrix.base_image.image }}
         if: github.event.pull_request.head.repo.fork != true
         run: |
-          ./containers/build.sh -i runtime -o ${{ github.repository_owner }} --push -t ${{ matrix.base_image.tag }}
+          ./containers/build.sh runtime ${{ github.repository_owner }} --push ${{ matrix.base_image.tag }}
       # Forked repos can't push to GHCR, so we need to upload the image as an artifact
       - name: Build runtime image ${{ matrix.base_image.image }} for fork
         if: github.event.pull_request.head.repo.fork

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -1,13 +1,40 @@
 #!/bin/bash
 set -eo pipefail
 
-image_name=$1
-org_name=$2
+# Initialize variables with default values
+image_name=""
+org_name=""
 push=0
-if [[ $3 == "--push" ]]; then
-  push=1
+load=0
+tag_suffix=""
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>]"
+    echo "  -i: Image name (required)"
+    echo "  -o: Organization name"
+    echo "  --push: Push the image"
+    echo "  --load: Load the image"
+    echo "  -t: Tag suffix"
+    exit 1
+}
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -i) image_name="$2"; shift 2 ;;
+        -o) org_name="$2"; shift 2 ;;
+        --push) push=1; shift ;;
+        --load) load=1; shift ;;
+        -t) tag_suffix="$2"; shift 2 ;;
+        *) usage ;;
+    esac
+done
+# Check if required arguments are provided
+if [[ -z "$image_name" ]]; then
+    echo "Error: Image name is required."
+    usage
 fi
-tag_suffix=$4
 
 echo "Building: $image_name"
 tags=()
@@ -93,6 +120,10 @@ done
 if [[ $push -eq 1 ]]; then
   args+=" --push"
   args+=" --cache-to=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag,mode=max"
+fi
+
+if [[ $load -eq 1 ]]; then
+  args+=" --load"
 fi
 
 echo "Args: $args"

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -1,40 +1,13 @@
 #!/bin/bash
 set -eo pipefail
 
-# Initialize variables with default values
-image_name=""
-org_name=""
+image_name=$1
+org_name=$2
 push=0
-load=0
-tag_suffix=""
-
-# Function to display usage information
-usage() {
-    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>]"
-    echo "  -i: Image name (required)"
-    echo "  -o: Organization name"
-    echo "  --push: Push the image"
-    echo "  --load: Load the image"
-    echo "  -t: Tag suffix"
-    exit 1
-}
-
-# Parse command-line options
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -i) image_name="$2"; shift 2 ;;
-        -o) org_name="$2"; shift 2 ;;
-        --push) push=1; shift ;;
-        --load) load=1; shift ;;
-        -t) tag_suffix="$2"; shift 2 ;;
-        *) usage ;;
-    esac
-done
-# Check if required arguments are provided
-if [[ -z "$image_name" ]]; then
-    echo "Error: Image name is required."
-    usage
+if [[ $3 == "--push" ]]; then
+  push=1
 fi
+tag_suffix=$4
 
 echo "Building: $image_name"
 tags=()
@@ -120,10 +93,6 @@ done
 if [[ $push -eq 1 ]]; then
   args+=" --push"
   args+=" --cache-to=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag,mode=max"
-fi
-
-if [[ $load -eq 1 ]]; then
-  args+=" --load"
 fi
 
 echo "Args: $args"


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Issue: https://openhands-ai.slack.com/archives/C078L0FUGUX/p1727493895903219

Basically, when PR is from a fork, the build app image workflow will failed to get the image hash, causing the CI to fail.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- This PR refactored `build.sh` to support `--load` built image locally
- Fix the get app hash for fork

---
**Link of any specific issues this addresses**
