### PR TITLE
[ALL-570] fix(frontend): Don't wrap filenames in the file explorer

### DIFF
--- a/frontend/src/components/file-explorer/TreeNode.tsx
+++ b/frontend/src/components/file-explorer/TreeNode.tsx
@@ -19,7 +19,7 @@ function Title({ name, type, isOpen, onClick }: TitleProps) {
   return (
     <div
       onClick={onClick}
-      className="cursor-pointer rounded-[5px] p-1 nowrap flex items-center gap-2 aria-selected:bg-neutral-600 aria-selected:text-white hover:text-white"
+      className="cursor-pointer text-nowrap rounded-[5px] p-1 nowrap flex items-center gap-2 aria-selected:bg-neutral-600 aria-selected:text-white hover:text-white"
     >
       <div className="flex-shrink-0">
         {type === "folder" && <FolderIcon isOpen={isOpen} />}


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Before:
![image](https://github.com/user-attachments/assets/f884b35a-d7d2-4241-b9df-c7c77450de98)


After:
<img width="228" alt="image" src="https://github.com/user-attachments/assets/830e21d4-70d6-4df6-9dfa-d9b52e1ea363">



---
**Link of any specific issues this addresses**
