### PR TITLE
ALL-677 fix(frontend) Truncate long CMD outputs to prevent UI freezing

### DIFF
--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -9,10 +9,18 @@ import { addAssistantMessage } from "#/state/chatSlice";
 
 export function handleObservationMessage(message: ObservationMessage) {
   switch (message.observation) {
-    case ObservationType.RUN:
+    case ObservationType.RUN: {
       if (message.extras.hidden) break;
-      store.dispatch(appendOutput(message.content));
+      let { content } = message;
+
+      if (content.length > 5000) {
+        const head = content.slice(0, 5000);
+        content = `${head}\r\n\n... (truncated ${message.content.length - 5000} characters) ...`;
+      }
+
+      store.dispatch(appendOutput(content));
       break;
+    }
     case ObservationType.RUN_IPYTHON:
       // FIXME: render this as markdown
       store.dispatch(appendJupyterOutput(message.content));


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
UI would freeze on long CMD outputs (e.g., after a `poetry install` on the OpenHands repo)

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Truncates text if greater than 5000 characters


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3c883f7-nikolaik   --name openhands-app-3c883f7   docker.all-hands.dev/all-hands-ai/openhands:3c883f7
```