### PR TITLE
Fix unawaited

### DIFF
--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -14,7 +14,7 @@ class LocalhostCORSMiddleware(CORSMiddleware):
     def __init__(self, app: ASGIApp, **kwargs) -> None:
         super().__init__(app, **kwargs)
 
-    async def is_allowed_origin(self, origin: str) -> bool:
+    def is_allowed_origin(self, origin: str) -> bool:
         if origin:
             parsed = urlparse(origin)
             hostname = parsed.hostname or ''
@@ -24,7 +24,7 @@ class LocalhostCORSMiddleware(CORSMiddleware):
                 return True
 
         # For missing origin or other origins, use the parent class's logic
-        return await super().is_allowed_origin(origin)
+        return super().is_allowed_origin(origin)
 
 
 class NoCacheMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
**Fix for regression from yesterday**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Fix regression from yesterday**
```
RuntimeWarning: coroutine 'LocalhostCORSMiddleware.is_allowed_origin' was never awaited
  elif not self.allow_all_origins and self.is_allowed_origin(origin=origin):
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:08df881-nikolaik   --name openhands-app-08df881   ghcr.io/all-hands-ai/runtime:08df881
```