### PR TITLE
Feature: Any Port in a (Local) Storm

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -13,6 +13,7 @@ from pathspec.patterns import GitWildMatchPattern
 
 from openhands.security.options import SecurityAnalyzers
 from openhands.server.data_models.feedback import FeedbackDataModel, store_feedback
+from openhands.server.middleware import CustomCORSMiddleware, NoCacheMiddleware
 from openhands.storage import get_file_store
 from openhands.utils.async_utils import call_sync_from_async
 
@@ -29,12 +30,10 @@ from fastapi import (
     WebSocket,
     status,
 )
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPBearer
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from starlette.middleware.base import BaseHTTPMiddleware
 
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands.controller.agent import Agent
@@ -77,31 +76,8 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=['http://localhost:3001', 'http://127.0.0.1:3001'],
-    allow_credentials=True,
-    allow_methods=['*'],
-    allow_headers=['*'],
-)
 
-
-class NoCacheMiddleware(BaseHTTPMiddleware):
-    """
-    Middleware to disable caching for all routes by adding appropriate headers
-    """
-
-    async def dispatch(self, request, call_next):
-        response = await call_next(request)
-        if not request.url.path.startswith('/assets'):
-            response.headers['Cache-Control'] = (
-                'no-cache, no-store, must-revalidate, max-age=0'
-            )
-            response.headers['Pragma'] = 'no-cache'
-            response.headers['Expires'] = '0'
-        return response
-
-
+app.add_middleware(CustomCORSMiddleware)
 app.add_middleware(NoCacheMiddleware)
 
 security_scheme = HTTPBearer()

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -1,8 +1,8 @@
 from urllib.parse import urlparse
 
-from engineio import ASGIApp
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
 
 
 class CustomCORSMiddleware(CORSMiddleware):

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -1,0 +1,42 @@
+from urllib.parse import urlparse
+
+from engineio import ASGIApp
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class CustomCORSMiddleware(CORSMiddleware):
+    """
+    Custom CORS middleware that allows CORS requests from any origin where the domain is localhost
+    (Allowing any port)
+    """
+
+    def __init__(self, app: ASGIApp):
+        super().__init__(
+            app=app,
+            allow_credentials=True,
+            allow_methods=['*'],
+            allow_headers=['*'],
+        )
+
+    def is_allowed_origin(self, origin: str) -> bool:
+        domain = urlparse(origin).netloc.split(':')[0]
+        if domain in ('localhost', '127.0.0.1'):
+            return True
+        return super().is_allowed_origin(origin)
+
+
+class NoCacheMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to disable caching for all routes by adding appropriate headers
+    """
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        if not request.url.path.startswith('/assets'):
+            response.headers['Cache-Control'] = (
+                'no-cache, no-store, must-revalidate, max-age=0'
+            )
+            response.headers['Pragma'] = 'no-cache'
+            response.headers['Expires'] = '0'
+        return response


### PR DESCRIPTION
**Allow CORS from servers running on any port on localhost - not just 3000 / 3001**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
## Motivation
Sometimes it is convenient to create small ad-hoc web app instances for the purpose of testing particular functionality, and running these on port 3001 is frustrating as it interferes with existing OpenHands functionality. This change allows CORS from any server running on localhost.

## Changes
* Moved the Custom Middleware into a `middleware.py` package for better code organization.
* Implemented CustomCORSMiddleware class to implement the specific logic required (I originally thought the stock middleware could do this and OpenHands disagreed with me - it turns out OpenHands was right).
