### PR TITLE
Fix issue where an exception is raised because we try to finish a thread that was never started

### DIFF
--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -144,7 +144,9 @@ class AgentSession:
             await self.security_analyzer.close()
 
         self.loop.call_soon_threadsafe(self.loop.stop)
-        self.thread.join()
+        if self.thread:
+            # We may be closing an agent_session that was never actually started
+            self.thread.join()
 
         self._closed = True
 


### PR DESCRIPTION
- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**I wasn't gonna put this in the release notes - I am pretty sure it only happens in the remote runtime.**

```
openhands-8fb79d76c-c6hwm openhands future: <Task finished name='Task-409' coro=<Session.close() done, defined at /app/openhands/server/session/session.py:51> exception=AttributeError("'AgentSession' object has no attribute 'thread'")>
openhands-8fb79d76c-c6hwm openhands Traceback (most recent call last):
openhands-8fb79d76c-c6hwm openhands   File "/app/openhands/server/session/session.py", line 53, in close
openhands-8fb79d76c-c6hwm openhands     await self.agent_session.close()
openhands-8fb79d76c-c6hwm openhands   File "/app/openhands/server/session/agent_session.py", line 147, in close
openhands-8fb79d76c-c6hwm openhands     self.thread.join()
```