### PR TITLE
Retry on litellm's APIError, which includes 502

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -14,6 +14,7 @@ from litellm import completion as litellm_completion
 from litellm import completion_cost as litellm_completion_cost
 from litellm.exceptions import (
     APIConnectionError,
+    APIError,
     InternalServerError,
     RateLimitError,
     ServiceUnavailableError,
@@ -31,6 +32,7 @@ __all__ = ['LLM']
 # tuple of exceptions to retry on
 LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
     APIConnectionError,
+    APIError,
     InternalServerError,
     RateLimitError,
     ServiceUnavailableError,


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Retry requests on APIError, which liteLLM throws for 502 (bad gateway). IMHO it makes sense to retry to on it, since it can be temporary, in the case of a proxy for example. We met this in evals with a liteLLM proxy.

Not retrying on it is due to a recent change [here](https://github.com/All-Hands-AI/OpenHands/commit/e582806004cf4bad0934dd640ab1631841d7c664#diff-b46ec9dd4b319d75809520e34b2559fd2ce46ca4895709eae9312aa04a8fa9a4L91), when I removed the base class of APIError (OpenAIError) from retryable exceptions. OpenAIError captures a lot of permanent errors, and even APIError in litellm is like a catch-all for other stuff, but it includes 502. Including a catch-all of sorts in our retries is not a great idea either (we may retry too much, at the expense of rate limits at least), but I'll dig into this some more.

---
**Link of any specific issues this addresses**
https://github.com/All-Hands-AI/OpenHands/issues/4166