### PR TITLE
eval: improve swebench infer error handling and retry

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -86,6 +86,10 @@ class EvalOutput(BaseModel):
         return json.dumps(dumped_dict)
 
 
+class EvalException(Exception):
+    pass
+
+
 def codeact_user_response(
     state: State,
     encapsulate_solution: bool = False,
@@ -250,6 +254,15 @@ def update_progress(
     )
     output_fp.write(json.dumps(result.model_dump()) + '\n')
     output_fp.flush()
+
+
+def assert_and_raise(condition: bool, msg: str):
+    """Raise an EvalException if the condition is not met.
+
+    This will be used in conjunction with _process_instance_wrapper to handle retries. An EvalException should trigger a retry.
+    """
+    if not condition:
+        raise EvalException(msg)
 
 
 def _process_instance_wrapper(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Improve error handling and retry for swebench inference

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Add a shared method `assert_and_raise` to replace the raw `assert` statements which will cause automatic retry to fail
- Use try and finally to properly cleanup runtime when an evaluation fails in the middle

---
**Link of any specific issues this addresses**
