### PR TITLE
fix(runtime): replace codec error in pexcept

### DIFF
--- a/openhands/runtime/client/client.py
+++ b/openhands/runtime/client/client.py
@@ -229,6 +229,7 @@ class RuntimeClient:
         self.shell = pexpect.spawn(
             f'su {username}',
             encoding='utf-8',
+            codec_errors='replace',
             echo=False,
         )
         self.__bash_PS1 = (


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Runtime API server inside sandbox sometime will throw errors when pexcept run into non-unicode. This PR applies the `codec_errors='replace'` suggestion from https://github.com/pexpect/pexpect/issues/381#issuecomment-312823577 


<img width="1569" alt="image" src="https://github.com/user-attachments/assets/49c2e42c-9e4b-49f8-8fcc-25e8a100d600">


---
**Link of any specific issues this addresses**
