### PR TITLE
feat(posthog): Identify users logged in with GitHub

### DIFF
--- a/frontend/src/api/github.ts
+++ b/frontend/src/api/github.ts
@@ -122,6 +122,9 @@ export const retrieveGitHubUser = async (
       id: data.id,
       login: data.login,
       avatar_url: data.avatar_url,
+      company: data.company,
+      name: data.name,
+      email: data.email,
     };
 
     return user;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -92,6 +92,9 @@ export const handlers = [
       id: 1,
       login: "octocat",
       avatar_url: "https://avatars.githubusercontent.com/u/583231?v=4",
+      company: "GitHub",
+      email: "placeholder@placeholder.placeholder",
+      name: "monalisa octocat",
     };
 
     return HttpResponse.json(user);

--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -169,12 +169,6 @@ export default function MainApp() {
 
   React.useEffect(() => {
     if (user && !isGitHubErrorReponse(user)) {
-      console.warn("Identifying user", {
-        login: user.login,
-        email: user.email,
-        name: user.name,
-        company: user.company,
-      });
       posthog.identify(user.login, {
         company: user.company,
         name: user.name,

--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -51,7 +51,7 @@ export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
 
   if (!userConsents) {
     posthog.opt_out_capturing();
-  } else {
+  } else if (userConsents && !posthog.has_opted_in_capturing()) {
     posthog.opt_in_capturing();
   }
 
@@ -166,6 +166,22 @@ export default function MainApp() {
   const [settingsFormError, setSettingsFormError] = React.useState<
     string | null
   >(null);
+
+  React.useEffect(() => {
+    if (user && !isGitHubErrorReponse(user)) {
+      console.warn("Identifying user", {
+        login: user.login,
+        email: user.email,
+        name: user.name,
+        company: user.company,
+      });
+      posthog.identify(user.login, {
+        company: user.company,
+        name: user.name,
+        email: user.email,
+      });
+    }
+  }, [user]);
 
   React.useEffect(() => {
     // We fetch this here instead of the data loader because the server seems to block

--- a/frontend/src/routes/logout.ts
+++ b/frontend/src/routes/logout.ts
@@ -1,8 +1,11 @@
 import { json } from "@remix-run/react";
+import posthog from "posthog-js";
 
 export const clientAction = () => {
   const ghToken = localStorage.getItem("ghToken");
   if (ghToken) localStorage.removeItem("ghToken");
+
+  posthog.reset();
 
   return json({ success: true });
 };

--- a/frontend/src/types/github.d.ts
+++ b/frontend/src/types/github.d.ts
@@ -8,6 +8,9 @@ interface GitHubUser {
   id: number;
   login: string;
   avatar_url: string;
+  company: string | null;
+  name: string | null;
+  email: string | null;
 }
 
 interface GitHubRepository {


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Follow recommend practices of identifying users: https://posthog.com/docs/product-analytics/identify
- Fix issue where a consented user calls the opt in method more than once


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2c7211b-nikolaik   --name openhands-app-2c7211b   docker.all-hands.dev/all-hands-ai/openhands:2c7211b
```