### PR TITLE
Fix issue #4756: [Documentation] When GITHUB_TOKEN is provided automatically through the UI

### DIFF
--- a/docs/modules/usage/how-to/gui-mode.md
+++ b/docs/modules/usage/how-to/gui-mode.md
@@ -21,12 +21,12 @@ OpenHands provides a user-friendly Graphical User Interface (GUI) mode for inter
 
 ### GitHub Token Setup
 
-You can provide a `GITHUB_TOKEN` is provided to OpenHands through two methods:
+OpenHands automatically exports a `GITHUB_TOKEN` to the shell environment if it is available. This can happen in two ways:
 
-1. When running locally: You can manually input your GitHub token
-2. When using online: The token is obtained through GitHub OAuth authentication
+1. Locally (OSS): The user directly inputs their GitHub token.
+2. Online (SaaS): The token is obtained through GitHub OAuth authentication.
 
-If this token exists, it is automatically exported to the shell environment for the agent to use.
+When you reach the `/app` route, the app checks if a token is present. If it finds one, it sets it in the environment for the agent to use.
 
 ### Advanced Settings
 

--- a/docs/modules/usage/how-to/gui-mode.md
+++ b/docs/modules/usage/how-to/gui-mode.md
@@ -19,6 +19,14 @@ OpenHands provides a user-friendly Graphical User Interface (GUI) mode for inter
 3. Enter the corresponding `API Key` for your chosen provider.
 4. Click "Save" to apply the settings.
 
+### GitHub Token Setup
+
+The `GITHUB_TOKEN` is provided to OpenHands in GUI mode through two methods:
+1. Direct input: Users can manually input their GitHub token (in OSS mode)
+2. GitHub OAuth: Token is obtained through GitHub OAuth authentication (in SaaS mode)
+
+Once a user arrives at the `/app` route with a valid GitHub token, it is automatically exported to the shell environment for the agent to use.
+
 ### Advanced Settings
 
 1. Toggle `Advanced Options` to access additional settings.
@@ -49,3 +57,4 @@ The main interface consists of several key components:
 3. Use one of the recommended models, as described in the [LLMs section](usage/llms/llms.md).
 
 Remember, the GUI mode of OpenHands is designed to make your interaction with the AI assistant as smooth and intuitive as possible. Don't hesitate to explore its features to maximize your productivity.
+

--- a/docs/modules/usage/how-to/gui-mode.md
+++ b/docs/modules/usage/how-to/gui-mode.md
@@ -21,11 +21,12 @@ OpenHands provides a user-friendly Graphical User Interface (GUI) mode for inter
 
 ### GitHub Token Setup
 
-The `GITHUB_TOKEN` is provided to OpenHands in GUI mode through two methods:
-1. Direct input: Users can manually input their GitHub token (in OSS mode)
-2. GitHub OAuth: Token is obtained through GitHub OAuth authentication (in SaaS mode)
+You can provide a `GITHUB_TOKEN` is provided to OpenHands through two methods:
 
-Once a user arrives at the `/app` route with a valid GitHub token, it is automatically exported to the shell environment for the agent to use.
+1. When running locally: You can manually input your GitHub token
+2. When using online: The token is obtained through GitHub OAuth authentication
+
+If this token exists, it is automatically exported to the shell environment for the agent to use.
 
 ### Advanced Settings
 


### PR DESCRIPTION
This pull request fixes #4756.

The issue has been successfully resolved because:

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=ghcr.io/all-hands-ai/runtime:c2fe46d-nikolaik   --name openhands-app-c2fe46d   ghcr.io/all-hands-ai/runtime:c2fe46d
```