### PR TITLE
fix(llm): bedrock throw errors if content contains empty string

### DIFF
--- a/openhands/core/message.py
+++ b/openhands/core/message.py
@@ -98,6 +98,13 @@ class Message(BaseModel):
                 content.extend(d)
 
         ret: dict = {'content': content, 'role': self.role}
+        # pop content if it's empty
+        if not content or (
+            len(content) == 1
+            and content[0]['type'] == 'text'
+            and content[0]['text'] == ''
+        ):
+            ret.pop('content')
 
         if role_tool_with_prompt_caching:
             ret['cache_control'] = {'type': 'ephemeral'}

--- a/openhands/llm/debug_mixin.py
+++ b/openhands/llm/debug_mixin.py
@@ -14,7 +14,9 @@ class DebugMixin:
 
         messages = messages if isinstance(messages, list) else [messages]
         debug_message = MESSAGE_SEPARATOR.join(
-            self._format_message_content(msg) for msg in messages if msg['content']
+            self._format_message_content(msg)
+            for msg in messages
+            if msg.get('content', None)
         )
 
         if debug_message:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Bedrock would complain if we send `content=[{'type': 'text', 'text': ''}]` to its API. This PR fixes this. Discovered from https://github.com/All-Hands-AI/OpenHands/issues/4912.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0e38e23-nikolaik   --name openhands-app-0e38e23   docker.all-hands.dev/all-hands-ai/openhands:0e38e23
```