### PR TITLE
Add error handling for issue references

### DIFF
--- a/openhands/resolver/issue_definitions.py
+++ b/openhands/resolver/issue_definitions.py
@@ -469,17 +469,20 @@ class PRHandler(IssueHandler):
         )
 
         for issue_number in unique_issue_references:
-            url = f'https://api.github.com/repos/{self.owner}/{self.repo}/issues/{issue_number}'
-            headers = {
-                'Authorization': f'Bearer {self.token}',
-                'Accept': 'application/vnd.github.v3+json',
-            }
-            response = requests.get(url, headers=headers)
-            response.raise_for_status()
-            issue_data = response.json()
-            issue_body = issue_data.get('body', '')
-            if issue_body:
-                closing_issues.append(issue_body)
+            try:
+                url = f'https://api.github.com/repos/{self.owner}/{self.repo}/issues/{issue_number}'
+                headers = {
+                    'Authorization': f'Bearer {self.token}',
+                    'Accept': 'application/vnd.github.v3+json',
+                }
+                response = requests.get(url, headers=headers)
+                response.raise_for_status()
+                issue_data = response.json()
+                issue_body = issue_data.get('body', '')
+                if issue_body:
+                    closing_issues.append(issue_body)
+            except requests.exceptions.RequestException as e:
+                logger.warning(f'Failed to fetch issue {issue_number}: {str(e)}')
 
         return closing_issues
 

--- a/tests/unit/resolver/test_issue_handler_error_handling.py
+++ b/tests/unit/resolver/test_issue_handler_error_handling.py
@@ -1,0 +1,94 @@
+import pytest
+import requests
+from unittest.mock import patch, MagicMock
+
+from openhands.resolver.issue_definitions import IssueHandler
+from openhands.resolver.github_issue import ReviewThread
+
+
+def test_handle_nonexistent_issue_reference():
+    handler = IssueHandler("test-owner", "test-repo", "test-token")
+    
+    # Mock the requests.get to simulate a 404 error
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Client Error: Not Found")
+    
+    with patch('requests.get', return_value=mock_response):
+        # Call the method with a non-existent issue reference
+        result = handler._IssueHandler__get_context_from_external_issues_references(
+            closing_issues=[],
+            closing_issue_numbers=[],
+            issue_body="This references #999999",  # Non-existent issue
+            review_comments=[],
+            review_threads=[],
+            thread_comments=None
+        )
+        
+        # The method should return an empty list since the referenced issue couldn't be fetched
+        assert result == []
+
+
+def test_handle_rate_limit_error():
+    handler = IssueHandler("test-owner", "test-repo", "test-token")
+    
+    # Mock the requests.get to simulate a rate limit error
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "403 Client Error: Rate Limit Exceeded"
+    )
+    
+    with patch('requests.get', return_value=mock_response):
+        # Call the method with an issue reference
+        result = handler._IssueHandler__get_context_from_external_issues_references(
+            closing_issues=[],
+            closing_issue_numbers=[],
+            issue_body="This references #123",
+            review_comments=[],
+            review_threads=[],
+            thread_comments=None
+        )
+        
+        # The method should return an empty list since the request was rate limited
+        assert result == []
+
+
+def test_handle_network_error():
+    handler = IssueHandler("test-owner", "test-repo", "test-token")
+    
+    # Mock the requests.get to simulate a network error
+    with patch('requests.get', side_effect=requests.exceptions.ConnectionError("Network Error")):
+        # Call the method with an issue reference
+        result = handler._IssueHandler__get_context_from_external_issues_references(
+            closing_issues=[],
+            closing_issue_numbers=[],
+            issue_body="This references #123",
+            review_comments=[],
+            review_threads=[],
+            thread_comments=None
+        )
+        
+        # The method should return an empty list since the network request failed
+        assert result == []
+
+
+def test_successful_issue_reference():
+    handler = IssueHandler("test-owner", "test-repo", "test-token")
+    
+    # Mock a successful response
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"body": "This is the referenced issue body"}
+    
+    with patch('requests.get', return_value=mock_response):
+        # Call the method with an issue reference
+        result = handler._IssueHandler__get_context_from_external_issues_references(
+            closing_issues=[],
+            closing_issue_numbers=[],
+            issue_body="This references #123",
+            review_comments=[],
+            review_threads=[],
+            thread_comments=None
+        )
+        
+        # The method should return a list with the referenced issue body
+        assert result == ["This is the referenced issue body"]


### PR DESCRIPTION
This PR adds error handling for when referenced issues cannot be fetched from GitHub API. Changes include:

- Added try-catch block around GitHub API calls when fetching referenced issues
- Added unit tests to verify error handling behavior
- Logs warning when an issue cannot be fetched instead of crashing

This builds on top of the changes in #5059 to make issue reference handling more robust.