### PR TITLE
Add WSL unit test workflow

### DIFF
--- a/.github/workflows/py-unit-tests-wsl.yml
+++ b/.github/workflows/py-unit-tests-wsl.yml
@@ -1,0 +1,60 @@
+name: Run Python Unit Tests on WSL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-on-wsl:
+    name: Python Unit Tests on WSL
+    runs-on: windows-latest
+    env:
+      INSTALL_DOCKER: '0'  # Set to '0' to skip Docker installation
+    strategy:
+      matrix:
+        python-version: ['3.12']
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup WSL
+        uses: Vampire/setup-wsl@v3
+        with:
+          distribution: Ubuntu-22.04
+          update: true
+          additional-packages: python3-pip python3-venv make
+      
+      - name: Install poetry via pipx
+        shell: wsl-bash {0}
+        run: |
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+          pipx install poetry
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+      
+      - name: Install Python dependencies using Poetry
+        shell: wsl-bash {0}
+        run: poetry install --without evaluation,llama-index
+      
+      - name: Build Environment
+        shell: wsl-bash {0}
+        run: make build
+      
+      - name: Run Tests
+        shell: wsl-bash {0}
+        run: poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
+      
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/py-unit-tests-wsl.yml
+++ b/.github/workflows/py-unit-tests-wsl.yml
@@ -27,32 +27,42 @@ jobs:
         with:
           distribution: Ubuntu-22.04
           update: true
-          additional-packages: python3-pip python3-venv make
+          additional-packages: python3-pip python3-venv make curl
       
-      - name: Install poetry via pipx
+      - name: Set up Python in WSL
         shell: wsl-bash {0}
         run: |
-          python3 -m pip install --user pipx
-          python3 -m pipx ensurepath
-          pipx install poetry
-      
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
+          # Install Python 3.12
+          sudo add-apt-repository ppa:deadsnakes/ppa -y
+          sudo apt-get update
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
+          
+          # Create and activate virtual environment
+          python3.12 -m venv ~/.venv
+          source ~/.venv/bin/activate
+          
+          # Install poetry
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       
       - name: Install Python dependencies using Poetry
         shell: wsl-bash {0}
-        run: poetry install --without evaluation,llama-index
+        run: |
+          source ~/.venv/bin/activate
+          export PATH="$HOME/.local/bin:$PATH"
+          poetry install --without evaluation,llama-index
       
       - name: Build Environment
         shell: wsl-bash {0}
-        run: make build
+        run: |
+          source ~/.venv/bin/activate
+          make build
       
       - name: Run Tests
         shell: wsl-bash {0}
-        run: poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
+        run: |
+          source ~/.venv/bin/activate
+          poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/py-unit-tests-wsl.yml
+++ b/.github/workflows/py-unit-tests-wsl.yml
@@ -53,7 +53,8 @@ jobs:
           python3 -m pipx install poetry
           
           # Add local bin to PATH
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.local/bin:$PATH"
+          echo "PATH=$PATH" >> $GITHUB_ENV
       
       - name: Install Python dependencies using Poetry
         shell: wsl-bash {0}

--- a/.github/workflows/py-unit-tests-wsl.yml
+++ b/.github/workflows/py-unit-tests-wsl.yml
@@ -39,24 +39,21 @@ jobs:
           # Install Python 3.12 from deadsnakes PPA
           sudo add-apt-repository ppa:deadsnakes/ppa -y
           sudo apt-get update
-          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils python3.12-pip
           
           # Create symlinks for python3.12
           sudo ln -sf /usr/bin/python3.12 /usr/local/bin/python3
           sudo ln -sf /usr/bin/python3.12 /usr/local/bin/python
+          sudo ln -sf /usr/bin/pip3.12 /usr/local/bin/pip3
+          sudo ln -sf /usr/bin/pip3.12 /usr/local/bin/pip
           
-          # Install pip for Python 3.12
-          curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-          sudo python3.12 get-pip.py
-          sudo ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip3
-          sudo ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip
+          # Install pipx and poetry
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+          python3 -m pipx install poetry
           
-          # Install pipx
-          sudo pip3 install pipx
-          pipx ensurepath
-          
-          # Install poetry via pipx
-          pipx install poetry
+          # Add local bin to PATH
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       
       - name: Install Python dependencies using Poetry
         shell: wsl-bash {0}

--- a/.github/workflows/py-unit-tests-wsl.yml
+++ b/.github/workflows/py-unit-tests-wsl.yml
@@ -32,39 +32,41 @@ jobs:
       - name: Set up Python in WSL
         shell: wsl-bash {0}
         run: |
