### PR TITLE
[Runtime] Audit HTTP Retry timeouts

### DIFF
--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -33,13 +33,13 @@ DEFAULT_RETRY_EXCEPTIONS = [
 ]
 
 
-def send_request(
+def send_request_with_retry(
     session: requests.Session,
     method: str,
     url: str,
+    timeout: int,
     retry_exceptions: list[Type[Exception]] | None = None,
     retry_fns: list[Callable[[Exception], bool]] | None = None,
-    timeout: int = 120,
     **kwargs: Any,
 ) -> requests.Response:
     exceptions_to_catch = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS
@@ -54,7 +54,7 @@ def send_request(
 
     @retry(
         stop=stop_after_delay(timeout) | stop_if_should_exit(),
-        wait=wait_exponential(multiplier=1, min=4, max=60),
+        wait=wait_exponential(multiplier=1, min=4, max=20),
         retry=retry_condition,
         reraise=True,
     )


### PR DESCRIPTION
**More deliberate timeouts on retry operations**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Ever have something not quite work and the server sits there for 5 minutes before the logs even tell you what's wrong? There was a lot of that in my last 24 hours. This has to stop! ;)

 * **Renamed the method `send_request` to `send_request_with_retry`** : This more accurately describes what it does.
 * **Removed the default timeout on `send_request_with_retry`** : Each operation is different, and there is no one size fits all for these timeouts. Now developers must think about each of these operations deliberately and supply a timeout if they want to use this function
 * **Reduced the limit on the exponential backoff** : Time between retries now starts at 4 seconds and maxes out at 20 seconds (Instead of 60 seconds). When something is ready, why wait much longer?
* **Audited each use of `send_request_with_retry`** and supplied a timeout that seems reasonable.

## Testing

Obviously, the linter gave no issues and tests passed. When deciding on timeouts, I was relatively conservative and did not change cases which may result in disruptions to Actions or builds. My efforts focused on the other lifecycle and shutdown events, where I typically reduced the retry timeout from 5 minutes to 30 seconds. I think with further testing we could eliminate a lot of these retries altogether, but I was trying to be conservative with this change.
