### PR TITLE
UX: Show a loading indicator when downloading a zip

### DIFF
--- a/frontend/src/components/project-menu/ProjectMenuCard.tsx
+++ b/frontend/src/components/project-menu/ProjectMenuCard.tsx
@@ -12,6 +12,7 @@ import { ProjectMenuCardContextMenu } from "./project.menu-card-context-menu";
 import { ProjectMenuDetailsPlaceholder } from "./project-menu-details-placeholder";
 import { ProjectMenuDetails } from "./project-menu-details";
 import { downloadWorkspace } from "#/utils/download-workspace";
+import { LoadingSpinner } from "../modals/LoadingProject";
 
 interface ProjectMenuCardProps {
   isConnectedToGitHub: boolean;
@@ -32,6 +33,7 @@ export function ProjectMenuCard({
   const [contextMenuIsOpen, setContextMenuIsOpen] = React.useState(false);
   const [connectToGitHubModalOpen, setConnectToGitHubModalOpen] =
     React.useState(false);
+  const [working, setWorking] = React.useState(false);
 
   const toggleMenuVisibility = () => {
     setContextMenuIsOpen((prev) => !prev);
@@ -63,7 +65,11 @@ Finally, open up a pull request using the GitHub API and the token in the GITHUB
   const handleDownloadWorkspace = () => {
     posthog.capture("download_workspace_button_clicked");
     try {
-      downloadWorkspace();
+      setWorking(true);
+      downloadWorkspace().then(
+        () => setWorking(false),
+        () => setWorking(false),
+      );
     } catch (error) {
       toast.error("Failed to download workspace");
     }
@@ -71,7 +77,7 @@ Finally, open up a pull request using the GitHub API and the token in the GITHUB
 
   return (
     <div className="px-4 py-[10px] w-[337px] rounded-xl border border-[#525252] flex justify-between items-center relative">
-      {contextMenuIsOpen && (
+      {!working && contextMenuIsOpen && (
         <ProjectMenuCardContextMenu
           isConnectedToGitHub={isConnectedToGitHub}
           onConnectToGitHub={() => setConnectToGitHubModalOpen(true)}
@@ -98,7 +104,11 @@ Finally, open up a pull request using the GitHub API and the token in the GITHUB
         onClick={toggleMenuVisibility}
         aria-label="Open project menu"
       >
-        <EllipsisH width={36} height={36} />
+        {working ? (
+          <LoadingSpinner size="small" />
+        ) : (
+          <EllipsisH width={36} height={36} />
+        )}
       </button>
       {connectToGitHubModalOpen && (
         <ModalBackdrop onClose={() => setConnectToGitHubModalOpen(false)}>


### PR DESCRIPTION
**Show a Loading indicator when downloading a zip**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Currently, downloading a zip is a silent operation. This shows a working indicator when a zip file is downloading
<img width="449" alt="image" src="https://github.com/user-attachments/assets/53c1dd96-d792-41a0-861d-9870c4f7a6d3">

<img width="397" alt="image" src="https://github.com/user-attachments/assets/acafc8f2-32e2-482f-af8d-4c3530067e1c">
