### PR TITLE
Fix init order in the agent controller

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -105,17 +105,17 @@ class AgentController:
         self.agent = agent
         self.headless_mode = headless_mode
 
+        # subscribe to the event stream
+        self.event_stream = event_stream
+        self.event_stream.subscribe(
+            EventStreamSubscriber.AGENT_CONTROLLER, self.on_event, self.id
+        )
+
         # state from the previous session, state from a parent agent, or a fresh state
         self.set_initial_state(
             state=initial_state,
             max_iterations=max_iterations,
             confirmation_mode=confirmation_mode,
-        )
-
-        # subscribe to the event stream
-        self.event_stream = event_stream
-        self.event_stream.subscribe(
-            EventStreamSubscriber.AGENT_CONTROLLER, self.on_event, self.id
         )
 
         self.max_budget_per_task = max_budget_per_task


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix initialization order of the stream in the agent controller.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Please see the discussion in the [previous PR](https://github.com/All-Hands-AI/OpenHands/pull/4526#discussion_r1830494161).

```
File "/Users/enyst/repos/odie/openhands/controller/agent_controller.py", line 109, in __init__
    self.set_initial_state(
  File "/Users/enyst/repos/odie/openhands/controller/agent_controller.py", line 641, in set_initial_state
    self._init_history()
  File "/Users/enyst/repos/odie/openhands/controller/agent_controller.py", line 661, in _init_history
    else self.event_stream.get_latest_event_id()
         ^^^^^^^^^^^^^^^^^

ERROR:root:<class 'AttributeError'>: 'AgentController' object has no attribute 'event_stream'
```

This PR fixes it, the controller needs to have the eventstream set before restoring state.

@tofarr if it matters that it doesn't subscribe yet (although I'm not sure it should), maybe we can do only that one later.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:631ddd1-nikolaik   --name openhands-app-631ddd1   docker.all-hands.dev/all-hands-ai/openhands:631ddd1
```