### PR TITLE
Fix browsing actions to be more robust

### DIFF
--- a/agenthub/browsing_agent/response_parser.py
+++ b/agenthub/browsing_agent/response_parser.py
@@ -72,17 +72,22 @@ class BrowsingActionParserBrowseInteractive(ActionParser):
         return True
 
     def parse(self, action_str: str) -> Action:
-        thought = action_str.split('```')[0].strip()
-        action_str = action_str.split('```')[1].strip()
+        # parse the action string into browser actions and thought
+        # the LLMs return currently only the browser actions, no thought
+        parts = action_str.split('```')
+        browser_actions = parts[0].strip()
+        thought = parts[1].strip() if len(parts) > 1 else ''
+
+        # if the LLM wants to talk to the user, we extract the message
         msg_content = ''
-        for sub_action in action_str.split('\n'):
+        for sub_action in browser_actions.split('\n'):
             if 'send_msg_to_user(' in sub_action:
                 tree = ast.parse(sub_action)
                 args = tree.body[0].value.args  # type: ignore
                 msg_content = args[0].value
 
         return BrowseInteractiveAction(
-            browser_actions=action_str,
+            browser_actions=browser_actions,
             thought=thought,
             browsergym_send_msg_to_user=msg_content,
         )

--- a/agenthub/browsing_agent/response_parser.py
+++ b/agenthub/browsing_agent/response_parser.py
@@ -72,17 +72,20 @@ class BrowsingActionParserBrowseInteractive(ActionParser):
         return True
 
     def parse(self, action_str: str) -> Action:
-        # parse the action string into browser actions and thought
-        # when both are present, it looks like this:
+        # parse the action string into browser_actions and thought
+        # the LLM can return only one string, or both
+
+        # when both are returned, it looks like this:
         ### Based on the current state of the page and the goal of finding out the president of the USA, the next action should involve searching for information related to the president.
         ### To achieve this, we can navigate to a reliable source such as a search engine or a specific website that provides information about the current president of the USA.
         ### Here is an example of a valid action to achieve this:
         ### ```
-        ### goto('https://www.whitehouse.gov/about-the-white-house/presidents/')
+        ### goto('https://www.whitehouse.gov/about-the-white-house/presidents/'
+        # in practice, BrowsingResponseParser.parse_response also added )``` to the end of the string
 
-        # the LLMs can also return only the browser actions, no thought, like this:
+        # when the LLM returns only one string, it looks like this:
         ### goto('https://www.whitehouse.gov/about-the-white-house/presidents/')
-        ### ```
+        # and parse_response added )``` to the end of the string
         parts = action_str.split('```')
         browser_actions = (
             parts[1].strip() if parts[1].strip() != '' else parts[0].strip()

--- a/agenthub/browsing_agent/response_parser.py
+++ b/agenthub/browsing_agent/response_parser.py
@@ -73,10 +73,21 @@ class BrowsingActionParserBrowseInteractive(ActionParser):
 
     def parse(self, action_str: str) -> Action:
         # parse the action string into browser actions and thought
-        # the LLMs return currently only the browser actions, no thought
+        # when both are present, it looks like this:
+        ### Based on the current state of the page and the goal of finding out the president of the USA, the next action should involve searching for information related to the president.
+        ### To achieve this, we can navigate to a reliable source such as a search engine or a specific website that provides information about the current president of the USA.
+        ### Here is an example of a valid action to achieve this:
+        ### ```
+        ### goto('https://www.whitehouse.gov/about-the-white-house/presidents/')
+
+        # the LLMs can also return only the browser actions, no thought, like this:
+        ### goto('https://www.whitehouse.gov/about-the-white-house/presidents/')
+        ### ```
         parts = action_str.split('```')
-        browser_actions = parts[0].strip()
-        thought = parts[1].strip() if len(parts) > 1 else ''
+        browser_actions = (
+            parts[1].strip() if parts[1].strip() != '' else parts[0].strip()
+        )
+        thought = parts[0].strip() if parts[1].strip() != '' else ''
 
         # if the LLM wants to talk to the user, we extract the message
         msg_content = ''

--- a/tests/unit/test_browsing_agent_parser.py
+++ b/tests/unit/test_browsing_agent_parser.py
@@ -1,0 +1,54 @@
+import pytest
+
+from agenthub.browsing_agent.response_parser import (
+    BrowseInteractiveAction,
+    BrowsingResponseParser,
+)
+
+
+@pytest.mark.parametrize(
+    'action_str, expected',
+    [
+        ("click('81'", "click('81')```"),
+        (
+            '"We need to search the internet\n```goto("google.com")',
+            '"We need to search the internet\n```goto("google.com"))```',
+        ),
+        ("```click('81'", "```click('81')```"),
+        ("click('81')", "click('81'))```"),
+    ],
+)
+def test_parse_response(action_str: str, expected: str) -> None:
+    # BrowsingResponseParser.parse_response
+    parser = BrowsingResponseParser()
+    response = {'choices': [{'message': {'content': action_str}}]}
+    result = parser.parse_response(response)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'action_str, expected_browser_actions, expected_thought, expected_msg_content',
+    [
+        ("click('81')```", "click('81')", '', ''),
+        ("```click('81')```", "click('81')", '', ''),
+        (
+            "We need to perform a click\n```click('81')",
+            "click('81')",
+            'We need to perform a click',
+            '',
+        ),
+    ],
+)
+def test_parse_action(
+    action_str: str,
+    expected_browser_actions: str,
+    expected_thought: str,
+    expected_msg_content: str,
+) -> None:
+    # BrowsingResponseParser.parse_action
+    parser = BrowsingResponseParser()
+    action = parser.parse_action(action_str)
+    assert isinstance(action, BrowseInteractiveAction)
+    assert action.browser_actions == expected_browser_actions
+    assert action.thought == expected_thought
+    assert action.browsergym_send_msg_to_user == expected_msg_content


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix browsing agent parsing responses.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes an adjustment to browsing actions parsing.
Browsing agent responses can be a simple command or set of commands, with no "thoughts", or can contain both, with the thought first. In the first case, no actions were parsed, so its "previous actions" was empty in the prompt. This was tested first with delegation, and it just didn't work at all with several LLMs. Tested after with UI and browsing agent.

Tested with claude, got-4o, gemini. The prompt shows in the Previous Action section a list of previous actions, e.g.

Previously: 
(after several steps of the browsing agent, Previous Actions is empty, current page never got updated either)
```
IMPORTANT! Last action is incorrect:

Think again with the current observation of the page.


# Current Page URL:
about:blank

# Current Accessibility Tree:
RootWebArea '', focused

# Previous Actions




Here is an example ...

```

After:
```
# Current Page URL:
https://www.whitehouse.gov/

# Current Accessibility Tree:
RootWebArea 'The White House', focused
	[64] banner ''
...

# Previous Actions
goto('https://www.whitehouse.gov/'))
click('69'))

Here is an example ...
```

---
**Link of any specific issues this addresses**
