### PR TITLE
fix(runtime build): only check for image exist on exact hash tag

### DIFF
--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -60,7 +60,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         target_image_tag = tags[1].split(':')[1] if len(tags) > 1 else None
 
         # Check if the image exists and pull if necessary
-        self.image_exists(target_image_repo)
+        self.image_exists(target_image_hash_name, tag=target_image_hash_tag)
 
         buildx_cmd = [
             'docker',
@@ -166,11 +166,15 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         )
         return target_image_hash_name
 
-    def image_exists(self, image_name: str, pull_from_repo: bool = True) -> bool:
+    def image_exists(
+        self, image_name: str, tag: str | None = None, pull_from_repo: bool = True
+    ) -> bool:
         """Check if the image exists in the registry (try to pull it first) or in the local store.
 
         Args:
             image_name (str): The Docker image to check (<image repo>:<image tag>)
+            tag (str): The tag to pull. If ``tag`` is ``None`` or empty, it
+                is set to ``latest``.
             pull_from_repo (bool): Whether to pull from the remote repo if the image not present locally
         Returns:
             bool: Whether the Docker image exists in the registry or in the local store
@@ -186,9 +190,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
             return True
         except docker.errors.ImageNotFound:
             if not pull_from_repo:
-                logger.debug(
-                    f'Image {image_name} not found locally'
-                )
+                logger.debug(f'Image {image_name} not found locally')
                 return False
             try:
                 logger.debug(
@@ -198,7 +200,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
                 layers: dict[str, dict[str, str]] = {}
                 previous_layer_count = 0
                 for line in self.docker_client.api.pull(
-                    image_name, stream=True, decode=True
+                    image_name, tag=tag, stream=True, decode=True
                 ):
                     self._output_build_progress(line, layers, previous_layer_count)
                     previous_layer_count = len(layers)

--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -195,11 +195,13 @@ class DockerRuntimeBuilder(RuntimeBuilder):
 
                 layers: dict[str, dict[str, str]] = {}
                 previous_layer_count = 0
-                _splited_image_name = image_name.split(':')
-                image_repo = _splited_image_name[0]
-                image_tag = (
-                    _splited_image_name[1] if len(_splited_image_name) > 1 else None
-                )
+
+                if ':' in image_name:
+                    image_repo, image_tag = image_name.split(':', 1)
+                else:
+                    image_repo = image_name
+                    image_tag = None
+
                 for line in self.docker_client.api.pull(
                     image_repo, tag=image_tag, stream=True, decode=True
                 ):


### PR DESCRIPTION
- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces**



---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Right now, we check for image existence **without explicitly checking the tag** before build - this adds additional time for docker pull without actually helping speed up building because the pulled docker image may have a different hash.

This PR specifically check for tag in the `image_exists` check.

---
**Link of any specific issues this addresses**
