### PR TITLE
fix: run only linting hooks in lint-fix workflow

### DIFF
--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -44,7 +44,11 @@ jobs:
         run: pip install pre-commit==3.7.0
       - name: Fix python lint issues
         run: |
-          pre-commit run --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml
+          pre-commit run trailing-whitespace --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml
+          pre-commit run end-of-file-fixer --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml
+          pre-commit run pyproject-fmt --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml
+          pre-commit run ruff --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml
+          pre-commit run ruff-format --files openhands/**/* evaluation/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml
 
       # Commit and push changes if any
       - name: Check for changes


### PR DESCRIPTION
When the lint-fix.yml workflow runs and tests are failing, git is stopped by pre-commit. This change modifies the workflow to only run linting hooks that can auto-fix issues, skipping test hooks.

Changes:
- Run each linting hook individually instead of running all hooks at once
- Only run hooks that can auto-fix issues (trailing-whitespace, end-of-file-fixer, pyproject-fmt, ruff, ruff-format)
- Skip test hooks and type checking hooks

Fixes: https://github.com/All-Hands-AI/OpenHands/issues/5102

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:38f5c90-nikolaik   --name openhands-app-38f5c90   docker.all-hands.dev/all-hands-ai/openhands:38f5c90
```