### PR TITLE
AgentDelegateAction: make delegate start with the task in execute tags, not the rest of the parent LLM response

### DIFF
--- a/openhands/agenthub/codeact_agent/action_parser.py
+++ b/openhands/agenthub/codeact_agent/action_parser.py
@@ -158,8 +158,11 @@ class CodeActActionParserAgentDelegate(ActionParser):
         ), 'self.agent_delegate should not be None when parse is called'
         thought = action_str.replace(self.agent_delegate.group(0), '').strip()
         browse_actions = self.agent_delegate.group(1).strip()
-        task = f'{thought}. I should start with: {browse_actions}'
-        return AgentDelegateAction(agent='BrowsingAgent', inputs={'task': task})
+        thought = f'{thought}. I should start with: {browse_actions}'
+
+        return AgentDelegateAction(
+            agent='BrowsingAgent', thought=thought, inputs={'task': browse_actions}
+        )
 
 
 class CodeActActionParserMessage(ActionParser):

--- a/openhands/agenthub/codeact_agent/action_parser.py
+++ b/openhands/agenthub/codeact_agent/action_parser.py
@@ -158,7 +158,11 @@ class CodeActActionParserAgentDelegate(ActionParser):
         ), 'self.agent_delegate should not be None when parse is called'
         thought = action_str.replace(self.agent_delegate.group(0), '').strip()
         browse_actions = self.agent_delegate.group(1).strip()
