### PR TITLE
Fix markdown ordered lists counter reset

### DIFF
--- a/frontend/src/components/markdown/list.tsx
+++ b/frontend/src/components/markdown/list.tsx
@@ -17,6 +17,11 @@ export function ol({
   React.HTMLAttributes<HTMLElement> &
   ExtraProps) {
   return (
-    <ol className="list-decimal ml-5 pl-2 whitespace-normal" style={{ counterReset: "list-item" }}>{children}</ol>
+    <ol
+      className="list-decimal ml-5 pl-2 whitespace-normal"
+      style={{ counterReset: "list-item" }}
+    >
+      {children}
+    </ol>
   );
 }

--- a/frontend/src/components/markdown/list.tsx
+++ b/frontend/src/components/markdown/list.tsx
@@ -17,6 +17,6 @@ export function ol({
   React.HTMLAttributes<HTMLElement> &
   ExtraProps) {
   return (
-    <ol className="list-decimal ml-5 pl-2 whitespace-normal">{children}</ol>
+    <ol className="list-decimal ml-5 pl-2 whitespace-normal" style={{ counterReset: "list-item" }}>{children}</ol>
   );
 }


### PR DESCRIPTION
This PR fixes the issue where markdown ordered lists were not incrementing numbers correctly. The fix adds a `counterReset: "list-item"` style to ensure each ordered list starts with a fresh counter.

**Changes:**
- Added `style={{ counterReset: "list-item" }}` to the ordered list component
- Maintains existing spacing and styling

**Before:**
All list items showed as "1." instead of incrementing numbers.

**After:**
List items now correctly show as "1.", "2.", "3.", etc.

**Note on Tests:**
Some tests are failing due to missing i18n declarations, which is a separate issue with the test environment setup. These failures are unrelated to our changes since we only modified the markdown list component and its styling.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fd6820f-nikolaik   --name openhands-app-fd6820f   docker.all-hands.dev/all-hands-ai/openhands:fd6820f
```