### PR TITLE
Fix broken remote runtime

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -287,7 +287,7 @@ class RemoteRuntime(Runtime):
             logger.info(
                 f'Waiting for runtime pod to be active. Current status: {pod_status}'
             )
-            if pod_status == 'Ready':
+            if pod_status in ('Ready', 'Running'):
                 pod_running = True
                 break
             elif pod_status == 'Not Found' and not_found_count < max_not_found_count:
@@ -295,11 +295,7 @@ class RemoteRuntime(Runtime):
                 logger.info(
                     f'Runtime pod not found. Count: {not_found_count} / {max_not_found_count}'
                 )
-            elif (
-                pod_status == 'Failed'
-                or pod_status == 'Unknown'
-                or pod_status == 'Not Found'
-            ):
+            elif pod_status in ('Failed', 'Unknown', 'Not Found'):
                 # clean up the runtime
                 self.close()
                 raise RuntimeError(


### PR DESCRIPTION
**Fix broken remote runtime**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
For me the remote runtime is not working right now - it gets stuck with this message repeating:
```
INFO - Waiting for runtime pod to be active. Current status: Running
```
This PR updates the check so that it looks for both `ready` and `running`

