### PR TITLE
fix(FE): do not share hidden events which may contains GITHUB TOKEN

### DIFF
--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -37,21 +37,24 @@ export const removeUnwantedKeys = (
     "focused_element_bid",
   ];
 
-  return data.map((item) => {
-    // Create a shallow copy of item
-    const newItem = { ...item };
+  return data
+    // Filter out hidden events
+    .filter((item) => !item.args?.hidden)
+    .map((item) => {
+      // Create a shallow copy of item
+      const newItem = { ...item };
 
-    // Check if extras exists and delete it from a new extras object
-    if (newItem.extras) {
-      const newExtras = { ...newItem.extras };
-      UNDESIRED_KEYS.forEach((key) => {
-        delete newExtras[key as keyof typeof newExtras];
-      });
-      newItem.extras = newExtras;
-    }
+      // Check if extras exists and delete it from a new extras object
+      if (newItem.extras) {
+        const newExtras = { ...newItem.extras };
+        UNDESIRED_KEYS.forEach((key) => {
+          delete newExtras[key as keyof typeof newExtras];
+        });
+        newItem.extras = newExtras;
+      }
 
-    return newItem;
-  });
+      return newItem;
+    });
 };
 
 export const removeApiKey = (


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

OpenHand's share currently could share hidden events, which may contains sensitive info like GITHUB TOKEN, see example: https://www.all-hands.dev/share?share_id=f45425fe1bc9c96b1e7d702701a229168bd0fb287c10f01d5e42ad98ac7d528b

This PR try to fix it by do not include hidden events for sharing.

---
**Link of any specific issues this addresses**
