### PR TITLE
Fix for issue where we hammer docker needlessly

### DIFF
--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import threading
+from functools import lru_cache
 from typing import Callable
 from zipfile import ZipFile
 
@@ -174,22 +175,22 @@ class EventStreamRuntime(Runtime):
         self.skip_container_logs = (
             os.environ.get('SKIP_CONTAINER_LOGS', 'false').lower() == 'true'
         )
-        if self.runtime_container_image is None:
-            if self.base_container_image is None:
-                raise ValueError(
-                    'Neither runtime container image nor base container image is set'
-                )
-            logger.info('Preparing container, this might take a few minutes...')
-            self.send_status_message('STATUS$STARTING_CONTAINER')
-            self.runtime_container_image = build_runtime_image(
-                self.base_container_image,
-                self.runtime_builder,
-                platform=self.config.sandbox.platform,
-                extra_deps=self.config.sandbox.runtime_extra_deps,
-                force_rebuild=self.config.sandbox.force_rebuild_runtime,
-            )
-
         if not attach_to_existing:
+            if self.runtime_container_image is None:
+                if self.base_container_image is None:
+                    raise ValueError(
+                        'Neither runtime container image nor base container image is set'
+                    )
+                logger.info('Preparing container, this might take a few minutes...')
+                self.send_status_message('STATUS$STARTING_CONTAINER')
+                self.runtime_container_image = build_runtime_image(
+                    self.base_container_image,
+                    self.runtime_builder,
+                    platform=self.config.sandbox.platform,
+                    extra_deps=self.config.sandbox.runtime_extra_deps,
+                    force_rebuild=self.config.sandbox.force_rebuild_runtime,
+                )
+
             self._init_container(
                 sandbox_workspace_dir=self.config.workspace_mount_path_in_sandbox,  # e.g. /workspace
                 mount_dir=self.config.workspace_mount_path,  # e.g. /opt/openhands/_test_workspace
@@ -221,6 +222,7 @@ class EventStreamRuntime(Runtime):
         self.send_status_message(' ')
 
     @staticmethod
+    @lru_cache(maxsize=1)
     def _init_docker_client() -> docker.DockerClient:
         try:
             return docker.from_env()


### PR DESCRIPTION
**Fix for issue where we hit docker with more requests than is necessary**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
1. We cache the DockerClient using `lru_cache` - this adds a little speed
2. We don't check for docker images if we already know we have an appropriate docker container.

## Testing

Obviously we test manually and make sure all automated tests pass.

I also ran the following script from the browser:
```
for(let i = 0; i < 200; i++) {
    fetch("http://localhost:3001/api/list-files", {
      "headers": {
        "accept": "*/*",
        "accept-language": "en-US,en;q=0.9",
        "authorization": "Bearer ******",
        "cache-control": "no-cache",
        "pragma": "no-cache",
        "sec-ch-ua": "\"Google Chrome\";v=\"129\", \"Not=A?Brand\";v=\"8\", \"Chromium\";v=\"129\"",
        "sec-ch-ua-mobile": "?0",
        "sec-ch-ua-platform": "\"macOS\"",
        "sec-fetch-dest": "empty",
        "sec-fetch-mode": "cors",
        "sec-fetch-site": "same-origin"
      },
      "referrer": "http://localhost:3001/app",
      "referrerPolicy": "strict-origin-when-cross-origin",
      "body": null,
      "method": "GET",
      "mode": "cors",
      "credentials": "include"
    });
}
```

It was slow, but the server did not lock up.
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/5b8f9ebc-6246-402f-8def-c5912dec3463">


I also ran the following script to be sure the DockerClient was okay with multi threaded access:

```
import threading
import time
from uuid import uuid4
import docker

def use_docker(task_id: str, docker_client: docker.DockerClient):
    print(f"START:{task_id}")

    # Find a runtime image
    images = docker_client.images.list(all=True)
    image = next(i for i in images if next(True for t in i.tags if t.startswith("ghcr.io/all-hands-ai/runtime:")))

    # Create a container
    container = docker_client.containers.run(
        image.tags[0],
        command="bash",
        name=f"delete_me_{task_id}",
        detach=True,
    )

    # Wait 10 seconds
    time.sleep(10)

    #Destroy the container
    container.remove(force=True)

    print(f"FINISH:{task_id}")


if __name__ == "__main__":
    docker_client = docker.from_env()
    threads = [
        threading.Thread(target=lambda: use_docker(f"task-{uuid4()}", docker_client))
        for _ in range(5)
    ]
    for thread in threads:
        thread.start()
    for thread in threads:
        thread.join()
```



---
This should address: https://github.com/All-Hands-AI/OpenHands/issues/4538
