### PR TITLE
Fix issue #4695: [Bug]: Dependabot PRs fail on "Update PR Description" github action step

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -401,7 +401,7 @@ jobs:
           exit 1
   update_pr_description:
     name: Update PR Description
-    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'
     needs: [ghcr_build_runtime]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request fixes #4695.

The issue has been successfully resolved. The AI agent modified the GitHub workflow file to add a specific condition (`github.actor != 'dependabot[bot]'`) that prevents the "Update PR Description" job from running when Dependabot is the actor. This directly addresses the reported bug where Dependabot PRs were failing on the "Update PR Description" step.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:f975a01-nikolaik   --name openhands-app-f975a01   ghcr.io/all-hands-ai/runtime:f975a01
```