### PR TITLE
Reduce output from frontend tests

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -91,6 +91,7 @@ export default defineConfig(({ mode }) => {
     test: {
       environment: "jsdom",
       setupFiles: ["vitest.setup.ts"],
+      reporters: "basic",
       exclude: [...configDefaults.exclude, "tests"],
       coverage: {
         reporter: ["text", "json", "html", "lcov", "text-summary"],

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -13,7 +13,7 @@ vi.mock("react-i18next", async (importOriginal) => ({
 }));
 
 // Mock requests during tests
-beforeAll(() => server.listen());
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
 afterEach(() => {
   server.resetHandlers();
   // Cleanup the document body after each test


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- `msw` would output warnings from unhandled requests during tests
<img width="680" alt="image" src="https://github.com/user-attachments/assets/e3084005-7328-4d6b-8aea-8b46680f7b9e">

- Passing test output was too long

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Ignore requests unhandled with `msw`
- Reduce test output by setting the reported to [basic](https://vitest.dev/guide/reporters#basic-reporter). Maybe we can have it dot (like our Python tests)?


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0c37294-nikolaik   --name openhands-app-0c37294   docker.all-hands.dev/all-hands-ai/openhands:0c37294
```