### PR TITLE
fix: make llm_completions optional to fix `eval_infer.py`

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -61,7 +61,7 @@ class EvalOutput(BaseModel):
     history: (
         list[dict[str, Any]] | list[tuple[dict[str, Any], dict[str, Any]]] | None
     ) = None
-    llm_completions: list[dict[str, Any]]
+    llm_completions: list[dict[str, Any]] | None = None
     metrics: dict[str, Any] | None = None
     error: str | None = None
 


### PR DESCRIPTION
- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces**

EvalOutput current have required llm_completions, which will not be added in SWE-Bench's `eval_infer.py`.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

make llm_completions optional to fix `eval_infer.py`

---
**Link of any specific issues this addresses**
