### PR TITLE
fix(frontend): Remove unnecessary encoding in `/list-files` API endpoint path param

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -62,7 +62,7 @@ class OpenHands {
    */
   static async getFiles(token: string, path?: string): Promise<string[]> {
     const url = new URL(`${OpenHands.BASE_URL}/api/list-files`);
-    if (path) url.searchParams.append("path", encodeURIComponent(path));
+    if (path) url.searchParams.append("path", path);
 
     const response = await fetch(url.toString(), {
       headers: OpenHands.generateHeaders(token),


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
`url.searchParams.append` already escapes the relevant characters, encoding the path produced a different value than what was required

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Removes the encoding


---
**Link of any specific issues this addresses**
