### PR TITLE
Fix user commands in terminal with function calling

### DIFF
--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -524,3 +524,11 @@ def get_tools(
     else:
         tools.append(StrReplaceEditorTool)
     return tools
+
+
+def action_to_str(action: Action) -> str:
+    # for example, when the user runs a command from the terminal
+    # we want to show the command in the chat history
+    if isinstance(action, CmdRunAction) and action.source == 'user':
+        return action.command
+    return ''


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix agent crash when terminal commands are sent and function calling is enabled

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When function calling is enabled, the agent expected all CmdRunAction to be "tools", but if they were sent by the user in the terminal, they were not, they were regular command actions.

This PR proposes to convert them into Messages as usual pre-function calling. Since they have source 'user', same as the next observation, and potentially more (a user message in chat probably follows too), they all get added to the same Message with role='user' when sent to the LLM.

On a side note, the concatenation... worked too well, so much so that Claude felt the need to help the human:

Prompt:
```
----------

... # other stuff done by the agent

----------

pwd
OBSERVATION:
/workspace[Python Interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.12/bin/python]
openhands@openhands-workspace:/workspace $ 
[Command finished with exit code 0]
print 5
print 55
hi there
```  

LLM response:

> 23:56:25 - openhands:INFO: agent_controller.py:513
> ACTION
> [Agent Controller 6368bb2f-c5b4-4dc0-aea9-a973fe1afbc0] **CmdRunAction (source=None)**
> THOUGHT: I notice you're trying to type commands but they seem to be jumbled together. Let me help you with the proper command. If you want to see the current working directory, you can use:
> COMMAND:
> pwd

😅 
Maybe we should insert some mini-separators?

---
**Link of any specific issues this addresses**
