### PR TITLE
allow specifying exact remote image

### DIFF
--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -84,37 +84,35 @@ class RemoteRuntime(Runtime):
             sid + str(uuid.uuid4()) if sid is not None else str(uuid.uuid4())
         )
         if self.config.sandbox.runtime_container_image is not None:
-            raise ValueError(
-                'Setting runtime_container_image is not supported in the remote runtime.'
+            self.container_image = self.config.sandbox.runtime_container_image
+        else:
+            self.container_name = 'oh-remote-runtime-' + self.instance_id
+            logger.debug(f'RemoteRuntime `{sid}` config:\n{self.config}')
+            response = send_request(
+                self.session,
+                'GET',
+                f'{self.config.sandbox.remote_runtime_api_url}/registry_prefix',
             )
-        self.container_image: str = self.config.sandbox.base_container_image
-        self.container_name = 'oh-remote-runtime-' + self.instance_id
-        logger.debug(f'RemoteRuntime `{sid}` config:\n{self.config}')
-        response = send_request(
-            self.session,
-            'GET',
-            f'{self.config.sandbox.remote_runtime_api_url}/registry_prefix',
-        )
-        response_json = response.json()
-        registry_prefix = response_json['registry_prefix']
-        os.environ['OH_RUNTIME_RUNTIME_IMAGE_REPO'] = (
-            registry_prefix.rstrip('/') + '/runtime'
-        )
-        logger.info(
-            f'Runtime image repo: {os.environ["OH_RUNTIME_RUNTIME_IMAGE_REPO"]}'
-        )
-
-        if self.config.sandbox.runtime_extra_deps:
+            response_json = response.json()
+            registry_prefix = response_json['registry_prefix']
+            os.environ['OH_RUNTIME_RUNTIME_IMAGE_REPO'] = (
+                registry_prefix.rstrip('/') + '/runtime'
+            )
             logger.info(
-                f'Installing extra user-provided dependencies in the runtime image: {self.config.sandbox.runtime_extra_deps}'
+                f'Runtime image repo: {os.environ["OH_RUNTIME_RUNTIME_IMAGE_REPO"]}'
             )
 
-        # Build the container image
-        self.container_image = build_runtime_image(
-            self.container_image,
-            self.runtime_builder,
-            extra_deps=self.config.sandbox.runtime_extra_deps,
-        )
+            if self.config.sandbox.runtime_extra_deps:
+                logger.info(
+                    f'Installing extra user-provided dependencies in the runtime image: {self.config.sandbox.runtime_extra_deps}'
+                )
+
+            # Build the container image
+            self.container_image = build_runtime_image(
+                self.container_image,
+                self.runtime_builder,
+                extra_deps=self.config.sandbox.runtime_extra_deps,
+            )
 
         # Use the /image_exists endpoint to check if the image exists
         response = send_request(

--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -83,6 +83,7 @@ class RemoteRuntime(Runtime):
         self.instance_id = (
             sid + str(uuid.uuid4()) if sid is not None else str(uuid.uuid4())
         )
+        self.container_name = 'oh-remote-runtime-' + self.instance_id
         if self.config.sandbox.runtime_container_image is not None:
             logger.info(
                 f'Running remote runtime with image: {self.config.sandbox.runtime_container_image}'
@@ -92,7 +93,6 @@ class RemoteRuntime(Runtime):
             logger.info(
                 f'Building remote runtime with base image: {self.config.sandbox.base_container_image}'
             )
-            self.container_name = 'oh-remote-runtime-' + self.instance_id
             logger.debug(f'RemoteRuntime `{sid}` config:\n{self.config}')
             response = send_request(
                 self.session,
@@ -197,7 +197,7 @@ class RemoteRuntime(Runtime):
         reraise=True,
     )
     def _wait_until_alive(self):
-        logger.info('Waiting for sandbox to be alive...')
+        logger.info(f'Waiting for runtime to be alive at url: {self.runtime_url}')
         response = send_request(
             self.session,
             'GET',

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 from threading import Thread
 from typing import Callable, Optional
 
@@ -75,6 +76,13 @@ class AgentSession:
         self.thread = Thread(target=self._run, daemon=True)
         self.thread.start()
 
+        def coro_callback(task):
+            fut: concurrent.futures.Future = concurrent.futures.Future()
+            try:
+                fut.set_result(task.result())
+            except Exception as e:
+                logger.error(f'Error starting session: {e}')
+
         coro = self._start(
             runtime_name,
             config,
@@ -85,7 +93,9 @@ class AgentSession:
             agent_configs,
             status_message_callback,
         )
-        asyncio.run_coroutine_threadsafe(coro, self.loop)  # type: ignore
+        asyncio.run_coroutine_threadsafe(coro, self.loop).add_done_callback(
+            coro_callback
+        )  # type: ignore
 
     async def _start(
         self,
@@ -172,13 +182,17 @@ class AgentSession:
         logger.info(f'Initializing runtime `{runtime_name}` now...')
         runtime_cls = get_runtime_cls(runtime_name)
 
-        self.runtime = runtime_cls(
-            config=config,
-            event_stream=self.event_stream,
-            sid=self.sid,
-            plugins=agent.sandbox_plugins,
-            status_message_callback=status_message_callback,
-        )
+        try:
+            self.runtime = runtime_cls(
+                config=config,
+                event_stream=self.event_stream,
+                sid=self.sid,
+                plugins=agent.sandbox_plugins,
+                status_message_callback=status_message_callback,
+            )
+        except Exception as e:
+            logger.error(f'Runtime initialization failed: {e}')
+            raise
 
         if self.runtime is not None:
             logger.debug(


### PR DESCRIPTION
- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces**



---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This provides the option, when running with the remote runtime, to specify a pre-built image rather than just a base image


---
**Link of any specific issues this addresses**
