### PR TITLE
chore: do not include "status" dict in share-openhands

### DIFF
--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -37,7 +37,14 @@ export const removeUnwantedKeys = (
     "focused_element_bid",
   ];
 
-  return data.map((item) => {
+  return data.filter(item => {
+    // Skip items that only have a status key
+    const keys = Object.keys(item);
+    if (keys.length === 1 && keys[0] === "status") {
+      return false;
+    }
+    return true;
+  }).map((item) => {
     // Create a shallow copy of item
     const newItem = { ...item };
 

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -40,7 +40,7 @@ export const removeUnwantedKeys = (
   return data
     .filter((item) => {
       // Skip items that have a status key
-      if ('status' in item) {
+      if ("status" in item) {
         return false;
       }
       return true;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -37,28 +37,30 @@ export const removeUnwantedKeys = (
     "focused_element_bid",
   ];
 
-  return data.filter(item => {
-    // Skip items that only have a status key
-    const keys = Object.keys(item);
-    if (keys.length === 1 && keys[0] === "status") {
-      return false;
-    }
-    return true;
-  }).map((item) => {
-    // Create a shallow copy of item
-    const newItem = { ...item };
+  return data
+    .filter((item) => {
+      // Skip items that only have a status key
+      const keys = Object.keys(item);
+      if (keys.length === 1 && keys[0] === "status") {
+        return false;
+      }
+      return true;
+    })
+    .map((item) => {
+      // Create a shallow copy of item
+      const newItem = { ...item };
 
-    // Check if extras exists and delete it from a new extras object
-    if (newItem.extras) {
-      const newExtras = { ...newItem.extras };
-      UNDESIRED_KEYS.forEach((key) => {
-        delete newExtras[key as keyof typeof newExtras];
-      });
-      newItem.extras = newExtras;
-    }
+      // Check if extras exists and delete it from a new extras object
+      if (newItem.extras) {
+        const newExtras = { ...newItem.extras };
+        UNDESIRED_KEYS.forEach((key) => {
+          delete newExtras[key as keyof typeof newExtras];
+        });
+        newItem.extras = newExtras;
+      }
 
-    return newItem;
-  });
+      return newItem;
+    });
 };
 
 export const removeApiKey = (

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -39,9 +39,8 @@ export const removeUnwantedKeys = (
 
   return data
     .filter((item) => {
-      // Skip items that only have a status key
-      const keys = Object.keys(item);
-      if (keys.length === 1 && keys[0] === "status") {
+      // Skip items that have a status key
+      if ('status' in item) {
         return false;
       }
       return true;


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In ShareOpenHands, we may have a lot of "status" dict that is not visualized. This PR filter then out and stop sending them to the share-oh server.

![image](https://github.com/user-attachments/assets/4a9d52f7-4209-4a33-9ff1-9d2ead2276ff)


---
**Link of any specific issues this addresses**
