### PR TITLE
fix(frontend): Fix request headers

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -71,7 +71,9 @@ class OpenHands {
     if (path) url.searchParams.append("path", path);
 
     const response = await fetch(url.toString(), {
-      headers: OpenHands.generateHeaders(token),
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
 
     return response.json();
@@ -87,7 +89,9 @@ class OpenHands {
     const url = new URL(`${OpenHands.BASE_URL}/api/select-file`);
     url.searchParams.append("file", path);
     const response = await fetch(url.toString(), {
-      headers: OpenHands.generateHeaders(token),
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
 
     const data = await response.json();
@@ -109,7 +113,10 @@ class OpenHands {
     const response = await fetch(`${OpenHands.BASE_URL}/api/save-file`, {
       method: "POST",
       body: JSON.stringify({ filePath: path, content }),
-      headers: OpenHands.generateHeaders(token),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
     });
 
     return response.json();
@@ -130,8 +137,10 @@ class OpenHands {
 
     const response = await fetch(`${OpenHands.BASE_URL}/api/upload-files`, {
       method: "POST",
-      headers: OpenHands.generateHeaders(token),
       body: formData,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
 
     return response.json();
@@ -144,8 +153,11 @@ class OpenHands {
    */
   static async getWorkspaceZip(token: string): Promise<Blob> {
     const response = await fetch(`${OpenHands.BASE_URL}/api/zip-directory`, {
-      headers: OpenHands.generateHeaders(token),
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
+
     return response.blob();
   }
 
@@ -158,12 +170,14 @@ class OpenHands {
   static async sendFeedback(
     token: string,
     data: Feedback,
-    // TODO: Type the response
   ): Promise<FeedbackResponse> {
     const response = await fetch(`${OpenHands.BASE_URL}/api/submit-feedback`, {
       method: "POST",
-      headers: OpenHands.generateHeaders(token),
       body: JSON.stringify(data),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
     });
 
     return response.json();
@@ -180,20 +194,12 @@ class OpenHands {
     const response = await fetch(`${OpenHands.BASE_URL}/github/callback`, {
       method: "POST",
       body: JSON.stringify({ code }),
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
 
     return response.json();
-  }
-
-  /**
-   * Generate the headers for the request
-   * @param token User token provided by the server
-   * @returns Headers for the request
-   */
-  private static generateHeaders(token: string) {
-    return {
-      Authorization: `Bearer ${token}`,
-    };
   }
 }
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
Requests were attempting to send JSON data without setting content-type, causing 422's in the server.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Adds `"Content-Type": "application/json"` to the headers of requests that send JSON data


---
**Link of any specific issues this addresses**
Resolves #4348
