### PR TITLE
Fix for #4717

### DIFF
--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -17,7 +17,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
 
         version_info = self.docker_client.version()
         server_version = version_info.get('Version', '').replace('-', '.')
-        if tuple(map(int, server_version.split('.'))) < (18, 9):
+        if tuple(map(int, server_version.split('.')[:2])) < (18, 9):
             raise RuntimeError('Docker server version must be >= 18.09 to use BuildKit')
 
         self.rolling_logger = RollingLogger(max_lines=10)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Only get major, minor version of Docker version

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Gets the major and minor version of Docker because the tuple expects 2 values (major, minor)

---
**Link of any specific issues this addresses**
#4717 