-          # Install Python 3.12
+          # Install Python 3.12 from deadsnakes PPA
           sudo add-apt-repository ppa:deadsnakes/ppa -y
           sudo apt-get update
-          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils
           
-          # Create virtual environment
-          python3.12 -m venv ~/.venv
+          # Install pip for Python 3.12
+          curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
           
-          # Install poetry
-          source ~/.venv/bin/activate
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "export PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc
+          # Install pipx
+          python3.12 -m pip install --user pipx
+          python3.12 -m pipx ensurepath
+          
+          # Add local bin to PATH
+          export PATH="/root/.local/bin:$PATH"
+          
+          # Install poetry via pipx
+          pipx install poetry
       
       - name: Install Python dependencies using Poetry
         shell: wsl-bash {0}
         run: |
-          source ~/.venv/bin/activate
-          source ~/.bashrc
-          $HOME/.local/bin/poetry install --without evaluation,llama-index
+          export PATH="/root/.local/bin:$PATH"
+          poetry install --without evaluation,llama-index
       
       - name: Build Environment
         shell: wsl-bash {0}
         run: |
-          source ~/.venv/bin/activate
-          source ~/.bashrc
+          export PATH="/root/.local/bin:$PATH"
           make build
       
       - name: Run Tests
         shell: wsl-bash {0}
         run: |
-          source ~/.venv/bin/activate
-          source ~/.bashrc
-          $HOME/.local/bin/poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
+          export PATH="/root/.local/bin:$PATH"
+          poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/py-unit-tests-wsl.yml
+++ b/.github/workflows/py-unit-tests-wsl.yml
@@ -32,41 +32,43 @@ jobs:
       - name: Set up Python in WSL
         shell: wsl-bash {0}
         run: |
+          # Update package list and install software-properties-common
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          
           # Install Python 3.12 from deadsnakes PPA
           sudo add-apt-repository ppa:deadsnakes/ppa -y
           sudo apt-get update
           sudo apt-get install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils
           
+          # Create symlinks for python3.12
+          sudo ln -sf /usr/bin/python3.12 /usr/local/bin/python3
+          sudo ln -sf /usr/bin/python3.12 /usr/local/bin/python
+          
           # Install pip for Python 3.12
-          curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
+          curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          sudo python3.12 get-pip.py
+          sudo ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip3
+          sudo ln -sf /usr/local/bin/pip3.12 /usr/local/bin/pip
           
           # Install pipx
-          python3.12 -m pip install --user pipx
-          python3.12 -m pipx ensurepath
-          
-          # Add local bin to PATH
-          export PATH="/root/.local/bin:$PATH"
+          sudo pip3 install pipx
+          pipx ensurepath
           
           # Install poetry via pipx
           pipx install poetry
       
       - name: Install Python dependencies using Poetry
         shell: wsl-bash {0}
-        run: |
-          export PATH="/root/.local/bin:$PATH"
-          poetry install --without evaluation,llama-index
+        run: poetry install --without evaluation,llama-index
       
       - name: Build Environment
         shell: wsl-bash {0}
-        run: |
-          export PATH="/root/.local/bin:$PATH"
-          make build
+        run: make build
       
       - name: Run Tests
         shell: wsl-bash {0}
-        run: |
-          export PATH="/root/.local/bin:$PATH"
-          poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
+        run: poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/py-unit-tests-wsl.yml
+++ b/.github/workflows/py-unit-tests-wsl.yml
@@ -37,32 +37,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
           
-          # Create and activate virtual environment
+          # Create virtual environment
           python3.12 -m venv ~/.venv
-          source ~/.venv/bin/activate
           
           # Install poetry
+          source ~/.venv/bin/activate
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "export PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc
       
       - name: Install Python dependencies using Poetry
         shell: wsl-bash {0}
         run: |
           source ~/.venv/bin/activate
-          export PATH="$HOME/.local/bin:$PATH"
-          poetry install --without evaluation,llama-index
+          source ~/.bashrc
+          $HOME/.local/bin/poetry install --without evaluation,llama-index
       
       - name: Build Environment
         shell: wsl-bash {0}
         run: |
           source ~/.venv/bin/activate
+          source ~/.bashrc
           make build
       
       - name: Run Tests
         shell: wsl-bash {0}
         run: |
           source ~/.venv/bin/activate
-          poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
+          source ~/.bashrc
+          $HOME/.local/bin/poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
This PR adds a new workflow for running Python unit tests on WSL.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e6e6659-nikolaik   --name openhands-app-e6e6659   docker.all-hands.dev/all-hands-ai/openhands:e6e6659
```