### PR TITLE
Fix issue #4480: '[Bug]: Being blocked by cloudflare results in futile retries

### DIFF
--- a/openhands/core/exceptions.py
+++ b/openhands/core/exceptions.py
@@ -84,3 +84,9 @@ class OperationCancelled(Exception):
 
     def __init__(self, message='Operation was cancelled'):
         super().__init__(message)
+
+
+class CloudFlareBlockageError(Exception):
+    """Exception raised when a request is blocked by CloudFlare."""
+
+    pass

--- a/openhands/exceptions.py
+++ b/openhands/exceptions.py
@@ -1,0 +1,3 @@
+class CloudFlareBlockageError(Exception):
+    """Exception raised when a request is blocked by CloudFlare."""
+    pass

--- a/openhands/exceptions.py
+++ b/openhands/exceptions.py
@@ -1,3 +1,0 @@
-class CloudFlareBlockageError(Exception):
-    """Exception raised when a request is blocked by CloudFlare."""
-    pass

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -19,9 +19,9 @@ from litellm.exceptions import (
     RateLimitError,
     ServiceUnavailableError,
 )
-from openhands.exceptions import CloudFlareBlockageError
 from litellm.types.utils import CostPerToken, ModelResponse, Usage
 
+from openhands.core.exceptions import CloudFlareBlockageError
 from openhands.core.logger import openhands_logger as logger
 from openhands.core.message import Message
 from openhands.core.metrics import Metrics
@@ -213,8 +213,10 @@ class LLM(RetryMixin, DebugMixin):
 
                 return resp
             except APIError as e:
-                if "Attention Required! | Cloudflare" in str(e):
-                    raise CloudFlareBlockageError("Request blocked by CloudFlare") from e
+                if 'Attention Required! | Cloudflare' in str(e):
+                    raise CloudFlareBlockageError(
+                        'Request blocked by CloudFlare'
+                    ) from e
                 raise
 
         self._completion = wrapper

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -337,18 +337,19 @@ def test_completion_with_two_positional_args(mock_litellm_completion, default_co
 @patch('openhands.llm.llm.litellm_completion')
 def test_llm_cloudflare_blockage(mock_litellm_completion, default_config):
     from litellm.exceptions import APIError
-    from openhands.exceptions import CloudFlareBlockageError
+
+    from openhands.core.exceptions import CloudFlareBlockageError
 
     llm = LLM(default_config)
     mock_litellm_completion.side_effect = APIError(
-        message="Attention Required! | Cloudflare",
-        llm_provider="test_provider",
-        model="test_model",
-        status_code=403
+        message='Attention Required! | Cloudflare',
+        llm_provider='test_provider',
+        model='test_model',
+        status_code=403,
     )
 
-    with pytest.raises(CloudFlareBlockageError, match="Request blocked by CloudFlare"):
-        llm.completion(messages=[{"role": "user", "content": "Hello"}])
+    with pytest.raises(CloudFlareBlockageError, match='Request blocked by CloudFlare'):
+        llm.completion(messages=[{'role': 'user', 'content': 'Hello'}])
 
     # Ensure the completion was called
     mock_litellm_completion.assert_called_once()

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -332,3 +332,23 @@ def test_completion_with_two_positional_args(mock_litellm_completion, default_co
     assert (
         len(call_args) == 0
     )  # No positional args should be passed to litellm_completion here
+
+
+@patch('openhands.llm.llm.litellm_completion')
+def test_llm_cloudflare_blockage(mock_litellm_completion, default_config):
+    from litellm.exceptions import APIError
+    from openhands.exceptions import CloudFlareBlockageError
+
+    llm = LLM(default_config)
+    mock_litellm_completion.side_effect = APIError(
+        message="Attention Required! | Cloudflare",
+        llm_provider="test_provider",
+        model="test_model",
+        status_code=403
+    )
+
+    with pytest.raises(CloudFlareBlockageError, match="Request blocked by CloudFlare"):
+        llm.completion(messages=[{"role": "user", "content": "Hello"}])
+
+    # Ensure the completion was called
+    mock_litellm_completion.assert_called_once()


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Fixed unlimited retries when queries are blocked by CloudFlare.

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR fixes the fact that OpenHands will perform unlimited retries when a query is blocked by CloudFlare.

---
**Link of any specific issues this addresses**

Fixes #4480