### PR TITLE
Fix agent session error in logs

### DIFF
--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -139,7 +139,11 @@ class AgentSession:
             await self.security_analyzer.close()
 
         if self.loop:
-            if not self.loop.is_closed():
+            if self.loop.is_closed():
+                logger.debug(
+                    'Trying to close already closed loop. (It probably never started correctly)'
+                )
+            else:
                 self.loop.stop()
             self.loop = None
 

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -139,7 +139,9 @@ class AgentSession:
             await self.security_analyzer.close()
 
         if self.loop:
-            self.loop.stop()
+            if not self.loop.is_closed():
+                self.loop.stop()
+            self.loop = None
 
         self._closed = True
 


### PR DESCRIPTION
**Fix for error in logs on file change if the app did not finish starting up.**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Happens in development mode when you save a file if the app did not finish starting up correctly - basically we try to close and event loop that was never opened:
```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/Users/tofarr/dev/all-hands/OpenHands/openhands/server/session/session.py", line 62, in loop_recv
    data = await self.websocket.receive_json()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/websockets.py", line 135, in receive_json
    self._raise_on_disconnect(message)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/websockets.py", line 113, in _raise_on_disconnect
    raise WebSocketDisconnect(message["code"], message.get("reason"))
starlette.websockets.WebSocketDisconnect: (1012, None)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 242, in run_asgi
    result = await self.app(self.scope, self.asgi_receive, self.asgi_send)  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 152, in __call__
    await self.app(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 101, in __call__
    await self.app(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 101, in __call__
    await self.app(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 77, in __call__
    await self.app(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/routing.py", line 362, in handle
    await self.app(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/routing.py", line 95, in app
    await wrap_app_handling_exceptions(app, session)(scope, receive, send)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/starlette/routing.py", line 93, in app
    await func(session)
  File "/Users/tofarr/dev/all-hands/OpenHands/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 383, in app
    await dependant.call(**solved_result.values)
  File "/Users/tofarr/dev/all-hands/OpenHands/openhands/server/listen.py", line 357, in websocket_endpoint
    await session.loop_recv()
  File "/Users/tofarr/dev/all-hands/OpenHands/openhands/server/session/session.py", line 68, in loop_recv
    await self.close()
  File "/Users/tofarr/dev/all-hands/OpenHands/openhands/server/session/session.py", line 54, in close
    await self.agent_session.close()
  File "/Users/tofarr/dev/all-hands/OpenHands/openhands/server/session/agent_session.py", line 142, in close
    self.loop.stop()
  File "uvloop/loop.pyx", line 1357, in uvloop.loop.Loop.stop
  File "uvloop/loop.pyx", line 678, in uvloop.loop.Loop._call_soon_handle
  File "uvloop/loop.pyx", line 673, in uvloop.loop.Loop._append_ready_handle
  File "uvloop/loop.pyx", line 705, in uvloop.loop.Loop._check_closed
RuntimeError: Event loop is closed
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:f2881d9-nikolaik   --name openhands-app-f2881d9   ghcr.io/all-hands-ai/runtime:f2881d9
```