### PR TITLE
test(runtime) #4623: file permission when running the file_editor

### DIFF
--- a/tests/runtime/test_ipython.py
+++ b/tests/runtime/test_ipython.py
@@ -234,13 +234,17 @@ def test_ipython_package_install(temp_dir, runtime_cls, run_as_openhands):
     _close_test_runtime(runtime)
 
 
-def test_ipython_file_editor_permissions(temp_dir, runtime_cls, run_as_openhands):
+def test_ipython_file_editor_permissions_as_openhands(
+    temp_dir, runtime_cls, run_as_openhands
+):
     """Test file editor permission behavior when running as different users."""
     runtime = _load_runtime(temp_dir, runtime_cls, run_as_openhands)
     sandbox_dir = _get_sandbox_folder(runtime)
 
     # Create a file owned by root with restricted permissions
-    action = CmdRunAction(command='sudo touch /root/test.txt && sudo chmod 600 /root/test.txt')
+    action = CmdRunAction(
+        command='sudo touch /root/test.txt && sudo chmod 600 /root/test.txt'
+    )
     logger.info(action, extra={'msg_type': 'ACTION'})
     obs = runtime.run_action(action)
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
@@ -263,7 +267,9 @@ def test_ipython_file_editor_permissions(temp_dir, runtime_cls, run_as_openhands
     assert 'Permission denied' in obs.content
 
     # Try to create a file in root directory - should fail with permission denied
-    test_code = "print(file_editor(command='create', path='/root/new.txt', file_text='test'))"
+    test_code = (
+        "print(file_editor(command='create', path='/root/new.txt', file_text='test'))"
+    )
     action = IPythonRunCellAction(code=test_code)
     logger.info(action, extra={'msg_type': 'ACTION'})
     obs = runtime.run_action(action)

--- a/tests/runtime/test_ipython.py
+++ b/tests/runtime/test_ipython.py
@@ -234,11 +234,9 @@ def test_ipython_package_install(temp_dir, runtime_cls, run_as_openhands):
     _close_test_runtime(runtime)
 
 
-def test_ipython_file_editor_permissions_as_openhands(
-    temp_dir, runtime_cls, run_as_openhands
-):
+def test_ipython_file_editor_permissions_as_openhands(temp_dir, runtime_cls):
     """Test file editor permission behavior when running as different users."""
-    runtime = _load_runtime(temp_dir, runtime_cls, run_as_openhands)
+    runtime = _load_runtime(temp_dir, runtime_cls, run_as_openhands=True)
     sandbox_dir = _get_sandbox_folder(runtime)
 
     # Create a file owned by root with restricted permissions

--- a/tests/runtime/test_ipython.py
+++ b/tests/runtime/test_ipython.py
@@ -234,8 +234,8 @@ def test_ipython_package_install(temp_dir, runtime_cls, run_as_openhands):
     _close_test_runtime(runtime)
 
 
-def test_ipython_file_permissions(temp_dir, runtime_cls, run_as_openhands):
-    """Test file permission behavior when running as different users."""
+def test_ipython_file_editor_permissions(temp_dir, runtime_cls, run_as_openhands):
+    """Test file editor permission behavior when running as different users."""
     runtime = _load_runtime(temp_dir, runtime_cls, run_as_openhands)
     sandbox_dir = _get_sandbox_folder(runtime)
 
@@ -246,35 +246,55 @@ def test_ipython_file_permissions(temp_dir, runtime_cls, run_as_openhands):
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
     assert obs.exit_code == 0
 
-    # Try to read the file as openhands user - should fail with permission denied
-    action = FileReadAction(path='/root/test.txt')
+    # Try to view the file as openhands user - should fail with permission denied
+    test_code = "print(file_editor(command='view', path='/root/test.txt'))"
+    action = IPythonRunCellAction(code=test_code)
     logger.info(action, extra={'msg_type': 'ACTION'})
     obs = runtime.run_action(action)
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert isinstance(obs, ErrorObservation)
     assert 'Permission denied' in obs.content
 
-    # Try to write to the file as openhands user - should fail with permission denied 
-    action = FileWriteAction(path='/root/test.txt', content='test')
+    # Try to edit the file as openhands user - should fail with permission denied
+    test_code = "print(file_editor(command='str_replace', path='/root/test.txt', old_str='', new_str='test'))"
+    action = IPythonRunCellAction(code=test_code)
     logger.info(action, extra={'msg_type': 'ACTION'})
     obs = runtime.run_action(action)
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert isinstance(obs, ErrorObservation)
     assert 'Permission denied' in obs.content
 
-    # Try to read/write file in openhands home directory
-    action = FileWriteAction(path=f'{sandbox_dir}/test.txt', content='test')
+    # Try to create a file in root directory - should fail with permission denied
+    test_code = "print(file_editor(command='create', path='/root/new.txt', file_text='test'))"
+    action = IPythonRunCellAction(code=test_code)
     logger.info(action, extra={'msg_type': 'ACTION'})
     obs = runtime.run_action(action)
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert isinstance(obs, FileWriteObservation)
+    assert 'Permission denied' in obs.content
 
-    action = FileReadAction(path=f'{sandbox_dir}/test.txt')
+    # Try to use file editor in openhands sandbox directory - should work
+    test_code = f"""
+# Create file
+print(file_editor(command='create', path='{sandbox_dir}/test.txt', file_text='Line 1\\nLine 2\\nLine 3'))
+
+# View file
+print(file_editor(command='view', path='{sandbox_dir}/test.txt'))
+
+# Edit file
+print(file_editor(command='str_replace', path='{sandbox_dir}/test.txt', old_str='Line 2', new_str='New Line 2'))
+
+# Undo edit
+print(file_editor(command='undo_edit', path='{sandbox_dir}/test.txt'))
+"""
+    action = IPythonRunCellAction(code=test_code)
     logger.info(action, extra={'msg_type': 'ACTION'})
     obs = runtime.run_action(action)
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert isinstance(obs, FileReadObservation)
-    assert obs.content == 'test\n'
+    assert 'File created successfully' in obs.content
+    assert 'Line 1' in obs.content
+    assert 'Line 2' in obs.content
+    assert 'Line 3' in obs.content
+    assert 'New Line 2' in obs.content
+    assert 'Last edit to' in obs.content
+    assert 'undone successfully' in obs.content
 
     # Clean up
     action = CmdRunAction(command=f'rm -f {sandbox_dir}/test.txt')


### PR DESCRIPTION
…erent users

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Add a test case for `file_editor` when running with different user inside runtime.

---
**Link of any specific issues this addresses**

Fix https://github.com/All-Hands-AI/OpenHands/issues/4623