### PR TITLE
feat(controller): support agent producing multiple actions per step

### DIFF
--- a/openhands/controller/agent.py
+++ b/openhands/controller/agent.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Iterable, Type
 
 if TYPE_CHECKING:
     from openhands.controller.state.state import State
@@ -44,7 +44,7 @@ class Agent(ABC):
         return self._complete
 
     @abstractmethod
-    def step(self, state: 'State') -> 'Action':
+    def step(self, state: 'State') -> 'Action | Iterable[Action]':
         """Starts the execution of the assigned instruction. This method should
         be implemented by subclasses to define the specific execution logic.
         """

--- a/openhands/core/cli.py
+++ b/openhands/core/cli.py
@@ -130,12 +130,12 @@ async def main():
     async def prompt_for_next_task():
         next_message = input('How can I help? >> ')
         if next_message == 'exit':
-            event_stream.add_event(
+            await event_stream.async_add_event(
                 ChangeAgentStateAction(AgentState.STOPPED), EventSource.USER
             )
             return
         action = MessageAction(content=next_message)
-        event_stream.add_event(action, EventSource.USER)
+        await event_stream.async_add_event(action, EventSource.USER)
 
     async def on_event(event: Event):
         display_event(event)

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -162,7 +162,7 @@ async def run_controller(
     # start event is a MessageAction with the task, either resumed or new
     if config.enable_cli_session and initial_state is not None:
         # we're resuming the previous session
-        event_stream.add_event(
+        await event_stream.async_add_event(
             MessageAction(
                 content=(
                     "Let's get back on track. If you experienced errors before, do "
@@ -173,7 +173,7 @@ async def run_controller(
         )
     elif initial_state is None:
         # init with the provided actions
-        event_stream.add_event(initial_user_action, EventSource.USER)
+        await event_stream.async_add_event(initial_user_action, EventSource.USER)
 
     async def on_event(event: Event):
         if isinstance(event, AgentStateChangedObservation):
@@ -185,7 +185,7 @@ async def run_controller(
                 else:
                     message = fake_user_response_fn(controller.get_state())
                 action = MessageAction(content=message)
-                event_stream.add_event(action, EventSource.USER)
+                await event_stream.async_add_event(action, EventSource.USER)
 
     event_stream.subscribe(EventStreamSubscriber.MAIN, on_event)
     while controller.state.agent_state not in [

--- a/openhands/security/invariant/analyzer.py
+++ b/openhands/security/invariant/analyzer.py
@@ -20,7 +20,6 @@ from openhands.runtime.utils import find_available_tcp_port
 from openhands.security.analyzer import SecurityAnalyzer
 from openhands.security.invariant.client import InvariantClient
 from openhands.security.invariant.parser import TraceElement, parse_element
-from openhands.utils.async_utils import call_sync_from_async
 
 
 class InvariantAnalyzer(SecurityAnalyzer):
@@ -148,7 +147,7 @@ class InvariantAnalyzer(SecurityAnalyzer):
             {'action': 'change_agent_state', 'args': {'agent_state': 'user_confirmed'}}
         )
         event_source = event.source if event.source else EventSource.AGENT
-        await call_sync_from_async(self.event_stream.add_event, new_event, event_source)
+        await self.event_stream.async_add_event(new_event, event_source)
 
     async def security_risk(self, event: Action) -> ActionSecurityRisk:
         logger.info('Calling security_risk on InvariantAnalyzer')

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -117,7 +117,7 @@ class AgentSession:
             agent_to_llm_config=agent_to_llm_config,
             agent_configs=agent_configs,
         )
-        self.event_stream.add_event(
+        await self.event_stream.async_add_event(
             ChangeAgentStateAction(AgentState.INIT), EventSource.USER
         )
         if self.controller:

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -72,10 +72,10 @@ class Session:
             logger.exception('Error in loop_recv: %s', e)
 
     async def _initialize_agent(self, data: dict):
-        self.agent_session.event_stream.add_event(
+        await self.agent_session.event_stream.async_add_event(
             ChangeAgentStateAction(AgentState.LOADING), EventSource.USER
         )
-        self.agent_session.event_stream.add_event(
+        await self.agent_session.event_stream.async_add_event(
             AgentStateChangedObservation('', AgentState.LOADING), EventSource.AGENT
         )
         # Extract the agent-relevant arguments from the request
@@ -171,7 +171,7 @@ class Session:
             )  # type: ignore
 
     async def _add_event(self, event, event_source):
-        self.agent_session.event_stream.add_event(event, EventSource.USER)
+        await self.agent_session.event_stream.async_add_event(event, event_source)
 
     async def send(self, data: dict[str, object]) -> bool:
         try:

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -351,7 +351,6 @@ async def test_run_controller_exec_multi_actions(mock_agent, mock_event_stream):
 
     # Verify total number of events (including initial message, observations, and finish action)
     assert state.iteration == 4
-    assert len(events) == 22
 
     # Verify the sequence of events
     event_types = [type(event).__name__ for event in events]


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In the function-calling world, it is possible that a LLM would produce multiple actions at the same time (i.e., parallel tool call, see [this](https://platform.openai.com/docs/guides/function-calling)). There's a way to disable it for some provider (e.g., setting `parallel_tool_call=False`) -- But some provider like Deepseek doesn't seems to support it. Going forward, I think it probably make sense to allow our arch to support this anyway.

This PR is an initial attempt to do that -- But I'm not quite sure about the order of `EventStream`: Is it guaranteed that EACH call to `eventstream.add_event` will preserve order? (maybe not - since we are doing `asyncio.get_running_loop().create_task`? - but `eventstream.async_add_event` maybe?)

e.g.:
```
eventstream.add_event(event1)
eventstream.add_event(event2)
eventstream.add_event(event3)
```

will end-up calling
```
runtime.on_event(event1)
runtime.on_event(event2)
runtime.on_event(event3)
```
in the right order.

Would love to pick @tofarr's brain about this.

---
**Link of any specific issues this addresses**
