### PR TITLE
Fix issue #4941: [Bug]: Browser tab does not reset after starting a new session

### DIFF
--- a/frontend/__tests__/clear-session.test.ts
+++ b/frontend/__tests__/clear-session.test.ts
@@ -12,7 +12,7 @@ describe("clearSession", () => {
       removeItem: vi.fn(),
       clear: vi.fn(),
     };
-    global.localStorage = localStorageMock;
+    vi.stubGlobal("localStorage", localStorageMock);
 
     // Set initial browser state to non-default values
     store.dispatch({

--- a/frontend/__tests__/clear-session.test.ts
+++ b/frontend/__tests__/clear-session.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clearSession } from "../src/utils/clear-session";
+import store from "../src/store";
+import { initialState as browserInitialState } from "../src/state/browserSlice";
+
+describe("clearSession", () => {
+  beforeEach(() => {
+    // Mock localStorage
+    const localStorageMock = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    global.localStorage = localStorageMock;
+
+    // Set initial browser state to non-default values
+    store.dispatch({
+      type: "browser/setUrl",
+      payload: "https://example.com",
+    });
+    store.dispatch({
+      type: "browser/setScreenshotSrc",
+      payload: "base64screenshot",
+    });
+  });
+
+  it("should clear localStorage and reset browser state", () => {
+    clearSession();
+
+    // Verify localStorage items were removed
+    expect(localStorage.removeItem).toHaveBeenCalledWith("token");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("repo");
+
+    // Verify browser state was reset
+    const state = store.getState();
+    expect(state.browser.url).toBe(browserInitialState.url);
+    expect(state.browser.screenshotSrc).toBe(browserInitialState.screenshotSrc);
+  });
+});

--- a/frontend/src/utils/clear-session.ts
+++ b/frontend/src/utils/clear-session.ts
@@ -1,7 +1,21 @@
+import store from "#/store";
+import { initialState as browserInitialState } from "#/state/browserSlice";
+
 /**
- * Clear the session data from the local storage. This will remove the token and repo
+ * Clear the session data from the local storage and reset relevant Redux state
  */
 export const clearSession = () => {
+  // Clear local storage
   localStorage.removeItem("token");
   localStorage.removeItem("repo");
+
+  // Reset browser state to initial values
+  store.dispatch({
+    type: "browser/setUrl",
+    payload: browserInitialState.url,
+  });
+  store.dispatch({
+    type: "browser/setScreenshotSrc",
+    payload: browserInitialState.screenshotSrc,
+  });
 };


### PR DESCRIPTION
This pull request fixes #4941.

The issue has been successfully resolved through PR #4942. The fix addresses the core problem of browser screenshots persisting between sessions by:

1. Modifying the session clearing functionality in `/workspace/frontend/src/utils/clear-session.ts` to properly reset the Redux state
2. Specifically targeting the browser slice of the Redux store, resetting both URL and screenshot data to initial values
3. Implementing and successfully running tests to verify both localStorage cleanup and browser state reset functionality

The test results confirm the changes work as intended, with the only test failures being unrelated to this fix (i18n declaration files). The implementation ensures that when a new session starts, the browser tab will be properly cleared of any previous screenshots.

For the human reviewer: This PR implements a fix for browser screenshots persisting between sessions by adding Redux state cleanup for the browser slice in the clear-session utility. The changes have been verified with new test cases, and all relevant tests are passing. The implementation maintains existing localStorage cleanup while adding the necessary state reset functionality.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:775e06d-nikolaik   --name openhands-app-775e06d   docker.all-hands.dev/all-hands-ai/openhands:775e06d
```