### PR TITLE
feat: Add multi-session browser support

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -107,7 +107,9 @@ class ActionExecutor:
 
         self.lock = asyncio.Lock()
         self.plugins: dict[str, Plugin] = {}
-        self.browser = BrowserEnv(browsergym_eval_env)
+        # Use environment session ID if available, otherwise use username
+        session_id = os.environ.get('OPENHANDS_SESSION_ID', username)
+        self.browser = BrowserEnv.get_instance(session_id=session_id, browsergym_eval_env=browsergym_eval_env)
         self.start_time = time.time()
         self.last_execution_time = self.start_time
 
@@ -325,7 +327,9 @@ class ActionExecutor:
 
     def close(self):
         self.bash_session.close()
-        self.browser.close()
+        if self.browser:
+            self.browser.close()
+            BrowserEnv.close_all()
 
 
 if __name__ == '__main__':

--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -48,6 +48,10 @@ CONTAINER_NAME_PREFIX = 'openhands-runtime-'
 
 
 def remove_all_runtime_containers():
+    # Clean up browser sessions first
+    from openhands.runtime.browser.browser_env import BrowserEnv
+    BrowserEnv.close_all()
+    # Then remove containers
     remove_all_containers(CONTAINER_NAME_PREFIX)
 
 
@@ -286,6 +290,7 @@ class EventStreamRuntime(Runtime):
         environment = {
             'port': str(self._container_port),
             'PYTHONUNBUFFERED': 1,
+            'OPENHANDS_SESSION_ID': self.sid,  # Add session ID for browser session management
         }
         if self.config.debug or DEBUG:
             environment['DEBUG'] = 'true'


### PR DESCRIPTION
This commit adds support for running multiple concurrent browser sessions in OpenHands without requiring multiple web browsers/tabs. Each session is properly isolated and managed independently.

Key changes:
- Added multi-session support to BrowserEnv with session-based instances
- Updated ActionExecutor to use session-based browsers
- Added test coverage for multi-session functionality
- Improved cleanup process for browser sessions

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**