-        thought = f'{thought}. I should start with: {browse_actions}'
+        thought = (
+            f'{thought}\nI should start with: {browse_actions}'
+            if thought
+            else f'I should start with: {browse_actions}'
+        )
 
         return AgentDelegateAction(
             agent='BrowsingAgent', thought=thought, inputs={'task': browse_actions}

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_002.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_002.log
@@ -4,7 +4,7 @@ possible next action to accomplish your goal. Your answer will be interpreted
 and executed by a program, make sure to follow the formatting instructions.
 
 # Goal:
-. I should start with: Get the content on "http://localhost:8000"
+Get the content on "http://localhost:8000"
 
 # Action Space
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_003.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_003.log
@@ -4,7 +4,7 @@ possible next action to accomplish your goal. Your answer will be interpreted
 and executed by a program, make sure to follow the formatting instructions.
 
 # Goal:
-. I should start with: Get the content on "http://localhost:8000"
+Get the content on "http://localhost:8000"
 
 # Action Space
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_004.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_004.log
@@ -4,7 +4,7 @@ possible next action to accomplish your goal. Your answer will be interpreted
 and executed by a program, make sure to follow the formatting instructions.
 
 # Goal:
-. I should start with: Get the content on "http://localhost:8000"
+Get the content on "http://localhost:8000"
 
 # Action Space
 

--- a/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
+++ b/tests/integration/mock/eventstream_runtime/CodeActAgent/test_browse_internet/prompt_005.log
@@ -406,9 +406,9 @@ Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me fo
 
 ----------
 
-
+I should start with: Get the content on "http://localhost:8000"
 <execute_browse>
-. I should start with: Get the content on "http://localhost:8000"
+Get the content on "http://localhost:8000"
 </execute_browse>
 
 ----------

--- a/tests/unit/test_codeact_agent_parser.py
+++ b/tests/unit/test_codeact_agent_parser.py
@@ -1,0 +1,53 @@
+import pytest
+
+from openhands.agenthub.codeact_agent.action_parser import (
+    CodeActActionParserAgentDelegate,
+)
+from openhands.events.action import AgentDelegateAction
+
+
+@pytest.mark.parametrize(
+    'action_str, expected_agent, expected_thought, expected_task',
+    [
+        (
+            'I need to search for information.\n<execute_browse>Tell me who is the Vice President of the USA</execute_browse>',
+            'BrowsingAgent',
+            'I need to search for information.',
+            'Tell me who is the Vice President of the USA',
+        ),
+        (
+            '<execute_browse>Search for recent climate change data</execute_browse>',
+            'BrowsingAgent',
+            '',
+            'Search for recent climate change data',
+        ),
+        (
+            "Let's use the browsing agent to find this information.\n<execute_browse>Find the population of Tokyo in 2023</execute_browse>\nThis will help us answer the question.",
+            'BrowsingAgent',
+            "Let's use the browsing agent to find this information.\n\nThis will help us answer the question.",
+            'Find the population of Tokyo in 2023',
+        ),
+    ],
+)
+def test_codeact_action_parser_agent_delegate(
+    action_str, expected_agent, expected_thought, expected_task
+):
+    parser = CodeActActionParserAgentDelegate()
+    assert parser.check_condition(action_str)
+
+    action = parser.parse(action_str)
+
+    assert isinstance(action, AgentDelegateAction)
+    assert action.agent == expected_agent
+    assert action.thought == expected_thought
+    assert action.inputs['task'] == expected_task
+
+
+def test_codeact_action_parser_agent_delegate_no_match():
+    parser = CodeActActionParserAgentDelegate()
+    action_str = 'This is a regular message without any browse command.'
+
+    assert not parser.check_condition(action_str)
+
+    with pytest.raises(AssertionError):
+        parser.parse(action_str)

--- a/tests/unit/test_codeact_agent_parser.py
+++ b/tests/unit/test_codeact_agent_parser.py
@@ -12,19 +12,19 @@ from openhands.events.action import AgentDelegateAction
         (
             'I need to search for information.\n<execute_browse>Tell me who is the Vice President of the USA</execute_browse>',
             'BrowsingAgent',
-            'I need to search for information.',
+            'I need to search for information.\nI should start with: Tell me who is the Vice President of the USA',
             'Tell me who is the Vice President of the USA',
         ),
         (
             '<execute_browse>Search for recent climate change data</execute_browse>',
             'BrowsingAgent',
-            '',
+            'I should start with: Search for recent climate change data',
             'Search for recent climate change data',
         ),
         (
             "Let's use the browsing agent to find this information.\n<execute_browse>Find the population of Tokyo in 2023</execute_browse>\nThis will help us answer the question.",
             'BrowsingAgent',
-            "Let's use the browsing agent to find this information.\n\nThis will help us answer the question.",
+            "Let's use the browsing agent to find this information.\n\nThis will help us answer the question.\nI should start with: Find the population of Tokyo in 2023",
             'Find the population of Tokyo in 2023',
         ),
     ],


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix AgentDelegateAction to send only the task to the delegate agent, not the main agent thoughts

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

It's a bit strange [to see](https://github.com/All-Hands-AI/OpenHands/actions/runs/11263110927/job/31320302649#step:8:327) the browsing agent starting with:

```
21:12:46 - ACTION
AgentDelegateAction(agent='BrowsingAgent', inputs={'task': "Thank you for providing the current content of the file. Now, let's summarize the information from the blog article and add it to the file. I'll start by browsing the article to gather the necessary information.. I should start with: Summarize the quality and cost information of various language models from https://www.all-hands.dev/blog/evaluation-of-llms-as-coding-agents-on-swe-bench-at-30x-speed"}, thought='', action='delegate')
```

Notes on the current AgentDelegateAction object:
- AgentDelegateAction has a `thought` attribute, but the `thought` ended up empty
- the LLM (of the parent) sent a thought in its response. It got lost from `thought` property, and it was included instead into the `inputs['task']`.
- the parent LLM sent in tags &lt;execute_browse&gt;_Summarize the quality and cost information of various language models ..._&lt;/execute_browse&gt;. I think the LLM responds with this _task_ for the delegate agent.

It seems to me that we need to put the contents of the `thought` in the `thought` and perhaps more importantly, keep the `task` without that part, because it can confuse the delegate LLM when it contains unintended stuff.

---
**Link of any specific issues this addresses**
