### PR TITLE
(Browsing agent) Fix send_msg_to_user

### DIFF
--- a/tests/unit/test_browsing_agent_parser.py
+++ b/tests/unit/test_browsing_agent_parser.py
@@ -12,10 +12,14 @@ from openhands.agenthub.browsing_agent.response_parser import (
         ("click('81'", "click('81')```"),
         (
             '"We need to search the internet\n```goto("google.com")',
-            '"We need to search the internet\n```goto("google.com"))```',
+            '"We need to search the internet\n```goto("google.com")```',
         ),
         ("```click('81'", "```click('81')```"),
-        ("click('81')", "click('81'))```"),
+        ("click('81')", "click('81')```"),
+        (
+            "send_msg_to_user('The server might not be running or accessible. Please check the server status and try again.')",
+            "send_msg_to_user('The server might not be running or accessible. Please check the server status and try again.')```",
+        ),
     ],
 )
 def test_parse_response(action_str: str, expected: str) -> None:
@@ -36,6 +40,30 @@ def test_parse_response(action_str: str, expected: str) -> None:
             "click('81')",
             'We need to perform a click',
             '',
+        ),
+        (
+            'Tell the user that the city was built in 1751.\n```send_msg_to_user("Based on the results of my search, the city was built in 1751.")',
+            'send_msg_to_user("Based on the results of my search, the city was built in 1751.")',
+            'Tell the user that the city was built in 1751.',
+            'Based on the results of my search, the city was built in 1751.',
+        ),
+        (
+            'Tell the user that the city was built in 1751.\n```send_msg_to_user("Based on the results of my search, the city was built in 1751.")```',
+            'send_msg_to_user("Based on the results of my search, the city was built in 1751.")',
+            'Tell the user that the city was built in 1751.',
+            'Based on the results of my search, the city was built in 1751.',
+        ),
+        (
+            "Tell the user that the city was built in 1751.\n```send_msg_to_user('Based on the results of my search, the city was built in 1751.')```",
+            "send_msg_to_user('Based on the results of my search, the city was built in 1751.')",
+            'Tell the user that the city was built in 1751.',
+            'Based on the results of my search, the city was built in 1751.',
+        ),
+        (
+            "send_msg_to_user('The server might not be running or accessible. Please check the server status and try again.'))```",
+            "send_msg_to_user('The server might not be running or accessible. Please check the server status and try again.'))",
+            '',
+            'The server might not be running or accessible. Please check the server status and try again.',
         ),
     ],
 )


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix syntax error in the browsing agent

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

One more issue with the browsing agent's parsing robustness. This PR attempts to fix a syntax error I noticed tonight in `send_msg_to_user`. The cause comes [from here](https://github.com/All-Hands-AI/OpenHands/blob/2692c0c8fd98bd8ff1bb88441e749dfbd53437e1/openhands/agenthub/browsing_agent/response_parser.py#L28), when the LLM response already has a `)` but not backticks, it will get 2 `))` plus backticks, then it fails [here](https://github.com/All-Hands-AI/OpenHands/blob/2692c0c8fd98bd8ff1bb88441e749dfbd53437e1/openhands/agenthub/browsing_agent/response_parser.py#L99) and the `ast.parse` has no mercy. (this made a swe-bench instance fail)

The original behavior (the double `))`) even works with actual browser actions e.g. `click(90))` or `click(90)` are accepted, but `send_msg_to_user` fails.

---
**Link of any specific issues this addresses**
