### PR TITLE
feat: give descriptive name to downloaded zip file

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -97,12 +97,11 @@ class OpenHands {
   }
 
   /**
-   * Get the blob of the workspace zip
-   * @returns Blob of the workspace zip
+   * Get the workspace zip from the server
+   * @returns Workspace zip as server response
    */
-  static async getWorkspaceZip(): Promise<Blob> {
-    const response = await request(`/api/zip-directory`, {}, false, true);
-    return response.blob();
+  static async getWorkspaceZip(): Promise<Response> {
+    return request(`/api/zip-directory`, {}, false, true);
   }
 
   /**

--- a/frontend/src/utils/download-workspace.ts
+++ b/frontend/src/utils/download-workspace.ts
@@ -4,12 +4,26 @@ import OpenHands from "#/api/open-hands";
  * Downloads the current workspace as a .zip file.
  */
 export const downloadWorkspace = async () => {
-  const blob = await OpenHands.getWorkspaceZip();
+  const response = await OpenHands.getWorkspaceZip();
 
+  // Extract filename from response headers
+  let filename = "workspace.zip";
+  const disposition = response.headers.get("Content-Disposition");
+  if (disposition && disposition.indexOf('filename=') !== -1) {
+    const matches = /filename="?([^"]+)"?/.exec(disposition);
+    if (matches != null && matches[1]) {
+      filename = matches[1];
+    }
+  }
+
+  // Get the response as a blob
+  const blob = await response.blob();
+
+  // Create download link and trigger download with extracted filename
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.setAttribute("download", "workspace.zip");
+  link.setAttribute("download", filename);
   document.body.appendChild(link);
   link.click();
   link.parentNode?.removeChild(link);

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -812,7 +812,7 @@ async def zip_current_workspace(request: Request):
 
         # Generate a summary
         if session_actions:
-            # Get relevant data from config
+            # Get relevant LLM data from config
             llm_config = config.llms['llm']
             api_key = llm_config.api_key
             model = llm_config.model


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When a user clicks the "download zip" button, the backend queries the LLM to summarize the actions from the current session into a descriptive phrase, which is then formatted into a valid zip file name.

In the frontend, the filename is extracted from the response headers before turning the response into a blob and triggering the download.

---
**Link of any specific issues this addresses**

Resolves #4706 
