### PR TITLE
Mention `build-essential` dependency for ubuntu in dev doc

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -5,12 +5,14 @@ Otherwise, you can clone the OpenHands project directly.
 
 ## Start the server for development
 ### 1. Requirements
-* Linux, Mac OS, or [WSL on Windows](https://learn.microsoft.com/en-us/windows/wsl/install)  [ Ubuntu <= 22.04]
+* Linux, Mac OS, or [WSL on Windows](https://learn.microsoft.com/en-us/windows/wsl/install)  [Ubuntu <= 22.04]
 * [Docker](https://docs.docker.com/engine/install/) (For those on MacOS, make sure to allow the default Docker socket to be used from advanced settings!)
 * [Python](https://www.python.org/downloads/) = 3.12
 * [NodeJS](https://nodejs.org/en/download/package-manager) >= 18.17.1
 * [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer) >= 1.8
-* netcat => sudo apt-get install netcat
+* OS-specific dependencies:
+  - Ubuntu: build-essential => `sudo apt-get install build-essential`
+  - WSL: netcat => `sudo apt-get install netcat`
 
 Make sure you have all these dependencies installed before moving on to `make build`.
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Add a mention to `build-essential` dependency for Ubuntu in `Development.md`. It seems to be required for `pylcs` added in https://github.com/All-Hands-AI/OpenHands/pull/3985.

I got the error like below without it on Ubuntu 22.04:
<img width="1025" alt="Screenshot 2024-10-22 at 15 24 18" src="https://github.com/user-attachments/assets/f582b7ee-a4e8-4fb3-a186-89a07cd6744d">

---
**Link of any specific issues this addresses**

