### PR TITLE
Fix for lockup - create the runtime in a background thread

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -40,6 +40,7 @@ from openhands.events.observation import (
 from openhands.events.serialization.event import truncate_content
 from openhands.llm.llm import LLM
 from openhands.runtime.utils.shutdown_listener import should_continue
+from openhands.utils.async_utils import call_coro_in_bg_thread
 
 # note: RESUME is only available on web GUI
 TRAFFIC_CONTROL_REMINDER = (
@@ -174,6 +175,9 @@ class AgentController:
         Args:
             event (Event): The incoming event to process.
         """
+        await call_coro_in_bg_thread(self._on_event, event=event)
+
+    async def _on_event(self, event: Event):
         if hasattr(event, 'hidden') and event.hidden:
             return
         if isinstance(event, Action):

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -40,7 +40,6 @@ from openhands.events.observation import (
 from openhands.events.serialization.event import truncate_content
 from openhands.llm.llm import LLM
 from openhands.runtime.utils.shutdown_listener import should_continue
-from openhands.utils.async_utils import call_coro_in_bg_thread
 
 # note: RESUME is only available on web GUI
 TRAFFIC_CONTROL_REMINDER = (
@@ -175,9 +174,6 @@ class AgentController:
         Args:
             event (Event): The incoming event to process.
         """
-        await call_coro_in_bg_thread(self._on_event, event=event)
-
-    async def _on_event(self, event: Event):
         if hasattr(event, 'hidden') and event.hidden:
             return
         if isinstance(event, Action):

--- a/openhands/runtime/runtime.py
+++ b/openhands/runtime/runtime.py
@@ -28,7 +28,7 @@ from openhands.events.observation import (
 )
 from openhands.events.serialization.action import ACTION_TYPE_TO_CLASS
 from openhands.runtime.plugins import JupyterRequirement, PluginRequirement
-from openhands.utils.async_utils import sync_from_async
+from openhands.utils.async_utils import call_sync_from_async
 
 
 def _default_env_vars(sandbox_config: SandboxConfig) -> dict[str, str]:
@@ -123,7 +123,7 @@ class Runtime:
             if event.timeout is None:
                 event.timeout = self.config.sandbox.timeout
             assert event.timeout is not None
-            observation = await sync_from_async(self.run_action, event)
+            observation = await call_sync_from_async(self.run_action, event)
             observation._cause = event.id  # type: ignore[attr-defined]
             source = event.source if event.source else EventSource.AGENT
             await self.event_stream.async_add_event(observation, source)  # type: ignore[arg-type]

--- a/openhands/security/invariant/analyzer.py
+++ b/openhands/security/invariant/analyzer.py
@@ -19,7 +19,7 @@ from openhands.runtime.utils import find_available_tcp_port
 from openhands.security.analyzer import SecurityAnalyzer
 from openhands.security.invariant.client import InvariantClient
 from openhands.security.invariant.parser import TraceElement, parse_element
-from openhands.utils.async_utils import sync_from_async
+from openhands.utils.async_utils import call_sync_from_async
 
 
 class InvariantAnalyzer(SecurityAnalyzer):
@@ -146,7 +146,7 @@ class InvariantAnalyzer(SecurityAnalyzer):
             {'action': 'change_agent_state', 'args': {'agent_state': 'user_confirmed'}}
         )
         event_source = event.source if event.source else EventSource.AGENT
-        await sync_from_async(self.event_stream.add_event, new_event, event_source)
+        await call_sync_from_async(self.event_stream.add_event, new_event, event_source)
 
     async def security_risk(self, event: Action) -> ActionSecurityRisk:
         logger.info('Calling security_risk on InvariantAnalyzer')

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -14,7 +14,7 @@ from pathspec.patterns import GitWildMatchPattern
 from openhands.security.options import SecurityAnalyzers
 from openhands.server.data_models.feedback import FeedbackDataModel, store_feedback
 from openhands.storage import get_file_store
-from openhands.utils.async_utils import sync_from_async
+from openhands.utils.async_utils import call_sync_from_async
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
@@ -441,7 +441,7 @@ async def list_files(request: Request, path: str | None = None):
         )
 
     runtime: Runtime = request.state.conversation.runtime
-    file_list = await sync_from_async(runtime.list_files, path)
+    file_list = await call_sync_from_async(runtime.list_files, path)
     if path:
         file_list = [os.path.join(path, f) for f in file_list]
 
@@ -490,7 +490,7 @@ async def select_file(file: str, request: Request):
 
     file = os.path.join(runtime.config.workspace_mount_path_in_sandbox, file)
     read_action = FileReadAction(file)
-    observation = await sync_from_async(runtime.run_action, read_action)
+    observation = await call_sync_from_async(runtime.run_action, read_action)
 
     if isinstance(observation, FileReadObservation):
         content = observation.content
@@ -687,7 +687,7 @@ async def save_file(request: Request):
             runtime.config.workspace_mount_path_in_sandbox, file_path
         )
         write_action = FileWriteAction(file_path, content)
-        observation = await sync_from_async(runtime.run_action, write_action)
+        observation = await call_sync_from_async(runtime.run_action, write_action)
 
         if isinstance(observation, FileWriteObservation):
             return JSONResponse(

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -211,8 +211,8 @@ async def attach_session(request: Request, call_next):
             content={'error': 'Invalid token'},
         )
 
