### PR TITLE
Fix: Implement caching for clientLoader to prevent repeated calls

### DIFF
--- a/frontend/src/routes/_oh._index/route.tsx
+++ b/frontend/src/routes/_oh._index/route.tsx
@@ -20,7 +20,9 @@ import OpenHands from "#/api/open-hands";
 import { generateGitHubAuthUrl } from "#/utils/generate-github-auth-url";
 import { GitHubRepositoriesSuggestionBox } from "#/components/github-repositories-suggestion-box";
 
-let cachedRepositories: ReturnType<typeof retrieveAllGitHubUserRepositories> | null = null;
+let cachedRepositories: ReturnType<
+  typeof retrieveAllGitHubUserRepositories
+> | null = null;
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   let isSaas = false;
   let githubClientId: string | null = null;

--- a/frontend/src/routes/_oh._index/route.tsx
+++ b/frontend/src/routes/_oh._index/route.tsx
@@ -20,6 +20,7 @@ import OpenHands from "#/api/open-hands";
 import { generateGitHubAuthUrl } from "#/utils/generate-github-auth-url";
 import { GitHubRepositoriesSuggestionBox } from "#/components/github-repositories-suggestion-box";
 
+let cachedRepositories: ReturnType<typeof retrieveAllGitHubUserRepositories> | null = null;
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   let isSaas = false;
   let githubClientId: string | null = null;
@@ -40,9 +41,12 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   let repositories: ReturnType<
     typeof retrieveAllGitHubUserRepositories
   > | null = null;
