### PR TITLE
Fix Better error message in development when version number changes.

### DIFF
--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -152,19 +152,6 @@ def prep_docker_build_folder(
     )
     hash = f'v{oh_version}_{dir_hash}'
 
-    my_dir = os.path.dirname(os.path.dirname(os.path.abspath(openhands.__file__)))
-    new_hash = dirhash(
-        my_dir,
-        'md5',
-        ignore=[
-            '.*/',  # hidden directories
-            '__pycache__/',
-            '*.pyc',
-        ],
-    )
-    logger.info("TRACE:prep_docker_build_folder:new_hash:{new_hash}")
-    logger.info("TRACE:prep_docker_build_folder:old_hash:{hash}")
-
     logger.info(
         f'Input base image: {base_image}\n'
         f'Skip init: {skip_init}\n'

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -151,7 +151,6 @@ def prep_docker_build_folder(
         ],
     )
     hash = f'v{oh_version}_{dir_hash}'
-
     logger.info(
         f'Input base image: {base_image}\n'
         f'Skip init: {skip_init}\n'

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -57,7 +57,7 @@ def _put_source_code_to_dir(temp_dir: str):
         raise RuntimeError(f'Image build failed:\n{result}')
 
     if not os.path.exists(tarball_path):
-        logger.error(f'Source distribution not found at {tarball_path}. (Do you need to run `poetry install`?)')
+        logger.error(f'Source distribution not found at {tarball_path}. (Do you need to run `make build`?)')
         raise RuntimeError(f'Source distribution not found at {tarball_path}')
     logger.info(f'Source distribution created at {tarball_path}')
 

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -57,7 +57,7 @@ def _put_source_code_to_dir(temp_dir: str):
         raise RuntimeError(f'Image build failed:\n{result}')
 
     if not os.path.exists(tarball_path):
-        logger.error(f'Source distribution not found at {tarball_path}')
+        logger.error(f'Source distribution not found at {tarball_path}. (Do you need to run `poetry install`?)')
         raise RuntimeError(f'Source distribution not found at {tarball_path}')
     logger.info(f'Source distribution created at {tarball_path}')
 
@@ -151,6 +151,20 @@ def prep_docker_build_folder(
         ],
     )
     hash = f'v{oh_version}_{dir_hash}'
+
+    my_dir = os.path.dirname(os.path.dirname(os.path.abspath(openhands.__file__)))
+    new_hash = dirhash(
+        my_dir,
+        'md5',
+        ignore=[
+            '.*/',  # hidden directories
+            '__pycache__/',
+            '*.pyc',
+        ],
+    )
+    logger.info("TRACE:prep_docker_build_folder:new_hash:{new_hash}")
+    logger.info("TRACE:prep_docker_build_folder:old_hash:{hash}")
+
     logger.info(
         f'Input base image: {base_image}\n'
         f'Skip init: {skip_init}\n'


### PR DESCRIPTION
**Better error message in Development when version number changes.**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Every time we release a new version and I do a `git pull` of main without an accompanying `poetry install`, I get the message:
```Source distribution not found at ...```

The message now prompts users to also run a `poetry install`.
