### PR TITLE
Adding one-click deploy options to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,6 @@ For a list of open source projects and licenses used in OpenHands, please see ou
       url={https://arxiv.org/abs/2407.16741},
 }
 ```
+### One-Click Deployment Options
+
+[![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=307)


### PR DESCRIPTION
Adding button enabling community access to deploy template for self-hosting on RepoCloud.io with one click
