### PR TITLE
Refactor CORS middleware and enhance localhost handling

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -33,7 +33,6 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPBearer
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from openhands.server.middleware import NoCacheMiddleware, LocalhostCORSMiddleware
 
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands.controller.agent import Agent
@@ -56,6 +55,7 @@ from openhands.events.serialization import event_to_dict
 from openhands.llm import bedrock
 from openhands.runtime.base import Runtime
 from openhands.server.auth import get_sid_from_token, sign_token
+from openhands.server.middleware import LocalhostCORSMiddleware, NoCacheMiddleware
 from openhands.server.session import SessionManager
 
 load_dotenv()
@@ -78,7 +78,6 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 app.add_middleware(
     LocalhostCORSMiddleware,
-    allow_origins=['http://localhost:3001', 'http://127.0.0.1:3001'],  # Fallback origins for non-localhost domains
     allow_credentials=True,
     allow_methods=['*'],
     allow_headers=['*'],

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlparse
+
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
@@ -9,22 +10,19 @@ class LocalhostCORSMiddleware(CORSMiddleware):
     Custom CORS middleware that allows any request from localhost/127.0.0.1 domains,
     while using standard CORS rules for other origins.
     """
-    def __init__(
-        self,
-        app: ASGIApp,
-        **kwargs
-    ) -> None:
+
+    def __init__(self, app: ASGIApp, **kwargs) -> None:
         super().__init__(app, **kwargs)
 
     async def is_allowed_origin(self, origin: str) -> bool:
         if origin:
             parsed = urlparse(origin)
-            hostname = parsed.hostname or ""
-            
+            hostname = parsed.hostname or ''
+
             # Allow any localhost/127.0.0.1 origin regardless of port
-            if hostname in ["localhost", "127.0.0.1"]:
+            if hostname in ['localhost', '127.0.0.1']:
                 return True
-            
+
         # For missing origin or other origins, use the parent class's logic
         return await super().is_allowed_origin(origin)
 

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -1,0 +1,45 @@
+from urllib.parse import urlparse
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+class LocalhostCORSMiddleware(CORSMiddleware):
+    """
+    Custom CORS middleware that allows any request from localhost/127.0.0.1 domains,
+    while using standard CORS rules for other origins.
+    """
+    def __init__(
+        self,
+        app: ASGIApp,
+        **kwargs
+    ) -> None:
+        super().__init__(app, **kwargs)
+
+    async def is_allowed_origin(self, origin: str) -> bool:
+        if origin:
+            parsed = urlparse(origin)
+            hostname = parsed.hostname or ""
+            
+            # Allow any localhost/127.0.0.1 origin regardless of port
+            if hostname in ["localhost", "127.0.0.1"]:
+                return True
+            
+        # For missing origin or other origins, use the parent class's logic
+        return await super().is_allowed_origin(origin)
+
+
+class NoCacheMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to disable caching for all routes by adding appropriate headers
+    """
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        if not request.url.path.startswith('/assets'):
+            response.headers['Cache-Control'] = (
+                'no-cache, no-store, must-revalidate, max-age=0'
+            )
+            response.headers['Pragma'] = 'no-cache'
+            response.headers['Expires'] = '0'
+        return response


### PR DESCRIPTION
This PR includes:

- Move NoCacheMiddleware to a dedicated middleware.py module
- Create LocalhostCORSMiddleware that allows any localhost/127.0.0.1 request while maintaining standard CORS behavior for other origins
- Update listen.py to use the new middleware

The changes improve code organization and make local development easier by automatically allowing any localhost/127.0.0.1 request regardless of port.