### PR TITLE
Fix old string serializer

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, fields
 from typing import Optional
 
 from openhands.core.config.config_utils import get_field_info
+from openhands.core.logger import LOG_DIR
 
 LLM_SENSITIVE_FIELDS = ['api_key', 'aws_access_key_id', 'aws_secret_access_key']
 
@@ -75,7 +76,7 @@ class LLMConfig:
     disable_vision: bool | None = None
     caching_prompt: bool = True
     log_completions: bool = False
-    log_completions_folder: str | None = None
+    log_completions_folder: str = os.path.join(LOG_DIR, 'completions')
     draft_editor: Optional['LLMConfig'] = None
     supports_function_calling: bool = False
 

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -203,8 +203,6 @@ def finalize_config(cfg: AppConfig):
     # make sure log_completions_folder is an absolute path
     for llm in cfg.llms.values():
         llm.log_completions_folder = os.path.abspath(llm.log_completions_folder)
-
-    for llm in cfg.llms.values():
         if llm.embedding_base_url is None:
             llm.embedding_base_url = llm.base_url
 

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -200,6 +200,10 @@ def finalize_config(cfg: AppConfig):
             parts = cfg.workspace_mount_rewrite.split(':')
             cfg.workspace_mount_path = base.replace(parts[0], parts[1])
 
+    # make sure log_completions_folder is an absolute path
+    for llm in cfg.llms.values():
+        llm.log_completions_folder = os.path.abspath(llm.log_completions_folder)
+
     for llm in cfg.llms.values():
         if llm.embedding_base_url is None:
             llm.embedding_base_url = llm.base_url

--- a/tests/unit/test_message_serialization.py
+++ b/tests/unit/test_message_serialization.py
@@ -78,10 +78,7 @@ def test_message_with_only_text_content_and_vision_disabled():
 
     expected_serialized_message = {
         'role': 'user',
-        'content': [
-            {'type': 'text', 'text': 'This is a text message'},
-            {'type': 'text', 'text': 'This is another text message'},
-        ],
+        'content': 'This is a text message\nThis is another text message',
     }
 
     assert serialized_message == expected_serialized_message
@@ -110,10 +107,7 @@ def test_message_with_mixed_content_and_vision_disabled():
     # Expected serialization ignores images and concatenates text
     expected_serialized_message = {
         'role': 'user',
-        'content': [
-            {'type': 'text', 'text': 'This is a text message'},
-            {'type': 'text', 'text': 'This is another text message'},
-        ],
+        'content': 'This is a text message\nThis is another text message',
     }
 
     # Assert serialized message matches expectation


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix compatibility for models like llama on Groq that don't support vision or tools.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- some providers like Groq require some or all elements of a Message dict to be single strings, unlike the vision or prompt caching or function calling -supporting APIs. We still need the single string serializer, this PR proposes to restore it
- be more lenient with `llm_completions`, maybe we don't need to fail hard?


Llama is an LLM with personality 😅. After the fix, I ran again the branch locally, and Llama said:
```
ACTION
[Agent Controller default] **MessageAction** (source=None)
CONTENT: I'm back online! It seems like I had a brief interruption. Before we continue, I'd like to clarify what my task is. Could you please tell me what you'd like me to assist you with?
```
---
**Link of any specific issues this addresses**
Fix https://github.com/All-Hands-AI/OpenHands/issues/4643