### PR TITLE
feat(frontend): Chat interface empty state

### DIFF
--- a/frontend/__tests__/components/chat/chat-interface.test.tsx
+++ b/frontend/__tests__/components/chat/chat-interface.test.tsx
@@ -70,9 +70,26 @@ describe("ChatInterface", () => {
       });
     });
 
-    it.todo(
-      "should render the other suggestions if the user selected to cloned a repo",
-    );
+    it("should render the other suggestions if the user selected to cloned a repo", () => {
+      localStorage.setItem("repo", "some/repo");
+      renderWithProviders(<ChatInterface />, {
+        preloadedState: {
+          chat: { messages: [] },
+        },
+      });
+
+      const suggestions = screen.getByTestId("suggestions");
+      const repoSuggestions = Object.keys(SUGGESTIONS.repo);
+
+      // check that there are at most 4 suggestions displayed
+      const displayedSuggestions = within(suggestions).getAllByRole("button");
+      expect(displayedSuggestions.length).toBeLessThanOrEqual(4);
+
+      // Check that each displayed suggestion is one of the repo suggestions
+      displayedSuggestions.forEach((suggestion) => {
+        expect(repoSuggestions).toContain(suggestion.textContent);
+      });
+    });
 
     it("should dispatch a user message when selecting a message", async () => {
       const addUserMessageSpy = vi.spyOn(ChatSlice, "addUserMessage");

--- a/frontend/__tests__/components/suggestion-item.test.tsx
+++ b/frontend/__tests__/components/suggestion-item.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SuggestionItem } from "#/components/suggestion-item";
+
+describe("SuggestionItem", () => {
+  const suggestionItem = { label: "suggestion1", value: "a long text value" };
+  const onClick = vi.fn();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render a suggestion", () => {
+    render(<SuggestionItem suggestion={suggestionItem} onClick={onClick} />);
+
+    expect(screen.getByTestId("suggestion")).toBeInTheDocument();
+    expect(screen.getByText(/suggestion1/i)).toBeInTheDocument();
+  });
+
+  it("should call onClick when clicking a suggestion", async () => {
+    const user = userEvent.setup();
+    render(<SuggestionItem suggestion={suggestionItem} onClick={onClick} />);
+
+    const suggestion = screen.getByTestId("suggestion");
+    await user.click(suggestion);
+
+    expect(onClick).toHaveBeenCalledWith("a long text value");
+  });
+});

--- a/frontend/__tests__/components/suggestions.test.tsx
+++ b/frontend/__tests__/components/suggestions.test.tsx
@@ -28,6 +28,7 @@ describe("Suggestions", () => {
       />,
     );
 
+    expect(screen.getByTestId("suggestions")).toBeInTheDocument();
     const suggestionElements = screen.getAllByTestId("suggestion");
 
     expect(suggestionElements).toHaveLength(2);

--- a/frontend/__tests__/components/suggestions.test.tsx
+++ b/frontend/__tests__/components/suggestions.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Suggestions } from "#/components/suggestions";
+
+describe("Suggestions", () => {
+  const firstSuggestion = {
+    label: "first-suggestion",
+    value: "value-of-first-suggestion",
+  };
+  const secondSuggestion = {
+    label: "second-suggestion",
+    value: "value-of-second-suggestion",
+  };
+  const suggestions = [firstSuggestion, secondSuggestion];
+
+  const onSuggestionClickMock = vi.fn();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render suggestions", () => {
+    render(
+      <Suggestions
+        suggestions={suggestions}
+        onSuggestionClick={onSuggestionClickMock}
+      />,
+    );
+
+    const suggestionElements = screen.getAllByTestId("suggestion");
+
+    expect(suggestionElements).toHaveLength(2);
+    expect(suggestionElements[0]).toHaveTextContent("first-suggestion");
+    expect(suggestionElements[1]).toHaveTextContent("second-suggestion");
+  });
+
+  it("should call onSuggestionClick when clicking a suggestion", async () => {
+    const user = userEvent.setup();
+    render(
+      <Suggestions
+        suggestions={suggestions}
+        onSuggestionClick={onSuggestionClickMock}
+      />,
+    );
+
+    const suggestionElements = screen.getAllByTestId("suggestion");
+
+    await user.click(suggestionElements[0]);
+    expect(onSuggestionClickMock).toHaveBeenCalledWith(
+      "value-of-first-suggestion",
+    );
+
+    await user.click(suggestionElements[1]);
+    expect(onSuggestionClickMock).toHaveBeenCalledWith(
+      "value-of-second-suggestion",
+    );
+  });
+});

