### PR TITLE
Add a "community" page with maintainer info

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,40 @@
+# 🙌 The OpenHands Community
+
+The OpenHands community is built around the belief that (1) AI and AI agents are going to fundamentally change the way we build software, and (2) if this is true, we should do everything we can to make sure that the benefits provided by such powerful technology are accessible to everyone.
+
+If this resonates with you, we'd love to have you join us in our quest!
+
+## 🤝 How to Join
+
+We do most of our communication through Slack, so this is the best place to start, but we also are happy to have you contact us on Discord or Github.
+
+- [Join our Slack workspace](https://join.slack.com/t/openhands-ai/shared_invite/zt-2tom0er4l-JeNUGHt_AxpEfIBstbLPiw) - Here we talk about research, architecture, and future development.
+- [Join our Discord server](https://discord.gg/ESHStjSjD4) - This is a community-run server for general discussion, questions, and feedback.
+- [Read and post Github Issues](https://github.com/All-Hands-AI/OpenHands/issues) - Check out the issues we're working on, or add your own ideas.
+
+## 💪 Becoming a Contributor
+
+We welcome contributions from everyone! Whether you're a developer, a researcher, or simply enthusiastic about advancing the field of software engineering with AI, there are many ways to get involved:
+
+- **Code Contributions:** Help us develop new core functionality, improve our agents, improve the frontend and other interfaces, or anything else that would help make OpenHands better.
+- **Research and Evaluation:** Contribute to our understanding of LLMs in software engineering, participate in evaluating the models, or suggest improvements.
+- **Feedback and Testing:** Use the OpenHands toolset, report bugs, suggest features, or provide feedback on usability.
+
+For details, please check [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Code of Conduct
+
+We have a [Code of Conduct](./CODE_OF_CONDUCT.md) that we expect all contributors to adhere to.
+Long story short, we are aiming for an open, welcoming, diverse, inclusive, and healthy community.
+All contributors are expected to contribute to building this sort of community.
+
+## 🛠️ Becoming a Maintainer
+
+For contributors who have made significant and sustained contributions to the project, there is a possibility of joining the maintainer team.
+The process for this is as follows:
+
+1. Any contributor who has had at least 5 PRs accepted into the codebase can be nominated by any maintainer. If you are interested you can reach out to any of the maintainers that have reviewed your PRs and ask for a nomination.
+2. Once a maintainer nominates a new maintainer, there will be a discussion period among the maintainers for at least 3 days.
+3. If no concerns are raised the nomination will be accepted by acclamation, and if concerns are raised there will be a discussion and possible vote.
+
+Note that just because someone has made 5 PRs does not mean they will be accepted as a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -33,8 +33,8 @@ All contributors are expected to contribute to building this sort of community.
 For contributors who have made significant and sustained contributions to the project, there is a possibility of joining the maintainer team.
 The process for this is as follows:
 
-1. Any contributor who has had at least 5 PRs accepted into the codebase can be nominated by any maintainer. If you are interested you can reach out to any of the maintainers that have reviewed your PRs and ask for a nomination.
+1. Any contributor who has made sustained and high-quality contributions to the codebase can be nominated by any maintainer. If you feel that you may qualify you can reach out to any of the maintainers that have reviewed your PRs and ask if you can be nominated.
 2. Once a maintainer nominates a new maintainer, there will be a discussion period among the maintainers for at least 3 days.
 3. If no concerns are raised the nomination will be accepted by acclamation, and if concerns are raised there will be a discussion and possible vote.
 
-Note that just because someone has made 5 PRs does not mean they will be accepted as a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](./CODE_OF_CONDUCT.md).
+Note that just making many PRs does not immediately imply that you will become a maintainer. We will be looking at sustained high-quality contributions over a period of time, as well as good teamwork and adherence to our [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -77,25 +77,15 @@ To learn more about the project, and for tips on using OpenHands,
 There you'll find resources on how to use different LLM providers,
 troubleshooting resources, and advanced configuration options.
 
-## 🤝 How to Contribute
+## 🤝 How to Join the Community
 
-OpenHands is a community-driven project, and we welcome contributions from everyone.
-Whether you're a developer, a researcher, or simply enthusiastic about advancing the field of
-software engineering with AI, there are many ways to get involved:
+OpenHands is a community-driven project, and we welcome contributions from everyone. As a first step, you can:
 
-- **Code Contributions:** Help us develop new agents, core functionality, the frontend and other interfaces, or sandboxing solutions.
-- **Research and Evaluation:** Contribute to our understanding of LLMs in software engineering, participate in evaluating the models, or suggest improvements.
-- **Feedback and Testing:** Use the OpenHands toolset, report bugs, suggest features, or provide feedback on usability.
+- [Join our Slack workspace](https://join.slack.com/t/openhands-ai/shared_invite/zt-2tom0er4l-JeNUGHt_AxpEfIBstbLPiw) - Here we talk about research, architecture, and future development.
+- [Join our Discord server](https://discord.gg/ESHStjSjD4) - This is a community-run server for general discussion, questions, and feedback.
+- [Read or post Github Issues](https://github.com/All-Hands-AI/OpenHands/issues) - Check out the issues we're working on, or add your own ideas.
 
-For details, please check [CONTRIBUTING.md](./CONTRIBUTING.md).
-
-## 🤖 Join Our Community
-
-Whether you're a developer, a researcher, or simply enthusiastic about OpenHands, we'd love to have you in our community.
-Let's make software engineering better together!
-
-- [Slack workspace](https://join.slack.com/t/openhands-ai/shared_invite/zt-2tom0er4l-JeNUGHt_AxpEfIBstbLPiw) - Here we talk about research, architecture, and future development.
-- [Discord server](https://discord.gg/ESHStjSjD4) - This is a community-run server for general discussion, questions, and feedback.
+See more about the community in [COMMUNITY.md](./COMMUNITY.md) or find details on contributing in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## 📈 Progress
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

This PR adds a somewhat more organized "community" page, and importantly adds information about how we nominate maintainers

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The maintainer policy is just a draft/RFP. I'd like maintainers to comment if you can!

---
**Link of any specific issues this addresses**

We did not have a clear policy about how maintainers are nominated, but this will fix that.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:96d82db-nikolaik   --name openhands-app-96d82db   docker.all-hands.dev/all-hands-ai/openhands:96d82db
```