### PR TITLE
fix container_image when using hard-coded image

### DIFF
--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -107,6 +107,7 @@ class RemoteRuntime(Runtime):
                 logger.info(
                     f'Running remote runtime with image: {self.config.sandbox.runtime_container_image}'
                 )
+                self.container_image = self.config.sandbox.runtime_container_image
             self._start_runtime(plugins)
         assert (
             self.runtime_id is not None


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no need

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This fixes an edge case where remote runtime crashes when an env var is set hard-coding the image to use

---
**Link of any specific issues this addresses**
