### PR TITLE
Fix permissions on __init__.py

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -71,7 +71,9 @@ RUN /openhands/micromamba/bin/micromamba create -n openhands -y && \
 RUN \
     if [ -d /openhands/code ]; then rm -rf /openhands/code; fi && \
     mkdir -p /openhands/code/openhands && \
-    touch /openhands/code/openhands/__init__.py
+    touch /openhands/code/openhands/__init__.py && \
+    chmod a+rwx /openhands/code/openhands/__init__.py
+
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 
 {{ install_dependencies() }}


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Still experimenting, need to trigger a build

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:a847a11-nikolaik   --name openhands-app-a847a11   ghcr.io/all-hands-ai/runtime:a847a11
```