### PR TITLE
Check group with name instead of ID

### DIFF
--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -32,6 +32,12 @@ else
   if id "enduser" &>/dev/null; then
     echo "User enduser already exists. Skipping creation."
   else
+    # We want to create a user to run the app that has:
+    # User name of enduser
+    # User ID of $SANDBOX_USER_ID
+    # Belong to groups of:
+    #   * app
+    #   * group of /var/run/docker.sock
     echo "Creating enduser with ID $SANDBOX_USER_ID"
 
     if ! useradd -l -m -u $SANDBOX_USER_ID -s /bin/bash enduser; then
@@ -46,26 +52,21 @@ else
     fi
   fi
 
-  usermod -aG app enduser
-
   # Get the user group of /var/run/docker.sock and set enduser to that group
   DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
   DOCKER_SOCKET_GROUP=$(stat -c '%G' /var/run/docker.sock)
-
-  GROUP_FROM_GID=$(getent group | grep ":$DOCKER_SOCKET_GID:" | awk -F: '{print $1}')
-
   echo "Docker socket group $DOCKER_SOCKET_GROUP with group ID $DOCKER_SOCKET_GID"
-  echo "Group associated with GID is: $GROUP_FROM_GID"
 
-  if getent group $DOCKER_SOCKET_GROUP || getent group $DOCKER_SOCKET_GID; then
+  if getent group $DOCKER_SOCKET_GID; then
     echo "Group $DOCKER_SOCKET_GROUP already exists"
   else
-    echo "Creating group $DOCKER_SOCKET_GROUP with id $DOCKER_SOCKET_GID"
-    groupadd -g $DOCKER_SOCKET_GID docker
+    echo "Could not find group $DOCKER_SOCKET_GROUP with id $DOCKER_SOCKET_GID. Adding enduser to docker group"
+    DOCKER_SOCKET_GROUP="docker"
   fi
 
-  echo "Adding group $GROUP_FROM_GID to enduser"
-  usermod -aG $GROUP_FROM_GID enduser
+  echo "Adding group app, $DOCKER_SOCKET_GROUP to enduser"
+  usermod -aG app enduser
+  usermod -aG $DOCKER_SOCKET_GROUP enduser
 
   mkdir -p /home/enduser/.cache/huggingface/hub/
   mkdir -p /home/enduser/.cache/ms-playwright/

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -50,12 +50,14 @@ else
         exit 1
       fi
     fi
+
+    echo "Created enduser with ID $SANDBOX_USER_ID"
   fi
 
   # Get the user group of /var/run/docker.sock and set enduser to that group
   DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
   DOCKER_SOCKET_GROUP=$(stat -c '%G' /var/run/docker.sock)
-  echo "Docker socket group $DOCKER_SOCKET_GROUP with group ID $DOCKER_SOCKET_GID"
+  echo "Docker socket has group $DOCKER_SOCKET_GROUP with group ID $DOCKER_SOCKET_GID"
 
   if getent group $DOCKER_SOCKET_GID; then
     echo "Group $DOCKER_SOCKET_GID already exists"
@@ -64,7 +66,7 @@ else
     DOCKER_SOCKET_GROUP="docker"
   fi
 
-  echo "Adding group app, $DOCKER_SOCKET_GROUP to enduser"
+  echo "Adding group app and $DOCKER_SOCKET_GROUP to enduser"
   usermod -aG app enduser
   usermod -aG $DOCKER_SOCKET_GROUP enduser
 

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -50,17 +50,22 @@ else
 
   # Get the user group of /var/run/docker.sock and set enduser to that group
   DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
-  DOCKER_SOCKER_GROUP=$(stat -c '%G' /var/run/docker.sock)
-  echo "Docker socket group $DOCKER_SOCKER_GROUP with group ID $DOCKER_SOCKET_GID"
+  DOCKER_SOCKET_GROUP=$(stat -c '%G' /var/run/docker.sock)
 
-  if getent group $DOCKER_SOCKER_GROUP; then
-    echo "Group $DOCKER_SOCKER_GROUP already exists"
+  GROUP_FROM_GID=$(getent group | grep ":$DOCKER_SOCKET_GID:" | awk -F: '{print $1}')
+
+  echo "Docker socket group $DOCKER_SOCKET_GROUP with group ID $DOCKER_SOCKET_GID"
+  echo "Group associated with GID is: $GROUP_FROM_GID"
+
+  if getent group $DOCKER_SOCKET_GROUP || getent group $DOCKER_SOCKET_GID; then
+    echo "Group $DOCKER_SOCKET_GROUP already exists"
   else
-    echo "Creating group $DOCKER_SOCKER_GROUP with id $DOCKER_SOCKET_GID"
+    echo "Creating group $DOCKER_SOCKET_GROUP with id $DOCKER_SOCKET_GID"
     groupadd -g $DOCKER_SOCKET_GID docker
   fi
 
-  usermod -aG $DOCKER_SOCKER_GROUP enduser
+  echo "Adding group $GROUP_FROM_GID to enduser"
+  usermod -aG $GROUP_FROM_GID enduser
 
   mkdir -p /home/enduser/.cache/huggingface/hub/
   mkdir -p /home/enduser/.cache/ms-playwright/

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -58,7 +58,7 @@ else
   echo "Docker socket group $DOCKER_SOCKET_GROUP with group ID $DOCKER_SOCKET_GID"
 
   if getent group $DOCKER_SOCKET_GID; then
-    echo "Group $DOCKER_SOCKET_GROUP already exists"
+    echo "Group $DOCKER_SOCKET_GID already exists"
   else
     echo "Could not find group $DOCKER_SOCKET_GROUP with id $DOCKER_SOCKET_GID. Adding enduser to docker group"
     DOCKER_SOCKET_GROUP="docker"


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Check group with name instead of ID

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Unsure if this will solve the problem but the `getent group` should be queried using the name. I'll see if I can get someone to test this out on linux before merging.

---
**Link of any specific issues this addresses**
Trying to fix: https://github.com/All-Hands-AI/OpenHands/issues/4494