### PR TITLE
Fix - terminal not working

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -139,6 +139,8 @@ class Session:
             return
         if event.source == EventSource.AGENT:
             await self.send(event_to_dict(event))
+        elif event.source == EventSource.USER and isinstance(event, CmdOutputObservation):
+            await self.send(event_to_dict(event))
         # NOTE: ipython observations are not sent here currently
         elif event.source == EventSource.ENVIRONMENT and isinstance(
             event, (CmdOutputObservation, AgentStateChangedObservation)


### PR DESCRIPTION
**Results of user commands were not being sent back to the client**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Fix for regression from last week - the terminal now works again:
<img width="411" alt="image" src="https://github.com/user-attachments/assets/5be5df9e-b680-442d-976f-6eeaf6a48627">

Previously `CmdOutputObservation` events were only sent to the client if the source was 'AGENT'



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:56db101-nikolaik   --name openhands-app-56db101   docker.all-hands.dev/all-hands-ai/openhands:56db101
```