### PR TITLE
chore: update browser message to be more human-readable in UI

### DIFF
--- a/openhands/events/action/browse.py
+++ b/openhands/events/action/browse.py
@@ -36,7 +36,9 @@ class BrowseInteractiveAction(Action):
 
     @property
     def message(self) -> str:
-        return f'Executing browser actions: {self.browser_actions}'
+        return (
+            f'I am interacting with the browser:\n' f'```\n{self.browser_actions}\n```'
+        )
 
     def __str__(self) -> str:
         ret = '**BrowseInteractiveAction**\n'


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When there's no thought, browser action's `.message` will be displayed to the user in UI:

This is what it looks like now
<img width="284" alt="image" src="https://github.com/user-attachments/assets/b6da5e26-0fd2-4ed1-8182-4a272dbf3889">

This PR tweak this message a bit so it is more human readable.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:864cfee-nikolaik   --name openhands-app-864cfee   docker.all-hands.dev/all-hands-ai/openhands:864cfee
```