### PR TITLE
Make trajectories_path support file path

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -32,7 +32,8 @@ workspace_base = "./workspace"
 # Enable saving and restoring the session when run from CLI
 #enable_cli_session = false
 
-# Path to store trajectories
+# Path to store trajectories, can be a folder or a file
+# If it's a folder, the session id will be used as the file name
 #trajectories_path="./trajectories"
 
 # File store path

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -212,7 +212,11 @@ async def run_controller(
 
     # save trajectories if applicable
     if config.trajectories_path is not None:
-        file_path = os.path.join(config.trajectories_path, sid + '.json')
+        # if trajectories_path is a folder, use session id as file name
+        if os.path.isdir(config.trajectories_path):
+            file_path = os.path.join(config.trajectories_path, sid + '.json')
+        else:
+            file_path = config.trajectories_path
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
         histories = [event_to_trajectory(event) for event in state.history]
         with open(file_path, 'w') as f:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Make config.trajectories_path support file path apart from folder path

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This is a follow-up of #4336 

The previous PR adds a config `trajectories_path`. Once configured, a {sid}.json trajectory file would be dumped to that folder once the controller finishes.

There's one thing that's missing, though: it doesn't allow users to specify the trajectory name. In my use case, I'd actually would like to use `traj_{sid}.json` format, thus this PR. If the config path is a file path, then use it; otherwise, use `{sid}.json` as filename.

<img width="352" alt="Screenshot 2024-11-07 at 10 00 59 PM" src="https://github.com/user-attachments/assets/97e70caa-146e-4b9a-a3e9-79cb18095fa1">


---
**Link of any specific issues this addresses**
