### PR TITLE
Add job to update PR description with docker run command

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -430,12 +430,9 @@ jobs:
 
           PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
 
-          # Check if the docker run command already exists in the PR description
           if echo "$PR_BODY" | grep -q "To run this PR locally, use the following command:"; then
-            # Replace the existing command
-            UPDATED_PR_BODY=$(echo "$PR_BODY" | sed -E "s|To run this PR locally, use the following command:\n\`\`\`\n.*\n\`\`\`|To run this PR locally, use the following command:\n\`\`\`\n$DOCKER_RUN_COMMAND\n\`\`\`|")
+            UPDATED_PR_BODY=$(echo "${PR_BODY}" | sed -E "s|docker run -it --rm.*|$DOCKER_RUN_COMMAND|")
           else
-            # Add the new command
             UPDATED_PR_BODY="${PR_BODY}
 
           ---

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -419,7 +419,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHORT_SHA: ${{ steps.short_sha.outputs.SHORT_SHA }}
         run: |
-          DOCKER_RUN_COMMAND="docker run -it --rm -p 3000:3000 -v \$(pwd):/workspace -w /workspace ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik python3 -m openhands.runtime.app"
+          DOCKER_RUN_COMMAND="docker run -it --rm -p 3000:3000 -v \${PWD}:/workspace -w /workspace ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik python3 -m openhands.runtime.app --host 0.0.0.0"
           PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
           
           # Check if the docker run command already exists in the PR description

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -419,9 +419,15 @@ jobs:
           REPO: ${{ github.repository }}
           SHORT_SHA: ${{ steps.short_sha.outputs.SHORT_SHA }}
         run: |
-          DOCKER_RUN_COMMAND="docker run -it --rm -p 3000:3000 -v \${PWD}:/workspace -w /workspace ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik python3 -m openhands.runtime.app --host 0.0.0.0"
+          DOCKER_RUN_COMMAND="docker run -it --rm \
+          -p 3000:3000 \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          --add-host host.docker.internal:host-gateway \
+          -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik \
+          --name openhands-app-$SHORT_SHA \
+          ghcr.io/all-hands-ai/runtime:$SHORT_SHA"
           PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
-          
+
           # Check if the docker run command already exists in the PR description
           if echo "$PR_BODY" | grep -q "To run this PR locally, use the following command:"; then
             # Replace the existing command
@@ -431,12 +437,11 @@ jobs:
             UPDATED_PR_BODY="${PR_BODY}
 
           ---
-          
+
           To run this PR locally, use the following command:
           \`\`\`
           $DOCKER_RUN_COMMAND
           \`\`\`"
           fi
-          
-          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"
 
+          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -421,7 +421,14 @@ jobs:
         run: |
           DOCKER_RUN_COMMAND="docker run -it --rm -p 3000:3000 -v \$(pwd):/workspace -w /workspace ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik python3 -m openhands.runtime.app"
           PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
-          UPDATED_PR_BODY="${PR_BODY}
+          
+          # Check if the docker run command already exists in the PR description
+          if echo "$PR_BODY" | grep -q "To run this PR locally, use the following command:"; then
+            # Replace the existing command
+            UPDATED_PR_BODY=$(echo "$PR_BODY" | sed -E "s|To run this PR locally, use the following command:\n\`\`\`\n.*\n\`\`\`|To run this PR locally, use the following command:\n\`\`\`\n$DOCKER_RUN_COMMAND\n\`\`\`|")
+          else
+            # Add the new command
+            UPDATED_PR_BODY="${PR_BODY}
 
           ---
           
@@ -429,5 +436,7 @@ jobs:
           \`\`\`
           $DOCKER_RUN_COMMAND
           \`\`\`"
+          fi
+          
           gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"
 

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -419,13 +419,15 @@ jobs:
           REPO: ${{ github.repository }}
           SHORT_SHA: ${{ steps.short_sha.outputs.SHORT_SHA }}
         run: |
+          echo "updating PR description"
           DOCKER_RUN_COMMAND="docker run -it --rm \
-          -p 3000:3000 \
-          -v /var/run/docker.sock:/var/run/docker.sock \
-          --add-host host.docker.internal:host-gateway \
-          -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik \
-          --name openhands-app-$SHORT_SHA \
-          ghcr.io/all-hands-ai/runtime:$SHORT_SHA"
+            -p 3000:3000 \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            --add-host host.docker.internal:host-gateway \
+            -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik \
+            --name openhands-app-$SHORT_SHA \
+            ghcr.io/all-hands-ai/runtime:$SHORT_SHA"
+
           PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
 
           # Check if the docker run command already exists in the PR description
@@ -444,4 +446,5 @@ jobs:
           \`\`\`"
           fi
 
+          echo "updated body: $UPDATED_PR_BODY"
           gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -399,3 +399,35 @@ jobs:
         run: |
           echo "Some runtime tests failed or were cancelled"
           exit 1
+  update_pr_description:
+    name: Update PR Description
+    if: github.event_name == 'pull_request'
+    needs: [ghcr_build_runtime]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get short SHA
+        id: short_sha
+        run: echo "SHORT_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Update PR Description
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SHORT_SHA: ${{ steps.short_sha.outputs.SHORT_SHA }}
+        run: |
+          DOCKER_RUN_COMMAND="docker run -it --rm -p 3000:3000 -v \$(pwd):/workspace -w /workspace ghcr.io/all-hands-ai/runtime:$SHORT_SHA-nikolaik python3 -m openhands.runtime.app"
+          PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
+          UPDATED_PR_BODY="${PR_BODY}
+
+          ---
+          
+          To run this PR locally, use the following command:
+          \`\`\`
+          $DOCKER_RUN_COMMAND
+          \`\`\`"
+          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"
+


### PR DESCRIPTION
This PR adds a new job to the ghcr-build.yml workflow that updates the PR description with a docker run command using the short SHA of the commit.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:6db0387-nikolaik   --name openhands-app-6db0387   ghcr.io/all-hands-ai/runtime:6db0387
```