### PR TITLE
fix(builder): Build the runtime with docker version that contains (-) in the version name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
 	"name": "OpenHands Codespaces",
 	"image": "mcr.microsoft.com/devcontainers/universal",
-	"user": "root",
 	"customizations":{
         "vscode":{
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "OpenHands Codespaces",
 	"image": "mcr.microsoft.com/devcontainers/universal",
+	"user": "root",
 	"customizations":{
         "vscode":{
             "extensions": [

--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -16,7 +16,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         self.docker_client = docker_client
 
         version_info = self.docker_client.version()
-        server_version = version_info.get('Version', '')
+        server_version = version_info.get('Version', '').replace('-', '.')
         if tuple(map(int, server_version.split('.'))) < (18, 9):
             raise RuntimeError('Docker server version must be >= 18.09 to use BuildKit')
 
@@ -53,7 +53,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         """
         self.docker_client = docker.from_env()
         version_info = self.docker_client.version()
-        server_version = version_info.get('Version', '')
+        server_version = version_info.get('Version', '').replace('-', '.')
         if tuple(map(int, server_version.split('.'))) < (18, 9):
             raise RuntimeError('Docker server version must be >= 18.09 to use BuildKit')
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When starting a GitHub Codespace, an error surfaced during code generation using OpenHands. The Docker version in this environment was 27.0.3-1, and the application failed to handle the version format correctly. Upon investigation, it was identified that the issue originated from the file openhands/runtime/builder/docker.py, particularly in this line:

`if tuple(map(int, server_version.split('.'))) < (18, 9):`

The code was unable to parse versions with hyphens properly, which caused the application to hang.

**Solution**
The solution involves modifying the code responsible for parsing the Docker version. This update replaces any hyphens in the version string with dots, ensuring compatibility with the version comparison logic. After implementing this change, I tested the solution:

- Started the Codespace.
- Launched the OpenHands application.
- Verified that code generation commands now complete successfully.

---
**Link of any specific issues this addresses**
