### PR TITLE
feature 3947

### DIFF
--- a/openhands/core/cli.py
+++ b/openhands/core/cli.py
@@ -91,7 +91,7 @@ async def main():
         return
 
     logger.setLevel(logging.WARNING)
-    config = load_app_config()
+    config = load_app_config(config_file=args.config)
     sid = 'cli'
 
     agent_cls: Type[Agent] = Agent.get_cls(config.default_agent)

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -282,6 +282,12 @@ def get_parser() -> argparse.ArgumentParser:
     """Get the parser for the command line arguments."""
     parser = argparse.ArgumentParser(description='Run an agent with a specific task')
     parser.add_argument(
+        '--config',
+        type=str,
+        default='config.toml',
+        help='Path to the config file (default: config.toml in the current directory)',
+    )
+    parser.add_argument(
         '-d',
         '--directory',
         type=str,
@@ -375,14 +381,17 @@ def parse_arguments() -> argparse.Namespace:
     return parsed_args
 
 
-def load_app_config(set_logging_levels: bool = True) -> AppConfig:
-    """Load the configuration from the config.toml file and environment variables.
+def load_app_config(
+    set_logging_levels: bool = True, config_file: str = 'config.toml'
+) -> AppConfig:
+    """Load the configuration from the specified config file and environment variables.
 
     Args:
         set_logger_levels: Whether to set the global variables for logging levels.
+        config_file: Path to the config file. Defaults to 'config.toml' in the current directory.
     """
     config = AppConfig()
-    load_from_toml(config)
+    load_from_toml(config, config_file)
     load_from_env(config, os.environ)
     finalize_config(config)
     if set_logging_levels:

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -228,7 +228,7 @@ if __name__ == '__main__':
     # Load the app config
     # this will load config from config.toml in the current directory
     # as well as from the environment variables
-    config = load_app_config()
+    config = load_app_config(config_file=args.config)
 
     # Override default LLM configs ([llm] section in config.toml)
     if args.llm_config:


### PR DESCRIPTION
- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

allows users to specify the location of the config.toml file rather than just have it at the root


---
have added a parser argument to take the location of the config file and have updated the load_app_config() function accordingly 


---
https://github.com/All-Hands-AI/OpenHands/issues/3947