### PR TITLE
Fix issue #5070: [Bug]: lint-fix workflow is failing

### DIFF
--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -43,7 +43,7 @@ jobs:
         run: pip install pre-commit==3.7.0
       - name: Fix python lint issues
         run: |
-          pre-commit run --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml --all-files
+          pre-commit run --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml
 
       # Commit and push changes if any
       - name: Check for changes


### PR DESCRIPTION
This pull request fixes #5070.

The issue has been successfully resolved because:

1. The root cause was clearly identified - the workflow was failing due to using mutually exclusive flags `--all-files` and `--files` in the pre-commit command
2. The fix was straightforward - removing the `--all-files` flag while keeping the `--files` flag with the specified file patterns
3. The solution is appropriate since:
   - Having `--files` with specified patterns (openhands/**/* evaluation/**/* tests/**/*) already covers the necessary files to check
   - The flags were mutually exclusive according to the pre-commit help output shown in the error message
   - No additional workflow or code changes were needed beyond this configuration fix
4. Since this was purely a CI workflow configuration issue, no application code changes or tests were required

The PR can be summarized for reviewers as:
"Fixed the lint-fix workflow by removing the redundant and conflicting `--all-files` flag from the pre-commit command, while maintaining the file pattern specifications with `--files`. This resolves the argument conflict that was causing the workflow to fail."

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6dc76df-nikolaik   --name openhands-app-6dc76df   docker.all-hands.dev/all-hands-ai/openhands:6dc76df
```