### PR TITLE
History microfixes

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -509,6 +509,16 @@ class AgentController:
             # update iteration that shall be shared across agents
             self.state.iteration = self.delegate.state.iteration
 
+            # emit AgentDelegateObservation when the delegate terminates due to error
+            delegate_outputs = (
+                self.delegate.state.outputs if self.delegate.state else {}
+            )
+            content = (
+                f'{self.delegate.agent.name} encountered an error during execution.'
+            )
+            obs = AgentDelegateObservation(outputs=delegate_outputs, content=content)
+            self.event_stream.add_event(obs, EventSource.AGENT)
+
             # close the delegate upon error
             await self.delegate.close()
             self.delegate = None
@@ -534,9 +544,7 @@ class AgentController:
             content = (
                 f'{self.delegate.agent.name} finishes task with {formatted_output}'
             )
-            obs: Observation = AgentDelegateObservation(
-                outputs=outputs, content=content
-            )
+            obs = AgentDelegateObservation(outputs=outputs, content=content)
 
             # clean up delegate status
             self.delegate = None

--- a/openhands/memory/history.py
+++ b/openhands/memory/history.py
@@ -12,6 +12,7 @@ from openhands.events.event import Event, EventSource
 from openhands.events.observation.agent import AgentStateChangedObservation
 from openhands.events.observation.delegate import AgentDelegateObservation
 from openhands.events.observation.empty import NullObservation
+from openhands.events.observation.error import FatalErrorObservation
 from openhands.events.observation.observation import Observation
 from openhands.events.serialization.event import event_to_dict
 from openhands.events.stream import EventStream
@@ -33,6 +34,7 @@ class ShortTermHistory(list[Event]):
         NullObservation,
         ChangeAgentStateAction,
         AgentStateChangedObservation,
+        FatalErrorObservation,
     )
 
     def __init__(self):


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes a couple of quick fixes for history behavior:
- don't add "fatal" type of obs to the agent history
- terminate delegate with a delegate observation on error

Split out of https://github.com/All-Hands-AI/OpenHands/pull/3808 since that is a larger refactoring proposal that's taking time to see if we go that route, and these are needed.

Tested manually provoking an error in the browsing agent => the main agent continues normally.

---
**Link of any specific issues this addresses**
Fix https://github.com/All-Hands-AI/OpenHands/issues/4677
Fix https://github.com/All-Hands-AI/OpenHands/issues/3879

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:a632356-nikolaik   --name openhands-app-a632356   ghcr.io/all-hands-ai/runtime:a632356
```