### PR TITLE
Context Window Exceeded fix

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -733,7 +733,7 @@ class AgentController:
             # Normal loading from start_id
             events = list(
                 self.event_stream.get_events(
-                    start_id=self.state.start_id if self.state.start_id >= 0 else 0,
+                    start_id=start_id,
                     end_id=end_id,
                     reverse=False,
                     filter_out_type=self.filter_out,

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -276,6 +276,8 @@ class AgentController:
             and len(self.state.history)
             > self.agent.llm.config.max_conversation_window * 2
         ):
+            self._trim_history()
+
             # Find first agent action in history
             first_agent_action_idx = None
             for i, event in enumerate(self.state.history):
@@ -836,6 +838,47 @@ class AgentController:
 
         # restore original order
         return list(reversed(kept_events))
+
+    def _trim_history(self):
+        """Trims the history to the conversation window size."""
+        if self.agent.llm.config.max_conversation_window is None:
+            return
+
+        max_window_size = self.agent.llm.config.max_conversation_window * 2
+
+        # find the first observation in history, which has a cause
+        # and whose cause is an action with source=agent
+        # or agent messages
+        oldest_obs = None
+        for event in self.state.history:
+            # find an old agent action and obs
+            if isinstance(event, Observation) and event.cause is not None:
+                oldest_obs_cause = event.cause
+                if (
+                    isinstance(oldest_obs_cause, Action)
+                    and oldest_obs_cause.source is not None
+                    and oldest_obs_cause.source == EventSource.AGENT
+                ):
+                    oldest_obs = event
+                    # clean up this pair
+                    self.state.history = [
+                        ev
+                        for ev in self.state.history
+                        if ev.id not in (oldest_obs.id, oldest_obs_cause.id)
+                    ]
+
+                    # if conversation window is now satisfied, break
+                    if len(self.state.history) <= max_window_size:
+                        break
+            # or find an old agent message
+            elif isinstance(event, MessageAction) and event.source == EventSource.AGENT:
+                # clean it up
+                self.state.history = [
+                    ev for ev in self.state.history if ev.id != event.id
+                ]
+                # if conversation window is now satisfied, break
+                if len(self.state.history) <= max_window_size:
+                    break
 
     def _is_stuck(self):
         """Checks if the agent or its delegate is stuck in a loop.

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -816,8 +816,8 @@ class AgentController:
             None,
         )
 
-        # Initial cut in half
-        mid_point = len(events) // 2
+        # cut in half
+        mid_point = max(1, len(events) // 2)
         kept_events = events[mid_point:]
 
         # Handle first event in truncated history

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -705,7 +705,7 @@ class AgentController:
                 (
                     e
                     for e in self.event_stream.get_events(
-                        start_id=self.state.start_id if self.state.start_id >= 0 else 0,
+                        start_id=start_id,
                         end_id=end_id,
                         reverse=False,
                         filter_out_type=self.filter_out,
@@ -718,28 +718,20 @@ class AgentController:
             if first_user_msg:
                 events.append(first_user_msg)
 
-            # Get rest of history from truncation point
-            truncated_events = list(
-                self.event_stream.get_events(
-                    start_id=self.state.truncation_id,
-                    end_id=end_id,
-                    reverse=False,
-                    filter_out_type=self.filter_out,
-                    filter_hidden=True,
-                )
+            # the rest of the events are from the truncation point
+            start_id = self.state.truncation_id
+
+        # Get rest of history
+        events_to_add = list(
+            self.event_stream.get_events(
+                start_id=start_id,
+                end_id=end_id,
+                reverse=False,
+                filter_out_type=self.filter_out,
+                filter_hidden=True,
             )
-            events.extend(truncated_events)
-        else:
-            # Normal loading from start_id
-            events = list(
-                self.event_stream.get_events(
-                    start_id=start_id,
-                    end_id=end_id,
-                    reverse=False,
-                    filter_out_type=self.filter_out,
-                    filter_hidden=True,
-                )
-            )
+        )
+        events.extend(events_to_add)
 
         # Find all delegate action/observation pairs
         delegate_ranges: list[tuple[int, int]] = []

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -699,7 +699,7 @@ class AgentController:
         events: list[Event] = []
 
         # If we have a truncation point, get first user message and then rest of history
-        if hasattr(self.state, 'truncation_id') and self.state.truncation_id:
+        if hasattr(self.state, 'truncation_id') and self.state.truncation_id > 0:
             # Find first user message from stream
             first_user_msg = next(
                 (
@@ -822,7 +822,7 @@ class AgentController:
 
         # Handle first event in truncated history
         if kept_events:
-            i = mid_point
+            i = 0
             while i < len(kept_events):
                 first_event = kept_events[i]
                 if isinstance(first_event, Observation) and first_event.cause:

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -700,7 +700,6 @@ class AgentController:
 
         # If we have a truncation point, get first user message and then rest of history
         if hasattr(self.state, 'truncation_id') and self.state.truncation_id:
-            # Get events from start_id until we find first user message
             # Find first user message from stream
             first_user_msg = next(
                 (

--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -92,6 +92,8 @@ class State:
     # start_id and end_id track the range of events in history
     start_id: int = -1
     end_id: int = -1
+    # truncation_id tracks where to load history after context window truncation
+    truncation_id: int = -1
     almost_stuck: int = 0
     delegates: dict[tuple[int, int], tuple[str, str]] = field(default_factory=dict)
     # NOTE: This will never be used by the controller, but it can be used by different

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -43,7 +43,6 @@ class LLMConfig:
         log_completions: Whether to log LLM completions to the state.
         log_completions_folder: The folder to log LLM completions to. Required if log_completions is True.
         draft_editor: A more efficient LLM to use for file editing. Introduced in [PR 3985](https://github.com/All-Hands-AI/OpenHands/pull/3985).
-        max_conversation_window: Maximum number of message pairs (action+observation) to keep in history
     """
 
     model: str = 'claude-3-5-sonnet-20241022'
@@ -78,9 +77,6 @@ class LLMConfig:
     log_completions: bool = False
     log_completions_folder: str = os.path.join(LOG_DIR, 'completions')
     draft_editor: Optional['LLMConfig'] = None
-    max_conversation_window: int | None = (
-        None  # maximum number of message pairs (action+observation) to keep in history
-    )
 
     def defaults_to_dict(self) -> dict:
         """Serialize fields to a dict for the frontend, including type hints, defaults, and whether it's optional."""

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -43,6 +43,7 @@ class LLMConfig:
         log_completions: Whether to log LLM completions to the state.
         log_completions_folder: The folder to log LLM completions to. Required if log_completions is True.
         draft_editor: A more efficient LLM to use for file editing. Introduced in [PR 3985](https://github.com/All-Hands-AI/OpenHands/pull/3985).
+        max_conversation_window: Maximum number of message pairs (action+observation) to keep in history
     """
 
     model: str = 'claude-3-5-sonnet-20241022'
@@ -77,6 +78,9 @@ class LLMConfig:
     log_completions: bool = False
     log_completions_folder: str = os.path.join(LOG_DIR, 'completions')
     draft_editor: Optional['LLMConfig'] = None
+    max_conversation_window: int | None = (
+        None  # maximum number of message pairs (action+observation) to keep in history
+    )
 
     def defaults_to_dict(self) -> dict:
         """Serialize fields to a dict for the frontend, including type hints, defaults, and whether it's optional."""

--- a/tests/unit/test_truncation.py
+++ b/tests/unit/test_truncation.py
@@ -86,6 +86,7 @@ class TestTruncation:
         cmd1 = CmdRunAction(command='ls')
         cmd1._id = 2
         obs1 = CmdOutputObservation(command='ls', content='file1.txt', command_id=2)
+        obs1._id = 3
         obs1._cause = 2
 
         # Set up mock event stream to return our events

--- a/tests/unit/test_truncation.py
+++ b/tests/unit/test_truncation.py
@@ -1,0 +1,176 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from litellm.exceptions import ContextWindowExceededError
+
+from openhands.controller.agent_controller import AgentController
+from openhands.events import EventSource, EventStream
+from openhands.events.action import CmdRunAction, MessageAction
+from openhands.events.observation import CmdOutputObservation
+from openhands.storage import get_file_store
+
+
+@pytest.fixture
+def temp_dir(tmp_path_factory: pytest.TempPathFactory) -> str:
+    return str(tmp_path_factory.mktemp('test_truncation'))
+
+
+@pytest.fixture
+def event_stream(temp_dir):
+    file_store = get_file_store('local', temp_dir)
+    event_stream = EventStream('test_truncation', file_store)
+    yield event_stream
+    event_stream.clear()
+
+
+@pytest.fixture
+def mock_agent():
+    return MagicMock()
+
+
+class TestTruncation:
+    def test_apply_conversation_window_basic(self, event_stream, mock_agent):
+        controller = AgentController(
+            agent=mock_agent,
+            event_stream=event_stream,
+            max_iterations=10,
+            sid='test_truncation',
+            confirmation_mode=False,
+            headless_mode=True,
+        )
+
+        # Create a sequence of events
+        first_msg = MessageAction(content='Hello, start task', wait_for_response=False)
+        first_msg._source = EventSource.USER
+        first_msg._id = 1
+
+        cmd1 = CmdRunAction(command='ls')
+        cmd1._id = 2
+        obs1 = CmdOutputObservation(command='ls', content='file1.txt', command_id=2)
+        obs1._cause = cmd1._id
+
+        cmd2 = CmdRunAction(command='pwd')
+        cmd2._id = 3
+        obs2 = CmdOutputObservation(command='pwd', content='/home', command_id=3)
+        obs2._cause = cmd2._id
+
+        events = [first_msg, cmd1, obs1, cmd2, obs2]
+
+        # Apply truncation
+        truncated = controller._apply_conversation_window(events)
+
+        # Should keep first user message and roughly half of other events
+        assert (
+            len(truncated) >= 3
+        )  # First message + at least one action-observation pair
+        assert truncated[0] == first_msg  # First message always preserved
+        assert controller.state.start_id == first_msg._id
+        assert controller.state.truncation_id is not None
+
+        # Verify pairs aren't split
+        for i, event in enumerate(truncated[1:]):
+            if isinstance(event, CmdOutputObservation):
+                assert any(e._id == event._cause for e in truncated[: i + 1])
+
+    @pytest.mark.asyncio
+    async def test_context_window_exceeded_handling(self, event_stream, mock_agent):
+        controller = AgentController(
+            agent=mock_agent,
+            event_stream=event_stream,
+            max_iterations=10,
+            sid='test_truncation',
+            confirmation_mode=False,
+            headless_mode=True,
+        )
+
+        # Setup initial history
+        first_msg = MessageAction(content='Start task', wait_for_response=False)
+        first_msg._source = EventSource.USER
+        first_msg._id = 1
+        event_stream.add_event(first_msg, EventSource.USER)
+
+        cmd1 = CmdRunAction(command='ls')
+        cmd1._id = 2
+        event_stream.add_event(cmd1, EventSource.AGENT)
+
+        obs1 = CmdOutputObservation(command='ls', content='file1.txt', command_id=2)
+        obs1._cause = cmd1._id
+        event_stream.add_event(obs1, EventSource.ENVIRONMENT)
+
+        # Initialize controller history
+        await controller._init_history()
+        original_history_len = len(controller.state.history)
+
+        # Simulate ContextWindowExceededError
+        with patch.object(mock_agent, 'step', side_effect=ContextWindowExceededError()):
+            await controller._step()
+
+        # Verify truncation occurred
+        assert len(controller.state.history) < original_history_len
+        assert controller.state.start_id == first_msg._id
+        assert controller.state.truncation_id is not None
+        assert controller.state.truncation_id > controller.state.start_id
+
+    @pytest.mark.asyncio
+    async def test_history_restoration_after_truncation(self, event_stream, mock_agent):
+        controller = AgentController(
+            agent=mock_agent,
+            event_stream=event_stream,
+            max_iterations=10,
+            sid='test_truncation',
+            confirmation_mode=False,
+            headless_mode=True,
+        )
+
+        # Add events to stream
+        first_msg = MessageAction(content='Start task', wait_for_response=False)
+        first_msg._source = EventSource.USER
+        first_msg._id = 1
+        event_stream.add_event(first_msg, EventSource.USER)
+
+        for i in range(5):
+            cmd = CmdRunAction(command=f'cmd{i}')
+            cmd._id = i + 2
+            event_stream.add_event(cmd, EventSource.AGENT)
+
+            obs = CmdOutputObservation(
+                command=f'cmd{i}', content=f'output{i}', command_id=cmd._id
+            )
+            obs._cause = cmd._id
+            event_stream.add_event(obs, EventSource.ENVIRONMENT)
+
+        # Initialize and force truncation
+        await controller._init_history()
+        original_history = controller.state.history.copy()
+
+        # Simulate truncation
+        truncated = controller._apply_conversation_window(original_history)
+        controller.state.history = truncated
+
+        # Save truncation state
+        saved_start_id = controller.state.start_id
+        saved_truncation_id = controller.state.truncation_id
+
+        # Create new controller instance
+        new_controller = AgentController(
+            agent=mock_agent,
+            event_stream=event_stream,
+            max_iterations=10,
+            sid='test_truncation',
+            confirmation_mode=False,
+            headless_mode=True,
+        )
+        new_controller.state.start_id = saved_start_id
+        new_controller.state.truncation_id = saved_truncation_id
+
+        # Initialize history with saved IDs
+        await new_controller._init_history()
+
+        # Verify restoration
+        assert len(new_controller.state.history) == len(truncated)
+        assert new_controller.state.history[0] == first_msg
+        assert new_controller.state.start_id == saved_start_id
+        assert all(
+            isinstance(e, (MessageAction, CmdRunAction, CmdOutputObservation))
+            for e in new_controller.state.history
+        )


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Truncate agent history when context window is exceeded

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes a simple fix for the ContextWindowExceededError:
- when raised, truncate the context roughly in half
- save state and reload the truncated history when session is restored

Please note that this is not well tested, but it is ready for code review.

---
**Link of any specific issues this addresses**
Fix https://github.com/All-Hands-AI/OpenHands/issues/4951
Fix https://github.com/All-Hands-AI/OpenHands/issues/4894

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2fcb088-nikolaik   --name openhands-app-2fcb088   docker.all-hands.dev/all-hands-ai/openhands:2fcb088
```