### PR TITLE
fix(runtime): only accept one request at a time for exec action requests

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -374,9 +374,12 @@ if __name__ == '__main__':
     @app.middleware('http')
     async def one_request_at_a_time(request: Request, call_next):
         assert client is not None
-        async with client.lock:
-            response = await call_next(request)
-        return response
+        # Only apply lock for execute_action endpoint
+        if request.url.path == '/execute_action':
+            async with client.lock:
+                response = await call_next(request)
+            return response
+        return await call_next(request)
 
     @app.middleware('http')
     async def authenticate_requests(request: Request, call_next):


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR change the action execution server's behavior to only accept one request at a time for exec action requests. 
Otherwise, if there's long running bash command - it may block the action execution server from responding to other requests (e.g., `/server_info`), hence causing instability on RemoteRuntime.

---
**Link of any specific issues this addresses**
