### PR TITLE
fix(frontend): Fix loader checking unset config variable in window

### DIFF
--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,4 +1,4 @@
 {
-  "APP_MODE": "saas",
+  "APP_MODE": "oss",
   "GITHUB_CLIENT_ID": ""
 }

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,4 +1,4 @@
 {
-  "APP_MODE": "oss",
+  "APP_MODE": "saas",
   "GITHUB_CLIENT_ID": ""
 }

--- a/frontend/src/routes/_oh._index/route.tsx
+++ b/frontend/src/routes/_oh._index/route.tsx
@@ -51,12 +51,15 @@ function GitHubAuth({
 
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   let isSaas = false;
+  let githubClientId: string | null = null;
 
   try {
     const config = await OpenHands.getConfig();
     isSaas = config.APP_MODE === "saas";
+    githubClientId = config.GITHUB_CLIENT_ID;
   } catch (error) {
     isSaas = false;
+    githubClientId = null;
   }
 
   const token = localStorage.getItem("token");
@@ -73,10 +76,9 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
 
   let githubAuthUrl: string | null = null;
   if (isSaas) {
-    const clientId = window.__GITHUB_CLIENT_ID__;
     const requestUrl = new URL(request.url);
     const redirectUri = `${requestUrl.origin}/oauth/github/callback`;
-    githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo,user,workflow`;
+    githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${githubClientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo,user`;
   }
 
   return json({ repositories, githubAuthUrl });

--- a/frontend/src/routes/_oh._index/route.tsx
+++ b/frontend/src/routes/_oh._index/route.tsx
@@ -78,7 +78,7 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   if (isSaas) {
     const requestUrl = new URL(request.url);
     const redirectUri = `${requestUrl.origin}/oauth/github/callback`;
-    githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${githubClientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo,user`;
+    githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${githubClientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo,user,workflow`;
   }
 
   return json({ repositories, githubAuthUrl });

--- a/frontend/src/routes/_oh._index/route.tsx
+++ b/frontend/src/routes/_oh._index/route.tsx
@@ -22,6 +22,7 @@ import { ModalBackdrop } from "#/components/modals/modal-backdrop";
 import store from "#/store";
 import { setInitialQuery } from "#/state/initial-query-slice";
 import { clientLoader as rootClientLoader } from "#/routes/_oh";
+import OpenHands from "#/api/open-hands";
 
 interface GitHubAuthProps {
   onConnectToGitHub: () => void;
@@ -49,6 +50,15 @@ function GitHubAuth({
 }
 
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
+  let isSaas = false;
+
+  try {
+    const config = await OpenHands.getConfig();
+    isSaas = config.APP_MODE === "saas";
+  } catch (error) {
+    isSaas = false;
+  }
+
   const token = localStorage.getItem("token");
   if (token) return redirect("/app");
 
@@ -62,7 +72,7 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   }
 
   let githubAuthUrl: string | null = null;
-  if (window.__APP_MODE__ === "saas") {
+  if (isSaas) {
     const clientId = window.__GITHUB_CLIENT_ID__;
     const requestUrl = new URL(request.url);
     const redirectUri = `${requestUrl.origin}/oauth/github/callback`;


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
The loader runs the same time the layout loader does, so initially the check is false even if the config returns `APP_MODE: "saas"`

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Calls `getConfig` in the index route as well (but does not set on `window` since that is done in the layout route)


---
**Link of any specific issues this addresses**
