### PR TITLE
Fix for docker leak

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -318,7 +318,7 @@ class RemoteRuntime(Runtime):
             raise RuntimeError(msg)
 
     def close(self, timeout: int = 10):
-        if self.config.sandbox.keep_remote_runtime_alive:
+        if self.config.sandbox.keep_remote_runtime_alive or self.attach_to_existing:
             self.session.close()
             return
         if self.runtime_id:

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -247,8 +247,10 @@ async def attach_session(request: Request, call_next):
             status_code=status.HTTP_404_NOT_FOUND,
             content={'error': 'Session not found'},
         )
-
-    response = await call_next(request)
+    try:
+        response = await call_next(request)
+    finally:
+        await session_manager.detach_from_conversation(request.state.conversation)
     return response
 
 

--- a/openhands/server/session/conversation.py
+++ b/openhands/server/session/conversation.py
@@ -37,3 +37,6 @@ class Conversation:
 
     async def connect(self):
         await self.runtime.connect()
+
+    async def disconnect(self):
+        self.runtime.close()

--- a/openhands/server/session/conversation.py
+++ b/openhands/server/session/conversation.py
@@ -1,9 +1,12 @@
+import asyncio
+
 from openhands.core.config import AppConfig
 from openhands.events.stream import EventStream
 from openhands.runtime import get_runtime_cls
 from openhands.runtime.base import Runtime
 from openhands.security import SecurityAnalyzer, options
 from openhands.storage.files import FileStore
+from openhands.utils.async_utils import call_sync_from_async
 
 
 class Conversation:
@@ -39,4 +42,4 @@ class Conversation:
         await self.runtime.connect()
 
     async def disconnect(self):
-        self.runtime.close()
+        asyncio.create_task(call_sync_from_async(self.runtime.close))

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -54,7 +54,7 @@ class SessionManager:
         return c
 
     async def detach_from_conversation(self, conversation: Conversation):
-        conversation.disconnect()
+        await conversation.disconnect()
 
     async def send(self, sid: str, data: dict[str, object]) -> bool:
         """Sends data to the client."""

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -53,6 +53,9 @@ class SessionManager:
         await c.connect()
         return c
 
+    async def detach_from_conversation(self, conversation: Conversation):
+        conversation.disconnect()
+
     async def send(self, sid: str, data: dict[str, object]) -> bool:
         """Sends data to the client."""
         session = self.get_session(sid)


### PR DESCRIPTION
*Fix for connection leak*

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
* Added an explicit `disconnect` function to conversation.
* Disconnect is called when conversations are in use.

# Testing
As pointed out by @diwu-sf, a connection leak persisted after the previous fix. Testing with this fix `lsof -p <PROCESS_ID> | grep TCP` shows TCP connections are no longer accumulating:

```
for(let i = 0; i < 200; i++) {
    fetch("http://localhost:3001/api/select-file?file=delaunay_triangulation.py", {
      "headers": {
        "accept": "*/*",
        "accept-language": "en-US,en;q=0.9",
        "authorization": "Bearer ********",
        "cache-control": "no-cache",
        "pragma": "no-cache",
        "sec-ch-ua": "\"Google Chrome\";v=\"129\", \"Not=A?Brand\";v=\"8\", \"Chromium\";v=\"129\"",
        "sec-ch-ua-mobile": "?0",
        "sec-ch-ua-platform": "\"macOS\"",
        "sec-fetch-dest": "empty",
        "sec-fetch-mode": "cors",
        "sec-fetch-site": "same-origin"
      },
      "referrer": "http://localhost:3001/app",
      "referrerPolicy": "strict-origin-when-cross-origin",
      "body": null,
      "method": "GET",
      "mode": "cors",
      "credentials": "include"
    });
}
```
![image](https://github.com/user-attachments/assets/291f715b-ee43-44b7-8978-07082fa9093f)
![image](https://github.com/user-attachments/assets/02b19f1d-1266-4685-a9d6-d1f1587d8779)


---
Should address https://github.com/All-Hands-AI/OpenHands/issues/4538
