### PR TITLE
fix #4363: replace task_id with instance_id

### DIFF
--- a/evaluation/humanevalfix/run_infer.py
+++ b/evaluation/humanevalfix/run_infer.py
@@ -99,7 +99,7 @@ def get_config(
 
 
 def _get_instance_id(instance: pd.Series) -> str:
-    return instance.task_id.replace('/', '__')
+    return instance.instance_id.replace('/', '__')
 
 
 def initialize_runtime(
@@ -206,9 +206,9 @@ def process_instance(
     # Setup the logger properly, so you can run multi-processing to parallelize the evaluation
     if reset_logger:
         log_dir = os.path.join(metadata.eval_output_dir, 'infer_logs')
-        reset_logger_for_multiprocessing(logger, instance.task_id, log_dir)
+        reset_logger_for_multiprocessing(logger, instance.instance_id, log_dir)
     else:
-        logger.info(f'Starting evaluation for instance {instance.task_id}.')
+        logger.info(f'Starting evaluation for instance {instance.instance_id}.')
 
     # Create file with HumanEvalFix problem
     # Prompt reference: https://github.com/bigcode-project/bigcode-evaluation-harness/blob/84b96da31b7f840b55c5733325346176140cdb6b/bigcode_eval/tasks/humanevalpack.py#L509
@@ -257,7 +257,7 @@ def process_instance(
 
     # Save the output
     output = EvalOutput(
-        instance_id=instance.task_id,
+        instance_id=instance.instance_id,
         instruction=instruction,
         metadata=metadata,
         history=histories,


### PR DESCRIPTION
## **End-user friendly description of the problem this fixes or functionality that this introduces**

This PR resolves an issue in the HumanEval benchmark's `run_infer.py` script where the code incorrectly references a column `task_id` that no longer exists. The correct column is `instance_id`. This fix ensures that the script runs without errors, making it compatible with the latest schema changes.

- [x] Include this change in the Release Notes.
End-user friendly description for the Release Notes:
"Fixes a column reference issue in run_infer.py where task_id was incorrectly used instead of instance_id."


---
## **Give a summary of what the PR does, explaining any non-trivial design decisions**
This PR refactors the Humaneval benchmark's `run_infer.py` script by replacing all occurrences of `task_id` with `instance_id` to align with the updated column naming convention. No major design changes were made, but the code now references the correct column to avoid attribute errors and ensure smooth execution of the Humaneval benchmark.


---
## **Link of any specific issues this addresses**
This PR addresses issue #4363, where an `AttributeError` occurs because the column name change from `task_id` to `instance_id` was not consistently applied throughout the file, leading to the error.