--- a/frontend/src/components/chat-interface.tsx
+++ b/frontend/src/components/chat-interface.tsx
@@ -20,6 +20,7 @@ import { ContinueButton } from "./continue-button";
 import { ScrollToBottomButton } from "./scroll-to-bottom-button";
 import { Suggestions } from "./suggestions";
 import { SUGGESTIONS } from "#/utils/suggestions";
+import BuildIt from "#/assets/build-it.svg?react";
 
 const isErrorMessage = (
   message: Message | ErrorMessage,
@@ -67,20 +68,28 @@ export function ChatInterface() {
   return (
     <div className="h-full flex flex-col justify-between">
       {messages.length === 0 && (
-        <Suggestions
-          suggestions={Object.entries(SUGGESTIONS["non-repo"]).map(
-            ([label, value]) => ({ label, value }),
-          )}
-          onSuggestionClick={(value) => {
-            dispatch(
-              addUserMessage({
-                content: value,
-                imageUrls: [],
-                timestamp: new Date().toISOString(),
-              }),
-            );
-          }}
-        />
+        <div className="flex flex-col gap-6 h-full px-4 items-center justify-center">
+          <div className="flex flex-col items-center p-4 bg-neutral-700 rounded-xl w-full">
+            <BuildIt width={45} height={54} />
+            <span className="font-semibold text-[20px] leading-6 -tracking-[0.01em] gap-1">
+              Let&apos;s start building!
+            </span>
+          </div>
+          <Suggestions
+            suggestions={Object.entries(SUGGESTIONS["non-repo"]).map(
+              ([label, value]) => ({ label, value }),
+            )}
+            onSuggestionClick={(value) => {
+              dispatch(
+                addUserMessage({
+                  content: value,
+                  imageUrls: [],
+                  timestamp: new Date().toISOString(),
+                }),
+              );
+            }}
+          />
+        </div>
       )}
 
       <div

--- a/frontend/src/components/chat-interface.tsx
+++ b/frontend/src/components/chat-interface.tsx
@@ -40,6 +40,24 @@ export function ChatInterface() {
     "positive" | "negative"
   >("positive");
   const [feedbackModalIsOpen, setFeedbackModalIsOpen] = React.useState(false);
+  const [suggestions, setSuggestions] = React.useState<Record<string, string>>(
+    SUGGESTIONS["non-repo"],
+  );
+
+  React.useEffect(() => {
+    // Function to update suggestions based on the current value in localStorage
+    const updateSuggestions = () => {
+      const repo = localStorage.getItem("repo");
+      if (repo) setSuggestions(SUGGESTIONS.repo);
+      else setSuggestions(SUGGESTIONS["non-repo"]);
+    };
+
+    // Initial fetch when component mounts
+    updateSuggestions();
+
+    window.addEventListener("storage", updateSuggestions);
+    return () => window.removeEventListener("storage", updateSuggestions);
+  }, []);
 
   const handleSendMessage = async (content: string, files: File[]) => {
     const promises = files.map((file) => convertImageToBase64(file));
@@ -76,9 +94,12 @@ export function ChatInterface() {
             </span>
           </div>
           <Suggestions
-            suggestions={Object.entries(SUGGESTIONS["non-repo"]).map(
-              ([label, value]) => ({ label, value }),
-            )}
+            suggestions={Object.entries(suggestions)
+              .slice(0, 4)
+              .map(([label, value]) => ({
+                label,
+                value,
+              }))}
             onSuggestionClick={(value) => {
               dispatch(
                 addUserMessage({

--- a/frontend/src/components/chat-interface.tsx
+++ b/frontend/src/components/chat-interface.tsx
@@ -18,6 +18,8 @@ import ConfirmationButtons from "./chat/ConfirmationButtons";
 import { ErrorMessage } from "./error-message";
 import { ContinueButton } from "./continue-button";
 import { ScrollToBottomButton } from "./scroll-to-bottom-button";
+import { Suggestions } from "./suggestions";
+import { SUGGESTIONS } from "#/utils/suggestions";
 
 const isErrorMessage = (
   message: Message | ErrorMessage,
@@ -64,6 +66,23 @@ export function ChatInterface() {
 
   return (
     <div className="h-full flex flex-col justify-between">
+      {messages.length === 0 && (
+        <Suggestions
+          suggestions={Object.entries(SUGGESTIONS["non-repo"]).map(
+            ([label, value]) => ({ label, value }),
+          )}
+          onSuggestionClick={(value) => {
+            dispatch(
+              addUserMessage({
+                content: value,
+                imageUrls: [],
+                timestamp: new Date().toISOString(),
+              }),
+            );
+          }}
+        />
+      )}
+
       <div
         ref={scrollRef}
         onScroll={(e) => onChatBodyScroll(e.currentTarget)}

--- a/frontend/src/components/suggestion-item.tsx
+++ b/frontend/src/components/suggestion-item.tsx
@@ -1,0 +1,20 @@
+export type Suggestion = { label: string; value: string };
+
+interface SuggestionItemProps {
+  suggestion: Suggestion;
+  onClick: (value: string) => void;
+}
+
+export function SuggestionItem({ suggestion, onClick }: SuggestionItemProps) {
+  return (
+    <li>
+      <button
+        type="button"
+        data-testid="suggestion"
+        onClick={() => onClick(suggestion.value)}
+      >
+        {suggestion.label}
+      </button>
+    </li>
+  );
+}

--- a/frontend/src/components/suggestion-item.tsx
+++ b/frontend/src/components/suggestion-item.tsx
@@ -7,11 +7,12 @@ interface SuggestionItemProps {
 
 export function SuggestionItem({ suggestion, onClick }: SuggestionItemProps) {
   return (
-    <li>
+    <li className="border border-neutral-600 rounded-xl hover:bg-neutral-700">
       <button
         type="button"
         data-testid="suggestion"
         onClick={() => onClick(suggestion.value)}
+        className="text-[16px] leading-6 -tracking-[0.01em] text-center w-full p-4 font-semibold"
       >
         {suggestion.label}
       </button>

--- a/frontend/src/components/suggestions.tsx
+++ b/frontend/src/components/suggestions.tsx
@@ -1,0 +1,23 @@
+import { SuggestionItem, type Suggestion } from "./suggestion-item";
+
+interface SuggestionsProps {
+  suggestions: Suggestion[];
+  onSuggestionClick: (value: string) => void;
+}
+
+export function Suggestions({
+  suggestions,
+  onSuggestionClick,
+}: SuggestionsProps) {
+  return (
+    <ul>
+      {suggestions.map((suggestion, index) => (
+        <SuggestionItem
+          key={index}
+          suggestion={suggestion}
+          onClick={onSuggestionClick}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/suggestions.tsx
+++ b/frontend/src/components/suggestions.tsx
@@ -10,7 +10,7 @@ export function Suggestions({
   onSuggestionClick,
 }: SuggestionsProps) {
   return (
-    <ul data-testid="suggestions" className="flex flex-col gap-4">
+    <ul data-testid="suggestions" className="flex flex-col gap-4 w-full">
       {suggestions.map((suggestion, index) => (
         <SuggestionItem
           key={index}

--- a/frontend/src/components/suggestions.tsx
+++ b/frontend/src/components/suggestions.tsx
@@ -10,7 +10,7 @@ export function Suggestions({
   onSuggestionClick,
 }: SuggestionsProps) {
   return (
-    <ul>
+    <ul data-testid="suggestions">
       {suggestions.map((suggestion, index) => (
         <SuggestionItem
           key={index}

--- a/frontend/src/components/suggestions.tsx
+++ b/frontend/src/components/suggestions.tsx
@@ -10,7 +10,7 @@ export function Suggestions({
   onSuggestionClick,
 }: SuggestionsProps) {
   return (
-    <ul data-testid="suggestions">
+    <ul data-testid="suggestions" className="flex flex-col gap-4">
       {suggestions.map((suggestion, index) => (
         <SuggestionItem
           key={index}

--- a/frontend/test-utils.tsx
+++ b/frontend/test-utils.tsx
@@ -6,6 +6,7 @@ import { configureStore } from "@reduxjs/toolkit";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { RenderOptions, render } from "@testing-library/react";
 import { AppStore, RootState, rootReducer } from "./src/store";
+import { SocketProvider } from "#/context/socket";
 
 const setupStore = (preloadedState?: Partial<RootState>): AppStore =>
   configureStore({
@@ -32,7 +33,11 @@ export function renderWithProviders(
   }: ExtendedRenderOptions = {},
 ) {
   function Wrapper({ children }: PropsWithChildren<object>): JSX.Element {
-    return <Provider store={store}>{children}</Provider>;
+    return (
+      <Provider store={store}>
+        <SocketProvider>{children}</SocketProvider>
+      </Provider>
+    );
   }
   return { store, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
 }


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- renders suggestions (non-repo by default) when there are no messages present in the chat interface
- renders repo suggestions when repo is detected in local storage
- clicking an option sends a user message event


---
NOTE ON DRAFT: This issue is set to draft mode until I complete another issue where the user is redirected to the empty state after selected a project zip or a repo to clone
