### PR TITLE
Fix KeyError when accessing content in messages with function calls

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -575,7 +575,9 @@ def convert_non_fncall_messages_to_fncall_messages(
     first_user_message_encountered = False
     for message in messages:
         role = message['role']
-        content = message.get('content') or ''  # handle cases where content is None or missing
+        content = (
+            message.get('content') or ''
+        )  # handle cases where content is None or missing
         # For system messages, remove the added suffix
         if role == 'system':
             if isinstance(content, str):
@@ -761,7 +763,9 @@ def convert_from_multiple_tool_calls_to_single_tool_call_messages(
     pending_tool_calls: dict[str, dict] = {}
     for message in messages:
         role = message['role']
-        content = message.get('content')  # Don't set default here as we need to handle function calls
+        content = message.get(
+            'content'
+        )  # Don't set default here as we need to handle function calls
         if role == 'assistant':
             if message.get('tool_calls') and len(message['tool_calls']) > 1:
                 # handle multiple tool calls by breaking them into multiple messages

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -320,7 +320,8 @@ def convert_fncall_messages_to_non_fncall_messages(
     converted_messages = []
     first_user_message_encountered = False
     for message in messages:
-        role, content = message['role'], message['content']
+        role = message['role']
+        content = message.get('content')
         if content is None:
             content = ''
 
@@ -573,8 +574,8 @@ def convert_non_fncall_messages_to_fncall_messages(
 
     first_user_message_encountered = False
     for message in messages:
-        role, content = message['role'], message['content']
-        content = content or ''  # handle cases where content is None
+        role = message['role']
+        content = message.get('content') or ''  # handle cases where content is None or missing
         # For system messages, remove the added suffix
         if role == 'system':
             if isinstance(content, str):
@@ -759,7 +760,8 @@ def convert_from_multiple_tool_calls_to_single_tool_call_messages(
 
     pending_tool_calls: dict[str, dict] = {}
     for message in messages:
-        role, content = message['role'], message['content']
+        role = message['role']
+        content = message.get('content')  # Don't set default here as we need to handle function calls
         if role == 'assistant':
             if message.get('tool_calls') and len(message['tool_calls']) > 1:
                 # handle multiple tool calls by breaking them into multiple messages

--- a/tests/unit/test_fn_call_converter.py
+++ b/tests/unit/test_fn_call_converter.py
@@ -1,30 +1,33 @@
-import pytest
-from openhands.llm.fn_call_converter import convert_fncall_messages_to_non_fncall_messages
-from openhands.core.exceptions import FunctionCallConversionError
+from openhands.llm.fn_call_converter import (
+    convert_fncall_messages_to_non_fncall_messages,
+)
+
 
 def test_convert_fncall_messages_no_content():
     """Test that messages without content are handled correctly."""
     messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Hello!"},
-        {"role": "assistant", "function_call": {"name": "greet", "arguments": "{}"}, "role": "assistant"},  # No content
+        {'role': 'system', 'content': 'You are a helpful assistant.'},
+        {'role': 'user', 'content': 'Hello!'},
+        {
+            'role': 'assistant',
+            'function_call': {'name': 'greet', 'arguments': '{}'},
+            'role': 'assistant',
+        },  # No content
     ]
     tools = [
         {
-            "type": "function",
-            "function": {
-                "name": "greet",
-                "description": "Greet the user",
-                "parameters": {
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }
-            }
+            'type': 'function',
+            'function': {
+                'name': 'greet',
+                'description': 'Greet the user',
+                'parameters': {'type': 'object', 'properties': {}, 'required': []},
+            },
         }
     ]
 
     # This should not raise a KeyError
-    result = convert_fncall_messages_to_non_fncall_messages(messages, tools, add_in_context_learning_example=False)
+    result = convert_fncall_messages_to_non_fncall_messages(
+        messages, tools, add_in_context_learning_example=False
+    )
     assert isinstance(result, list)
     assert len(result) == len(messages)

--- a/tests/unit/test_fn_call_converter.py
+++ b/tests/unit/test_fn_call_converter.py
@@ -1,0 +1,30 @@
+import pytest
+from openhands.llm.fn_call_converter import convert_fncall_messages_to_non_fncall_messages
+from openhands.core.exceptions import FunctionCallConversionError
+
+def test_convert_fncall_messages_no_content():
+    """Test that messages without content are handled correctly."""
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello!"},
+        {"role": "assistant", "function_call": {"name": "greet", "arguments": "{}"}, "role": "assistant"},  # No content
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "greet",
+                "description": "Greet the user",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            }
+        }
+    ]
+
+    # This should not raise a KeyError
+    result = convert_fncall_messages_to_non_fncall_messages(messages, tools, add_in_context_learning_example=False)
+    assert isinstance(result, list)
+    assert len(result) == len(messages)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Fixes a "message['content'] key" error

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Fixes #5142 

The error occurs when a message in the messages list doesn't have a 'content' key. This can happen with OpenRouter when using function calls, as some messages might only have function call information without content.

Let me summarize what OpenHands did to fix the issue ("I" = OpenHands):

I identified that the error was occurring in the convert_fncall_messages_to_non_fncall_messages function when trying to access the 'content' key from messages that only had function calls.

I wrote a test case to reproduce the issue, which showed that messages with function calls but no content were causing a KeyError.

I fixed the issue by modifying the code to use message.get('content') instead of message['content'] in three places:

In the main message processing loop
In the system message handling
In the assistant message handling
The fix ensures that messages without a 'content' key are handled gracefully, which is important when dealing with function calls from OpenRouter or other providers that might not include content in their function call messages.
