### PR TITLE
chore: remove specified sid

### DIFF
--- a/evaluation/discoverybench/run_infer.py
+++ b/evaluation/discoverybench/run_infer.py
@@ -250,9 +250,6 @@ def process_instance(
 
     config = get_config(metadata)
 
-    # use a session id for concurrent evaluation
-    sid = 'ID_' + str(instance.instance_id)
-
     # Setup the logger properly, so you can run
     # multi-processing to parallelize the evaluation
     if reset_logger:
@@ -284,7 +281,7 @@ def process_instance(
     instruction += AGENT_CLS_TO_INST_SUFFIX[metadata.agent_class]
 
     # Here's how you can run the agent (similar to the `main` function) and get the final task state
-    runtime = create_runtime(config, sid=sid)
+    runtime = create_runtime(config)
     call_async_from_sync(runtime.connect)
     initialize_runtime(runtime, instance.data_files)
 

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -59,7 +59,8 @@ def create_runtime(
     """Create a runtime for the agent to run on.
 
     config: The app config.
-    sid: The session id.
+    sid: (optional) The session id. IMPORTANT: please don't set this unless you know what you're doing.
+        Set it to incompatible value will cause unexpected behavior on RemoteRuntime.
     headless_mode: Whether the agent is run in headless mode. `create_runtime` is typically called within evaluation scripts,
         where we don't want to have the VSCode UI open, so it defaults to True.
     """
@@ -105,6 +106,8 @@ async def run_controller(
     Args:
         config: The app config.
         initial_user_action: An Action object containing initial user input
+        sid: (optional) The session id. IMPORTANT: please don't set this unless you know what you're doing.
+            Set it to incompatible value will cause unexpected behavior on RemoteRuntime.
         runtime: (optional) A runtime for the agent to run on.
         agent: (optional) A agent to run.
         exit_on_message: quit if agent asks for a message from user (optional)

--- a/openhands/resolver/resolve_issue.py
+++ b/openhands/resolver/resolve_issue.py
@@ -199,7 +199,7 @@ async def process_issue(
     )
     config.set_llm_config(llm_config)
 
-    runtime = create_runtime(config, sid=f'{issue.number}')
+    runtime = create_runtime(config)
     await runtime.connect()
 
     async def on_event(evt):


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Specifying SID won't work on RemoteRuntime - so we'd better stop manually setting the `sid` unless we know what we are doing.


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c1be2a4-nikolaik   --name openhands-app-c1be2a4   docker.all-hands.dev/all-hands-ai/openhands:c1be2a4
```