### PR TITLE
fix: prompt caching

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -324,13 +324,14 @@ class LLM(RetryMixin, DebugMixin):
         Returns:
             boolean: True if prompt caching is supported and enabled for the given model.
         """
-        return (
-            self.config.caching_prompt is True
-            and self.model_info is not None
-            and self.model_info.get('supports_prompt_caching', False)
-            and (
+        return self.config.caching_prompt is True and (
+            (
                 self.config.model in CACHE_PROMPT_SUPPORTED_MODELS
                 or self.config.model.split('/')[-1] in CACHE_PROMPT_SUPPORTED_MODELS
+            )
+            or (
+                self.model_info is not None
+                and self.model_info.get('supports_prompt_caching', False)
             )
         )
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Make the prompt caching condition a little more lenient - i was running into an issue where model_info is None, and even though the LLM support prompt caching and OpenHands didn't use it :( - and caused a huge bill on anthropic (bc i was running large eval).

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:b49beb8-nikolaik   --name openhands-app-b49beb8   ghcr.io/all-hands-ai/runtime:b49beb8
```