### PR TITLE
(fix) Fix logging in shared eval file to prevent key disclosure

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -40,9 +40,9 @@ class EvalMetadata(BaseModel):
     def model_dump_json(self, *args, **kwargs):
         dumped = super().model_dump_json(*args, **kwargs)
         dumped_dict = json.loads(dumped)
-        logger.debug(f'Dumped metadata: {dumped_dict}')
         # avoid leaking sensitive information
         dumped_dict['llm_config'] = self.llm_config.to_safe_dict()
+        logger.debug(f'Dumped metadata: {dumped_dict}')
         return json.dumps(dumped_dict)
 
 


### PR DESCRIPTION
**Short description of the problem this fixes or functionality that this introduces. This may be used for the CHANGELOG**

Fix logging in shared eval file to prevent key disclosure

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Fixed in `shared.py` the logging of the metadata to happen _after_ the call to `to_safe_dict` or the API key might be disclosed
