### PR TITLE
fix(agent controller): misplaced runtime.connect that cause swebench workspace to fail

### DIFF
--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -123,6 +123,7 @@ async def run_controller(
 
     if runtime is None:
         runtime = create_runtime(config, sid=sid)
+        await runtime.connect()
 
     event_stream = runtime.event_stream
 
@@ -187,8 +188,6 @@ async def run_controller(
                 event_stream.add_event(action, EventSource.USER)
 
     event_stream.subscribe(EventStreamSubscriber.MAIN, on_event, sid)
-
-    await runtime.connect()
 
     end_states = [
         AgentState.FINISHED,


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In agent controller, we should only call `runtime.connect()` when the runtime is not previously initialized.

In the case of SWE-Bench, we already .connect it before passing to `run_controller`, and .connect it inside agent controller again will cause the previous /workspace to disappear, causing the issue we see in In https://github.com/All-Hands-AI/OpenHands/issues/4776.


---
**Link of any specific issues this addresses**

Fix https://github.com/All-Hands-AI/OpenHands/issues/4776

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:efec7bb-nikolaik   --name openhands-app-efec7bb   docker.all-hands.dev/all-hands-ai/openhands:efec7bb
```