### PR TITLE
fix(frontend): Update build directory and referenced paths

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -90,7 +90,7 @@ RUN python openhands/core/download.py # No-op to download assets
 # openhands:openhands -> openhands:app
 RUN find /app \! -group app -exec chgrp app {} +
 
-COPY --chown=openhands:app --chmod=770 --from=frontend-builder /app/build/client ./frontend/build
+COPY --chown=openhands:app --chmod=770 --from=frontend-builder /app/build ./frontend/build
 COPY --chown=openhands:app --chmod=770 ./containers/app/entrypoint.sh /app/entrypoint.sh
 
 USER root

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "dev": "npm run make-i18n && VITE_MOCK_API=false remix vite:dev",
     "dev:mock": "npm run make-i18n && VITE_MOCK_API=true remix vite:dev",
     "build": "npm run make-i18n && tsc && remix vite:build",
-    "start": "npx sirv-cli build/client/ --single",
+    "start": "npx sirv-cli build/ --single",
     "test": "vitest run",
     "test:coverage": "npm run make-i18n && vitest run --coverage",
     "dev_wsl": "VITE_WATCH_USE_POLLING=true vite",

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -798,4 +798,4 @@ def github_callback(auth_code: AuthCode):
     )
 
 
-app.mount('/', StaticFiles(directory='./frontend/build/client', html=True), name='dist')
+app.mount('/', StaticFiles(directory='./frontend/build', html=True), name='dist')


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
The directory path of the static files served through `listen.py` is `frontend/build/client` which is different than what is used when building with Docker (`frontend/build` only)

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Update vite config to "unpack" the client directory
- Change previous reference to reflect this new path


---
**Link of any specific issues this addresses**