-    request.state.conversation = session_manager.attach_to_conversation(
-        request.state.sid
+    request.state.conversation = await call_sync_from_async(
+        session_manager.attach_to_conversation, request.state.sid
     )
     if request.state.conversation is None:
         return JSONResponse(
@@ -441,7 +441,9 @@ async def list_files(request: Request, path: str | None = None):
         )
 
     runtime: Runtime = request.state.conversation.runtime
-    file_list = await call_sync_from_async(runtime.list_files, path)
+    file_list = await asyncio.create_task(
+        call_sync_from_async(runtime.list_files, path)
+    )
     if path:
         file_list = [os.path.join(path, f) for f in file_list]
 

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -14,6 +14,7 @@ from openhands.runtime import get_runtime_cls
 from openhands.runtime.runtime import Runtime
 from openhands.security import SecurityAnalyzer, options
 from openhands.storage.files import FileStore
+from openhands.utils.async_utils import call_coro_in_bg_thread
 
 
 class AgentSession:
@@ -102,7 +103,14 @@ class AgentSession:
     ):
         self.loop = asyncio.get_running_loop()
         self._create_security_analyzer(config.security.security_analyzer)
-        self._create_runtime(runtime_name, config, agent, status_message_callback)
+
+        await call_coro_in_bg_thread(
+            self._create_runtime,
+            runtime_name=runtime_name,
+            config=config,
+            agent=agent,
+            status_message_callback=status_message_callback,
+        )
         self._create_controller(
             agent,
             config.security.confirmation_mode,

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -103,8 +103,6 @@ class AgentSession:
     ):
         self.loop = asyncio.get_running_loop()
         self._create_security_analyzer(config.security.security_analyzer)
-
-        logger.info('TRACE:BEFORE:CREATE_RUNTIME')
         await call_sync_from_async(
             self._create_runtime,
             runtime_name=runtime_name,
@@ -112,7 +110,6 @@ class AgentSession:
             agent=agent,
             status_message_callback=status_message_callback,
         )
-        logger.info('TRACE:AFTER:CREATE_RUNTIME')
         self._create_controller(
             agent,
             config.security.confirmation_mode,

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -14,7 +14,7 @@ from openhands.runtime import get_runtime_cls
 from openhands.runtime.runtime import Runtime
 from openhands.security import SecurityAnalyzer, options
 from openhands.storage.files import FileStore
-from openhands.utils.async_utils import call_coro_in_bg_thread
+from openhands.utils.async_utils import call_sync_from_async
 
 
 class AgentSession:
@@ -104,13 +104,15 @@ class AgentSession:
         self.loop = asyncio.get_running_loop()
         self._create_security_analyzer(config.security.security_analyzer)
 
-        await call_coro_in_bg_thread(
+        logger.info('TRACE:BEFORE:CREATE_RUNTIME')
+        await call_sync_from_async(
             self._create_runtime,
             runtime_name=runtime_name,
             config=config,
             agent=agent,
             status_message_callback=status_message_callback,
         )
+        logger.info('TRACE:AFTER:CREATE_RUNTIME')
         self._create_controller(
             agent,
             config.security.confirmation_mode,
@@ -158,7 +160,7 @@ class AgentSession:
                 security_analyzer, SecurityAnalyzer
             )(self.event_stream)
 
-    async def _create_runtime(
+    def _create_runtime(
         self,
         runtime_name: str,
         config: AppConfig,

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -158,7 +158,7 @@ class AgentSession:
                 security_analyzer, SecurityAnalyzer
             )(self.event_stream)
 
-    def _create_runtime(
+    async def _create_runtime(
         self,
         runtime_name: str,
         config: AppConfig,

--- a/openhands/utils/async_utils.py
+++ b/openhands/utils/async_utils.py
@@ -27,6 +27,11 @@ def call_async_from_sync(
     and awaiting the result
     """
 
+    if corofn is None:
+        raise ValueError('corofn is None')
+    if not asyncio.iscoroutinefunction(corofn):
+        raise ValueError('corofn is not a coroutine function')
+
     async def arun():
         coro = corofn(*args, **kwargs)
         result = await coro

--- a/openhands/utils/async_utils.py
+++ b/openhands/utils/async_utils.py
@@ -7,7 +7,7 @@ GENERAL_TIMEOUT: int = 15
 EXECUTOR = ThreadPoolExecutor()
 
 
-async def sync_from_async(fn: Callable, *args, **kwargs):
+async def call_sync_from_async(fn: Callable, *args, **kwargs):
     """
     Shorthand for running a function in the default background thread pool executor
     and awaiting the result. The nature of synchronous code is that the future
@@ -19,7 +19,7 @@ async def sync_from_async(fn: Callable, *args, **kwargs):
     return result
 
 
-def async_from_sync(
+def call_async_from_sync(
     corofn: Callable, timeout: float = GENERAL_TIMEOUT, *args, **kwargs
 ):
     """
@@ -44,6 +44,13 @@ def async_from_sync(
     futures.wait([future], timeout=timeout or None)
     result = future.result()
     return result
+
+
+async def call_coro_in_bg_thread(
+    corofn: Callable, timeout: float = GENERAL_TIMEOUT, *args, **kwargs
+):
+    """Function for running a coroutine in a background thread."""
+    await call_sync_from_async(call_async_from_sync, corofn, timeout, *args, **kwargs)
 
 
 async def wait_all(


### PR DESCRIPTION
**Fix lockups in SAAS environment**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
* Renamed asynci_utils methods for clarity (Added `call` to the start)
* Added new async_utils method for calling a coroutine in a background thread (Yes - this is a bit of a hack, but some of our coroutines are misbehaving and this gives us leverage)
* Create the runtime in a background thread

