### PR TITLE
fix(frontend): Always return user is authed if mode is oss

### DIFF
--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -55,7 +55,7 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
     posthog.opt_in_capturing();
   }
 
-  let isAuthed: boolean = false;
+  let isAuthed = false;
   let githubAuthUrl: string | null = null;
 
   try {

--- a/frontend/src/utils/user-is-authenticated.ts
+++ b/frontend/src/utils/user-is-authenticated.ts
@@ -1,6 +1,8 @@
 import OpenHands from "#/api/open-hands";
 
 export const userIsAuthenticated = async () => {
+  if (window.__APP_MODE__ === "oss") return true;
+
   try {
     await OpenHands.authenticate();
     return true;


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
The GitHub saas auth modal would display if the user is not signed in an mode is OSS

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Always return that the user is authed if the mode is OSS


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:4a745f0-nikolaik   --name openhands-app-4a745f0   ghcr.io/all-hands-ai/runtime:4a745f0
```