### PR TITLE
feat(runtime): add versioned runtime image (base_name+oh_version) 

### DIFF
--- a/openhands/runtime/impl/modal/modal_runtime.py
+++ b/openhands/runtime/impl/modal/modal_runtime.py
@@ -18,6 +18,7 @@ from openhands.runtime.impl.eventstream.eventstream_runtime import (
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.utils.command import get_remote_startup_command
 from openhands.runtime.utils.runtime_build import (
+    BuildFromImageType,
     prep_build_folder,
 )
 from openhands.utils.async_utils import call_sync_from_async
@@ -183,7 +184,7 @@ class ModalRuntime(EventStreamRuntime):
             prep_build_folder(
                 build_folder=Path(build_folder),
                 base_image=base_container_image_id,
-                build_from_scratch=True,
+                build_from=BuildFromImageType.SCRATCH,
                 extra_deps=runtime_extra_deps,
             )
 

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -4,6 +4,32 @@ FROM {{ base_image }}
 ENV POETRY_VIRTUALENVS_PATH=/openhands/poetry
 ENV MAMBA_ROOT_PREFIX=/openhands/micromamba
 
+{% macro install_dependencies() %}
+# Install all dependencies
+WORKDIR /openhands/code
+RUN \
+    /openhands/micromamba/bin/micromamba config set changeps1 False && \
+    # Configure Poetry and create virtual environment
+    /openhands/micromamba/bin/micromamba run -n openhands poetry config virtualenvs.path /openhands/poetry && \
+    /openhands/micromamba/bin/micromamba run -n openhands poetry env use python3.12 && \
+    # Install project dependencies
+    /openhands/micromamba/bin/micromamba run -n openhands poetry install --only main,runtime --no-interaction --no-root && \
+    # Update and install additional tools
+    apt-get update && \
+    /openhands/micromamba/bin/micromamba run -n openhands poetry run pip install playwright && \
+    /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install --with-deps chromium && \
+    # Set environment variables
+    echo "OH_INTERPRETER_PATH=$(/openhands/micromamba/bin/micromamba run -n openhands poetry run python -c "import sys; print(sys.executable)")" >> /etc/environment && \
+    # Clear caches
+    /openhands/micromamba/bin/micromamba run -n openhands poetry cache clear --all . && \
+    # Set permissions
+    chmod -R g+rws /openhands/poetry && \
+    mkdir -p /openhands/workspace && chmod -R g+rws,o+rw /openhands/workspace && \
+    # Clean up
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    /openhands/micromamba/bin/micromamba clean --all
+{% endmacro %}
+
 {% if build_from_scratch %}
 # ================================================================
 # START: Build Runtime Image from Scratch
@@ -48,29 +74,7 @@ RUN \
     touch /openhands/code/openhands/__init__.py
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 
-# Install all dependencies
-WORKDIR /openhands/code
-RUN \
-    /openhands/micromamba/bin/micromamba config set changeps1 False && \
-    # Configure Poetry and create virtual environment
-    /openhands/micromamba/bin/micromamba run -n openhands poetry config virtualenvs.path /openhands/poetry && \
-    /openhands/micromamba/bin/micromamba run -n openhands poetry env use python3.12 && \
-    # Install project dependencies
-    /openhands/micromamba/bin/micromamba run -n openhands poetry install --only main,runtime --no-interaction --no-root && \
-    # Update and install additional tools
-    apt-get update && \
-    /openhands/micromamba/bin/micromamba run -n openhands poetry run pip install playwright && \
-    /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install --with-deps chromium && \
-    # Set environment variables
-    echo "OH_INTERPRETER_PATH=$(/openhands/micromamba/bin/micromamba run -n openhands poetry run python -c "import sys; print(sys.executable)")" >> /etc/environment && \
-    # Clear caches
-    /openhands/micromamba/bin/micromamba run -n openhands poetry cache clear --all . && \
-    # Set permissions
-    chmod -R g+rws /openhands/poetry && \
-    mkdir -p /openhands/workspace && chmod -R g+rws,o+rw /openhands/workspace && \
-    # Clean up
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    /openhands/micromamba/bin/micromamba clean --all
+{{ install_dependencies() }}
 
 # ================================================================
 # END: Build Runtime Image from Scratch
@@ -83,6 +87,13 @@ RUN \
 RUN if [ -d /openhands/code/openhands ]; then rm -rf /openhands/code/openhands; fi
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 COPY ./code/openhands /openhands/code/openhands
+
+# ================================================================
+# END: Build from versioned image
+# ================================================================
+{% if build_from_versioned %}
+{{ install_dependencies() }}
+{% endif %}
 
 # Install extra dependencies if specified
 {% if extra_deps %}RUN {{ extra_deps }} {% endif %}


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In this PR, in additional to "lock" tag (which consists of a hash of "base image, poetry.lock, etc"), and a "lock+codebase" hash, we add an additional "versioned" tag - which is "base image + oh version".

This will allow us to avoid building images from scratch as much as possible:
1. If "lock tag" exists - go with it
2. If not, try build from "versioned" tag - this will be quicker because a lot of the pyproject dependencies are already installed
3. If not, build from scratch

---
**Link of any specific issues this addresses**
