### PR TITLE
Load GitHub users list at startup for improved authentication performance

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -80,28 +80,11 @@ def load_github_user_list():
             GITHUB_USER_LIST = [line.strip() for line in f if line.strip()]
     else:
         logger.warning("GitHub user list file not found or not specified.")
-
-GITHUB_CLIENT_ID = os.getenv('GITHUB_CLIENT_ID', '').strip()
-GITHUB_CLIENT_SECRET = os.getenv('GITHUB_CLIENT_SECRET', '').strip()
-
+load_github_user_list()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global session_manager
-    load_github_user_list()  # Load the GitHub user list at startup
-    async with session_manager:
-        yield
-
-
-app = FastAPI(lifespan=lifespan)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=['http://localhost:3001', 'http://127.0.0.1:3001'],
-    allow_credentials=True,
-    allow_methods=['*'],
-    allow_headers=['*'],
-)
-
     async with session_manager:
         yield
 

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -855,8 +855,6 @@ def authenticate(user: User | None = None):
                 status_code=status.HTTP_403_FORBIDDEN,
                 content={'error': 'User not on waitlist'},
             )
-    else:
-        logger.warning("No GitHub user list available for authentication.")
 
     return JSONResponse(
         status_code=status.HTTP_200_OK, content={'message': 'User authenticated'}

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -868,19 +868,3 @@ class SPAStaticFiles(StaticFiles):
 
 
 app.mount('/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist')
-
-
-
-class SPAStaticFiles(StaticFiles):
-    async def get_response(self, path: str, scope):
-        try:
-            return await super().get_response(path, scope)
-        except Exception:
-            # FIXME: just making this HTTPException doesn't work for some reason
-            return await super().get_response('index.html', scope)
-
-
-app.mount('/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist')
-
-
-

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -78,7 +78,7 @@ def load_github_user_list():
     if waitlist:
         with open(waitlist, 'r') as f:
             GITHUB_USER_LIST = [line.strip() for line in f if line.strip()]
-
+load_github_user_list()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global session_manager

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -78,9 +78,6 @@ def load_github_user_list():
     if waitlist:
         with open(waitlist, 'r') as f:
             GITHUB_USER_LIST = [line.strip() for line in f if line.strip()]
-    else:
-        logger.warning("GitHub user list file not found or not specified.")
-load_github_user_list()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -75,7 +75,7 @@ GITHUB_USER_LIST = None
 def load_github_user_list():
     global GITHUB_USER_LIST
     waitlist = os.getenv('GITHUB_USER_LIST_FILE')
-    if waitlist and os.path.exists(waitlist):
+    if waitlist:
         with open(waitlist, 'r') as f:
             GITHUB_USER_LIST = [line.strip() for line in f if line.strip()]
     else:

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -69,7 +69,7 @@ GITHUB_CLIENT_ID = os.getenv('GITHUB_CLIENT_ID', '').strip()
 GITHUB_CLIENT_SECRET = os.getenv('GITHUB_CLIENT_SECRET', '').strip()
 
 # New global variable to store the user list
-GITHUB_USER_LIST = []
+GITHUB_USER_LIST = None
 
 # New function to load the user list
 def load_github_user_list():

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -71,6 +71,7 @@ GITHUB_CLIENT_SECRET = os.getenv('GITHUB_CLIENT_SECRET', '').strip()
 # New global variable to store the user list
 GITHUB_USER_LIST = None
 
+
 # New function to load the user list
 def load_github_user_list():
     global GITHUB_USER_LIST
@@ -78,7 +79,11 @@ def load_github_user_list():
     if waitlist:
         with open(waitlist, 'r') as f:
             GITHUB_USER_LIST = [line.strip() for line in f if line.strip()]
+
+
 load_github_user_list()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global session_manager


### PR DESCRIPTION
This PR implements loading the GitHub users list at startup instead of during each authentication request. This change improves the performance of the authentication process.