### PR TITLE
Support displaying images/videos/pdfs in the workspace

### DIFF
--- a/frontend/src/routes/_oh.app._index/code-editor-component.tsx
+++ b/frontend/src/routes/_oh.app._index/code-editor-component.tsx
@@ -29,6 +29,8 @@ function CodeEditorCompoonent({
     if (selectedPath && value) modifyFileContent(selectedPath, value);
   };
 
+  const isBase64Image = (content: string) => content.startsWith("data:image/");
+
   React.useEffect(() => {
     const handleSave = async (event: KeyboardEvent) => {
       if (selectedPath && event.metaKey && event.key === "s") {
@@ -62,16 +64,18 @@ function CodeEditorCompoonent({
     );
   }
 
-  return (
+  const fileContent = modifiedFiles[selectedPath] || files[selectedPath];
+
+  return isBase64Image(fileContent) ? (
+    <section className="flex flex-col relative items-center overflow-auto h-[90%]">
+      <img src={fileContent} alt={selectedPath} className="object-contain" />
+    </section>
+  ) : (
     <Editor
       data-testid="code-editor"
       path={selectedPath ?? undefined}
       defaultValue=""
-      value={
-        selectedPath
-          ? modifiedFiles[selectedPath] || files[selectedPath]
-          : undefined
-      }
+      value={selectedPath ? fileContent : undefined}
       onMount={onMount}
       onChange={handleEditorChange}
       options={{ readOnly: isReadOnly }}

--- a/frontend/src/routes/_oh.app._index/code-editor-component.tsx
+++ b/frontend/src/routes/_oh.app._index/code-editor-component.tsx
@@ -30,6 +30,7 @@ function CodeEditorCompoonent({
   };
 
   const isBase64Image = (content: string) => content.startsWith("data:image/");
+  const isPDF = (content: string) => content.startsWith("data:application/pdf");
 
   React.useEffect(() => {
     const handleSave = async (event: KeyboardEvent) => {
@@ -66,11 +67,25 @@ function CodeEditorCompoonent({
 
   const fileContent = modifiedFiles[selectedPath] || files[selectedPath];
 
-  return isBase64Image(fileContent) ? (
-    <section className="flex flex-col relative items-center overflow-auto h-[90%]">
-      <img src={fileContent} alt={selectedPath} className="object-contain" />
-    </section>
-  ) : (
+  if (isBase64Image(fileContent)) {
+    return (
+      <section className="flex flex-col relative items-center overflow-auto h-[90%]">
+        <img src={fileContent} alt={selectedPath} className="object-contain" />
+      </section>
+    );
+  }
+
+  if (isPDF(fileContent)) {
+    return (
+      <iframe
+        src={fileContent}
+        title={selectedPath}
+        width="100%"
+        height="100%"
+      />
+    );
+  }
+  return (
     <Editor
       data-testid="code-editor"
       path={selectedPath ?? undefined}

--- a/frontend/src/routes/_oh.app._index/code-editor-component.tsx
+++ b/frontend/src/routes/_oh.app._index/code-editor-component.tsx
@@ -31,6 +31,7 @@ function CodeEditorCompoonent({
 
   const isBase64Image = (content: string) => content.startsWith("data:image/");
   const isPDF = (content: string) => content.startsWith("data:application/pdf");
+  const isVideo = (content: string) => content.startsWith("data:video/");
 
   React.useEffect(() => {
     const handleSave = async (event: KeyboardEvent) => {
@@ -83,6 +84,14 @@ function CodeEditorCompoonent({
         width="100%"
         height="100%"
       />
+    );
+  }
+
+  if (isVideo(fileContent)) {
+    return (
+      <video controls src={fileContent} width="100%" height="100%">
+        <track kind="captions" label="English captions" />
+      </video>
     );
   }
   return (

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -235,6 +235,16 @@ class ActionExecutor:
                     encoded_pdf = base64.b64encode(pdf_data).decode('utf-8')
                     encoded_pdf = f'data:application/pdf;base64,{encoded_pdf}'
                 return FileReadObservation(path=filepath, content=encoded_pdf)
+            elif filepath.lower().endswith(('.mp4', '.webm', '.ogg')):
+                with open(filepath, 'rb') as file:
+                    video_data = file.read()
+                    encoded_video = base64.b64encode(video_data).decode('utf-8')
+                    mime_type, _ = mimetypes.guess_type(filepath)
+                    if mime_type is None:
+                        mime_type = 'video/mp4'  # default to MP4 if MIME type cannot be determined
+                    encoded_video = f'data:{mime_type};base64,{encoded_video}'
+
+                return FileReadObservation(path=filepath, content=encoded_video)
 
             with open(filepath, 'r', encoding='utf-8') as file:
                 lines = read_lines(file.readlines(), action.start, action.end)

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -229,6 +229,12 @@ class ActionExecutor:
                     encoded_image = f'data:{mime_type};base64,{encoded_image}'
 
                 return FileReadObservation(path=filepath, content=encoded_image)
+            elif filepath.lower().endswith('.pdf'):
+                with open(filepath, 'rb') as file:
+                    pdf_data = file.read()
+                    encoded_pdf = base64.b64encode(pdf_data).decode('utf-8')
+                    encoded_pdf = f'data:application/pdf;base64,{encoded_pdf}'
+                return FileReadObservation(path=filepath, content=encoded_pdf)
 
             with open(filepath, 'r', encoding='utf-8') as file:
                 lines = read_lines(file.readlines(), action.start, action.end)

--- a/openhands/runtime/utils/files.py
+++ b/openhands/runtime/utils/files.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from pathlib import Path
 
@@ -81,8 +82,15 @@ async def read_file(
         )
 
     try:
-        with open(whole_path, 'r', encoding='utf-8') as file:
-            lines = read_lines(file.readlines(), start, end)
+        if whole_path.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp', '.gif')):
+            with open(whole_path, 'rb') as file:
+                image_data = file.read()
+                encoded_image = base64.b64encode(image_data).decode('utf-8')
+                print(encoded_image)
+            return FileReadObservation(path=path, content=encoded_image)
+        else:
+            with open(whole_path, 'r', encoding='utf-8') as file:
+                lines = read_lines(file.readlines(), start, end)
     except FileNotFoundError:
         return ErrorObservation(f'File not found: {path}')
     except UnicodeDecodeError:

--- a/openhands/runtime/utils/files.py
+++ b/openhands/runtime/utils/files.py
@@ -1,4 +1,3 @@
-import base64
 import os
 from pathlib import Path
 
@@ -82,15 +81,8 @@ async def read_file(
         )
 
     try:
-        if whole_path.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp', '.gif')):
-            with open(whole_path, 'rb') as file:
-                image_data = file.read()
-                encoded_image = base64.b64encode(image_data).decode('utf-8')
-                print(encoded_image)
-            return FileReadObservation(path=path, content=encoded_image)
-        else:
-            with open(whole_path, 'r', encoding='utf-8') as file:
-                lines = read_lines(file.readlines(), start, end)
+        with open(whole_path, 'r', encoding='utf-8') as file:
+            lines = read_lines(file.readlines(), start, end)
     except FileNotFoundError:
         return ErrorObservation(f'File not found: {path}')
     except UnicodeDecodeError:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

I noticed #1491 has been repetitively going stale; this PR addresses this by enabling viewing of images/videos/pdfs in the workspace. Summary of changes -
 
1. Selects file from backend and sends base64 encoding to frontend
2. Frontend renders the editor if its text; otherwise it will render the image, pdf, or video accordingly


---
**Link of any specific issues this addresses**
#1491 