### PR TITLE
fix(agent, browsing): too long tool description for openai

### DIFF
--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -284,6 +284,17 @@ _browser_action_space = HighLevelActionSet(
 
 
 _BROWSER_DESCRIPTION = """Interact with the browser using Python code.
+
+See the description of "code" parameter for more details.
+
+Multiple actions can be provided at once, but will be executed sequentially without any feedback from the page.
+More than 2-3 actions usually leads to failure or unexpected behavior. Example:
+fill('a12', 'example with "quotes"')
+click('a51')
+click('48', button='middle', modifiers=['Shift'])
+"""
+
+_BROWSER_TOOL_DESCRIPTION = """
 The following 15 functions are available. Nothing else is supported.
 
 goto(url: str)
@@ -385,20 +396,15 @@ upload_file(bid: str, file: str | list[str])
         upload_file('572', '/home/user/my_receipt.pdf')
 
         upload_file('63', ['/home/bob/Documents/image.jpg', '/home/bob/Documents/file.zip'])
-
-Multiple actions can be provided at once, but will be executed sequentially without any feedback from the page.
-More than 2-3 actions usually leads to failure or unexpected behavior. Example:
-fill('a12', 'example with "quotes"')
-click('a51')
-click('48', button='middle', modifiers=['Shift'])
 """
+
 
 for _, action in _browser_action_space.action_set.items():
     assert (
-        action.signature in _BROWSER_DESCRIPTION
+        action.signature in _BROWSER_TOOL_DESCRIPTION
     ), f'Browser description mismatch. Please double check if the BrowserGym updated their action space.\n\nAction: {action.signature}'
     assert (
-        action.description in _BROWSER_DESCRIPTION
+        action.description in _BROWSER_TOOL_DESCRIPTION
     ), f'Browser description mismatch. Please double check if the BrowserGym updated their action space.\n\nAction: {action.description}'
 
 BrowserTool = ChatCompletionToolParam(
@@ -411,7 +417,10 @@ BrowserTool = ChatCompletionToolParam(
             'properties': {
                 'code': {
                     'type': 'string',
-                    'description': 'The Python code that interacts with the browser.',
+                    'description': (
+                        'The Python code that interacts with the browser.\n'
+                        + _BROWSER_TOOL_DESCRIPTION
+                    ),
                 }
             },
             'required': ['code'],

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -279,8 +279,6 @@ class RemoteRuntime(Runtime):
         assert 'pod_status' in runtime_data
         pod_status = runtime_data['pod_status']
 
-        # FIXME: We should fix it at the backend of /start endpoint, make sure
-        # the pod is created before returning the response.
         # Retry a period of time to give the cluster time to start the pod
         n_attempts = 0
         while pod_status == 'Not Found' and n_attempts < 10:

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -279,6 +279,8 @@ class RemoteRuntime(Runtime):
         assert 'pod_status' in runtime_data
         pod_status = runtime_data['pod_status']
 
+        # FIXME: We should fix it at the backend of /start endpoint, make sure
+        # the pod is created before returning the response.
         # Retry a period of time to give the cluster time to start the pod
         n_attempts = 0
         while pod_status == 'Not Found' and n_attempts < 10:

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import threading
-import time
 from typing import Callable, Optional
 from zipfile import ZipFile
 
@@ -278,22 +277,6 @@ class RemoteRuntime(Runtime):
         assert runtime_data['runtime_id'] == self.runtime_id
         assert 'pod_status' in runtime_data
         pod_status = runtime_data['pod_status']
-
-        # Retry a period of time to give the cluster time to start the pod
-        n_attempts = 0
-        while pod_status == 'Not Found' and n_attempts < 10:
-            time.sleep(5)
-            runtime_info_response = self._send_request(
-                'GET',
-                f'{self.config.sandbox.remote_runtime_api_url}/runtime/{self.runtime_id}',
-            )
-            runtime_data = runtime_info_response.json()
-            assert 'runtime_id' in runtime_data
-            assert runtime_data['runtime_id'] == self.runtime_id
-            assert 'pod_status' in runtime_data
-            pod_status = runtime_data['pod_status']
-            n_attempts += 1
-
         if pod_status == 'Ready':
             try:
                 self._send_request(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Fix for this issue due to OpenAI 1024 character tool description restriction ([link](https://community.openai.com/t/tool-calling-api-upgrade-1024-char-limit-is-limiting/951951/5)):

![image](https://github.com/user-attachments/assets/042adf0e-63f3-4aa2-bc78-096cb38ffd20)

This PR also adds a retry for RemoteRuntime to get the initial pod status.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:67ba9c6-nikolaik   --name openhands-app-67ba9c6   docker.all-hands.dev/all-hands-ai/openhands:67ba9c6
```