### PR TITLE
Clean up file logs

### DIFF
--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import re
@@ -45,6 +46,29 @@ LOG_COLORS: Mapping[str, ColorType] = {
 }
 
 
+class NoColorFormatter(logging.Formatter):
+    """Formatter for non-colored logging in files."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Create a deep copy of the record to avoid modifying the original
+        new_record: logging.LogRecord = copy.deepcopy(record)
+        # Strip ANSI color codes from the message
+        new_record.msg = strip_ansi(new_record.msg)
+
+        return super().format(new_record)
+
+
+def strip_ansi(s: str) -> str:
+    """
+    Removes ANSI escape sequences from str, as defined by ECMA-048 in
+    http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf
+    # https://github.com/ewen-lbh/python-strip-ansi/blob/master/strip_ansi/__init__.py
+    """
+    pattern = re.compile(r'\x1B\[\d+(;\d+){0,2}m')
+    stripped = pattern.sub('', s)
+    return stripped
+
+
 class ColoredFormatter(logging.Formatter):
     def format(self, record):
         msg_type = record.__dict__.get('msg_type')
@@ -70,7 +94,7 @@ class ColoredFormatter(logging.Formatter):
         return super().format(record)
 
 
-file_formatter = logging.Formatter(
+file_formatter = NoColorFormatter(
     '%(asctime)s - %(name)s:%(levelname)s: %(filename)s:%(lineno)s - %(message)s',
     datefmt='%H:%M:%S',
 )


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes to clean up the file logs stripping the ANSI sequences.

Before:
```
    ^[[92m23:31:24 - openhands:DEBUG^[[0m: action_execution_server.py:167 - Action output:
    |**IPythonRunCellObservation**
    |[Code executed successfully with no output]
    |[Jupyter current working directory: /workspace]
    |[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.12/bin/python]
    |^[[92m23:31:24 - openhands:DEBUG^[[0m: event.py:89 - Event to dict: {'message': 'Code executed in IPython cell.', 'observation': 'run_ipython', 'content': '[Code executed successfully with no output]\n[Jupyter current working directory: /workspace]\n[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.12/bin/python]', 'extras': {'code': 'import os\nos.environ...
```

After:
```
    |19:28:20 - openhands:DEBUG: action_execution_server.py:167 - Action output:
    |**IPythonRunCellObservation**
    |[Code executed successfully with no output]
    |[Jupyter current working directory: /workspace]
    |[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.12/bin/python]
    |19:28:20 - openhands:DEBUG: event.py:89 - Event to dict: {'message': 'Code executed in IPython cell.', 'observation': 'run_ipython', 'content': '[Code executed successfully with no output]\n[Jupyter current working directory: /workspace]\n[Jupyter Python interpreter: /openhands/poetry/openhands-ai-5O4_aCHf-py3.12/bin/python]', 'extras': {'code': 'import os\nos.environ
```
---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:059046b-nikolaik   --name openhands-app-059046b   docker.all-hands.dev/all-hands-ai/openhands:059046b
```