### PR TITLE
fix(RemoteRuntime): add retry for pod status after /start

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -279,6 +279,8 @@ class RemoteRuntime(Runtime):
         assert 'pod_status' in runtime_data
         pod_status = runtime_data['pod_status']
 
+        # FIXME: We should fix it at the backend of /start endpoint, make sure
+        # the pod is created before returning the response.
         # Retry a period of time to give the cluster time to start the pod
         n_attempts = 0
         while pod_status == 'Not Found' and n_attempts < 10:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When running evaluation with high-level of parallelism, the RemoteRuntime may return "Not Found" after /start is called. This PR adds retry there to make sure we don't error out too early.

---
**Link of any specific issues this addresses**
