### PR TITLE
Fix issue #4842: [Bug]: Suggestions set into the chat input at /app contain quotations

### DIFF
--- a/frontend/src/utils/suggestions/repo-suggestions.ts
+++ b/frontend/src/utils/suggestions/repo-suggestions.ts
@@ -13,14 +13,14 @@ const KEY_2 = "Auto-merge Dependabot PRs";
 const VALUE_2 = `Please add a GitHub action to this repository which automatically merges pull requests from Dependabot so long as the tests are passing.`;
 
 const KEY_3 = "Fix up my README";
-const VALUE_3 = `"Please look at the README and make the following improvements, if they make sense:
+const VALUE_3 = `Please look at the README and make the following improvements, if they make sense:
 * correct any typos that you find
 * add missing language annotations on codeblocks
 * if there are references to other files or other sections of the README, turn them into links
 * make sure the readme has an h1 title towards the top
 * make sure any existing sections in the readme are appropriately separated with headings
 
-If there are no obvious ways to improve the README, make at least one small change to make the wording clearer or friendlier"`;
+If there are no obvious ways to improve the README, make at least one small change to make the wording clearer or friendlier`;
 
 const KEY_4 = "Clean up my dependencies";
 const VALUE_4 = `Examine the dependencies of the current codebase. Make sure you can run the code and any tests.

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -1,7 +1,6 @@
 import json
 import os
 from collections import deque
-from itertools import islice
 
 from litellm import ModelResponse
 
@@ -110,7 +109,9 @@ class CodeActAgent(Agent):
             self.action_parser = CodeActResponseParser()
             self.prompt_manager = PromptManager(
                 microagent_dir=os.path.join(os.path.dirname(__file__), 'micro'),
-                prompt_dir=os.path.join(os.path.dirname(__file__), 'prompts', 'default'),
+                prompt_dir=os.path.join(
+                    os.path.dirname(__file__), 'prompts', 'default'
+                ),
                 agent_skills_docs=AgentSkillsRequirement.documentation,
             )
 

--- a/openhands/agenthub/codeact_agent/prompts/tools/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/tools/system_prompt.j2
@@ -4,4 +4,3 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 * When configuring git credentials, use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
 * The assistant MUST NOT include comments in the code unless they are necessary to describe non-obvious behavior.
 </IMPORTANT>
-

--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -1,8 +1,8 @@
 import os
-from pathlib import Path
 import tempfile
 import threading
 from functools import lru_cache
+from pathlib import Path
 from typing import Callable
 from zipfile import ZipFile
 

--- a/openhands/runtime/impl/runloop/runloop_runtime.py
+++ b/openhands/runtime/impl/runloop/runloop_runtime.py
@@ -190,7 +190,7 @@ class RunloopRuntime(EventStreamRuntime):
             prebuilt='openhands',
             launch_parameters=LaunchParameters(
                 available_ports=[self._sandbox_port],
-                resource_size_request="LARGE",
+                resource_size_request='LARGE',
             ),
             metadata={'container-name': self.container_name},
         )


### PR DESCRIPTION
This pull request fixes #4842.

The issue has been successfully resolved according to the AI agent's last message. The fix involved:

1. Identifying the source of unwanted quotation marks in `/workspace/frontend/src/utils/suggestions/repo-suggestions.ts`
2. Removing the outer quotation marks from the suggestion text while preserving necessary inner quotations
3. Verifying the changes work through frontend testing

For the PR review, I would summarize:
"This PR fixes an issue where chat suggestions were being displayed with unnecessary quotation marks in the chat interface. The fix removes outer quotation marks from suggestion texts in repo-suggestions.ts while maintaining any internal quotation marks that are part of the actual suggestion content. The failing tests are unrelated to these changes and are due to missing i18n declaration files."

The specific problem identified in the issue description has been directly addressed by modifying how suggestions are formatted in the source file, and the AI confirms the fix is working as expected despite unrelated test failures.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6ec4f5d-nikolaik   --name openhands-app-6ec4f5d   docker.all-hands.dev/all-hands-ai/openhands:6ec4f5d
```