### PR TITLE
Fix: Add timeout on websocket accept

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import re
 import tempfile
@@ -257,7 +258,7 @@ async def websocket_endpoint(websocket: WebSocket):
         {"action": "finish", "args": {}}
         ```
     """
-    await websocket.accept()
+    await asyncio.wait_for(websocket.accept(), 10)
 
     if websocket.query_params.get('token'):
         token = websocket.query_params.get('token')


### PR DESCRIPTION
- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

** Prevent background task sleeping forever if client does not finish the websocket accept protocol **



---
Consider the following python script:
```
import websockets

async def main():
  await websockets.connect("ws://localhost:3000/ws")

asyncio.run(main())
```

On our server, this will initiate a call to `websocket.accept()`, but because the protocol does not finish, the task just hangs around forever in asnycio. This is not a big deal in every day use, but:

* It could be used to clog the server with malicious requests
* If you are running a dev server and you change a file, your server will get stuck at `Waiting for background tasks to complete. (CTRL+C to force quit)`