### PR TITLE
Fix issue #4985: [Bug]: Cannot exit the session when on Jupyter or Browser tab in the UI

### DIFF
--- a/frontend/src/routes/_oh.tsx
+++ b/frontend/src/routes/_oh.tsx
@@ -243,7 +243,7 @@ export default function MainApp() {
               type="button"
               aria-label="All Hands Logo"
               onClick={() => {
-                if (location.pathname === "/app")
+                if (location.pathname.startsWith("/app"))
                   setStartNewProjectModalIsOpen(true);
               }}
             >


### PR DESCRIPTION
This pull request fixes #4985.

Based on the issue description and AI agent's solution, the problem has been successfully resolved. The original bug was that the OpenHands icon (exit button) wasn't working on the Jupyter or Browser tabs, only functioning on the main workspace tab. 

The fix was simple but effective - instead of using a strict path equality check (`location.pathname === "/app"`), the code now uses `location.pathname.startsWith("/app")`. This change means the exit functionality will work on any path that begins with "/app", including:
- /app (main workspace)
- /app/jupyter
- /app/browser

This modification ensures users can exit their session from any tab in the UI, which directly addresses the reported bug. The solution maintains consistent behavior across the application while using a more inclusive path-matching approach.

A good PR description for human review would be:
"Fixed exit button functionality on Jupyter and Browser tabs by modifying path check condition. The exit button now works consistently across all application tabs by matching any path that starts with '/app' instead of requiring an exact match. This ensures users can exit their session from any location in the application."

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7f5dfbc-nikolaik   --name openhands-app-7f5dfbc   docker.all-hands.dev/all-hands-ai/openhands:7f5dfbc
```