### PR TITLE
fix(browser): reduce the info we put into a webpage

### DIFF
--- a/openhands/events/observation/browse.py
+++ b/openhands/events/observation/browse.py
@@ -64,7 +64,7 @@ class BrowserOutputObservation(Observation):
             # We do not filter visible only here because we want to show the full content
             # of the web page to the agent for simplicity.
             # FIXME: handle the case when the web page is too large
-            cur_axtree_txt = self.get_axtree_str(filter_visible_only=False)
+            cur_axtree_txt = self.get_axtree_str(filter_visible_only=True)
             text += (
                 f'============== BEGIN accessibility tree ==============\n'
                 f'{cur_axtree_txt}\n'
@@ -74,12 +74,12 @@ class BrowserOutputObservation(Observation):
             text += f'\n[Error encountered when processing the accessibility tree: {e}]'
         return text
 
-    def get_axtree_str(self, filter_visible_only: bool = False) -> str:
+    def get_axtree_str(self, filter_visible_only: bool = True) -> str:
         cur_axtree_txt = flatten_axtree_to_str(
             self.axtree_object,
             extra_properties=self.extra_element_properties,
             with_clickable=True,
-            skip_generic=False,
+            skip_generic=True,
             filter_visible_only=filter_visible_only,
         )
         self._axtree_str = cur_axtree_txt


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR reduce the info we put into a webpage - otherwise it can get too large and clustter the UI.


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bae4992-nikolaik   --name openhands-app-bae4992   docker.all-hands.dev/all-hands-ai/openhands:bae4992
```