### PR TITLE
Revert "Feature: Add ability to reconnect websockets"

### DIFF
--- a/frontend/src/context/socket.tsx
+++ b/frontend/src/context/socket.tsx
@@ -2,11 +2,9 @@ import React from "react";
 import { Data } from "ws";
 import EventLogger from "#/utils/event-logger";
 
-const RECONNECT_RETRIES = 5;
-
 interface WebSocketClientOptions {
   token: string | null;
-  onOpen?: (event: Event, isNewSession: boolean) => void;
+  onOpen?: (event: Event) => void;
   onMessage?: (event: MessageEvent<Data>) => void;
   onError?: (event: Event) => void;
   onClose?: (event: Event) => void;
@@ -16,8 +14,8 @@ interface WebSocketContextType {
   send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
   start: (options?: WebSocketClientOptions) => void;
   stop: () => void;
-  setRuntimeIsInitialized: (runtimeIsInitialized: boolean) => void;
-  runtimeIsInitialized: boolean;
+  setRuntimeIsInitialized: () => void;
+  runtimeActive: boolean;
   isConnected: boolean;
   events: Record<string, unknown>[];
 }
@@ -32,10 +30,13 @@ interface SocketProviderProps {
 
 function SocketProvider({ children }: SocketProviderProps) {
   const wsRef = React.useRef<WebSocket | null>(null);
-  const wsReconnectRetries = React.useRef<number>(RECONNECT_RETRIES);
   const [isConnected, setIsConnected] = React.useState(false);
-  const [runtimeIsInitialized, setRuntimeIsInitialized] = React.useState(false);
+  const [runtimeActive, setRuntimeActive] = React.useState(false);
   const [events, setEvents] = React.useState<Record<string, unknown>[]>([]);
+
+  const setRuntimeIsInitialized = () => {
+    setRuntimeActive(true);
+  };
 
   const start = React.useCallback((options?: WebSocketClientOptions): void => {
     if (wsRef.current) {
@@ -58,9 +59,7 @@ function SocketProvider({ children }: SocketProviderProps) {
 
     ws.addEventListener("open", (event) => {
       setIsConnected(true);
-      const isNewSession = sessionToken === "NO_JWT";
-      wsReconnectRetries.current = RECONNECT_RETRIES;
-      options?.onOpen?.(event, isNewSession);
+      options?.onOpen?.(event);
     });
 
     ws.addEventListener("message", (event) => {
@@ -77,22 +76,17 @@ function SocketProvider({ children }: SocketProviderProps) {
 
     ws.addEventListener("close", (event) => {
       EventLogger.event(event, "SOCKET CLOSE");
+
       setIsConnected(false);
-      setRuntimeIsInitialized(false);
+      setRuntimeActive(false);
       wsRef.current = null;
       options?.onClose?.(event);
-      if (wsReconnectRetries.current) {
-        wsReconnectRetries.current -= 1;
-        const token = localStorage.getItem("token");
-        setTimeout(() => start({ ...(options || {}), token }), 1);
-      }
     });
 
     wsRef.current = ws;
   }, []);
 
   const stop = React.useCallback((): void => {
-    wsReconnectRetries.current = 0;
     if (wsRef.current) {
       wsRef.current.close();
       wsRef.current = null;
@@ -117,7 +111,7 @@ function SocketProvider({ children }: SocketProviderProps) {
       start,
       stop,
       setRuntimeIsInitialized,
-      runtimeIsInitialized,
+      runtimeActive,
       isConnected,
       events,
     }),
@@ -126,7 +120,7 @@ function SocketProvider({ children }: SocketProviderProps) {
       start,
       stop,
       setRuntimeIsInitialized,
-      runtimeIsInitialized,
+      runtimeActive,
       isConnected,
       events,
     ],

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -105,19 +105,18 @@ class AgentController:
         self.agent = agent
         self.headless_mode = headless_mode
 
-        # state from the previous session, state from a parent agent, or a fresh state
-        self.set_initial_state(
-            state=initial_state,
-            max_iterations=max_iterations,
-            confirmation_mode=confirmation_mode,
-        )
-
         # subscribe to the event stream
         self.event_stream = event_stream
         self.event_stream.subscribe(
             EventStreamSubscriber.AGENT_CONTROLLER, self.on_event, self.id
         )
 
+        # state from the previous session, state from a parent agent, or a fresh state
+        self.set_initial_state(
+            state=initial_state,
+            max_iterations=max_iterations,
+            confirmation_mode=confirmation_mode,
+        )
         self.max_budget_per_task = max_budget_per_task
         self.agent_to_llm_config = agent_to_llm_config if agent_to_llm_config else {}
         self.agent_configs = agent_configs if agent_configs else {}

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -329,12 +329,11 @@ async def websocket_endpoint(websocket: WebSocket):
             await websocket.send_json({'error': 'Invalid token', 'error_code': 401})
             await websocket.close()
             return
-        logger.info(f'Existing session: {sid}')
     else:
         sid = str(uuid.uuid4())
         jwt_token = sign_token({'sid': sid}, config.jwt_secret)
-        logger.info(f'New session: {sid}')
 
+    logger.info(f'New session: {sid}')
     session = session_manager.add_or_restart_session(sid, websocket)
     await websocket.send_json({'token': jwt_token, 'status': 'ok'})
 

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -100,9 +100,9 @@ class AgentSession:
         config: AppConfig,
         agent: Agent,
         max_iterations: int,
-        max_budget_per_task: float | None,
-        agent_to_llm_config: dict[str, LLMConfig] | None,
-        agent_configs: dict[str, AgentConfig] | None,
+        max_budget_per_task: float | None = None,
+        agent_to_llm_config: dict[str, LLMConfig] | None = None,
+        agent_configs: dict[str, AgentConfig] | None = None,
     ):
         self._create_security_analyzer(config.security.security_analyzer)
         await self._create_runtime(

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -30,7 +30,7 @@ class Session:
     sid: str
     websocket: WebSocket | None
     last_active_ts: int = 0
-    is_alive: bool = False
+    is_alive: bool = True
     agent_session: AgentSession
     loop: asyncio.AbstractEventLoop
 
@@ -109,7 +109,6 @@ class Session:
 
         # Create the agent session
         try:
-            self.is_alive = True
             await self.agent_session.start(
                 runtime_name=self.config.runtime,
                 config=self.config,
@@ -156,8 +155,7 @@ class Session:
     async def dispatch(self, data: dict):
         action = data.get('action', '')
         if action == ActionType.INIT:
-            if not self.is_alive:
-                await self._initialize_agent(data)
+            await self._initialize_agent(data)
             return
         event = event_from_dict(data.copy())
         # This checks if the model supports images


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#4526

Sorry, I'm trying to see it work locally and it doesn't work for me at all. I left a session disconnect, then:
- tried to send a message in the UI, I can see the message in the chat box, but nothing else happens
- I sent 'continue' => nothing happens
- then I clicked around on the UI, selected a file in the workspace => now it does send something to the server which fails, it seems disconnect closed the container and that cleaned it up, and it doesn't remake it. How is it supposed to work?

```
INFO:     127.0.0.1:51330 - "GET /api/list-files?path=opendevin%2F HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/docker/api/client.py", line 275, in _raise_for_status
    response.raise_for_status()
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http+docker://localhost/v1.47/containers/openhands-runtime-51af8ca7-9008-4ccd-80db-25aa254532fe/json
```

<details>
<summary>More logs</summary>
```
  File "/Users/enyst/repos/odie/openhands/runtime/impl/eventstream/eventstream_runtime.py", line 358, in _attach_to_container
    container = self.docker_client.containers.get(self.container_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/docker/models/containers.py", line 954, in get
    resp = self.client.api.inspect_container(container_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/docker/api/container.py", line 793, in inspect_container
    return self._result(
           ^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/docker/api/client.py", line 281, in _result
    self._raise_for_status(response)
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/docker/api/client.py", line 277, in _raise_for_status
    raise create_api_error_from_http_exception(e) from e
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/docker/errors.py", line 39, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation) from e
docker.errors.NotFound: 404 Client Error for http+docker://localhost/v1.47/containers/openhands-runtime-51af8ca7-9008-4ccd-80db-25aa254532fe/json: Not Found ("No such container: openhands-runtime-51af8ca7-9008-4ccd-80db-25aa254532fe")
```

</details>


In addition:
- session restore crash, that may not require a revert, it can be solved by this PR https://github.com/All-Hands-AI/OpenHands/pull/4796

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bcfd4fc-nikolaik   --name openhands-app-bcfd4fc   docker.all-hands.dev/all-hands-ai/openhands:bcfd4fc
```