### PR TITLE
Fix resource leaks in runtime and server components

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -51,7 +51,20 @@ class Session:
 
     def close(self):
         self.is_alive = False
-        self.agent_session.close()
+        try:
+            if self.websocket is not None:
+                # Schedule websocket close in the event loop to avoid RuntimeError
+                asyncio.run_coroutine_threadsafe(
+                    self.websocket.close(), self.loop
+                )
+                self.websocket = None
+        except Exception as e:
+            logger.error(f'Error closing websocket: {e}')
+        finally:
+            try:
+                self.agent_session.close()
+            except Exception as e:
+                logger.error(f'Error closing agent session: {e}')
 
     async def loop_recv(self):
         try:


### PR DESCRIPTION
This PR fixes file descriptor and network connection leaks identified in the OpenHands project. The changes include:

### Changes

1. **Request Sessions**:
   - Added proper cleanup of request sessions in all runtime implementations
   - Added error handling and logging for session cleanup failures
   - Added checks to prevent NullPointerExceptions during cleanup
   - Ensured sessions are closed even if runtime stop fails

2. **WebSocket Connections**:
   - Added proper cleanup of WebSocket connections in the server
   - Added async-safe WebSocket closure using the event loop
   - Added error handling and logging for WebSocket cleanup failures
   - Nulled out WebSocket references after cleanup

3. **Runtime Resources**:
   - Added proper cleanup sequence for runtime resources
   - Added error handling for each cleanup step
   - Added nulling of references after cleanup to help garbage collection
   - Added logging for cleanup failures

4. **Google Cloud Storage**:
   - Added proper cleanup of Google Cloud storage clients
   - Added finalizer to ensure cleanup on object destruction
   - Added state tracking to prevent double-close issues
   - Added error handling and logging for cleanup failures

### Files Changed
- `openhands/runtime/impl/remote/remote_runtime.py`
- `openhands/server/session/session.py`
- `openhands/server/session/agent_session.py`
- `openhands/storage/google_cloud.py`

These changes should help prevent file descriptor and network connection leaks by ensuring proper cleanup of resources in all cases, including error scenarios.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8c1fa93-nikolaik   --name openhands-app-8c1fa93   docker.all-hands.dev/all-hands-ai/openhands:8c1fa93
```