### PR TITLE
Fix: [Bug]  Do not render editor action buttons (save/discard) when displaying non-code files

### DIFF
--- a/frontend/src/routes/_oh.app._index/route.tsx
+++ b/frontend/src/routes/_oh.app._index/route.tsx
@@ -12,6 +12,18 @@ import CodeEditorCompoonent from "./code-editor-component";
 import { useFiles } from "#/context/files";
 import { EditorActions } from "#/components/editor-actions";
 
+const ASSET_FILE_TYPES = [
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".bmp",
+  ".gif",
+  ".pdf",
+  ".mp4",
+  ".webm",
+  ".ogg",
+];
+
 export const clientLoader = async () => {
   const token = localStorage.getItem("token");
   return json({ token });
@@ -104,6 +116,10 @@ function CodeEditor() {
     if (selectedPath) discardChanges(selectedPath);
   };
 
+  const isAssetFileType = selectedPath
+    ? ASSET_FILE_TYPES.some((ext) => selectedPath.endsWith(ext))
+    : false;
+
   return (
     <div className="flex h-full bg-neutral-900 relative">
       <FileExplorer
@@ -112,7 +128,7 @@ function CodeEditor() {
         error={errors.getFiles}
       />
       <div className="w-full">
-        {selectedPath && (
+        {selectedPath && !isAssetFileType && (
           <div className="flex w-full items-center justify-between self-end p-2">
             <span className="text-sm text-neutral-500">{selectedPath}</span>
             <EditorActions


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We checks if the selected file matches expected filetypes for assets that aren't code files. In this case we decide not to render the action buttons


---
**Link of any specific issues this addresses**
#4899 