### PR TITLE
.gitignore: ignore all `node_modules` folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,7 +178,6 @@ evaluation/toolqa/data
 # frontend
 
 # dependencies
-frontend/node_modules
 frontend/.pnp
 frontend/bun.lockb
 frontend/yarn.lock
@@ -228,3 +227,4 @@ runtime_*.tar
 containers/runtime/Dockerfile
 containers/runtime/project.tar.gz
 containers/runtime/code
+**/node_modules/


### PR DESCRIPTION
Simply ignore any `node_modules` folder, not just the one in the `frontend` folder.

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
