### PR TITLE
[ALL-561] feat(frontend|backend): Display error messages in the chat

### DIFF
--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -1,24 +1,37 @@
 import ChatMessage from "./ChatMessage";
 import AgentState from "#/types/AgentState";
 
+const isMessage = (message: Message | ErrorMessage): message is Message =>
+  "sender" in message;
+
 interface ChatProps {
-  messages: Message[];
+  messages: (Message | ErrorMessage)[];
   curAgentState?: AgentState;
 }
 
 function Chat({ messages, curAgentState }: ChatProps) {
   return (
     <div className="flex flex-col gap-3 px-3 pt-3 mb-6">
-      {messages.map((message, index) => (
-        <ChatMessage
-          key={index}
-          message={message}
-          isLastMessage={messages && index === messages.length - 1}
-          awaitingUserConfirmation={
-            curAgentState === AgentState.AWAITING_USER_CONFIRMATION
-          }
-        />
-      ))}
+      {messages.map((message, index) =>
+        isMessage(message) ? (
+          <ChatMessage
+            key={index}
+            message={message}
+            isLastMessage={messages && index === messages.length - 1}
+            awaitingUserConfirmation={
+              curAgentState === AgentState.AWAITING_USER_CONFIRMATION
+            }
+          />
+        ) : (
+          <div key={index} className="flex gap-2 items-center justify-start">
+            <div className="bg-danger w-2 h-full rounded" />
+            <div className="text-sm leading-4 flex flex-col gap-2">
+              <p className="text-danger font-bold">{message.error}</p>
+              <p className="text-neutral-300">{message.message}</p>
+            </div>
+          </div>
+        ),
+      )}
     </div>
   );
 }

--- a/frontend/src/components/chat/message.d.ts
+++ b/frontend/src/components/chat/message.d.ts
@@ -4,3 +4,8 @@ type Message = {
   imageUrls: string[];
   timestamp: string;
 };
+
+type ErrorMessage = {
+  error: string;
+  message: string;
+};

--- a/frontend/src/state/chatSlice.ts
+++ b/frontend/src/state/chatSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-type SliceState = { messages: Message[] };
+type SliceState = { messages: (Message | ErrorMessage)[] };
 
 const initialState: SliceState = {
   messages: [],
@@ -37,12 +37,24 @@ export const chatSlice = createSlice({
       state.messages.push(message);
     },
 
+    addErrorMessage(
+      state,
+      action: PayloadAction<{ error: string; message: string }>,
+    ) {
+      const { error, message } = action.payload;
+      state.messages.push({ error, message });
+    },
+
     clearMessages(state) {
       state.messages = [];
     },
   },
 });
 
-export const { addUserMessage, addAssistantMessage, clearMessages } =
-  chatSlice.actions;
+export const {
+  addUserMessage,
+  addAssistantMessage,
+  addErrorMessage,
+  clearMessages,
+} = chatSlice.actions;
 export default chatSlice.reducer;

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -17,6 +17,7 @@ from openhands.events.observation import (
     CmdOutputObservation,
     NullObservation,
 )
+from openhands.events.observation.error import ErrorObservation
 from openhands.events.serialization import event_from_dict, event_to_dict
 from openhands.events.stream import EventStreamSubscriber
 from openhands.llm.llm import LLM
@@ -141,6 +142,8 @@ class Session:
             event, CmdOutputObservation
         ):
             await self.send(event_to_dict(event))
+        elif isinstance(event, ErrorObservation):
+            await self.send_error(event.message)
 
     async def dispatch(self, data: dict):
         action = data.get('action', '')


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
When something wrong occurred in the agent or backend, the frontend would be empty and hardly display any indicator to the user.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Utilize `send_error` to send `ErrorObservation`'s as well and modify the frontend to catch and display them. Some examples:

Exception caught by `report_error`
<img width="323" alt="Screenshot 2024-10-22 at 11 09 17" src="https://github.com/user-attachments/assets/2dd52df7-556e-4a9d-901c-94f674703b75">

Error sent directly by `send_error`
<img width="278" alt="Screenshot 2024-10-22 at 11 12 48" src="https://github.com/user-attachments/assets/447860c6-1679-4e25-a182-bc2c388ef133">

In some cases where the user may continue, the error remains displayed.
<img width="269" alt="Screenshot 2024-10-22 at 11 16 53" src="https://github.com/user-attachments/assets/f1c80cda-9568-45e1-9c7f-4c69cbd01ca7">

---
**Link of any specific issues this addresses**
