### PR TITLE
fix(controllor): make agent controller stops when encounter fatal observation

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -133,7 +133,12 @@ class AgentController:
         # update metrics especially for cost. Use deepcopy to avoid it being modified by agent.reset()
         self.state.local_metrics = copy.deepcopy(self.agent.llm.metrics)
 
-    async def report_error(self, message: str, exception: Exception | None = None):
+    async def report_error(
+        self,
+        message: str,
+        exception: Exception | None = None,
+        add_to_eventstream: bool = True,
+    ):
         """Reports an error to the user and sends the exception to the LLM next step, in the hope it can self-correct.
 
         This method should be called for a particular type of errors, which have:
@@ -146,9 +151,10 @@ class AgentController:
         detail = str(exception) if exception is not None else ''
         if exception is not None and isinstance(exception, litellm.AuthenticationError):
             detail = 'Please check your credentials. Is your API key correct?'
-        self.event_stream.add_event(
-            ErrorObservation(f'{message}:{detail}'), EventSource.USER
-        )
+        if add_to_eventstream:
+            self.event_stream.add_event(
+                ErrorObservation(f'{message}:{detail}'), EventSource.USER
+            )
 
     async def start_step_loop(self):
         """The main loop for the agent's step-by-step execution."""
@@ -255,7 +261,8 @@ class AgentController:
                 self.state.metrics.merge(self.state.local_metrics)
         elif isinstance(observation, FatalErrorObservation):
             await self.report_error(
-                'There was a fatal error during agent execution: ' + str(observation)
+                'There was a fatal error during agent execution: ' + str(observation),
+                add_to_eventstream=False,
             )
             await self.set_agent_state_to(AgentState.ERROR)
             self.state.metrics.merge(self.state.local_metrics)

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -165,7 +165,7 @@ async def test_run_controller_with_fatal_error(mock_agent, mock_event_stream):
         fake_user_response_fn=lambda _: 'repeat',
     )
     print(f'state: {state}')
-    print(f'event_stream: {len(list(event_stream.get_events()))}')
+    print(f'event_stream: {list(event_stream.get_events())}')
     assert state.iteration == 1
     # it will first become AgentState.ERROR, then become AgentState.STOPPED
     # in side run_controller (since the while loop + sleep no longer loop)

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -146,7 +146,6 @@ async def test_run_controller_with_fatal_error(mock_agent, mock_event_stream):
 
     fatal_error_obs = FatalErrorObservation('Fatal error detected')
     fatal_error_obs._cause = event.id
-    fatal_error_obs.trigger_by_llm_response = event.trigger_by_llm_response
 
     runtime = MagicMock(spec=Runtime)
 

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -6,10 +6,17 @@ import pytest
 from openhands.controller.agent import Agent
 from openhands.controller.agent_controller import AgentController
 from openhands.controller.state.state import TrafficControlState
+from openhands.core.config import AppConfig
 from openhands.core.exceptions import LLMMalformedActionError
+from openhands.core.main import run_controller
 from openhands.core.schema import AgentState
-from openhands.events import EventStream
-from openhands.events.action import ChangeAgentStateAction, MessageAction
+from openhands.events import Event, EventSource, EventStream, EventStreamSubscriber
+from openhands.events.action import ChangeAgentStateAction, CmdRunAction, MessageAction
+from openhands.events.observation import FatalErrorObservation
+from openhands.llm import LLM
+from openhands.llm.metrics import Metrics
+from openhands.runtime.base import Runtime
+from openhands.storage import get_file_store
 
 
 @pytest.fixture
@@ -121,6 +128,54 @@ async def test_step_with_exception(mock_agent, mock_event_stream):
     # Verify that report_error was called with the correct error message
     controller.report_error.assert_called_once_with('Malformed action')
     await controller.close()
+
+
+@pytest.mark.asyncio
+async def test_run_controller_with_fatal_error(mock_agent, mock_event_stream):
+    config = AppConfig()
+    file_store = get_file_store(config.file_store, config.file_store_path)
+    event_stream = EventStream(sid='test', file_store=file_store)
+
+    agent = MagicMock(spec=Agent)
+    # a random message to send to the runtime
+    event = CmdRunAction(command='ls')
+    agent.step.return_value = event
+    agent.llm = MagicMock(spec=LLM)
+    agent.llm.metrics = Metrics()
+    agent.llm.config = config.get_llm_config()
+
+    fatal_error_obs = FatalErrorObservation('Fatal error detected')
+    fatal_error_obs._cause = event.id
+    fatal_error_obs.trigger_by_llm_response = event.trigger_by_llm_response
+
+    runtime = MagicMock(spec=Runtime)
+
+    async def on_event(event: Event):
+        if isinstance(event, CmdRunAction):
+            await event_stream.async_add_event(fatal_error_obs, EventSource.USER)
+
+    event_stream.subscribe(EventStreamSubscriber.RUNTIME, on_event)
+    runtime.event_stream = event_stream
+
+    state = await run_controller(
+        config=config,
+        initial_user_action=MessageAction(content='Test message'),
+        runtime=runtime,
+        sid='test',
+        agent=agent,
+        fake_user_response_fn=lambda _: 'repeat',
+    )
+    print(f'state: {state}')
+    print(f'event_stream: {len(list(event_stream.get_events()))}')
+    assert state.iteration == 1
+    # it will first become AgentState.ERROR, then become AgentState.STOPPED
+    # in side run_controller (since the while loop + sleep no longer loop)
+    assert state.agent_state == AgentState.STOPPED
+    assert (
+        state.last_error
+        == 'There was a fatal error during agent execution: **FatalErrorObservation**\nFatal error detected'
+    )
+    assert len(list(event_stream.get_events())) == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…l error

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

