### PR TITLE
[Eval] Fix eval stuck when `result` is too large for pbar

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -248,7 +248,7 @@ def update_progress(
     """Update the progress bar and write the result to the output file."""
     pbar.update(1)
     pbar.set_description(f'Instance {result.instance_id}')
-    pbar.set_postfix_str(f'Test Result: {result.test_result}')
+    pbar.set_postfix_str(f'Test Result: {str(result.test_result)[:300]}...')
     logger.info(
         f'Finished evaluation for instance {result.instance_id}: {str(result.test_result)[:300]}...\n'
     )


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

On some really rare occasions, `eval_infer_remote.sh` will get stuck (on both single process & multi-processing settings). It turns out that passing a very large string to `bar.set_postfix_str` is a source of error. This PR introduces a manual truncation of the string to avoid hanging.

---
**Link of any specific issues this addresses**
