### PR TITLE
Feature: Add ability to reconnect websockets

### DIFF
--- a/frontend/src/context/socket.tsx
+++ b/frontend/src/context/socket.tsx
@@ -58,11 +58,8 @@ function SocketProvider({ children }: SocketProviderProps) {
 
     ws.addEventListener("open", (event) => {
       setIsConnected(true);
-      // const reconnecting = wsReconnectRetries.current !== RECONNECT_RETRIES;
       wsReconnectRetries.current = RECONNECT_RETRIES;
-      // if (!reconnecting) {
       options?.onOpen?.(event);
-      // }
     });
 
     ws.addEventListener("message", (event) => {

--- a/frontend/src/context/socket.tsx
+++ b/frontend/src/context/socket.tsx
@@ -6,7 +6,7 @@ const RECONNECT_RETRIES = 5;
 
 interface WebSocketClientOptions {
   token: string | null;
-  onOpen?: (event: Event) => void;
+  onOpen?: (event: Event, isNewSession: boolean) => void;
   onMessage?: (event: MessageEvent<Data>) => void;
   onError?: (event: Event) => void;
   onClose?: (event: Event) => void;
@@ -58,8 +58,9 @@ function SocketProvider({ children }: SocketProviderProps) {
 
     ws.addEventListener("open", (event) => {
       setIsConnected(true);
+      const isNewSession = sessionToken === "NO_JWT";
       wsReconnectRetries.current = RECONNECT_RETRIES;
-      options?.onOpen?.(event);
+      options?.onOpen?.(event, isNewSession);
     });
 
     ws.addEventListener("message", (event) => {

--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -312,7 +312,7 @@ function App() {
             className={cn(
               "w-2 h-2 rounded-full border",
               "absolute left-3 top-3",
-              runtimeActive
+              runtimeIsInitialized
                 ? "bg-green-800 border-green-500"
                 : "bg-red-800 border-red-500",
             )}

--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -131,7 +131,8 @@ function App() {
   const { files, importedProjectZip } = useSelector(
     (state: RootState) => state.initalQuery,
   );
-  const { start, send, setRuntimeIsInitialized, runtimeActive } = useSocket();
+  const { start, send, setRuntimeIsInitialized, runtimeIsInitialized } =
+    useSocket();
   const { settings, token, ghToken, repo, q, lastCommit } =
     useLoaderData<typeof clientLoader>();
   const fetcher = useFetcher();
@@ -225,7 +226,7 @@ function App() {
         isAgentStateChange(parsed) &&
         parsed.extras.agent_state === AgentState.INIT
       ) {
-        setRuntimeIsInitialized();
+        setRuntimeIsInitialized(true);
 
         // handle new session
         if (!token) {
@@ -271,15 +272,15 @@ function App() {
   });
 
   React.useEffect(() => {
-    if (runtimeActive && userId && ghToken) {
+    if (runtimeIsInitialized && userId && ghToken) {
       // Export if the user valid, this could happen mid-session so it is handled here
       send(getGitHubTokenCommand(ghToken));
     }
-  }, [userId, ghToken, runtimeActive]);
+  }, [userId, ghToken, runtimeIsInitialized]);
 
   React.useEffect(() => {
     (async () => {
-      if (runtimeActive && importedProjectZip) {
+      if (runtimeIsInitialized && importedProjectZip) {
         // upload files action
         try {
           const blob = base64ToBlob(importedProjectZip);
@@ -293,7 +294,7 @@ function App() {
         }
       }
     })();
-  }, [runtimeActive, importedProjectZip]);
+  }, [runtimeIsInitialized, importedProjectZip]);
 
   const {
     isOpen: securityModalIsOpen,

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -105,18 +105,19 @@ class AgentController:
         self.agent = agent
         self.headless_mode = headless_mode
 
-        # subscribe to the event stream
-        self.event_stream = event_stream
-        self.event_stream.subscribe(
-            EventStreamSubscriber.AGENT_CONTROLLER, self.on_event, self.id
-        )
-
         # state from the previous session, state from a parent agent, or a fresh state
         self.set_initial_state(
             state=initial_state,
             max_iterations=max_iterations,
             confirmation_mode=confirmation_mode,
         )
+
+        # subscribe to the event stream
+        self.event_stream = event_stream
+        self.event_stream.subscribe(
+            EventStreamSubscriber.AGENT_CONTROLLER, self.on_event, self.id
+        )
+
         self.max_budget_per_task = max_budget_per_task
         self.agent_to_llm_config = agent_to_llm_config if agent_to_llm_config else {}
         self.agent_configs = agent_configs if agent_configs else {}
@@ -355,9 +356,10 @@ class AgentController:
             EventSource.ENVIRONMENT,
         )
 
-        if new_state == AgentState.INIT and self.state.resume_state:
-            await self.set_agent_state_to(self.state.resume_state)
-            self.state.resume_state = None
+        if new_state == AgentState.INIT:
+            if self.state.resume_state:
+                await self.set_agent_state_to(self.state.resume_state)
+                self.state.resume_state = None
 
     def get_agent_state(self):
         """Returns the current state of the agent.

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -356,10 +356,9 @@ class AgentController:
             EventSource.ENVIRONMENT,
         )
 
-        if new_state == AgentState.INIT:
-            if self.state.resume_state:
-                await self.set_agent_state_to(self.state.resume_state)
-                self.state.resume_state = None
+        if new_state == AgentState.INIT and self.state.resume_state:
+            await self.set_agent_state_to(self.state.resume_state)
+            self.state.resume_state = None
 
     def get_agent_state(self):
         """Returns the current state of the agent.

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -334,7 +334,7 @@ async def websocket_endpoint(websocket: WebSocket):
         sid = str(uuid.uuid4())
         jwt_token = sign_token({'sid': sid}, config.jwt_secret)
         logger.info(f'New session: {sid}')
-    
+
     session = session_manager.add_or_restart_session(sid, websocket)
     await websocket.send_json({'token': jwt_token, 'status': 'ok'})
 

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -329,11 +329,12 @@ async def websocket_endpoint(websocket: WebSocket):
             await websocket.send_json({'error': 'Invalid token', 'error_code': 401})
             await websocket.close()
             return
+        logger.info(f'Existing session: {sid}')
     else:
         sid = str(uuid.uuid4())
         jwt_token = sign_token({'sid': sid}, config.jwt_secret)
-
-    logger.info(f'New session: {sid}')
+        logger.info(f'New session: {sid}')
+    
     session = session_manager.add_or_restart_session(sid, websocket)
     await websocket.send_json({'token': jwt_token, 'status': 'ok'})
 

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -100,9 +100,9 @@ class AgentSession:
         config: AppConfig,
         agent: Agent,
         max_iterations: int,
-        max_budget_per_task: float | None = None,
-        agent_to_llm_config: dict[str, LLMConfig] | None = None,
-        agent_configs: dict[str, AgentConfig] | None = None,
+        max_budget_per_task: float | None,
+        agent_to_llm_config: dict[str, LLMConfig] | None,
+        agent_configs: dict[str, AgentConfig] | None,
     ):
         self._create_security_analyzer(config.security.security_analyzer)
         await self._create_runtime(

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -30,7 +30,7 @@ class Session:
     sid: str
     websocket: WebSocket | None
     last_active_ts: int = 0
-    is_alive: bool = True
+    is_alive: bool = False
     agent_session: AgentSession
     loop: asyncio.AbstractEventLoop
 
@@ -48,6 +48,9 @@ class Session:
         )
         self.config = config
         self.loop = asyncio.get_event_loop()
+
+    async def start(self):
+        self._initialize_agent({"data": ActionType.INIT})
 
     def close(self):
         self.is_alive = False
@@ -109,6 +112,7 @@ class Session:
 
         # Create the agent session
         try:
+            self.is_alive = True
             await self.agent_session.start(
                 runtime_name=self.config.runtime,
                 config=self.config,
@@ -155,7 +159,8 @@ class Session:
     async def dispatch(self, data: dict):
         action = data.get('action', '')
         if action == ActionType.INIT:
-            await self._initialize_agent(data)
+            if not self.is_alive:
+                await self._initialize_agent(data)
             return
         event = event_from_dict(data.copy())
         # This checks if the model supports images

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -49,9 +49,6 @@ class Session:
         self.config = config
         self.loop = asyncio.get_event_loop()
 
-    async def start(self):
-        self._initialize_agent({"data": ActionType.INIT})
-
     def close(self):
         self.is_alive = False
         self.agent_session.close()


### PR DESCRIPTION
**When the websocket is disconnected in the frontend, the system will automatically try to reconnect 5 times.**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---


**Testing**
Do a really simple query:
![image](https://github.com/user-attachments/assets/7082c555-257d-466e-ac82-b38e55548601)

Once the query executes, in a chrome developer console, find the websocket using `queryObjects(WebSocket)`, store it as a global variable:
![image](https://github.com/user-attachments/assets/f4fcf8ff-01c1-4093-9e8d-ebbbb1cf1ff5)

And then close the websocket using `temp1.close()`:
![image](https://github.com/user-attachments/assets/f73f0ec0-4534-4072-8998-17dd3dad4128)

Your socket will auto reconnect and fire up a new session:
![image](https://github.com/user-attachments/assets/6a4d88a8-b10c-4457-a5bb-b075feb1efd4)

You can resume as if nothing happened:
![image](https://github.com/user-attachments/assets/d874e0e0-da3d-45b9-b40d-45428fb05662)


**Notes on the Code**
I think we need to look at the frontend. I had to use a bunch of `useRefs` to get this to work, which is a bit of a red flag to me. In the long term, I think we may need to look into refactoring _oh.app.tsx and socket.tsx

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5aafc8c-nikolaik   --name openhands-app-5aafc8c   docker.all-hands.dev/all-hands-ai/openhands:5aafc8c
```