### PR TITLE
Fix conversation server lockup

### DIFF
--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import threading
-from functools import lru_cache
 from typing import Callable
 from zipfile import ZipFile
 
@@ -222,7 +221,6 @@ class EventStreamRuntime(Runtime):
         self.send_status_message(' ')
 
     @staticmethod
-    @lru_cache(maxsize=1)
     def _init_docker_client() -> docker.DockerClient:
         try:
             return docker.from_env()

--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import threading
+from functools import lru_cache
 from typing import Callable
 from zipfile import ZipFile
 
@@ -221,6 +222,7 @@ class EventStreamRuntime(Runtime):
         self.send_status_message(' ')
 
     @staticmethod
+    @lru_cache(maxsize=1)
     def _init_docker_client() -> docker.DockerClient:
         try:
             return docker.from_env()

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -211,8 +211,8 @@ async def attach_session(request: Request, call_next):
             content={'error': 'Invalid token'},
         )
 
-    request.state.conversation = await call_sync_from_async(
-        session_manager.attach_to_conversation, request.state.sid
+    request.state.conversation = await session_manager.attach_to_conversation(
+        request.state.sid
     )
     if request.state.conversation is None:
         return JSONResponse(

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -18,11 +18,11 @@ from openhands.storage.files import FileStore
 class SessionManager:
     config: AppConfig
     file_store: FileStore
-    _sessions: Dict[str, Session] = field(default_factory=dict)
     cleanup_interval: int = 300
     session_timeout: int = 600
-    _session_cleanup_task: Optional[asyncio.Task] = None
+    _sessions: Dict[str, Session] = field(default_factory=dict)
     _conversations: Dict[str, Conversation] = field(default_factory=dict)
+    _session_cleanup_task: Optional[asyncio.Task] = None
 
     async def __aenter__(self):
         if not self._session_cleanup_task:

--- a/openhands/utils/async_utils.py
+++ b/openhands/utils/async_utils.py
@@ -55,7 +55,9 @@ async def call_coro_in_bg_thread(
     corofn: Callable, timeout: float = GENERAL_TIMEOUT, *args, **kwargs
 ):
     """Function for running a coroutine in a background thread."""
-    await call_sync_from_async(call_async_from_sync, corofn, timeout, *args, **kwargs)
+    return await call_sync_from_async(
+        call_async_from_sync, corofn, timeout, *args, **kwargs
+    )
 
 
 async def wait_all(


### PR DESCRIPTION
**Fix for lockups on file access**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
* Basically, the SessionManager now caches conversations in the same way it does sessions.
* The session manager is now a dataclass. This eliminates the need for fields as well as an init method (The init method was removed)
* Missing fields are now included (`config` and `file_store`)
* Sessions are now cached in the instance rather than globally - this is not a big deal but setting the class level variable to `{}` is generally considered confusing.
* SessionManager cleanup now cleans up conversations as well as sessions
* Fixed an issue where `call_coro_in_bg_thread` was not returning the result of the operation


---
This should address https://github.com/All-Hands-AI/OpenHands/issues/4538
