### PR TITLE
Fix sandbox runtime container image inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,7 @@ For a list of open source projects and licenses used in OpenHands, please see ou
       url={https://arxiv.org/abs/2407.16741},
 }
 ```
+
+## Note
+
+It is important to keep the sandbox runtime and backend versions in sync to avoid errors.

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
     image: openhands:latest
     container_name: openhands-app-${DATE:-}
     environment:
-      - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-ghcr.io/all-hands-ai/runtime:0.9-nikolaik}
+      - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-ghcr.io/all-hands-ai/runtime:0.12-nikolaik}
       - SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234}
       - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
     ports:

--- a/containers/dev/compose.yml
+++ b/containers/dev/compose.yml
@@ -11,7 +11,7 @@ services:
       - BACKEND_HOST=${BACKEND_HOST:-"0.0.0.0"}
       - SANDBOX_API_HOSTNAME=host.docker.internal
       #
-      - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-ghcr.io/all-hands-ai/runtime:0.9-nikolaik}
+      - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-ghcr.io/all-hands-ai/runtime:0.12-nikolaik}
       - SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234}
       - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
     ports:

--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -52,3 +52,7 @@ You can choose the tag that best suits your needs based on stability requirement
 For the development workflow, see [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
 
 Are you having trouble? Check out our [Troubleshooting Guide](https://docs.all-hands.dev/modules/usage/troubleshooting).
+
+## Note
+
+It is important to keep the sandbox runtime and backend versions in sync to avoid errors.


### PR DESCRIPTION
Fixes #4749

Update `SANDBOX_RUNTIME_CONTAINER_IMAGE` value to be consistent across the repository.

* **compose.yml**
  - Update `SANDBOX_RUNTIME_CONTAINER_IMAGE` to `runtime:0.12-nikolaik`.

* **containers/dev/compose.yml**
  - Update `SANDBOX_RUNTIME_CONTAINER_IMAGE` to `runtime:0.12-nikolaik`.

* **docs/modules/usage/installation.mdx**
  - Add a note emphasizing the importance of synchronizing the sandbox runtime and backend versions.

* **README.md**
  - Add a note emphasizing the importance of synchronizing the sandbox runtime and backend versions.

