### PR TITLE
Fix list-files async calls

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -333,7 +333,7 @@ async def websocket_endpoint(websocket: WebSocket):
         jwt_token = sign_token({'sid': sid}, config.jwt_secret)
 
     logger.info(f'New session: {sid}')
-    session = call_sync_from_async(session_manager.add_or_restart_session, sid, websocket)
+    session = await call_sync_from_async(session_manager.add_or_restart_session, sid, websocket)
     await websocket.send_json({'token': jwt_token, 'status': 'ok'})
 
     latest_event_id = -1
@@ -480,9 +480,7 @@ async def list_files(request: Request, path: str | None = None):
         )
 
     runtime: Runtime = request.state.conversation.runtime
-    file_list = await asyncio.create_task(
-        call_sync_from_async(runtime.list_files, path)
-    )
+    file_list = await call_sync_from_async(runtime.list_files, path)
     if path:
         file_list = [os.path.join(path, f) for f in file_list]
 

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -472,7 +472,6 @@ async def list_files(request: Request, path: str | None = None):
     Raises:
         HTTPException: If there's an error listing the files.
     """
-    print("START LIST FILES", flush=True)
     if not request.state.conversation.runtime:
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -333,7 +333,7 @@ async def websocket_endpoint(websocket: WebSocket):
         jwt_token = sign_token({'sid': sid}, config.jwt_secret)
 
     logger.info(f'New session: {sid}')
-    session = await call_sync_from_async(session_manager.add_or_restart_session, sid, websocket)
+    session = session_manager.add_or_restart_session(sid, websocket)
     await websocket.send_json({'token': jwt_token, 'status': 'ok'})
 
     latest_event_id = -1


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

`list-files` currently blocks while reading the gitignore--this fixes that

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:49a7b1f-nikolaik   --name openhands-app-49a7b1f   ghcr.io/all-hands-ai/runtime:49a7b1f
```