### PR TITLE
chore(frontend): Change the backend base url fallback to be dynamic to current host

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -1,3 +1,4 @@
+import { getValidFallbackHost } from "#/utils/get-valid-fallback-host";
 import {
   SaveFileSuccessResponse,
   FileUploadSuccessResponse,
@@ -12,7 +13,9 @@ import {
  * @returns Base URL of the OpenHands API
  */
 const generateBaseURL = () => {
-  const baseUrl = import.meta.env.VITE_BACKEND_BASE_URL || "localhost:3000";
+  const fallback = getValidFallbackHost();
+  const baseUrl = import.meta.env.VITE_BACKEND_BASE_URL || fallback;
+
   return `http://${baseUrl}`;
 };
 

--- a/frontend/src/context/socket.tsx
+++ b/frontend/src/context/socket.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Data } from "ws";
 import EventLogger from "#/utils/event-logger";
+import { getValidFallbackHost } from "#/utils/get-valid-fallback-host";
 
 interface WebSocketClientOptions {
   token: string | null;
@@ -45,7 +46,8 @@ function SocketProvider({ children }: SocketProviderProps) {
       );
     }
 
-    const baseUrl = import.meta.env.VITE_BACKEND_BASE_URL || "localhost:3000";
+    const fallback = getValidFallbackHost();
+    const baseUrl = import.meta.env.VITE_BACKEND_BASE_URL || fallback;
     const ws = new WebSocket(
       `ws://${baseUrl}/ws${options?.token ? `?token=${options.token}` : ""}`,
     );

--- a/frontend/src/utils/get-valid-fallback-host.ts
+++ b/frontend/src/utils/get-valid-fallback-host.ts
@@ -1,0 +1,20 @@
+/**
+ * Get the valid fallback host. Returns the host unless it is localhost, in which case it returns localhost:3000
+ * @returns Valid fallback host
+ *
+ * @example
+ * // If the host is localhost (e.g., localhost:5173), it returns localhost:3000
+ * const host = getValidFallbackHost(); // localhost:3000
+ *
+ * // If the host is not localhost, it returns the host
+ * const host = getValidFallbackHost(); // sub.example.com
+ */
+export const getValidFallbackHost = () => {
+  if (typeof window !== "undefined") {
+    const { hostname, host } = window.location;
+    if (hostname !== "localhost") return host;
+  }
+
+  // Fallback is localhost:3000 because that is the default port for the server
+  return "localhost:3000";
+};


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Instead of fixing the fallback to `localhost:3000`, it is dynamically determined by the current host. If the current `hostname` is `localhost`, then it will be set to `localhost:3000` since that is the default port for the server


---
**Link of any specific issues this addresses**
