### PR TITLE
Handle GitHub API rate limits properly

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -319,7 +319,9 @@ async def websocket_endpoint(websocket: WebSocket):
 
     is_authenticated, error = await authenticate_github_user(github_token)
     if not is_authenticated:
-        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason=error or 'Not authenticated')
+        await websocket.close(
+            code=status.WS_1008_POLICY_VIOLATION, reason=error or 'Not authenticated'
+        )
         return
 
     await asyncio.wait_for(websocket.accept(subprotocol=real_protocol), 10)


### PR DESCRIPTION
- Update get_github_user to check rate limit headers and return errors
- Update authenticate_github_user to return both auth status and error message
- Update all endpoints to handle rate limit errors and show proper messages

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3769dce-nikolaik   --name openhands-app-3769dce   docker.all-hands.dev/all-hands-ai/openhands:3769dce
```