### PR TITLE
Add GitHub Actions workflow for WSL unit tests

### DIFF
--- a/.github/workflows/wsl-tests.yml
+++ b/.github/workflows/wsl-tests.yml
@@ -34,20 +34,16 @@ jobs:
         uses: Vampire/setup-wsl@v2
         with:
           distribution: Ubuntu-22.04
-          
+          additional-packages: python3-pip python3-venv
 
-      - name: Install poetry via pipx
+      - name: Set up Python and Poetry in WSL
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-pip
-          python3 -m pip install pipx
+          sudo apt-get install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-venv
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+          source ~/.bashrc
           pipx install poetry
-          
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
           
       - name: Install Python dependencies using Poetry
         run: poetry install --without evaluation,llama-index

--- a/.github/workflows/wsl-tests.yml
+++ b/.github/workflows/wsl-tests.yml
@@ -1,0 +1,67 @@
+# Workflow that runs python unit tests on WSL
+name: Run Python Unit Tests on WSL
+
+# The jobs in this workflow are required, so they must run at all times
+# * Always run on "main"
+# * Always run on PRs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-on-wsl:
+    name: Python Unit Tests on WSL
+    runs-on: windows-latest
+    env:
+      INSTALL_DOCKER: '0'
+    defaults:
+      run:
+        shell: wsl-bash {0}
+    strategy:
+      matrix:
+        python-version: ['3.12']
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up WSL
+        uses: Vampire/setup-wsl@v2
+        with:
+          distribution: Ubuntu-22.04
+          
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Install poetry via pipx
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          python3 -m pip install pipx
+          pipx install poetry
+          
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+          
+      - name: Install Python dependencies using Poetry
+        run: poetry install --without evaluation,llama-index
+        
+      - name: Build Environment
+        run: make build
+        
+      - name: Run Tests
+        run: poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
+        
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/wsl-tests.yml
+++ b/.github/workflows/wsl-tests.yml
@@ -53,7 +53,9 @@ jobs:
         run: |
           # Ensure we're using Python 3.12
           poetry env use python3.12
-          poetry install --without evaluation,llama-index
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry install -vv --without evaluation,llama-index
         
       - name: Build Environment
         run: make build

--- a/.github/workflows/wsl-tests.yml
+++ b/.github/workflows/wsl-tests.yml
@@ -34,19 +34,26 @@ jobs:
         uses: Vampire/setup-wsl@v2
         with:
           distribution: Ubuntu-22.04
-          additional-packages: python3-pip python3-venv
+          additional-packages: python3-pip python3-venv curl software-properties-common
 
       - name: Set up Python and Poetry in WSL
         run: |
+          # Add deadsnakes PPA for Python 3.12
+          sudo add-apt-repository ppa:deadsnakes/ppa -y
           sudo apt-get update
-          sudo apt-get install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-venv
-          python3 -m pip install --user pipx
-          python3 -m pipx ensurepath
-          source ~/.bashrc
-          pipx install poetry
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
+          
+          # Install pip for Python 3.12
+          curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
+          
+          # Install poetry using pip
+          python3.12 -m pip install poetry
           
       - name: Install Python dependencies using Poetry
-        run: poetry install --without evaluation,llama-index
+        run: |
+          # Ensure we're using Python 3.12
+          poetry env use python3.12
+          poetry install --without evaluation,llama-index
         
       - name: Build Environment
         run: make build

--- a/.github/workflows/wsl-tests.yml
+++ b/.github/workflows/wsl-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test-on-wsl:
-    name: Python Unit Tests on WSL
+    name: Python Unit Tests on WSL (${{ matrix.python-version }})
     runs-on: windows-latest
     env:
       INSTALL_DOCKER: '0'
@@ -35,10 +35,7 @@ jobs:
         with:
           distribution: Ubuntu-22.04
           
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-        
+
       - name: Install poetry via pipx
         run: |
           sudo apt-get update

--- a/.github/workflows/wsl-tests.yml
+++ b/.github/workflows/wsl-tests.yml
@@ -41,12 +41,13 @@ jobs:
           # Add deadsnakes PPA for Python 3.12
           sudo add-apt-repository ppa:deadsnakes/ppa -y
           sudo apt-get update
-          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils
           
           # Install pip for Python 3.12
           curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
           
           # Install poetry using pip
+          python3.12 -m pip install --upgrade pip setuptools wheel
           python3.12 -m pip install poetry
           
       - name: Install Python dependencies using Poetry
@@ -55,7 +56,8 @@ jobs:
           poetry env use python3.12
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          poetry install -vv --without evaluation,llama-index
+          poetry config installer.max-workers 10
+          poetry install --no-interaction --without evaluation,llama-index
         
       - name: Build Environment
         run: make build


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to run unit tests in Windows Subsystem for Linux (WSL). The workflow follows the same patterns as the existing unit test workflow while maintaining WSL-specific setup requirements.

Key features:
- Runs on Windows with WSL (Ubuntu 22.04)
- Uses the same test configuration as the Linux workflow
- Includes code coverage reporting
- Follows existing workflow patterns and best practices

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1f1bbdf-nikolaik   --name openhands-app-1f1bbdf   docker.all-hands.dev/all-hands-ai/openhands:1f1bbdf
```