### PR TITLE
Fix eval output path in case of @ char

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -152,7 +152,7 @@ def make_metadata(
     details: dict[str, Any] | None = None,
 ) -> EvalMetadata:
     model_name = llm_config.model.split('/')[-1]
-    model_path = model_name.replace(':', '_')
+    model_path = model_name.replace(':', '_').replace('@', '-')
     eval_note = f'_N_{eval_note}' if eval_note else ''
 
     eval_output_path = os.path.join(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Fix eval output path in case of @ char

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This is causing issues because the model I'm using is `openai/claude-3-5-sonnet@20240620` and because of the `@` some systems don't accept that as a valid char in directory paths.

Tested the scenario and as long as the `@` is replaced, it works.

---
**Link of any specific issues this addresses**
