### PR TITLE
fix freeze on zip-files endpoint

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -741,7 +741,7 @@ async def zip_current_workspace(request: Request):
         runtime: Runtime = request.state.conversation.runtime
 
         path = runtime.config.workspace_mount_path_in_sandbox
-        zip_file_bytes = runtime.copy_from(path)
+        zip_file_bytes = await call_sync_from_async(runtime.copy_from, path)
         zip_stream = io.BytesIO(zip_file_bytes)  # Wrap to behave like a file stream
         response = StreamingResponse(
             zip_stream,


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
bugfix: backend freezes when zipping a large directory

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
This turns zip-files into an async call


---
**Link of any specific issues this addresses**
