### PR TITLE
Fix issue #5021: Add links to the resolver messages

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -135,7 +135,7 @@ jobs:
               issue_number: ${{ env.ISSUE_NUMBER }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `OpenHands started fixing the ${issueType}! You can monitor the progress [here](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`
+              body: `[OpenHands](https://github.com/All-Hands-AI/OpenHands) started fixing the ${issueType}! You can monitor the progress [here](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`
             });
 
       - name: Install OpenHands
@@ -262,6 +262,6 @@ jobs:
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `The workflow to fix this issue encountered an error. Please check the workflow logs for more information.`
+                body: `The workflow to fix this issue encountered an error. Please check the [workflow logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for more information.`
               });
             }


### PR DESCRIPTION
This pull request fixes #5021.

The PR successfully addresses both requirements from the original issue:

1. Added a backlink to the OpenHands repository by modifying the start message to use Markdown link syntax `[OpenHands](https://github.com/All-Hands-AI/OpenHands)`
2. Added a dynamic link to the workflow logs for failed actions using GitHub context variables: `[workflow logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`

The changes are straightforward modifications to the workflow's message formatting, adding proper Markdown links that will improve navigation and user experience. Since these are purely configuration changes to message formatting and don't affect the functional behavior of the workflow, no additional testing is required.

For a human reviewer, I would summarize this as:
"This PR adds clickable links to the workflow messages for better navigation - both for the OpenHands repository mention and for accessing workflow logs when failures occur. Changes are limited to message formatting only, with no functional modifications to the workflow behavior."

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6edfbc1-nikolaik   --name openhands-app-6edfbc1   docker.all-hands.dev/all-hands-ai/openhands:6edfbc1
```