### PR TITLE
Feature: Minor refactor of SessionManager to make it a dataclass

### DIFF
--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from dataclasses import dataclass, field
 from typing import Optional
 
 from fastapi import WebSocket
@@ -13,15 +14,14 @@ from openhands.server.session.session import Session
 from openhands.storage.files import FileStore
 
 
+@dataclass
 class SessionManager:
-    _sessions: dict[str, Session] = {}
+    config: AppConfig
+    file_store: FileStore
     cleanup_interval: int = 300
     session_timeout: int = 600
+    _sessions: dict[str, Session] = field(default_factory=dict)
     _session_cleanup_task: Optional[asyncio.Task] = None
-
-    def __init__(self, config: AppConfig, file_store: FileStore):
-        self.config = config
-        self.file_store = file_store
 
     async def __aenter__(self):
         if not self._session_cleanup_task:


### PR DESCRIPTION
**Closer adherence to best practices for understandability of code**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
* The session manager is now a dataclass. This eliminates the need for fields as well as an init method (The init method was removed)
* Missing fields are now included (config and file_store)
* Sessions are now cached in the instance rather than globally - this is not a big deal but setting the class level variable to {} is generally considered confusing.
