### PR TITLE
Remove concurrency from ghcr-build so it always runs on main commits

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -1,11 +1,5 @@
-# Workflow that builds, tests and then pushes the runtime docker images to the ghcr.io repository
+# Workflow that builds, tests and then pushes the OpenHands and runtime docker images to the ghcr.io repository
 name: Build, Test and Publish RT Image
-
-# Only run one workflow of the same group at a time.
-# There can be at most one running and one pending job in a concurrency group at any time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Always run on "main"
 # Always run on tags


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Remove concurrency from ghcr-build so it always runs on main commits

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This will make it so every commit to main will run these jobs now. Requested by @rbren 

---
**Link of any specific issues this addresses**
