### PR TITLE
feat: add drag & paste image support to ChatInput

### DIFF
--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -40,14 +40,12 @@ export function ChatInput({
   const [isDraggingOver, setIsDraggingOver] = React.useState(false);
 
   const handlePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    event.preventDefault();
     if (onImagePaste && event.clipboardData.files.length > 0) {
       const files = Array.from(event.clipboardData.files).filter((file) =>
         file.type.startsWith("image/"),
       );
-      if (files.length > 0) {
-        event.preventDefault();
-        onImagePaste(files);
-      }
+      if (files.length > 0) onImagePaste(files);
     }
   };
 

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -53,7 +53,7 @@ export function ChatInput({
 
   const handleDragOver = (event: React.DragEvent<HTMLTextAreaElement>) => {
     event.preventDefault();
-    if (event.dataTransfer.types.includes('Files')) {
+    if (event.dataTransfer.types.includes("Files")) {
       setIsDraggingOver(true);
     }
   };
@@ -118,7 +118,9 @@ export function ChatInput({
         className={cn(
           "grow text-sm self-center placeholder:text-neutral-400 text-white resize-none outline-none ring-0",
           "transition-all duration-200 ease-in-out",
-          isDraggingOver ? "bg-neutral-600/50 rounded-lg px-2" : "bg-transparent",
+          isDraggingOver
+            ? "bg-neutral-600/50 rounded-lg px-2"
+            : "bg-transparent",
           className,
         )}
       />

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -16,6 +16,7 @@ interface ChatInputProps {
   onChange?: (message: string) => void;
   onFocus?: () => void;
   onBlur?: () => void;
+  onImagePaste?: (files: File[]) => void;
   className?: React.HTMLAttributes<HTMLDivElement>["className"];
 }
 
@@ -32,9 +33,34 @@ export function ChatInput({
   onChange,
   onFocus,
   onBlur,
+  onImagePaste,
   className,
 }: ChatInputProps) {
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const handlePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (onImagePaste && event.clipboardData.files.length > 0) {
+      const files = Array.from(event.clipboardData.files).filter(file => 
+        file.type.startsWith('image/')
+      );
+      if (files.length > 0) {
+        event.preventDefault();
+        onImagePaste(files);
+      }
+    }
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLTextAreaElement>) => {
+    if (onImagePaste && event.dataTransfer.files.length > 0) {
+      const files = Array.from(event.dataTransfer.files).filter(file => 
+        file.type.startsWith('image/')
+      );
+      if (files.length > 0) {
+        event.preventDefault();
+        onImagePaste(files);
+      }
+    }
+  };
 
   const handleSubmitMessage = () => {
     if (textareaRef.current?.value) {
@@ -67,6 +93,9 @@ export function ChatInput({
         onChange={handleChange}
         onFocus={onFocus}
         onBlur={onBlur}
+        onPaste={handlePaste}
+        onDrop={handleDrop}
+        onDragOver={(e) => e.preventDefault()}
         value={value}
         minRows={1}
         maxRows={maxRows}

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -40,8 +40,8 @@ export function ChatInput({
 
   const handlePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     if (onImagePaste && event.clipboardData.files.length > 0) {
-      const files = Array.from(event.clipboardData.files).filter(file => 
-        file.type.startsWith('image/')
+      const files = Array.from(event.clipboardData.files).filter((file) =>
+        file.type.startsWith("image/"),
       );
       if (files.length > 0) {
         event.preventDefault();
@@ -52,8 +52,8 @@ export function ChatInput({
 
   const handleDrop = (event: React.DragEvent<HTMLTextAreaElement>) => {
     if (onImagePaste && event.dataTransfer.files.length > 0) {
-      const files = Array.from(event.dataTransfer.files).filter(file => 
-        file.type.startsWith('image/')
+      const files = Array.from(event.dataTransfer.files).filter((file) =>
+        file.type.startsWith("image/"),
       );
       if (files.length > 0) {
         event.preventDefault();

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -37,6 +37,7 @@ export function ChatInput({
   className,
 }: ChatInputProps) {
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const [isDraggingOver, setIsDraggingOver] = React.useState(false);
 
   const handlePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     if (onImagePaste && event.clipboardData.files.length > 0) {
@@ -50,13 +51,26 @@ export function ChatInput({
     }
   };
 
+  const handleDragOver = (event: React.DragEvent<HTMLTextAreaElement>) => {
+    event.preventDefault();
+    if (event.dataTransfer.types.includes('Files')) {
+      setIsDraggingOver(true);
+    }
+  };
+
+  const handleDragLeave = (event: React.DragEvent<HTMLTextAreaElement>) => {
+    event.preventDefault();
+    setIsDraggingOver(false);
+  };
+
   const handleDrop = (event: React.DragEvent<HTMLTextAreaElement>) => {
+    event.preventDefault();
+    setIsDraggingOver(false);
     if (onImagePaste && event.dataTransfer.files.length > 0) {
       const files = Array.from(event.dataTransfer.files).filter((file) =>
         file.type.startsWith("image/"),
       );
       if (files.length > 0) {
-        event.preventDefault();
         onImagePaste(files);
       }
     }
@@ -95,13 +109,16 @@ export function ChatInput({
         onBlur={onBlur}
         onPaste={handlePaste}
         onDrop={handleDrop}
-        onDragOver={(e) => e.preventDefault()}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
         value={value}
         minRows={1}
         maxRows={maxRows}
+        data-dragging-over={isDraggingOver}
         className={cn(
-          "grow text-sm self-center placeholder:text-neutral-400 text-white resize-none bg-transparent outline-none ring-0",
-          "transition-[height] duration-200 ease-in-out",
+          "grow text-sm self-center placeholder:text-neutral-400 text-white resize-none outline-none ring-0",
+          "transition-all duration-200 ease-in-out",
+          isDraggingOver ? "bg-neutral-600/50 rounded-lg px-2" : "bg-transparent",
           className,
         )}
       />

--- a/frontend/src/components/interactive-chat-box.tsx
+++ b/frontend/src/components/interactive-chat-box.tsx
@@ -53,6 +53,13 @@ export function InteractiveChatBox({
         className={cn(
           "flex items-end gap-1",
           "bg-neutral-700 border border-neutral-600 rounded-lg px-2 py-[10px]",
+          "transition-colors duration-200",
+          "hover:border-neutral-500 focus-within:border-neutral-500",
+          "group relative",
+          "before:pointer-events-none before:absolute before:inset-0 before:rounded-lg before:transition-colors",
+          "before:border-2 before:border-dashed before:border-transparent",
+          "[&:has(*:focus-within)]:before:border-neutral-500/50",
+          "[&:has(*[data-dragging-over='true'])]:before:border-neutral-500/50",
         )}
       >
         <UploadImageInput onUpload={handleUpload} />

--- a/frontend/src/components/interactive-chat-box.tsx
+++ b/frontend/src/components/interactive-chat-box.tsx
@@ -62,6 +62,7 @@ export function InteractiveChatBox({
           placeholder="What do you want to build?"
           onSubmit={handleSubmit}
           onStop={onStop}
+          onImagePaste={handleUpload}
         />
       </div>
     </div>

--- a/frontend/src/routes/_oh._index/task-form.tsx
+++ b/frontend/src/routes/_oh._index/task-form.tsx
@@ -100,8 +100,14 @@ export function TaskForm({ importedProjectZip }: TaskFormProps) {
         />
         <div
           className={cn(
-            "border border-neutral-600 px-4 py-[17px] rounded-lg text-[17px] leading-5 w-full",
+            "border border-neutral-600 px-4 py-[17px] rounded-lg text-[17px] leading-5 w-full transition-colors duration-200",
             inputIsFocused ? "bg-neutral-600" : "bg-neutral-700",
+            "hover:border-neutral-500 focus-within:border-neutral-500",
+            "group relative",
+            "before:pointer-events-none before:absolute before:inset-0 before:rounded-lg before:transition-colors",
+            "before:border-2 before:border-dashed before:border-transparent",
+            "[&:has(*:focus-within)]:before:border-neutral-500/50",
+            "[&:has(*[data-dragging-over='true'])]:before:border-neutral-500/50"
           )}
         >
           <ChatInput

--- a/frontend/src/routes/_oh._index/task-form.tsx
+++ b/frontend/src/routes/_oh._index/task-form.tsx
@@ -107,7 +107,7 @@ export function TaskForm({ importedProjectZip }: TaskFormProps) {
             "before:pointer-events-none before:absolute before:inset-0 before:rounded-lg before:transition-colors",
             "before:border-2 before:border-dashed before:border-transparent",
             "[&:has(*:focus-within)]:before:border-neutral-500/50",
-            "[&:has(*[data-dragging-over='true'])]:before:border-neutral-500/50"
+            "[&:has(*[data-dragging-over='true'])]:before:border-neutral-500/50",
           )}
         >
           <ChatInput

--- a/frontend/src/routes/_oh._index/task-form.tsx
+++ b/frontend/src/routes/_oh._index/task-form.tsx
@@ -112,6 +112,13 @@ export function TaskForm({ importedProjectZip }: TaskFormProps) {
             onChange={(message) => setText(message)}
             onFocus={() => setInputIsFocused(true)}
             onBlur={() => setInputIsFocused(false)}
+            onImagePaste={async (files) => {
+              const promises = files.map(convertImageToBase64);
+              const base64Images = await Promise.all(promises);
+              base64Images.forEach((base64) => {
+                dispatch(addFile(base64));
+              });
+            }}
             placeholder={placeholder}
             value={text}
             maxRows={15}

--- a/frontend/src/routes/_oh._index/task-form.tsx
+++ b/frontend/src/routes/_oh._index/task-form.tsx
@@ -112,8 +112,8 @@ export function TaskForm({ importedProjectZip }: TaskFormProps) {
             onChange={(message) => setText(message)}
             onFocus={() => setInputIsFocused(true)}
             onBlur={() => setInputIsFocused(false)}
-            onImagePaste={async (files) => {
-              const promises = files.map(convertImageToBase64);
+            onImagePaste={async (imageFiles) => {
+              const promises = imageFiles.map(convertImageToBase64);
               const base64Images = await Promise.all(promises);
               base64Images.forEach((base64) => {
                 dispatch(addFile(base64));


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Add the ability to drag images into chat input

<img width="894" alt="image" src="https://github.com/user-attachments/assets/d4423d83-54de-4abe-a94e-41d22f207681">

<img width="426" alt="image" src="https://github.com/user-attachments/assets/06c314e3-6acf-44bb-bcb5-64fe504ad51c">

- Add the ability to paste image to chat input

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:271a307-nikolaik   --name openhands-app-271a307   docker.all-hands.dev/all-hands-ai/openhands:271a307
```