### PR TITLE
fix: improve remote runtime reliability on large-scale evaluation

### DIFF
--- a/evaluation/swe_bench/eval_infer.py
+++ b/evaluation/swe_bench/eval_infer.py
@@ -83,6 +83,7 @@ def get_config(instance: pd.Series) -> AppConfig:
             timeout=1800,
             api_key=os.environ.get('ALLHANDS_API_KEY', None),
             remote_runtime_api_url=os.environ.get('SANDBOX_REMOTE_RUNTIME_API_URL'),
+            remote_runtime_init_timeout=1800,
         ),
         # do not mount workspace
         workspace_base=None,

--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -146,6 +146,7 @@ def get_config(
             api_key=os.environ.get('ALLHANDS_API_KEY', None),
             remote_runtime_api_url=os.environ.get('SANDBOX_REMOTE_RUNTIME_API_URL'),
             keep_remote_runtime_alive=False,
+            remote_runtime_init_timeout=1800,
         ),
         # do not mount workspace
         workspace_base=None,

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -14,7 +14,8 @@ class SandboxConfig:
         base_container_image: The base container image from which to build the runtime image.
         runtime_container_image: The runtime container image to use.
         user_id: The user ID for the sandbox.
-        timeout: The timeout for the sandbox.
+        timeout: The timeout for the default sandbox action execution.
+        remote_runtime_init_timeout: The timeout for the remote runtime to start.
         enable_auto_lint: Whether to enable auto-lint.
         use_host_network: Whether to use the host network.
         initialize_plugins: Whether to initialize plugins.
@@ -41,6 +42,7 @@ class SandboxConfig:
     runtime_container_image: str | None = None
     user_id: int = os.getuid() if hasattr(os, 'getuid') else 1000
     timeout: int = 120
+    remote_runtime_init_timeout: int = 180
     enable_auto_lint: bool = (
         False  # once enabled, OpenHands would lint files after editing
     )

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -89,7 +89,6 @@ class RemoteRuntime(Runtime):
         )
         self.runtime_id: str | None = None
         self.runtime_url: str | None = None
-        self.runtime_init_timeout = self.config.sandbox.remote_runtime_init_timeout
 
     async def connect(self):
         try:
@@ -263,7 +262,9 @@ class RemoteRuntime(Runtime):
 
     def _wait_until_alive(self):
         retry_decorator = tenacity.retry(
-            stop=tenacity.stop_after_delay(self.runtime_init_timeout)
+            stop=tenacity.stop_after_delay(
+                self.config.sandbox.remote_runtime_init_timeout
+            )
             | stop_if_should_exit(),
             reraise=True,
             retry=tenacity.retry_if_exception_type(RuntimeNotReadyError),

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -262,7 +262,7 @@ class RemoteRuntime(Runtime):
             )
 
     @tenacity.retry(
-        stop=tenacity.stop_after_delay(360) | stop_if_should_exit(),
+        stop=tenacity.stop_after_delay(180) | stop_if_should_exit(),
         reraise=True,
         retry=tenacity.retry_if_exception_type(RuntimeNotReadyError),
         wait=tenacity.wait_fixed(2),

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import threading
-import time
 from pathlib import Path
 from typing import Callable, Optional
 from zipfile import ZipFile
@@ -286,20 +285,6 @@ class RemoteRuntime(Runtime):
             raise RuntimeNotReadyError(
                 f'Runtime (ID={self.runtime_id}) is not yet ready. Status: {pod_status}'
             )
-
-        # Wait for pending status
-        while pod_status in ('Pending', 'Running'):
-            time.sleep(2)
-            runtime_info_response = self._send_request(
-                'GET',
-                f'{self.config.sandbox.remote_runtime_api_url}/runtime/{self.runtime_id}',
-            )
-            runtime_data = runtime_info_response.json()
-            assert 'runtime_id' in runtime_data
-            assert runtime_data['runtime_id'] == self.runtime_id
-            assert 'pod_status' in runtime_data
-            pod_status = runtime_data['pod_status']
-
         if pod_status == 'Ready':
             try:
                 self._send_request(
@@ -314,7 +299,7 @@ class RemoteRuntime(Runtime):
                     f'Runtime /alive failed to respond with 200: {e}'
                 )
             return
-        elif pod_status in ('Failed', 'Unknown'):
+        if pod_status in ('Failed', 'Unknown'):
             # clean up the runtime
             self.close()
             raise RuntimeError(
@@ -323,9 +308,9 @@ class RemoteRuntime(Runtime):
 
         self.log(
             'debug',
-            f'Unexpected runtime pod status: {pod_status}',
+            f'Waiting for runtime pod to be active. Current status: {pod_status}',
         )
-        raise RuntimeError(f'Unexpected runtime pod status: {pod_status}')
+        raise RuntimeNotReadyError()
 
     def close(self, timeout: int = 10):
         if self.config.sandbox.keep_remote_runtime_alive or self.attach_to_existing:

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -1,7 +1,8 @@
 import os
-from pathlib import Path
 import tempfile
 import threading
+import time
+from pathlib import Path
 from typing import Callable, Optional
 from zipfile import ZipFile
 
@@ -261,7 +262,7 @@ class RemoteRuntime(Runtime):
             )
 
     @tenacity.retry(
-        stop=tenacity.stop_after_delay(180) | stop_if_should_exit(),
+        stop=tenacity.stop_after_delay(360) | stop_if_should_exit(),
         reraise=True,
         retry=tenacity.retry_if_exception_type(RuntimeNotReadyError),
         wait=tenacity.wait_fixed(2),
@@ -285,6 +286,20 @@ class RemoteRuntime(Runtime):
             raise RuntimeNotReadyError(
                 f'Runtime (ID={self.runtime_id}) is not yet ready. Status: {pod_status}'
             )
+
+        # Wait for pending status (until it changes)
+        while pod_status == 'Pending':
+            time.sleep(2)
+            runtime_info_response = self._send_request(
+                'GET',
+                f'{self.config.sandbox.remote_runtime_api_url}/runtime/{self.runtime_id}',
+            )
+            runtime_data = runtime_info_response.json()
+            assert 'runtime_id' in runtime_data
+            assert runtime_data['runtime_id'] == self.runtime_id
+            assert 'pod_status' in runtime_data
+            pod_status = runtime_data['pod_status']
+
         if pod_status == 'Ready':
             try:
                 self._send_request(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When running large-scale evaluation, it could take more than 180 seconds for a pod to switch from Pending to Running - and the ceiling of the time taken is actually unknown (e.g., some images are very large that take a while to pull, maybe the cluster is full and we need to create new node to put the pod, etc).

This PR try to add back the while logic for the "Pending" and "Running" states - we no longer throw `RuntimeNotReadyError` for these two states and instead wait patiently for it. Without this, evaluation break pretty easily (eval 300 instances need 5-8 restarts which is a little bit unacceptable).


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3781da6-nikolaik   --name openhands-app-3781da6   docker.all-hands.dev/all-hands-ai/openhands:3781da6
```