-  if (ghToken) {
+  if (cachedRepositories) {
+    repositories = cachedRepositories;
+  } else if (ghToken) {
     const data = retrieveAllGitHubUserRepositories(ghToken);
     repositories = data;
+    cachedRepositories = data;
   }
 
   let githubAuthUrl: string | null = null;

--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -67,7 +67,7 @@ const isAgentStateChange = (
   data.extras instanceof Object &&
   "agent_state" in data.extras;
 
-let lastCommit: GitHubCommit | null = null;
+let lastCommitCached: GitHubCommit | null = null;
 let repoForLastCommit: string | null = null;
 export const clientLoader = async () => {
   const ghToken = localStorage.getItem("ghToken");
@@ -82,14 +82,14 @@ export const clientLoader = async () => {
 
   if (repo) localStorage.setItem("repo", repo);
 
-  if (!lastCommit || repoForLastCommit !== repo) {
+  if (!lastCommitCached || repoForLastCommit !== repo) {
     if (ghToken && repo) {
       const data = await retrieveLatestGitHubCommit(ghToken, repo);
       if (isGitHubErrorReponse(data)) {
         // TODO: Handle error
         console.error("Failed to retrieve latest commit", data);
       } else {
-        [lastCommit] = data;
+        [lastCommitCached] = data;
         repoForLastCommit = repo;
       }
     }
@@ -101,7 +101,7 @@ export const clientLoader = async () => {
     ghToken,
     repo,
     q,
-    lastCommit,
+    lastCommit: lastCommitCached,
   });
 };
 

--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -67,6 +67,8 @@ const isAgentStateChange = (
   data.extras instanceof Object &&
   "agent_state" in data.extras;
 
+let lastCommit: GitHubCommit | null = null;
+let repoForLastCommit: string | null = null;
 export const clientLoader = async () => {
   const ghToken = localStorage.getItem("ghToken");
 
@@ -80,14 +82,16 @@ export const clientLoader = async () => {
 
   if (repo) localStorage.setItem("repo", repo);
 
-  let lastCommit: GitHubCommit | null = null;
-  if (ghToken && repo) {
-    const data = await retrieveLatestGitHubCommit(ghToken, repo);
-    if (isGitHubErrorReponse(data)) {
-      // TODO: Handle error
-      console.error("Failed to retrieve latest commit", data);
-    } else {
-      [lastCommit] = data;
+  if (!lastCommit || repoForLastCommit !== repo) {
+    if (ghToken && repo) {
+      const data = await retrieveLatestGitHubCommit(ghToken, repo);
+      if (isGitHubErrorReponse(data)) {
+        // TODO: Handle error
+        console.error("Failed to retrieve latest commit", data);
+      } else {
+        [lastCommit] = data;
+        repoForLastCommit = repo;
+      }
     }
   }
 

--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -114,7 +114,6 @@ export const clientAction = async ({ request }: ClientActionFunctionArgs) => {
 };
 
 function App() {
-  console.log("render app");
   const dispatch = useDispatch();
   const { files, importedProjectZip } = useSelector(
     (state: RootState) => state.initalQuery,

--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -38,7 +38,6 @@ import AgentState from "#/types/AgentState";
 let clientLoaderCache: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
-
   try {
     const config = await OpenHands.getConfig();
     window.__APP_MODE__ = config.APP_MODE;
@@ -63,7 +62,6 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   let githubAuthUrl: string | null = null;
   let user: GitHubUser | GitHubErrorReponse | null = null;
   if (!clientLoaderCache || clientLoaderCache.ghToken !== ghToken) {
-    console.log('gh token changed', clientLoaderCache, ghToken);
     try {
       isAuthed = await userIsAuthenticated();
       if (!isAuthed && window.__GITHUB_CLIENT_ID__) {

--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -63,6 +63,7 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   let githubAuthUrl: string | null = null;
   let user: GitHubUser | GitHubErrorReponse | null = null;
   if (!clientLoaderCache || clientLoaderCache.ghToken !== ghToken) {
+    console.log('gh token changed', clientLoaderCache, ghToken);
     try {
       isAuthed = await userIsAuthenticated();
       if (!isAuthed && window.__GITHUB_CLIENT_ID__) {
@@ -94,7 +95,7 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   }
 
   // Store the results in cache
-  clientLoaderCache = defer({
+  clientLoaderCache = {
     token,
     ghToken,
     isAuthed,
@@ -103,9 +104,9 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
     settingsIsUpdated,
     settings,
     analyticsConsent,
-  });
+  };
 
-  return clientLoaderCache;
+  return defer(clientLoaderCache);
 };
 
 export function ErrorBoundary() {

--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -35,7 +35,7 @@ import { setCurrentAgentState } from "#/state/agentSlice";
 import AgentState from "#/types/AgentState";
 
 // Cache for clientLoader results
-let clientLoaderCache: any = null;
+let clientLoaderCache: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
   // Return cached results if they exist

--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -34,7 +34,15 @@ import { AnalyticsConsentFormModal } from "#/components/analytics-consent-form-m
 import { setCurrentAgentState } from "#/state/agentSlice";
 import AgentState from "#/types/AgentState";
 
+// Cache for clientLoader results
+let clientLoaderCache: any = null;
+
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
+  // Return cached results if they exist
+  if (clientLoaderCache) {
+    return clientLoaderCache;
+  }
+
   try {
     const config = await OpenHands.getConfig();
     window.__APP_MODE__ = config.APP_MODE;
@@ -84,7 +92,8 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
     token = null;
   }
 
-  return defer({
+  // Store the results in cache
+  clientLoaderCache = defer({
     token,
     ghToken,
     isAuthed,
@@ -94,6 +103,8 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
     settings,
     analyticsConsent,
   });
+
+  return clientLoaderCache;
 };
 
 export function ErrorBoundary() {

--- a/frontend/src/utils/user-is-authenticated.ts
+++ b/frontend/src/utils/user-is-authenticated.ts
@@ -1,6 +1,8 @@
 import OpenHands from "#/api/open-hands";
 
 export const userIsAuthenticated = async () => {
+  if (window.__APP_MODE__ === "oss") return true;
+
   try {
     await OpenHands.authenticate();
     return true;

--- a/frontend/src/utils/user-is-authenticated.ts
+++ b/frontend/src/utils/user-is-authenticated.ts
@@ -1,8 +1,6 @@
 import OpenHands from "#/api/open-hands";
 
 export const userIsAuthenticated = async () => {
-  if (window.__APP_MODE__ === "oss") return true;
-
   try {
     await OpenHands.authenticate();
     return true;


### PR DESCRIPTION
This PR fixes an issue where the clientLoader in `frontend/src/routes/_oh.tsx` was being called repeatedly during app use.

Changes made:
- Added a cache variable to store the loader results
- Modified clientLoader to return cached results if available
- Only execute the full loader logic on first call

This ensures the expensive operations (config fetching, auth checking, etc.) only happen once during initial page load.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e6036c6-nikolaik   --name openhands-app-e6036c6   docker.all-hands.dev/all-hands-ai/openhands:e6036c6
```