### PR TITLE
Fix: _interrupt_bash to send multiple Ctrl+C

### DIFF
--- a/openhands/runtime/client/client.py
+++ b/openhands/runtime/client/client.py
@@ -319,12 +319,11 @@ class RuntimeClient:
         interrupt_timeout: int | None = None,
         max_retries: int = 2,
     ) -> tuple[str, int]:
-        self.shell.sendintr()  # send SIGINT to the shell
-        logger.debug('Sent SIGINT to bash. Waiting for output...')
-
         interrupt_timeout = interrupt_timeout or 1  # default timeout for SIGINT
         # try to interrupt the bash shell use SIGINT
         while max_retries > 0:
+            self.shell.sendintr()  # send SIGINT to the shell
+            logger.debug('Sent SIGINT to bash. Waiting for output...')
             try:
                 self.shell.expect(self.__bash_expect_regex, timeout=interrupt_timeout)
                 output = self.shell.before


### PR DESCRIPTION
Really cool to see the remote runtime client! @xingyaoww 

Minor detail that I noticed while reading the code:

Perhaps I'm missing something, but so far, the `max_retries` loop seems to be equivalent to simply using a longer `pexpect` timeout (namely `max_retries * interrupt_timeout`): If `self.shell.expect` terminates: great, we simply return. If not, it only tries to `expect` again. And this could probably even cause a problematic scenario if the timeout occurs just while the `self.__bash_expect_regex` is printing.

I assume you meant to send multiple `Ctrl+C` instead? (that's what this PR is doing)