### PR TITLE
test(frontend): Pass failing tests

### DIFF
--- a/frontend/__tests__/utils/extractModelAndProvider.test.ts
+++ b/frontend/__tests__/utils/extractModelAndProvider.test.ts
@@ -59,9 +59,9 @@ describe("extractModelAndProvider", () => {
       separator: "/",
     });
 
-    expect(extractModelAndProvider("claude-3-5-sonnet-20241022")).toEqual({
+    expect(extractModelAndProvider("claude-3-5-sonnet-20240620")).toEqual({
       provider: "anthropic",
-      model: "claude-3-5-sonnet-20241022",
+      model: "claude-3-5-sonnet-20240620",
       separator: "/",
     });
 

--- a/frontend/__tests__/utils/organizeModelsAndProviders.test.ts
+++ b/frontend/__tests__/utils/organizeModelsAndProviders.test.ts
@@ -15,7 +15,7 @@ test("organizeModelsAndProviders", () => {
     "gpt-4o",
     "together-ai-21.1b-41b",
     "gpt-4o-mini",
-    "claude-3-5-sonnet-20241022",
+    "anthropic/claude-3-5-sonnet-20241022",
     "claude-3-haiku-20240307",
     "claude-2",
     "claude-2.1",

--- a/frontend/src/utils/organizeModelsAndProviders.ts
+++ b/frontend/src/utils/organizeModelsAndProviders.ts
@@ -26,6 +26,7 @@ import { extractModelAndProvider } from "./extractModelAndProvider";
  */
 export const organizeModelsAndProviders = (models: string[]) => {
   const object: Record<string, { separator: string; models: string[] }> = {};
+
   models.forEach((model) => {
     const {
       separator,
@@ -45,5 +46,6 @@ export const organizeModelsAndProviders = (models: string[]) => {
     }
     object[key].models.push(modelId);
   });
+
   return object;
 };


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
#4871 introduced two failing frontend tests. I suspect those tests failed because LiteLLM returns the `claude-3-5-sonnet-20241022` model string as `anthropic/claude-3-5-sonnet-20241022`. Our app assumed it did not, and if it were to find the string `claude-3-5-sonnet-20241022`, to append it manually. This resulted in a duplication. One that is parsed if the string contains a provider, and one that is manually entered for specified models.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Update tests to use a model that does not already contain the provider (for manual parsing tests)
- Update tests to reflect that the model is expected to contain the provider as well (`anthropic/claude-3-5-sonnet-20241022`)


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:eda7002-nikolaik   --name openhands-app-eda7002   docker.all-hands.dev/all-hands-ai/openhands:eda7002
```