### PR TITLE
Fix markdown ordered list numbering

### DIFF
--- a/frontend/src/components/markdown/list.tsx
+++ b/frontend/src/components/markdown/list.tsx
@@ -13,10 +13,13 @@ export function ul({
 // Custom component to render <ol> in markdown
 export function ol({
   children,
+  ...props
 }: React.ClassAttributes<HTMLElement> &
   React.HTMLAttributes<HTMLElement> &
   ExtraProps) {
   return (
-    <ol className="list-decimal ml-5 pl-2 whitespace-normal">{children}</ol>
+    <ol className="list-decimal ml-5 pl-2 whitespace-normal" {...props}>
+      {children}
+    </ol>
   );
 }

--- a/frontend/src/components/markdown/list.tsx
+++ b/frontend/src/components/markdown/list.tsx
@@ -4,8 +4,8 @@ import { ExtraProps } from "react-markdown";
 // Custom component to render <ul> in markdown
 export function ul({
   children,
-}: React.ClassAttributes<HTMLElement> &
-  React.HTMLAttributes<HTMLElement> &
+}: React.ClassAttributes<HTMLUListElement> &
+  React.HTMLAttributes<HTMLUListElement> &
   ExtraProps) {
   return <ul className="list-disc ml-5 pl-2 whitespace-normal">{children}</ul>;
 }
@@ -14,8 +14,8 @@ export function ul({
 export function ol({
   children,
   start,
-}: React.ClassAttributes<HTMLElement> &
-  React.HTMLAttributes<HTMLElement> &
+}: React.ClassAttributes<HTMLOListElement> &
+  React.OlHTMLAttributes<HTMLOListElement> &
   ExtraProps) {
   return (
     <ol className="list-decimal ml-5 pl-2 whitespace-normal" start={start}>

--- a/frontend/src/components/markdown/list.tsx
+++ b/frontend/src/components/markdown/list.tsx
@@ -13,12 +13,12 @@ export function ul({
 // Custom component to render <ol> in markdown
 export function ol({
   children,
-  ...props
+  start,
 }: React.ClassAttributes<HTMLElement> &
   React.HTMLAttributes<HTMLElement> &
   ExtraProps) {
   return (
-    <ol className="list-decimal ml-5 pl-2 whitespace-normal" {...props}>
+    <ol className="list-decimal ml-5 pl-2 whitespace-normal" start={start}>
       {children}
     </ol>
   );


### PR DESCRIPTION
This PR fixes the markdown renderer to preserve starting numbers in ordered lists. Previously, all ordered lists would start at 1 regardless of the specified starting number.

### Changes
- Modified the ordered list component to pass through all props, including the `start` attribute

### Before
All lists would start at 1:
```markdown
1. First item
2. Second item

5. This would show as 1.
6. This would show as 2.
```

### After
Lists preserve their starting numbers:
```markdown
1. First item
2. Second item

5. This shows as 5.
6. This shows as 6.
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ca5b9ab-nikolaik   --name openhands-app-ca5b9ab   docker.all-hands.dev/all-hands-ai/openhands:ca5b9ab
```