### PR TITLE
Fix issue #4113: Document github action

### DIFF
--- a/docs/modules/usage/getting-started.mdx
+++ b/docs/modules/usage/getting-started.mdx
@@ -32,8 +32,7 @@ docker run -it --pull=always \
     ghcr.io/all-hands-ai/openhands:0.9
 ```
 
-You can also run OpenHands in a scriptable [headless mode](https://docs.all-hands.dev/modules/usage/how-to/headless-mode),
-or as an [interactive CLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode).
+You can also run OpenHands in a scriptable [headless mode](https://docs.all-hands.dev/modules/usage/how-to/headless-mode), as an [interactive CLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode), or using the [OpenHands GitHub Action](https://docs.all-hands.dev/modules/usage/how-to/github-action).
 
 ## Setup
 

--- a/docs/modules/usage/how-to/github-action.md
+++ b/docs/modules/usage/how-to/github-action.md
@@ -4,7 +4,7 @@ This guide explains how to use the OpenHands GitHub Action, both within the Open
 
 ## Using the Action in the OpenHands Repository
 
-To use the OpenHands GitHub Action in the OpenHands repository:
+To use the OpenHands GitHub Action in the OpenHands repository, an OpenHands maintainer can:
 
 1. Create an issue in the repository.
 2. Add the `fix-me` label to the issue.

--- a/docs/modules/usage/how-to/github-action.md
+++ b/docs/modules/usage/how-to/github-action.md
@@ -12,43 +12,4 @@ To use the OpenHands GitHub Action in the OpenHands repository:
 
 ## Installing the Action in a New Repository
 
-To install the OpenHands GitHub Action in your own repository:
-
-1. Create a `.github/workflows` directory in your repository if it doesn't already exist.
-2. Create a new file named `openhands-resolver.yml` in the `.github/workflows` directory.
-3. Copy the following content into the `openhands-resolver.yml` file:
-
-```yaml
-name: OpenHands Resolver
-
-on:
-  issues:
-    types: [labeled]
-
-jobs:
-  resolve_issue:
-    if: github.event.label.name == 'fix-me'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install git+https://github.com/All-Hands-AI/OpenHands.git
-      - name: Run OpenHands
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          openhands resolve-issue --repo ${{ github.repository }} --issue ${{ github.event.issue.number }}
-
-```
-
-4. Commit and push the new file to your repository.
-
-Now, whenever an issue in your repository is labeled with `fix-me`, the OpenHands GitHub Action will automatically trigger and attempt to resolve the issue.
-
-Note: Make sure you have the necessary permissions and secrets set up in your repository for the action to work correctly.
+To install the OpenHands GitHub Action in your own repository, follow the [directions in the OpenHands Resolver repo](https://github.com/All-Hands-AI/OpenHands-resolver?tab=readme-ov-file#using-the-github-actions-workflow).

--- a/docs/modules/usage/how-to/github-action.md
+++ b/docs/modules/usage/how-to/github-action.md
@@ -1,0 +1,54 @@
+# Using the OpenHands GitHub Action
+
+This guide explains how to use the OpenHands GitHub Action, both within the OpenHands repository and in your own projects.
+
+## Using the Action in the OpenHands Repository
+
+To use the OpenHands GitHub Action in the OpenHands repository:
+
+1. Create an issue in the repository.
+2. Add the `fix-me` label to the issue.
+3. The action will automatically trigger and attempt to resolve the issue.
+
+## Installing the Action in a New Repository
+
+To install the OpenHands GitHub Action in your own repository:
+
+1. Create a `.github/workflows` directory in your repository if it doesn't already exist.
+2. Create a new file named `openhands-resolver.yml` in the `.github/workflows` directory.
+3. Copy the following content into the `openhands-resolver.yml` file:
+
+```yaml
+name: OpenHands Resolver
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  resolve_issue:
+    if: github.event.label.name == 'fix-me'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/All-Hands-AI/OpenHands.git
+      - name: Run OpenHands
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          openhands resolve-issue --repo ${{ github.repository }} --issue ${{ github.event.issue.number }}
+
+```
+
+4. Commit and push the new file to your repository.
+
+Now, whenever an issue in your repository is labeled with `fix-me`, the OpenHands GitHub Action will automatically trigger and attempt to resolve the issue.
+
+Note: Make sure you have the necessary permissions and secrets set up in your repository for the action to work correctly.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -74,6 +74,10 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'doc',
+          id: 'usage/how-to/github-action',
+        },
+        {
+          type: 'doc',
           id: 'usage/how-to/custom-sandbox-guide',
         },
         {


### PR DESCRIPTION
This pull request fixes #4113.

A new documentation page for the OpenHands GitHub Action has been created. This documentation includes instructions on how to use the action within the OpenHands repository by adding the 'fix-me' tag to an issue, as well as how to install the action in a new repository. The content appears to cover the requested information, addressing both key points mentioned in the original issue description. This new documentation should provide users with the necessary guidance to effectively use and implement the GitHub Action, thus resolving the initial lack of documentation.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