### PR TITLE
Link the resolver link to its new migrated location

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
   <h1 align="center">OpenHands: Code Less, Make More</h1>
 </div>
 
-
 <div align="center">
   <a href="https://github.com/All-Hands-AI/OpenHands/graphs/contributors"><img src="https://img.shields.io/github/contributors/All-Hands-AI/OpenHands?style=for-the-badge&color=blue" alt="Contributors"></a>
   <a href="https://github.com/All-Hands-AI/OpenHands/stargazers"><img src="https://img.shields.io/github/stars/All-Hands-AI/OpenHands?style=for-the-badge&color=blue" alt="Stargazers"></a>
@@ -61,7 +60,7 @@ works best, but you have [many options](https://docs.all-hands.dev/modules/usage
 You can also [connect OpenHands to your local filesystem](https://docs.all-hands.dev/modules/usage/runtimes),
 run OpenHands in a scriptable [headless mode](https://docs.all-hands.dev/modules/usage/how-to/headless-mode),
 interact with it via a [friendly CLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode),
-or run it on tagged issues with [a github action](https://github.com/All-Hands-AI/OpenHands-resolver).
+or run it on tagged issues with [a github action](https://github.com/All-Hands-AI/OpenHands/tree/main/openhands/resolver).
 
 Visit [Installation](https://docs.all-hands.dev/modules/usage/installation) for more information and setup instructions.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <h1 align="center">OpenHands: Code Less, Make More</h1>
 </div>
 
+
 <div align="center">
   <a href="https://github.com/All-Hands-AI/OpenHands/graphs/contributors"><img src="https://img.shields.io/github/contributors/All-Hands-AI/OpenHands?style=for-the-badge&color=blue" alt="Contributors"></a>
   <a href="https://github.com/All-Hands-AI/OpenHands/stargazers"><img src="https://img.shields.io/github/stars/All-Hands-AI/OpenHands?style=for-the-badge&color=blue" alt="Stargazers"></a>


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The Readme.md link to where the github actions openhands-resolver is now pointing to the wrong location, as that codebase has migrated to within this repo

---
**Link of any specific issues this addresses**

Openhands-resolver was migrated in https://github.com/All-Hands-AI/OpenHands/pull/4964
