### PR TITLE
Don't persist cache on reload

### DIFF
--- a/frontend/__tests__/utils/cache.test.ts
+++ b/frontend/__tests__/utils/cache.test.ts
@@ -18,7 +18,7 @@ describe("Cache", () => {
   it("sets data in memory with expiration", () => {
     cache.set(testKey, testData, testTTL);
     const cachedEntry = JSON.parse(
-      cached.cacheMemory[`app_cache_${testKey}`] || "",
+      cache.cacheMemory[testKey] || "",
     );
 
     expect(cachedEntry.data).toEqual(testData);
@@ -38,7 +38,7 @@ describe("Cache", () => {
     vi.advanceTimersByTime(5 * 60 * 1000 + 1);
 
     expect(cache.get(testKey)).toBeNull();
-    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeNull();
+    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeUndefined();
   });
 
   it("returns null if cached data is expired", () => {
@@ -46,14 +46,14 @@ describe("Cache", () => {
 
     vi.advanceTimersByTime(testTTL + 1);
     expect(cache.get(testKey)).toBeNull();
-    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeNull();
+    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeUndefined();
   });
 
   it("deletes data from memory", () => {
     cache.set(testKey, testData, testTTL);
     cache.delete(testKey);
 
-    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeNull();
+    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeUndefined();
   });
 
   it("clears all data with the app prefix from memory", () => {
@@ -61,6 +61,6 @@ describe("Cache", () => {
     cache.set("anotherKey", { data: "More data" }, testTTL);
     cache.clearAll();
 
-    expect(Object.keys(cache.cacheMemory)).toBe(0);
+    expect(Object.keys(cache.cacheMemory).length).toBe(0);
   });
 });

--- a/frontend/__tests__/utils/cache.test.ts
+++ b/frontend/__tests__/utils/cache.test.ts
@@ -15,16 +15,6 @@ describe("Cache", () => {
     vi.useRealTimers();
   });
 
-  it("sets data in memory with expiration", () => {
-    cache.set(testKey, testData, testTTL);
-    const cachedEntry = JSON.parse(
-      cache.cacheMemory[testKey] || "",
-    );
-
-    expect(cachedEntry.data).toEqual(testData);
-    expect(cachedEntry.expiration).toBeGreaterThan(Date.now());
-  });
-
   it("gets data from memory if not expired", () => {
     cache.set(testKey, testData, testTTL);
 
@@ -38,7 +28,6 @@ describe("Cache", () => {
     vi.advanceTimersByTime(5 * 60 * 1000 + 1);
 
     expect(cache.get(testKey)).toBeNull();
-    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeUndefined();
   });
 
   it("returns null if cached data is expired", () => {
@@ -46,21 +35,19 @@ describe("Cache", () => {
 
     vi.advanceTimersByTime(testTTL + 1);
     expect(cache.get(testKey)).toBeNull();
-    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeUndefined();
   });
 
   it("deletes data from memory", () => {
     cache.set(testKey, testData, testTTL);
     cache.delete(testKey);
-
-    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeUndefined();
+    expect(cache.get(testKey)).toBeNull();
   });
 
   it("clears all data with the app prefix from memory", () => {
     cache.set(testKey, testData, testTTL);
     cache.set("anotherKey", { data: "More data" }, testTTL);
     cache.clearAll();
-
-    expect(Object.keys(cache.cacheMemory).length).toBe(0);
+    expect(cache.get(testKey)).toBeNull();
+    expect(cache.get("anotherKey")).toBeNull();
   });
 });

--- a/frontend/__tests__/utils/cache.test.ts
+++ b/frontend/__tests__/utils/cache.test.ts
@@ -63,11 +63,4 @@ describe("Cache", () => {
 
     expect(Object.keys(cache.cacheMemory)).toBe(0);
   });
-
-  it("does not retrieve non-prefixed data from memory when clearing", () => {
-    cache.cacheMemory["nonPrefixedKey"] = "should remain";
-    cache.set(testKey, testData, testTTL);
-    cache.clearAll();
-    expect(cache.cacheMemory["nonPrefixedKey"]).toBe("should remain");
-  });
 });

--- a/frontend/__tests__/utils/cache.test.ts
+++ b/frontend/__tests__/utils/cache.test.ts
@@ -8,7 +8,6 @@ describe("Cache", () => {
   const testTTL = 1000; // 1 second
 
   beforeEach(() => {
-    localStorage.clear();
     vi.useFakeTimers();
   });
 
@@ -16,17 +15,17 @@ describe("Cache", () => {
     vi.useRealTimers();
   });
 
-  it("sets data in localStorage with expiration", () => {
+  it("sets data in memory with expiration", () => {
     cache.set(testKey, testData, testTTL);
     const cachedEntry = JSON.parse(
-      localStorage.getItem(`app_cache_${testKey}`) || "",
+      cached.cacheMemory[`app_cache_${testKey}`] || "",
     );
 
     expect(cachedEntry.data).toEqual(testData);
     expect(cachedEntry.expiration).toBeGreaterThan(Date.now());
   });
 
-  it("gets data from localStorage if not expired", () => {
+  it("gets data from memory if not expired", () => {
     cache.set(testKey, testData, testTTL);
 
     expect(cache.get(testKey)).toEqual(testData);
@@ -39,7 +38,7 @@ describe("Cache", () => {
     vi.advanceTimersByTime(5 * 60 * 1000 + 1);
 
     expect(cache.get(testKey)).toBeNull();
-    expect(localStorage.getItem(`app_cache_${testKey}`)).toBeNull();
+    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeNull();
   });
 
   it("returns null if cached data is expired", () => {
@@ -47,28 +46,28 @@ describe("Cache", () => {
 
     vi.advanceTimersByTime(testTTL + 1);
     expect(cache.get(testKey)).toBeNull();
-    expect(localStorage.getItem(`app_cache_${testKey}`)).toBeNull();
+    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeNull();
   });
 
-  it("deletes data from localStorage", () => {
+  it("deletes data from memory", () => {
     cache.set(testKey, testData, testTTL);
     cache.delete(testKey);
 
-    expect(localStorage.getItem(`app_cache_${testKey}`)).toBeNull();
+    expect(cache.cacheMemory[`app_cache_${testKey}`]).toBeNull();
   });
 
-  it("clears all data with the app prefix from localStorage", () => {
+  it("clears all data with the app prefix from memory", () => {
     cache.set(testKey, testData, testTTL);
     cache.set("anotherKey", { data: "More data" }, testTTL);
     cache.clearAll();
 
-    expect(localStorage.length).toBe(0);
+    expect(Object.keys(cache.cacheMemory)).toBe(0);
   });
 
-  it("does not retrieve non-prefixed data from localStorage when clearing", () => {
-    localStorage.setItem("nonPrefixedKey", "should remain");
+  it("does not retrieve non-prefixed data from memory when clearing", () => {
+    cache.cacheMemory["nonPrefixedKey"] = "should remain";
     cache.set(testKey, testData, testTTL);
     cache.clearAll();
-    expect(localStorage.getItem("nonPrefixedKey")).toBe("should remain");
+    expect(cache.cacheMemory["nonPrefixedKey"]).toBe("should remain");
   });
 });

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -12,8 +12,8 @@ class Cache {
   private cacheMemory = {};
 
   /**
-   * Generate a unique key with prefix for local storage
-   * @param key The key to be stored in local storage
+   * Generate a unique key with prefix
+   * @param key The key to be stored in memory
    * @returns The unique key with prefix
    */
   private getKey(key: CacheKey): string {
@@ -21,9 +21,9 @@ class Cache {
   }
 
   /**
-   * Retrieve the cached data from local storage
-   * @param key The key to be retrieved from local storage
-   * @returns The data stored in local storage
+   * Retrieve the cached data from memory
+   * @param key The key to be retrieved from memory
+   * @returns The data stored in memory
    */
   public get<T>(key: CacheKey): T | null {
     const cachedEntry = this.cacheMemory[this.getKey(key)];
@@ -37,9 +37,9 @@ class Cache {
   }
 
   /**
-   * Store the data in local storage with expiration
-   * @param key The key to be stored in local storage
-   * @param data The data to be stored in local storage
+   * Store the data in memory with expiration
+   * @param key The key to be stored in memory
+   * @param data The data to be stored in memory
    * @param ttl The time to live for the data in milliseconds
    * @returns void
    */
@@ -50,8 +50,8 @@ class Cache {
   }
 
   /**
-   * Remove the data from local storage
-   * @param key The key to be removed from local storage
+   * Remove the data from memory
+   * @param key The key to be removed from memory
    * @returns void
    */
   public delete(key: CacheKey): void {
@@ -59,7 +59,7 @@ class Cache {
   }
 
   /**
-   * Clear all data with the app prefix from local storage
+   * Clear all data with the app prefix from memory
    * @returns void
    */
   public clearAll(): void {

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -4,12 +4,12 @@ type CacheEntry<T> = {
   expiration: number;
 };
 
-
 class Cache {
   private prefix = "app_cache_";
 
   private defaultTTL = 5 * 60 * 1000; // 5 minutes
-  private cacheMemory = {};
+
+  private cacheMemory: Record<string, string> = {};
 
   /**
    * Generate a unique key with prefix

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -5,20 +5,9 @@ type CacheEntry<T> = {
 };
 
 class Cache {
-  private prefix = "app_cache_";
-
   private defaultTTL = 5 * 60 * 1000; // 5 minutes
 
   private cacheMemory: Record<string, string> = {};
-
-  /**
-   * Generate a unique key with prefix
-   * @param key The key to be stored in memory
-   * @returns The unique key with prefix
-   */
-  private getKey(key: CacheKey): string {
-    return `${this.prefix}${key}`;
-  }
 
   /**
    * Retrieve the cached data from memory
@@ -26,7 +15,7 @@ class Cache {
    * @returns The data stored in memory
    */
   public get<T>(key: CacheKey): T | null {
-    const cachedEntry = this.cacheMemory[this.getKey(key)];
+    const cachedEntry = this.cacheMemory[key];
     if (cachedEntry) {
       const { data, expiration } = JSON.parse(cachedEntry) as CacheEntry<T>;
       if (Date.now() < expiration) return data;
@@ -46,7 +35,7 @@ class Cache {
   public set<T>(key: CacheKey, data: T, ttl = this.defaultTTL): void {
     const expiration = Date.now() + ttl;
     const entry: CacheEntry<T> = { data, expiration };
-    this.cacheMemory[this.getKey(key)] = JSON.stringify(entry);
+    this.cacheMemory[key] = JSON.stringify(entry);
   }
 
   /**
@@ -55,16 +44,16 @@ class Cache {
    * @returns void
    */
   public delete(key: CacheKey): void {
-    delete this.cacheMemory[this.getKey(key)];
+    delete this.cacheMemory[key];
   }
 
   /**
-   * Clear all data with the app prefix from memory
+   * Clear all data
    * @returns void
    */
   public clearAll(): void {
     Object.keys(this.cacheMemory).forEach((key) => {
-      if (key.startsWith(this.prefix)) delete this.cacheMemory[key];
+      delete this.cacheMemory[key];
     });
   }
 }

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -4,10 +4,12 @@ type CacheEntry<T> = {
   expiration: number;
 };
 
+
 class Cache {
   private prefix = "app_cache_";
 
   private defaultTTL = 5 * 60 * 1000; // 5 minutes
+  private this.cacheMemory = {};
 
   /**
    * Generate a unique key with prefix for local storage
@@ -24,7 +26,7 @@ class Cache {
    * @returns The data stored in local storage
    */
   public get<T>(key: CacheKey): T | null {
-    const cachedEntry = localStorage.getItem(this.getKey(key));
+    const cachedEntry = this.cacheMemory[this.getKey(key)];
     if (cachedEntry) {
       const { data, expiration } = JSON.parse(cachedEntry) as CacheEntry<T>;
       if (Date.now() < expiration) return data;
@@ -44,7 +46,7 @@ class Cache {
   public set<T>(key: CacheKey, data: T, ttl = this.defaultTTL): void {
     const expiration = Date.now() + ttl;
     const entry: CacheEntry<T> = { data, expiration };
-    localStorage.setItem(this.getKey(key), JSON.stringify(entry));
+    this.cacheMemory[this.getKey(key)] = JSON.stringify(entry);
   }
 
   /**
@@ -53,7 +55,7 @@ class Cache {
    * @returns void
    */
   public delete(key: CacheKey): void {
-    localStorage.removeItem(this.getKey(key));
+    delete this.cacheMemory[this.getKey(key)];
   }
 
   /**
@@ -61,8 +63,8 @@ class Cache {
    * @returns void
    */
   public clearAll(): void {
-    Object.keys(localStorage).forEach((key) => {
-      if (key.startsWith(this.prefix)) localStorage.removeItem(key);
+    Object.keys(this.cacheMemory).forEach((key) => {
+      if (key.startsWith(this.prefix)) delete this.cacheMemory[key];
     });
   }
 }

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -9,7 +9,7 @@ class Cache {
   private prefix = "app_cache_";
 
   private defaultTTL = 5 * 60 * 1000; // 5 minutes
-  private this.cacheMemory = {};
+  private cacheMemory = {};
 
   /**
    * Generate a unique key with prefix for local storage


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This was killing me in dev mode 🙃 

Full refresh should clear this cache, even in prod. Removing local storage

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:74054dd-nikolaik   --name openhands-app-74054dd   docker.all-hands.dev/all-hands-ai/openhands:74054dd
```