### PR TITLE
feat: make add_in_context_learning_example configurable in fn call converter

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -307,6 +307,7 @@ def convert_tools_to_description(tools: list[dict]) -> str:
 def convert_fncall_messages_to_non_fncall_messages(
     messages: list[dict],
     tools: list[ChatCompletionToolParam],
+    add_in_context_learning_example: bool = True,
 ) -> list[dict]:
     """Convert function calling messages to non-function calling messages."""
     messages = copy.deepcopy(messages)
@@ -341,7 +342,7 @@ def convert_fncall_messages_to_non_fncall_messages(
         # 2. USER MESSAGES (no change)
         elif role == 'user':
             # Add in-context learning example for the first user message
-            if not first_user_message_encountered:
+            if not first_user_message_encountered and add_in_context_learning_example:
                 first_user_message_encountered = True
                 # Check tools
                 if not (
@@ -751,6 +752,7 @@ def convert_non_fncall_messages_to_fncall_messages(
 
 def convert_from_multiple_tool_calls_to_single_tool_call_messages(
     messages: list[dict],
+    ignore_final_tool_result: bool = False,
 ) -> list[dict]:
     """Break one message with multiple tool calls into multiple messages."""
     converted_messages = []
@@ -787,7 +789,7 @@ def convert_from_multiple_tool_calls_to_single_tool_call_messages(
             ), f'Found pending tool calls but not expect to handle it with role {role}: {pending_tool_calls=}, {message=}'
             converted_messages.append(message)
 
-    if len(pending_tool_calls) > 0:
+    if not ignore_final_tool_result and len(pending_tool_calls) > 0:
         raise FunctionCallConversionError(
             f'Found pending tool calls but no tool result: {pending_tool_calls=}'
         )


### PR DESCRIPTION


**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Make add_in_context_learning_example configurable in fn call converter -- this isn't used any where yet, but will be useful for future model training.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8ca920e-nikolaik   --name openhands-app-8ca920e   docker.all-hands.dev/all-hands-ai/openhands:8ca920e
```