### PR TITLE
fix(frontend): Prevent editor from changing width unpredictably

### DIFF
--- a/frontend/__tests__/components/file-explorer/FileExplorer.test.tsx
+++ b/frontend/__tests__/components/file-explorer/FileExplorer.test.tsx
@@ -16,13 +16,16 @@ vi.mock("../../services/fileService", async () => ({
 }));
 
 const renderFileExplorerWithRunningAgentState = () =>
-  renderWithProviders(<FileExplorer error={null} />, {
-    preloadedState: {
-      agent: {
-        curAgentState: AgentState.RUNNING,
+  renderWithProviders(
+    <FileExplorer error={null} isOpen onToggle={() => {}} />,
+    {
+      preloadedState: {
+        agent: {
+          curAgentState: AgentState.RUNNING,
+        },
       },
     },
-  });
+  );
 
 describe.skip("FileExplorer", () => {
   afterEach(() => {

--- a/frontend/src/components/file-explorer/FileExplorer.tsx
+++ b/frontend/src/components/file-explorer/FileExplorer.tsx
@@ -91,14 +91,15 @@ function ExplorerActions({
 }
 
 interface FileExplorerProps {
+  isOpen: boolean;
+  onToggle: () => void;
   error: string | null;
 }
 
-function FileExplorer({ error }: FileExplorerProps) {
+function FileExplorer({ error, isOpen, onToggle }: FileExplorerProps) {
   const { revalidate } = useRevalidator();
 
   const { paths, setPaths } = useFiles();
-  const [isHidden, setIsHidden] = React.useState(false);
   const [isDragging, setIsDragging] = React.useState(false);
 
   const { curAgentState } = useSelector((state: RootState) => state.agent);
@@ -211,7 +212,7 @@ function FileExplorer({ error }: FileExplorerProps) {
       <div
         className={twMerge(
           "bg-neutral-800 h-full border-r-1 border-r-neutral-600 flex flex-col",
-          isHidden ? "w-12" : "w-60",
+          !isOpen ? "w-12" : "w-60",
         )}
       >
         <div className="flex flex-col relative h-full px-3 py-2">
@@ -219,17 +220,17 @@ function FileExplorer({ error }: FileExplorerProps) {
             <div
               className={twMerge(
                 "flex items-center",
-                isHidden ? "justify-center" : "justify-between",
+                !isOpen ? "justify-center" : "justify-between",
               )}
             >
-              {!isHidden && (
+              {isOpen && (
                 <div className="text-neutral-300 font-bold text-sm">
                   {t(I18nKey.EXPLORER$LABEL_WORKSPACE)}
                 </div>
               )}
               <ExplorerActions
-                isHidden={isHidden}
-                toggleHidden={() => setIsHidden((prev) => !prev)}
+                isHidden={!isOpen}
+                toggleHidden={onToggle}
                 onRefresh={refreshWorkspace}
                 onUpload={selectFileInput}
               />
@@ -237,7 +238,7 @@ function FileExplorer({ error }: FileExplorerProps) {
           </div>
           {!error && (
             <div className="overflow-auto flex-grow">
-              <div style={{ display: isHidden ? "none" : "block" }}>
+              <div style={{ display: !isOpen ? "none" : "block" }}>
                 <ExplorerTree files={paths} />
               </div>
             </div>

--- a/frontend/src/routes/_oh.app._index/code-editor-component.tsx
+++ b/frontend/src/routes/_oh.app._index/code-editor-component.tsx
@@ -1,18 +1,21 @@
-import { Editor, Monaco } from "@monaco-editor/react";
+import { Editor, EditorProps } from "@monaco-editor/react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { VscCode } from "react-icons/vsc";
-import { type editor } from "monaco-editor";
 import toast from "react-hot-toast";
 import { I18nKey } from "#/i18n/declaration";
 import { useFiles } from "#/context/files";
 import OpenHands from "#/api/open-hands";
 
 interface CodeEditorCompoonentProps {
+  onMount: EditorProps["onMount"];
   isReadOnly: boolean;
 }
 
-function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
+function CodeEditorCompoonent({
+  onMount,
+  isReadOnly,
+}: CodeEditorCompoonentProps) {
   const { t } = useTranslation();
   const {
     files,
@@ -21,22 +24,6 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
     modifyFileContent,
     saveFileContent: saveNewFileContent,
   } = useFiles();
-
-  const handleEditorDidMount = React.useCallback(
-    (editor: editor.IStandaloneCodeEditor, monaco: Monaco): void => {
-      monaco.editor.defineTheme("my-theme", {
-        base: "vs-dark",
-        inherit: true,
-        rules: [],
-        colors: {
-          "editor.background": "#171717",
-        },
-      });
-
-      monaco.editor.setTheme("my-theme");
-    },
-    [],
-  );
 
   const handleEditorChange = (value: string | undefined) => {
     if (selectedPath && value) modifyFileContent(selectedPath, value);
@@ -68,7 +55,7 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
     return (
       <div
         data-testid="code-editor-empty-message"
-        className="flex flex-col items-center text-neutral-400"
+        className="flex flex-col h-full items-center justify-center text-neutral-400"
       >
         <VscCode size={100} />
         {t(I18nKey.CODE_EDITOR$EMPTY_MESSAGE)}
@@ -79,7 +66,6 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
   return (
     <Editor
       data-testid="code-editor"
-      height="100%"
       path={selectedPath ?? undefined}
       defaultValue=""
       value={
@@ -87,7 +73,7 @@ function CodeEditorCompoonent({ isReadOnly }: CodeEditorCompoonentProps) {
           ? modifiedFiles[selectedPath] || files[selectedPath]
           : undefined
       }
-      onMount={handleEditorDidMount}
+      onMount={onMount}
       onChange={handleEditorChange}
       options={{ readOnly: isReadOnly }}
     />

--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -315,11 +315,11 @@ function App() {
   return (
     <div className="flex flex-col h-full gap-3">
       <div className="flex h-full overflow-auto gap-3">
-        <Container className="w-[375px] max-h-full">
+        <Container className="w-1/4 max-h-full">
           <ChatInterface />
         </Container>
 
-        <div className="flex flex-col grow gap-3">
+        <div className="flex flex-col w-3/4 gap-3">
           <Container
             className="h-2/3"
             labels={[

--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -315,11 +315,11 @@ function App() {
   return (
     <div className="flex flex-col h-full gap-3">
       <div className="flex h-full overflow-auto gap-3">
-        <Container className="w-1/4 max-h-full">
+        <Container className="w-[390px] max-h-full">
           <ChatInterface />
         </Container>
 
-        <div className="flex flex-col w-3/4 gap-3">
+        <div className="flex flex-col grow gap-3">
           <Container
             className="h-2/3"
             labels={[


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Dynamically adjust the monaco editor's layout when toggling the file explorer


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:e47d7ca-nikolaik   --name openhands-app-e47d7ca   ghcr.io/all-hands-ai/runtime:e47d7ca
```