### PR TITLE
Log cache hit/miss for deepseek

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -291,19 +291,21 @@ class LLM(RetryMixin, DebugMixin):
             # read the prompt caching status as received from the provider
             model_extra = usage.get('model_extra', {})
 
-            cache_creation_input_tokens = model_extra.get('cache_creation_input_tokens')
-            if cache_creation_input_tokens:
-                stats += (
-                    'Input tokens (cache write): '
-                    + str(cache_creation_input_tokens)
-                    + '\n'
-                )
+            # NOTE: the keys are different for Anthropic and DeepSeek
+            # Anthropic: cache_creation_input_tokens, cache_read_input_tokens
+            # DeepSeek: prompt_cache_miss_tokens, prompt_cache_hit_tokens
 
-            cache_read_input_tokens = model_extra.get('cache_read_input_tokens')
-            if cache_read_input_tokens:
-                stats += (
-                    'Input tokens (cache read): ' + str(cache_read_input_tokens) + '\n'
-                )
+            cache_write_tokens = model_extra.get(
+                'cache_creation_input_tokens'
+            ) or model_extra.get('prompt_cache_miss_tokens')
+            if cache_write_tokens:
+                stats += 'Input tokens (cache write): ' + str(cache_write_tokens) + '\n'
+
+            cache_read_tokens = model_extra.get(
+                'cache_read_input_tokens'
+            ) or model_extra.get('prompt_cache_hit_tokens')
+            if cache_read_tokens:
+                stats += 'Input tokens (cache hit): ' + str(cache_read_tokens) + '\n'
 
         # log the stats
         if stats:

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -9,7 +9,7 @@ from openhands.core.config import LLMConfig
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
     import litellm
-from litellm import ModelInfo
+from litellm import ModelInfo, PromptTokensDetails
 from litellm import completion as litellm_completion
 from litellm import completion_cost as litellm_completion_cost
 from litellm.exceptions import (
@@ -288,24 +288,23 @@ class LLM(RetryMixin, DebugMixin):
                     + '\n'
                 )
 
-            # read the prompt caching status as received from the provider
+            # read the prompt cache hit, if any
+            prompt_tokens_details: PromptTokensDetails = usage.get(
+                'prompt_tokens_details'
+            )
+            cache_hit_tokens = (
+                prompt_tokens_details.cached_tokens if prompt_tokens_details else None
+            )
+            if cache_hit_tokens:
+                stats += 'Input tokens (cache hit): ' + str(cache_hit_tokens) + '\n'
+
+            # For Anthropic, the cache writes have a different cost than regular input tokens
+            # but litellm doesn't separate them in the usage stats
+            # so we can read it from the provider-specific extra field
             model_extra = usage.get('model_extra', {})
-
-            # NOTE: the keys are different for Anthropic and DeepSeek
-            # Anthropic: cache_creation_input_tokens, cache_read_input_tokens
-            # DeepSeek: prompt_cache_miss_tokens, prompt_cache_hit_tokens
-
-            cache_write_tokens = model_extra.get(
-                'cache_creation_input_tokens'
-            ) or model_extra.get('prompt_cache_miss_tokens')
+            cache_write_tokens = model_extra.get('cache_creation_input_tokens')
             if cache_write_tokens:
                 stats += 'Input tokens (cache write): ' + str(cache_write_tokens) + '\n'
-
-            cache_read_tokens = model_extra.get(
-                'cache_read_input_tokens'
-            ) or model_extra.get('prompt_cache_hit_tokens')
-            if cache_read_tokens:
-                stats += 'Input tokens (cache hit): ' + str(cache_read_tokens) + '\n'
 
         # log the stats
         if stats:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Display in the logs the prompt cache hit or miss for Deepseek Chat.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Just a small tweak, display in the logs the cache hit/miss for Deepseek as we are doing for Anthropic.

---
**Link of any specific issues this addresses**
