### PR TITLE
fix(frontend): Recover full message history if exists

### DIFF
--- a/frontend/src/components/event-handler.tsx
+++ b/frontend/src/components/event-handler.tsx
@@ -14,7 +14,6 @@ import {
 } from "#/context/ws-client-provider";
 import { ErrorObservation } from "#/types/core/observations";
 import { addErrorMessage, addUserMessage } from "#/state/chatSlice";
-import { handleAssistantMessage } from "#/services/actions";
 import {
   getCloneRepoCommand,
   getGitHubTokenCommand,
@@ -112,9 +111,7 @@ export function EventHandler({ children }: React.PropsWithChildren) {
           message: event.message,
         }),
       );
-      return;
     }
-    handleAssistantMessage(event);
   }, [events.length]);
 
   React.useEffect(() => {

--- a/frontend/src/components/event-message.tsx
+++ b/frontend/src/components/event-message.tsx
@@ -1,0 +1,54 @@
+import { UserMessageAction } from "#/types/core/actions";
+import { LocalUserMessageAction } from "#/types/core/variances";
+import {
+  isLocalUserMessage,
+  isUserMessageAction,
+  isAssistantMessageAction,
+} from "#/utils/type-guards";
+import { ChatMessage } from "./chat-message";
+import ConfirmationButtons from "./chat/ConfirmationButtons";
+import { ErrorMessage } from "./error-message";
+import { ImageCarousel } from "./image-carousel";
+
+const isErrorMessage = (
+  message: Record<string, unknown>,
+): message is ErrorMessage => "error" in message;
+
+const isUserMessage = (
+  message: unknown,
+): message is LocalUserMessageAction | UserMessageAction =>
+  isLocalUserMessage(message) || isUserMessageAction(message);
+
+interface EventMessageProps {
+  message: Record<string, unknown>;
+  isAwaitingUserConfirmation?: boolean;
+}
+
+export function EventMessage({
+  message,
+  isAwaitingUserConfirmation,
+}: EventMessageProps) {
+  if (isErrorMessage(message)) {
+    return <ErrorMessage id={message.id} message={message.message} />;
+  }
+
+  if (isAssistantMessageAction(message)) {
+    return (
+      <ChatMessage type="assistant" message={message.args.content}>
+        {isAwaitingUserConfirmation && <ConfirmationButtons />}
+      </ChatMessage>
+    );
+  }
+
+  if (isUserMessage(message)) {
+    return (
+      <ChatMessage type="user" message={message.args.content}>
+        {message.args.image_urls.length > 0 && (
+          <ImageCarousel size="small" images={message.args.image_urls} />
+        )}
+      </ChatMessage>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -4,6 +4,7 @@ import { Settings } from "#/services/settings";
 import ActionType from "#/types/ActionType";
 import EventLogger from "#/utils/event-logger";
 import AgentState from "#/types/AgentState";
+import { handleAssistantMessage } from "#/services/actions";
 
 const RECONNECT_RETRIES = 5;
 
@@ -80,6 +81,8 @@ export function WsClientProvider({
     ) {
       setStatus(WsClientProviderStatus.ERROR);
     }
+
+    handleAssistantMessage(event);
   }
 
   function handleClose() {

--- a/frontend/src/utils/type-guards.ts
+++ b/frontend/src/utils/type-guards.ts
@@ -1,0 +1,38 @@
+import {
+  AssistantMessageAction,
+  UserMessageAction,
+} from "#/types/core/actions";
+import { LocalUserMessageAction } from "#/types/core/variances";
+
+const isValidObject = (data: unknown): data is object =>
+  typeof data === "object" && data !== null;
+
+export const isLocalUserMessage = (
+  message: unknown,
+): message is LocalUserMessageAction =>
+  isValidObject(message) &&
+  "action" in message &&
+  message.action === "message" &&
+  "args" in message &&
+  typeof message.args === "object" &&
+  message.args !== null &&
+  "content" in message.args &&
+  "image_urls" in message.args;
+
+export const isUserMessageAction = (
+  message: unknown,
+): message is UserMessageAction =>
+  isValidObject(message) &&
+  "action" in message &&
+  message.action === "message" &&
+  "source" in message &&
+  message.source === "user";
+
+export const isAssistantMessageAction = (
+  message: unknown,
+): message is AssistantMessageAction =>
+  isValidObject(message) &&
+  "action" in message &&
+  message.action === "message" &&
+  "source" in message &&
+  message.source === "agent";


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
@tofarr I too would have preferred keeping this logic away from the new WS context but I had to use `handleAssistantMessage(event);` to update the data as it came (previously we defined the onmessage handler in the component rather than the context)

---
**Link of any specific issues this addresses**
Resolves #4938