### PR TITLE
fix: reuse config parser for cli

### DIFF
--- a/openhands/core/cli.py
+++ b/openhands/core/cli.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import logging
 from typing import Type
@@ -10,6 +9,7 @@ from openhands import __version__
 from openhands.controller import AgentController
 from openhands.controller.agent import Agent
 from openhands.core.config import (
+    get_parser,
     load_app_config,
 )
 from openhands.core.logger import openhands_logger as logger
@@ -63,10 +63,10 @@ def display_event(event: Event):
         display_command_output(event.content)
 
 
-def get_parser() -> argparse.ArgumentParser:
-    """Get the parser for the command line arguments."""
-    parser = argparse.ArgumentParser(description='Run an agent with a specific task')
+async def main():
+    """Runs the agent in CLI mode"""
 
+    parser = get_parser()
     # Add the version argument
     parser.add_argument(
         '-v',
@@ -76,14 +76,6 @@ def get_parser() -> argparse.ArgumentParser:
         help='Show the version number and exit',
         default=None,
     )
-
-    return parser
-
-
-async def main():
-    """Runs the agent in CLI mode"""
-
-    parser = get_parser()
     args = parser.parse_args()
 
     if args.version:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Fix parser error https://openhands-ai.slack.com/archives/C078L0FUGUX/p1727959913904369?thread_ts=1727958145.317089&cid=C078L0FUGUX
```
mahmoudwork@Mahmouds-Mini OpenHands % poetry run python -m openhands.core.cli
ERROR:root:  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/mahmoudwork/Desktop/Main/OpenHands/openhands/core/cli.py", line 165, in <module>
    loop.run_until_complete(main())
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/mahmoudwork/Desktop/Main/OpenHands/openhands/core/cli.py", line 94, in main
    config = load_app_config(config_file=args.config_file)
                                         ^^^^^^^^^^^^^^^^

ERROR:root:<class 'AttributeError'>: 'Namespace' object has no attribute 'config_file'
mahmoudwork@Mahmouds-Mini OpenHands % 
```

---
**Link of any specific issues this addresses**
