### PR TITLE
feat(frontend): Make loader synchronous

### DIFF
--- a/frontend/src/components/github-repositories-suggestion-box.tsx
+++ b/frontend/src/components/github-repositories-suggestion-box.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import {
+  isGitHubErrorReponse,
+  retrieveAllGitHubUserRepositories,
+} from "#/api/github";
+import { SuggestionBox } from "#/routes/_oh._index/suggestion-box";
+import { ConnectToGitHubModal } from "./modals/connect-to-github-modal";
+import { ModalBackdrop } from "./modals/modal-backdrop";
+import { GitHubRepositorySelector } from "#/routes/_oh._index/github-repo-selector";
+import ModalButton from "./buttons/ModalButton";
+import GitHubLogo from "#/assets/branding/github-logo.svg?react";
+
+interface GitHubAuthProps {
+  onConnectToGitHub: () => void;
+  repositories: GitHubRepository[];
+  isLoggedIn: boolean;
+}
+
+function GitHubAuth({
+  onConnectToGitHub,
+  repositories,
+  isLoggedIn,
+}: GitHubAuthProps) {
+  if (isLoggedIn) {
+    return <GitHubRepositorySelector repositories={repositories} />;
+  }
+
+  return (
+    <ModalButton
+      text="Connect to GitHub"
+      icon={<GitHubLogo width={20} height={20} />}
+      className="bg-[#791B80] w-full"
+      onClick={onConnectToGitHub}
+    />
+  );
+}
+
+interface GitHubRepositoriesSuggestionBoxProps {
+  repositories: Awaited<
+    ReturnType<typeof retrieveAllGitHubUserRepositories>
+  > | null;
+  gitHubAuthUrl: string | null;
+  user: GitHubErrorReponse | GitHubUser | null;
+}
+
+export function GitHubRepositoriesSuggestionBox({
+  repositories,
+  gitHubAuthUrl,
+  user,
+}: GitHubRepositoriesSuggestionBoxProps) {
+  const [connectToGitHubModalOpen, setConnectToGitHubModalOpen] =
+    React.useState(false);
+
+  const handleConnectToGitHub = () => {
+    if (gitHubAuthUrl) {
+      window.location.href = gitHubAuthUrl;
+    } else {
+      setConnectToGitHubModalOpen(true);
+    }
+  };
+
+  if (isGitHubErrorReponse(repositories)) {
+    return (
+      <SuggestionBox
+        title="Error Fetching Repositories"
+        content={
+          <p className="text-danger text-center">{repositories.message}</p>
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      <SuggestionBox
+        title="Open a Repo"
+        content={
+          <GitHubAuth
+            isLoggedIn={!!user && !isGitHubErrorReponse(user)}
+            repositories={repositories || []}
+            onConnectToGitHub={handleConnectToGitHub}
+          />
+        }
+      />
+      {connectToGitHubModalOpen && (
+        <ModalBackdrop onClose={() => setConnectToGitHubModalOpen(false)}>
+          <ConnectToGitHubModal
+            onClose={() => setConnectToGitHubModalOpen(false)}
+          />
+        </ModalBackdrop>
+      )}
+    </>
+  );
+}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -70,7 +70,9 @@ const openHandsHandlers = [
 
 export const handlers = [
   ...openHandsHandlers,
-  http.get("https://api.github.com/user/repos", ({ request }) => {
+  http.get("https://api.github.com/user/repos", async ({ request }) => {
+    await delay(3500);
+
     const token = request.headers
       .get("Authorization")
       ?.replace("Bearer", "")


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
When routing to `/`, the default index route waited on the `clientLoader` to complete its asynchronous task before rendering the UI.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Defer async data in `clientAction` so the UI renders immediately
- Create fallback and loading variants of the github suggestion box to display while it loads


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:b96de6d-nikolaik   --name openhands-app-b96de6d   ghcr.io/all-hands-ai/runtime:b96de6d
```