### PR TITLE
fix #5111: add FunctionCallNotExistsError to handle cases where tool calling failed

### DIFF
--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -145,7 +145,7 @@ def get_config(
             platform='linux/amd64',
             api_key=os.environ.get('ALLHANDS_API_KEY', None),
             remote_runtime_api_url=os.environ.get('SANDBOX_REMOTE_RUNTIME_API_URL'),
-            keep_remote_runtime_alive=False,
+            keep_runtime_alive=False,
             remote_runtime_init_timeout=3600,
         ),
         # do not mount workspace

--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -145,7 +145,7 @@ def get_config(
             platform='linux/amd64',
             api_key=os.environ.get('ALLHANDS_API_KEY', None),
             remote_runtime_api_url=os.environ.get('SANDBOX_REMOTE_RUNTIME_API_URL'),
-            keep_runtime_alive=False,
+            keep_remote_runtime_alive=False,
             remote_runtime_init_timeout=3600,
         ),
         # do not mount workspace

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -12,6 +12,7 @@ from litellm import (
     ModelResponse,
 )
 
+from openhands.core.exceptions import FunctionCallNotExistsError
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import (
     Action,
@@ -484,7 +485,9 @@ def response_to_actions(response: ModelResponse) -> list[Action]:
             elif tool_call.function.name == 'browser':
                 action = BrowseInteractiveAction(browser_actions=arguments['code'])
             else:
-                raise RuntimeError(f'Unknown tool call: {tool_call.function.name}')
+                raise FunctionCallNotExistsError(
+                    f'Tool {tool_call.function.name} is not registered. (arguments: {arguments}). Please check the tool name and retry with an existing tool.'
+                )
 
             # We only add thought to the first action
             if i == 0:

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -12,6 +12,7 @@ from openhands.controller.state.state import State, TrafficControlState
 from openhands.controller.stuck import StuckDetector
 from openhands.core.config import AgentConfig, LLMConfig
 from openhands.core.exceptions import (
+    FunctionCallNotExistsError,
     FunctionCallValidationError,
     LLMMalformedActionError,
     LLMNoActionError,
@@ -488,6 +489,7 @@ class AgentController:
             LLMNoActionError,
             LLMResponseError,
             FunctionCallValidationError,
+            FunctionCallNotExistsError,
         ) as e:
             self.event_stream.add_event(
                 ErrorObservation(

--- a/openhands/core/exceptions.py
+++ b/openhands/core/exceptions.py
@@ -114,3 +114,10 @@ class FunctionCallValidationError(Exception):
 
     def __init__(self, message):
         super().__init__(message)
+
+
+class FunctionCallNotExistsError(Exception):
+    """Exception raised when an LLM call a tool that is not registered."""
+
+    def __init__(self, message):
+        super().__init__(message)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

add FunctionCallNotExistsError to handle cases where tool calling failed, and throw it back to LLM for retry.


---
**Link of any specific issues this addresses**

Fix https://github.com/All-Hands-AI/OpenHands/issues/5111

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:78cd090-nikolaik   --name openhands-app-78cd090   docker.all-hands.dev/all-hands-ai/openhands:78cd090
```