### PR TITLE
fix swebench repo/version being string

### DIFF
--- a/evaluation/swe_bench/scripts/setup/instance_swe_entry.sh
+++ b/evaluation/swe_bench/scripts/setup/instance_swe_entry.sh
@@ -23,7 +23,7 @@ if [[ -z "$item" ]]; then
   exit 1
 fi
 
-WORKSPACE_NAME=$(echo "$item" | jq -r '.repo + "__" + .version | gsub("/"; "__")')
+WORKSPACE_NAME=$(echo "$item" | jq -r '(.repo | tostring) + "__" + (.version | tostring) | gsub("/"; "__")')
 
 echo "WORKSPACE_NAME: $WORKSPACE_NAME"
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Previously, JQ would throw an error in concatenating the repo and version together because one of them is not string. This PR converts both to string first before concatenating them.

---
**Link of any specific issues this addresses**

Fix https://github.com/All-Hands-AI/OpenHands/issues/4235
