### PR TITLE
[openhands] ALL-621: Fix race condition in file content loading

### DIFF
--- a/frontend/src/components/file-explorer/TreeNode.tsx
+++ b/frontend/src/components/file-explorer/TreeNode.tsx
@@ -83,11 +83,12 @@ function TreeNode({ path, defaultOpen = false }: TreeNodeProps) {
       setIsOpen((prev) => !prev);
     } else if (token) {
       const code = modifiedFiles[path] || files[path];
+      setSelectedPath(path);
 
       try {
         const fetchedCode = await OpenHands.getFile(token, path);
-        setSelectedPath(path);
-        if (!code || fetchedCode !== files[path]) {
+        // Only update the file content if this is still the selected path
+        if (selectedPath === path && (!code || fetchedCode !== files[path])) {
           setFileContent(path, fetchedCode);
         }
       } catch (error) {


### PR DESCRIPTION
- Added check to ensure file content is only updated if it's still the selected file
- Prevents incorrect content display when clicking through files quickly
- Maintains UI responsiveness while handling async file loading safely

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**
Resolves #4576

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:0475d09-nikolaik   --name openhands-app-0475d09   ghcr.io/all-hands-ai/runtime:0475d09
```