### PR TITLE
Add eval workflow that triggers remote eval job

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -1,0 +1,39 @@
+# Run evaluation on a PR
+name: Run Eval
+
+# Runs when a PR is labeled with one of the "run-eval-" labels
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  trigger-job:
+    name: Trigger remote eval job
+    # TODO: Add different labels for different eval instances
+    if: ${{ github.event.label.name == 'run-eval-s' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Trigger remote job
+        run: |
+          REPO_URL="https://github.com/${{ github.repository }}"
+          PR_BRANCH="${{ github.head_ref }}"
+          echo "Repository URL: $REPO_URL"
+          echo "PR Branch: $PR_BRANCH"
+
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.PAT_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -d "{\"ref\": \"main\", \"inputs\": {\"github-repo\": \"${REPO_URL}\", \"github-branch\": \"${PR_BRANCH}\", \"pr-number\": \"${{ github.event.pull_request.number }}\"}}" \
+            https://api.github.com/repos/All-Hands-AI/evaluation/actions/workflows/create-branch.yml/dispatches
+
+          # Send Slack message
+          PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          slack_text="PR $PR_URL has triggered evaluation..."
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"'"$slack_text"'"}' \
+            https://hooks.slack.com/services/${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   trigger-job:
     name: Trigger remote eval job
-    # TODO: Add different labels for different eval instances
-    if: ${{ github.event.label.name == 'run-eval-s' }}
+    if: ${{ github.event.label.name == 'run-eval-xs' || github.event.label.name == 'run-eval-s' || github.event.label.name == 'run-eval-m' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -26,10 +25,18 @@ jobs:
           echo "Repository URL: $REPO_URL"
           echo "PR Branch: $PR_BRANCH"
 
+          if [[ "${{ github.event.label.name }}" == "run-eval-xs" ]]; then
+            EVAL_INSTANCES="1"
+          elif [[ "${{ github.event.label.name }}" == "run-eval-s" ]]; then
+            EVAL_INSTANCES="5"
+          elif [[ "${{ github.event.label.name }}" == "run-eval-m" ]]; then
+            EVAL_INSTANCES="30"
+          fi
+
           curl -X POST \
             -H "Authorization: Bearer ${{ secrets.PAT_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
-            -d "{\"ref\": \"main\", \"inputs\": {\"github-repo\": \"${REPO_URL}\", \"github-branch\": \"${PR_BRANCH}\", \"pr-number\": \"${{ github.event.pull_request.number }}\"}}" \
+            -d "{\"ref\": \"main\", \"inputs\": {\"github-repo\": \"${REPO_URL}\", \"github-branch\": \"${PR_BRANCH}\", \"pr-number\": \"${{ github.event.pull_request.number }}\", \"eval-instances\": \"${EVAL_INSTANCES}\"}}" \
             https://api.github.com/repos/All-Hands-AI/evaluation/actions/workflows/create-branch.yml/dispatches
 
           # Send Slack message

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -44,3 +44,10 @@ jobs:
           slack_text="PR $PR_URL has triggered evaluation on $EVAL_INSTANCES instances..."
           curl -X POST -H 'Content-type: application/json' --data '{"text":"'"$slack_text"'"}' \
             https://hooks.slack.com/services/${{ secrets.SLACK_TOKEN }}
+
+      - name: Comment on PR
+        uses: KeisukeYamashita/create-comment@v1
+        with:
+          unique: false
+          comment: |
+            Running evaluation on the PR. Once eval is done, the results will be posted.

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -41,6 +41,6 @@ jobs:
 
           # Send Slack message
           PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          slack_text="PR $PR_URL has triggered evaluation..."
+          slack_text="PR $PR_URL has triggered evaluation on $EVAL_INSTANCES instances..."
           curl -X POST -H 'Content-type: application/json' --data '{"text":"'"$slack_text"'"}' \
             https://hooks.slack.com/services/${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This workflow triggers a remote eval job that runs an evaluation of 1 instance for now. This is to get the basic setup working.


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b2e8440-nikolaik   --name openhands-app-b2e8440   docker.all-hands.dev/all-hands-ai/openhands:b2e8440
```