### PR TITLE
feat: clean-up retries RemoteRuntime & add FatalErrorObservation

### DIFF
--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -384,6 +384,15 @@ def process_instance(
             )
         )
 
+        # if fatal error, throw EvalError to trigger re-run
+        assert_and_raise(
+            not (
+                state.last_error
+                and 'fatal error during agent execution' in state.last_error
+            ),
+            'Fatal error detected: ' + state.last_error,
+        )
+
         # ======= THIS IS SWE-Bench specific =======
         # Get git patch
         return_val = complete_runtime(runtime, instance)

--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -11,6 +11,7 @@ from datasets import load_dataset
 import openhands.agenthub
 from evaluation.swe_bench.prompt import CODEACT_SWE_PROMPT
 from evaluation.utils.shared import (
+    EvalException,
     EvalMetadata,
     EvalOutput,
     assert_and_raise,
@@ -385,13 +386,11 @@ def process_instance(
         )
 
         # if fatal error, throw EvalError to trigger re-run
-        assert_and_raise(
-            not (
-                state.last_error
-                and 'fatal error during agent execution' in state.last_error
-            ),
-            'Fatal error detected: ' + state.last_error,
-        )
+        if (
+            state.last_error
+            and 'fatal error during agent execution' in state.last_error
+        ):
+            raise EvalException('Fatal error detected: ' + state.last_error)
 
         # ======= THIS IS SWE-Bench specific =======
         # Get git patch

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -35,6 +35,7 @@ from openhands.events.observation import (
     AgentStateChangedObservation,
     CmdOutputObservation,
     ErrorObservation,
+    FatalErrorObservation,
     Observation,
 )
 from openhands.events.serialization.event import truncate_content
@@ -249,6 +250,12 @@ class AgentController:
         elif isinstance(observation, ErrorObservation):
             if self.state.agent_state == AgentState.ERROR:
                 self.state.metrics.merge(self.state.local_metrics)
+        elif isinstance(observation, FatalErrorObservation):
+            await self.report_error(
+                'There was a fatal error during agent execution: ' + str(observation)
+            )
+            await self.set_agent_state_to(AgentState.ERROR)
+            self.state.metrics.merge(self.state.local_metrics)
 
     async def _handle_message_action(self, action: MessageAction):
         """Handles message actions from the event stream.

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -6,8 +6,11 @@ from openhands.events.observation.commands import (
 )
 from openhands.events.observation.delegate import AgentDelegateObservation
 from openhands.events.observation.empty import NullObservation
-from openhands.events.observation.error import ErrorObservation
-from openhands.events.observation.files import FileReadObservation, FileWriteObservation
+from openhands.events.observation.error import ErrorObservation, FatalErrorObservation
+from openhands.events.observation.files import (
+    FileReadObservation,
+    FileWriteObservation,
+)
 from openhands.events.observation.observation import Observation
 from openhands.events.observation.reject import UserRejectObservation
 from openhands.events.observation.success import SuccessObservation
@@ -21,6 +24,7 @@ __all__ = [
     'FileReadObservation',
     'FileWriteObservation',
     'ErrorObservation',
+    'FatalErrorObservation',
     'AgentStateChangedObservation',
     'AgentDelegateObservation',
     'SuccessObservation',

--- a/openhands/events/observation/error.py
+++ b/openhands/events/observation/error.py
@@ -6,10 +6,31 @@ from openhands.events.observation.observation import Observation
 
 @dataclass
 class ErrorObservation(Observation):
-    """This data class represents an error encountered by the agent."""
+    """This data class represents an error encountered by the agent.
+
+    This is the type of error that LLM can recover from.
+    E.g., Linter error after editing a file.
+    """
 
     observation: str = ObservationType.ERROR
 
     @property
     def message(self) -> str:
         return self.content
+
+    def __str__(self) -> str:
+        return f'**ErrorObservation**\n{self.content}'
+
+
+@dataclass
+class FatalErrorObservation(Observation):
+    """This data class represents a fatal error encountered by the agent.
+
+    This is the type of error that LLM CANNOT recover from, and the agent controller should stop the execution and report the error to the user.
+    E.g., Remote runtime action execution failure: 503 Server Error: Service Unavailable for url OR 404 Not Found.
+    """
+
+    observation: str = ObservationType.ERROR
+
+    def __str__(self) -> str:
+        return f'**FatalErrorObservation**\n{self.content}'

--- a/openhands/runtime/remote/runtime.py
+++ b/openhands/runtime/remote/runtime.py
@@ -31,8 +31,8 @@ from openhands.runtime.builder.remote import RemoteRuntimeBuilder
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.runtime import Runtime
 from openhands.runtime.utils.request import (
-    DEFAULT_RETRY_EXCEPTIONS,
     is_404_error,
+    is_503_error,
     send_request_with_retry,
 )
 from openhands.runtime.utils.runtime_build import build_runtime_image
@@ -90,7 +90,6 @@ class RemoteRuntime(Runtime):
             status_message_callback,
             attach_to_existing,
         )
-        self._wait_until_alive()
         self.setup_initial_env()
 
     def _start_or_attach_to_runtime(
@@ -307,10 +306,10 @@ class RemoteRuntime(Runtime):
             self.session,
             'GET',
             f'{self.runtime_url}/alive',
-            # Retry 404 errors for the /alive endpoint
+            # Retry 404 & 503 errors for the /alive endpoint
             # because the runtime might just be starting up
             # and have not registered the endpoint yet
-            retry_fns=[is_404_error],
+            retry_fns=[is_404_error, is_503_error],
             # leave enough time for the runtime to start up
             timeout=600,
         )
@@ -367,13 +366,6 @@ class RemoteRuntime(Runtime):
                     f'{self.runtime_url}/execute_action',
                     json=request_body,
                     timeout=action.timeout,
-                    retry_exceptions=list(
-                        filter(lambda e: e != TimeoutError, DEFAULT_RETRY_EXCEPTIONS)
-                    ),
-                    # Retry 404 errors for the /execute_action endpoint
-                    # because the runtime might just be starting up
-                    # and have not registered the endpoint yet
-                    retry_fns=[is_404_error],
                 )
                 if response.status_code == 200:
                     output = response.json()
@@ -444,9 +436,6 @@ class RemoteRuntime(Runtime):
                 f'{self.runtime_url}/upload_file',
                 files=upload_data,
                 params=params,
-                retry_exceptions=list(
-                    filter(lambda e: e != TimeoutError, DEFAULT_RETRY_EXCEPTIONS)
-                ),
                 timeout=300,
             )
             if response.status_code == 200:
@@ -477,9 +466,6 @@ class RemoteRuntime(Runtime):
                 'POST',
                 f'{self.runtime_url}/list_files',
                 json=data,
-                retry_exceptions=list(
-                    filter(lambda e: e != TimeoutError, DEFAULT_RETRY_EXCEPTIONS)
-                ),
                 timeout=30,
             )
             if response.status_code == 200:
@@ -496,7 +482,6 @@ class RemoteRuntime(Runtime):
 
     def copy_from(self, path: str) -> bytes:
         """Zip all files in the sandbox and return as a stream of bytes."""
-        self._wait_until_alive()
         try:
             params = {'path': path}
             response = send_request_with_retry(
@@ -505,9 +490,6 @@ class RemoteRuntime(Runtime):
                 f'{self.runtime_url}/download_files',
                 params=params,
                 timeout=30,
-                retry_exceptions=list(
-                    filter(lambda e: e != TimeoutError, DEFAULT_RETRY_EXCEPTIONS)
-                ),
             )
             if response.status_code == 200:
                 return response.content

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -1,7 +1,10 @@
 from typing import Any, Callable, Type
 
 import requests
-from requests.exceptions import ConnectionError, Timeout
+from requests.exceptions import (
+    ChunkedEncodingError,
+    ConnectionError,
+)
 from tenacity import (
     retry,
     retry_if_exception,
@@ -9,6 +12,7 @@ from tenacity import (
     stop_after_delay,
     wait_exponential,
 )
+from urllib3.exceptions import IncompleteRead
 
 from openhands.utils.tenacity_stop import stop_if_should_exit
 
@@ -27,9 +31,17 @@ def is_404_error(exception):
     )
 
 
+def is_503_error(exception):
+    return (
+        isinstance(exception, requests.HTTPError)
+        and exception.response.status_code == 503
+    )
+
+
 DEFAULT_RETRY_EXCEPTIONS = [
     ConnectionError,
-    Timeout,
+    IncompleteRead,
+    ChunkedEncodingError,
 ]
 
 
@@ -43,9 +55,7 @@ def send_request_with_retry(
     **kwargs: Any,
 ) -> requests.Response:
     exceptions_to_catch = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS
-    retry_condition = retry_if_exception_type(
-        tuple(exceptions_to_catch)
-    ) | retry_if_exception(is_server_error)
+    retry_condition = retry_if_exception_type(tuple(exceptions_to_catch))
     if retry_fns is not None:
         for fn in retry_fns:
             retry_condition |= retry_if_exception(fn)

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -38,6 +38,13 @@ def is_503_error(exception):
     )
 
 
+def is_502_error(exception):
+    return (
+        isinstance(exception, requests.HTTPError)
+        and exception.response.status_code == 502
+    )
+
+
 DEFAULT_RETRY_EXCEPTIONS = [
     ConnectionError,
     IncompleteRead,
@@ -55,7 +62,9 @@ def send_request_with_retry(
     **kwargs: Any,
 ) -> requests.Response:
     exceptions_to_catch = retry_exceptions or DEFAULT_RETRY_EXCEPTIONS
-    retry_condition = retry_if_exception_type(tuple(exceptions_to_catch))
+    retry_condition = retry_if_exception_type(
+        tuple(exceptions_to_catch)
+    ) | retry_if_exception(is_502_error)
     if retry_fns is not None:
         for fn in retry_fns:
             retry_condition |= retry_if_exception(fn)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

These are part of changes from my editing PR branch: https://github.com/All-Hands-AI/OpenHands/pull/3985

1. Remove unnecessary retries from RemoteRuntime - once the runtime is available, we only retry on HTTP 502, but not 503 & 404 - we will just fail hard on that bc they typically mean there's something wrong happening on pods from the server end
2. add `FatalErrorObservation,` which distinguishes itself from `ErrorObservation` - it represents a type of error that's not the agent's fault (e.g., runtime pod died due to some k8s scheduling) and is not recoverable. I also tweaked the agent controller so it will properly stop when a FatalErrorObservation is sent as an exception. 
3. I use FatalErrorObservation to replace all the RuntimeError exceptions directly thrown out of the `RemoteRuntime` class - this also helps alleviate some async issues caused by throwing exceptions inside `on_event` (e.g., `future: <Task finished name='Task-45' coro=<Runtime.on_event() done, ...` )
4. Add runtime ID information to all the logging in `RemoteRuntime` to help us better debug issues.