### PR TITLE
lint.yml: commit benign linter changes in workflow (spaces, linebreaks)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,3 +47,16 @@ jobs:
         run: pip install pre-commit==3.7.0
       - name: Run pre-commit hooks
         run: pre-commit run --files openhands/**/* agenthub/**/* evaluation/**/* tests/**/* --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+      - name: Commit linting changes
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          if git diff --quiet --exit-code; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -am "Apply automatic linting fixes" || echo "No changes to commit"
+          git push

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,17 +46,18 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit==3.7.0
       - name: Run pre-commit hooks
-        run: pre-commit run --files openhands/**/* agenthub/**/* evaluation/**/* tests/**/* --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+        run: |
+          CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD^ HEAD)
+          pre-commit run --files $CHANGED_FILES --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
       - name: Commit linting changes
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          if git diff --quiet --exit-code; then
+          if ! git diff-index --quiet HEAD --; then # Check for changes after pre-commit
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git add .
+            git commit -am "Apply automatic linting fixes"
+            git push
+          else
             echo "No changes to commit"
-            exit 0
           fi
-
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add .
-          git commit -am "Apply automatic linting fixes" || echo "No changes to commit"
-          git push

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,7 @@ jobs:
         run: pip install pre-commit==3.7.0
 
       - name: Run formatting hook
+        continue-on-error: true
         run: |
           CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD^ HEAD)
           pre-commit run ruff-format --files $CHANGED_FILES \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,26 +38,39 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
           cache: 'pip'
+
       - name: Install pre-commit
         run: pip install pre-commit==3.7.0
-      - name: Run pre-commit hooks
+
+      - name: Run formatting hook
         run: |
           CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD^ HEAD)
-          pre-commit run --files $CHANGED_FILES --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
-      - name: Commit linting changes
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+          pre-commit run ruff-format --files $CHANGED_FILES \
+            --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+
+      - name: Commit formatting changes
+        if: >
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          if ! git diff-index --quiet HEAD --; then # Check for changes after pre-commit
+          if ! git diff-index --quiet HEAD --; then
             git config --global user.name 'github-actions[bot]'
             git config --global user.email 'github-actions[bot]@users.noreply.github.com'
             git add .
-            git commit -am "Apply automatic linting fixes"
+            git commit -m "Apply automatic formatting fixes"
             git push
           else
-            echo "No changes to commit"
+            echo "No formatting changes to commit"
           fi
+
+      - name: Run pre-commit hooks
+        run: |
+          CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD^ HEAD)
+          pre-commit run --files $CHANGED_FILES \
+            --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml

--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -13,24 +13,22 @@ repos:
     rev: 1.7.0
     hooks:
       - id: pyproject-fmt
+
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.16
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.4.1
     hooks:
-      # Run the linter.
+      - id: ruff-format
+        entry: ruff format --config dev_config/python/ruff.toml
+        types_or: [python, pyi, jupyter]
       - id: ruff
         entry: ruff check --config dev_config/python/ruff.toml
         types_or: [python, pyi, jupyter]
         args: [--fix]
-      # Run the formatter.
-      - id: ruff-format
-        entry: ruff format --config dev_config/python/ruff.toml
-        types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0

--- a/openhands/runtime/client/runtime.py
+++ b/openhands/runtime/client/runtime.py
@@ -40,8 +40,6 @@ from openhands.runtime.utils.request import (
 )
 from openhands.runtime.utils.runtime_build import build_runtime_image
 from openhands.utils.tenacity_stop import stop_if_should_exit
-
-
 class LogBuffer:
     """Synchronous buffer for Docker container logs.
 
@@ -93,9 +91,7 @@ class LogBuffer:
 
     def __del__(self):
         if self.log_stream_thread.is_alive():
-            logger.warn(
-                "LogBuffer was not properly closed. Use 'log_buffer.close()' for clean shutdown."
-            )
+            logger.warn("LogBuffer was not properly closed. Use 'log_buffer.close()' for clean shutdown.")
             self.close(timeout=5)
 
     def close(self, timeout: float = 5.0):

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -1,18 +1,10 @@
 from pathlib import Path
-
 import pytest
-
 from openhands.runtime.utils import files
-
 SANDBOX_PATH_PREFIX = '/workspace'
 WORKSPACE_BASE = 'workspace'
-
-
-def test_resolve_path():  
-    assert (
-        files.resolve_path('test.txt', '/workspace')
-        == Path(WORKSPACE_BASE) / 'test.txt'
-    )
+def test_resolve_path():
+    assert (files.resolve_path('test.txt', '/workspace') == Path(WORKSPACE_BASE) / 'test.txt')
     assert (
         files.resolve_path('subdir/test.txt', '/workspace')
         == Path(WORKSPACE_BASE) / 'subdir' / 'test.txt'

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -1,10 +1,18 @@
 from pathlib import Path
+
 import pytest
+
 from openhands.runtime.utils import files
+
 SANDBOX_PATH_PREFIX = '/workspace'
 WORKSPACE_BASE = 'workspace'
+
+
 def test_resolve_path():
-    assert (files.resolve_path('test.txt', '/workspace') == Path(WORKSPACE_BASE) / 'test.txt')
+    assert (
+        files.resolve_path('test.txt', '/workspace')
+        == Path(WORKSPACE_BASE) / 'test.txt'
+    )
     assert (
         files.resolve_path('subdir/test.txt', '/workspace')
         == Path(WORKSPACE_BASE) / 'subdir' / 'test.txt'

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -8,7 +8,7 @@ SANDBOX_PATH_PREFIX = '/workspace'
 WORKSPACE_BASE = 'workspace'
 
 
-def test_resolve_path():
+def test_resolve_path():  
     assert (
         files.resolve_path('test.txt', '/workspace')
         == Path(WORKSPACE_BASE) / 'test.txt'


### PR DESCRIPTION
For PR's within repo-branches: auto-commit benign lint process changes automatically

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR is only for e.g. maintainers, that have their PR branches within the repo, not for branches that reside in forks!
The `lint` workflow happily reformats files when it finds issues related to e.g. trailing blanks or missing/too many linebreaks.
When e.g. using the web interace on GitHub to fix merge conflicts, often then the lint process causes extra effort and negates the
ease-of-use of the web interface. At least for maintainers, this could be helped by auto-committing the "corrected" files.

@rbren - I took the idea from the regenerate workflow action, my hope is that this PR makes our life easier.
