### PR TITLE
mitigate memory leak

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -57,6 +57,9 @@ class Session:
                 self.websocket = None
         finally:
             self.agent_session.close()
+            del (
+                self.agent_session
+            )  # FIXME: this should not be necessary but it mitigates a memory leak
 
     async def loop_recv(self):
         try:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

I still haven't tracked down the source of the memory leak, but the repro is something like:
* upload a ~10MB text file to the workspace
* ask openhands to run `cat bigfile.txt`
* repeatedly refresh the page

You'll see mem usage jump by ~12MB on each refresh.

This seems to cut down on _most_ of the leakage, but there's probably a separate leak somewhere

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9cab1e9-nikolaik   --name openhands-app-9cab1e9   docker.all-hands.dev/all-hands-ai/openhands:9cab1e9
```