While running SWE-Bench eval, I found a few cases where FatalErrorObservation didn't really stop the agent controller (see below).
This PR:
- fixes this issue
- add a unit test to make sure this doesn't happen again

```
2024-10-25 21:10:05,132 - INFO - **CmdRunAction (source=None)**
THOUGHT: Now that we've created the script, let's run it to see if we can reproduce the error:
COMMAND:
python /workspace/django__django__3.0/reproduce_error.py
2024-10-25 21:10:22,559 - ERROR - Error during action execution: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:22,560 - INFO - **FatalErrorObservation**
[Runtime (ID=5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4)] Action execution failed: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:22,855 - INFO - CodeActAgent LEVEL 0 LOCAL STEP 3 GLOBAL STEP 3
2024-10-25 21:10:26,597 - INFO - Cost: 0.01 USD | Accumulated Cost: 0.21 USD
Input tokens: 13599 | Output tokens: 119
Input tokens (cache hit): 13371
Input tokens (cache write): 223

2024-10-25 21:10:26,598 - INFO - **CmdRunAction (source=None)**
THOUGHT: I apologize for the error. It seems that the script couldn't run properly. Let's modify our approach and create a minimal Django project structure to reproduce the issue.

First, let's create a new directory for our test project:
COMMAND:
mkdir -p /workspace/django__django__3.0/test_project
2024-10-25 21:10:26,616 - ERROR - Error during action execution: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:26,617 - INFO - **FatalErrorObservation**
[Runtime (ID=5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4)] Action execution failed: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:26,700 - INFO - CodeActAgent LEVEL 0 LOCAL STEP 4 GLOBAL STEP 4
2024-10-25 21:10:34,737 - INFO - Cost: 0.01 USD | Accumulated Cost: 0.23 USD
Input tokens: 13849 | Output tokens: 304
Input tokens (cache hit): 13594
Input tokens (cache write): 250

2024-10-25 21:10:34,737 - INFO - **IPythonRunCellAction**
THOUGHT: I apologize for the continued errors. It seems that we're having issues with executing bash commands. Let's try to create the necessary files directly using the `str_replace_editor` function.

Let's create the main Django project file:
CODE:
print(file_editor(**{'command': 'create', 'path': '/workspace/django__django__3.0/test_project/manage.py', 'file_text': '#!/usr/bin/env python\nimport os\nimport sys\n\nif __name__ == "__main__":\n    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")\n    try:\n        from django.core.management import execute_from_command_line\n    except ImportError as exc:\n        raise ImportError(\n            "Couldn\'t import Django. Are you sure it\'s installed and "\n            "available on your PYTHONPATH environment variable? Did you "\n            "forget to activate a virtual environment?"\n        ) from exc\n    execute_from_command_line(sys.argv)'}))
2024-10-25 21:10:34,744 - ERROR - Error during action execution: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:34,745 - INFO - **FatalErrorObservation**
[Runtime (ID=5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4)] Action execution failed: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:34,841 - INFO - CodeActAgent LEVEL 0 LOCAL STEP 5 GLOBAL STEP 5
2024-10-25 21:10:40,048 - INFO - Cost: 0.01 USD | Accumulated Cost: 0.25 USD
Input tokens: 14282 | Output tokens: 182
Input tokens (cache hit): 13844
Input tokens (cache write): 433

2024-10-25 21:10:40,048 - INFO - **IPythonRunCellAction**
THOUGHT: I apologize for the persistent errors. It seems that we're encountering issues with the environment or permissions. Let's try a different approach. Instead of creating a new project, let's modify an existing file in the Django codebase to reproduce the issue.

Let's edit the `/workspace/django__django__3.0/django/urls/resolvers.py` file to add our custom converter and modify the error handling:
CODE:
print(file_editor(**{'command': 'view', 'path': '/workspace/django__django__3.0/django/urls/resolvers.py'}))
2024-10-25 21:10:40,054 - ERROR - Error during action execution: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:40,055 - INFO - **FatalErrorObservation**
[Runtime (ID=5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4)] Action execution failed: 404 Client Error: Not Found for url: https://5b68ee14-4288-4189-bae0-048d0fbb31be-e1d222bb4dca1ef4.eval-runtime.all-hands.dev/execute_action
2024-10-25 21:10:40,151 - INFO - CodeActAgent LEVEL 0 LOCAL STEP 6 GLOBAL STEP 6
2024-10-25 21:10:57,753 - INFO - Cost: 0.02 USD | Accumulated Cost: 0.29 USD
Input tokens: 14595 | Output tokens: 909
Input tokens (cache hit): 14277
Input tokens (cache write): 313

```

cc @enyst - i think this is actually related to the `report_error` thing you mentioned earlier 😓 

---
**Link of any specific issues this addresses**

