### PR TITLE
Fix issue #5080: [Bug]: lint-fix.yml github action doesn't work on a branch not from this repo

### DIFF
--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This pull request fixes #5080.

The issue has been successfully resolved. The original problem was that the GitHub Action was failing when trying to check out code from PRs originating from forks because it couldn't properly access the source repository. The fix implemented adds the correct `repository` parameter to the `actions/checkout` action, specifically using `${{ github.event.pull_request.head.repo.full_name }}` which dynamically references the source repository of the PR.

This solution:
1. Addresses the core issue by ensuring the action can access code from forked repositories
2. Still maintains compatibility with PRs from the same repository
3. Fixes the specific error where the action couldn't find the branch `checkout-a-non-main-branch-option`

The PR reviewer should know that this is a straightforward configuration change to the GitHub Actions workflow that improves the robustness of the lint-fix action by making it work with PRs from both internal branches and external forks. No code changes were required, only workflow configuration updates.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a8ab4bf-nikolaik   --name openhands-app-a8ab4bf   docker.all-hands.dev/all-hands-ai/openhands:a8ab4bf
```