### PR TITLE
feat(posthog): Emit user activated event

### DIFF
--- a/frontend/src/routes/_oh.app.tsx
+++ b/frontend/src/routes/_oh.app.tsx
@@ -11,6 +11,7 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import WebSocket from "ws";
 import toast from "react-hot-toast";
+import posthog from "posthog-js";
 import { getSettings } from "#/services/settings";
 import Security from "../components/modals/security/Security";
 import { Controls } from "#/components/controls";
@@ -159,6 +160,11 @@ function App() {
   const sendInitialQuery = (query: string, base64Files: string[]) => {
     const timestamp = new Date().toISOString();
     send(createChatMessage(query, base64Files, timestamp));
+
+    const userSettings = getSettings();
+    if (userSettings.LLM_API_KEY) {
+      posthog.capture("user_activated");
+    }
   };
 
   const handleOpen = React.useCallback(() => {


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Emit a `user_activated` event when the user is confirmed to have set an API key and the socket connection is established


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5840727-nikolaik   --name openhands-app-5840727   docker.all-hands.dev/all-hands-ai/openhands:5840727
```