### PR TITLE
issue/4599-add cursor position information down inside the editor area.

### DIFF
--- a/frontend/src/routes/_oh.app._index/code-editor-component.tsx
+++ b/frontend/src/routes/_oh.app._index/code-editor-component.tsx
@@ -1,5 +1,5 @@
 import { Editor, Monaco } from "@monaco-editor/react";
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { VscCode } from "react-icons/vsc";
 import { type editor } from "monaco-editor";
@@ -22,6 +22,8 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
     saveFileContent: saveNewFileContent,
   } = useFiles();
 
+  const [cursorPosition, setCursorPosition] = useState({ line: 1, column: 1 });
+
   const handleEditorDidMount = React.useCallback(
     (editor: editor.IStandaloneCodeEditor, monaco: Monaco): void => {
       monaco.editor.defineTheme("my-theme", {
@@ -34,6 +36,13 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
       });
 
       monaco.editor.setTheme("my-theme");
+
+      editor.onDidChangeCursorPosition((e) => {
+        setCursorPosition({
+          line: e.position.lineNumber,
+          column: e.position.column,
+        });
+      });
     },
     [],
   );
@@ -62,7 +71,7 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
     return () => {
       document.removeEventListener("keydown", handleSave);
     };
-  }, [saveNewFileContent]);
+  }, [saveNewFileContent, selectedPath]);
 
   if (!selectedPath) {
     return (
@@ -77,20 +86,29 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
   }
 
   return (
-    <Editor
-      data-testid="code-editor"
-      height="100%"
-      path={selectedPath ?? undefined}
-      defaultValue=""
-      value={
-        selectedPath
-          ? modifiedFiles[selectedPath] || files[selectedPath]
-          : undefined
-      }
-      onMount={handleEditorDidMount}
-      onChange={handleEditorChange}
-      options={{ readOnly: isReadOnly }}
-    />
+    <div className="flex grow flex-col h-full w-full">
+      {/* Ensure that the editor takes up the maximum amount of space in the parent container */}
+      <div className="flex-grow min-h-0">
+        <Editor
+          data-testid="code-editor"
+          height="100%"
+          path={selectedPath ?? undefined}
+          defaultValue=""
+          value={
+            selectedPath
+              ? modifiedFiles[selectedPath] || files[selectedPath]
+              : undefined
+          }
+          onMount={handleEditorDidMount}
+          onChange={handleEditorChange}
+          options={{ readOnly: isReadOnly }}
+        />
+      </div>
+      {/* cursor position information */}
+      <div className="p-2 text-neutral-500 flex-shrink-0">
+        Row: {cursorPosition.line}, Column: {cursorPosition.column}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
## **Give a summary of what the PR does, explaining any non-trivial design decisions**
This PR add information of where the cursor is inside the editor area. The information goes like:

> Row: 4, Column: 15

Here's the implementation:
![image](https://github.com/user-attachments/assets/400fb0c8-1634-44f2-9892-5a6af327b751)

I've made this change by only modifying

> frontend/src/routes/_oh.app._index/code-editor-component.tsx

> 1. State management: Use React's useState hook to create a state called cursorPosition that stores the position of the cursor (row and column numbers).
> 2. Register events for cursor position changes: In the handleEditorDidMount callback, use Monaco Editor's onDidChangeCursorPosition event to monitor cursor position changes. When the cursor position changes, this code updates the cursorPosition state, storing the row and column numbers of the current cursor.
![image](https://github.com/user-attachments/assets/c65bc7d2-e0eb-4bfe-98e6-86d4e43e8d82)
> 3. Cursor Position Display: In the component's JSX return, the cursorPosition state is used to dynamically display the current cursor position.
![image](https://github.com/user-attachments/assets/6e91449f-bd0a-4e11-b13f-b2670275600a)

---
**Link of any specific issues this addresses**
source issue [issue#4599](https://github.com/All-Hands-AI/OpenHands/issues/4599)
