### PR TITLE
docs: Add note about organizational token policies

### DIFF
--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -14,7 +14,7 @@ This repository includes a GitHub Actions workflow that can automatically attemp
 Follow these steps to use this workflow in your own repository:
 
 1. [Create a personal access token](https://github.com/settings/tokens?type=beta) with read/write scope for "contents", "issues", "pull requests", and "workflows"
-   
+
    Note: If you're working with an organizational repository, you may need to configure the organization's personal access token policy first. See [Setting a personal access token policy for your organization](https://docs.github.com/en/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization) for details.
 
 2. Create an API key for the [Claude API](https://www.anthropic.com/api) (recommended) or another supported LLM service
@@ -85,11 +85,14 @@ pip install openhands-ai
 3. Set up environment variables:
 
 ```bash
+
 # GitHub credentials
+
 export GITHUB_TOKEN="your-github-token"
 export GITHUB_USERNAME="your-github-username"  # Optional, defaults to token owner
 
 # LLM configuration
+
 export LLM_MODEL="anthropic/claude-3-5-sonnet-20241022"  # Recommended
 export LLM_API_KEY="your-llm-api-key"
 export LLM_BASE_URL="your-api-url"  # Optional, for API proxies

--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -14,6 +14,8 @@ This repository includes a GitHub Actions workflow that can automatically attemp
 Follow these steps to use this workflow in your own repository:
 
 1. [Create a personal access token](https://github.com/settings/tokens?type=beta) with read/write scope for "contents", "issues", "pull requests", and "workflows"
+   
+   Note: If you're working with an organizational repository, you may need to configure the organization's personal access token policy first. See [Setting a personal access token policy for your organization](https://docs.github.com/en/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization) for details.
 
 2. Create an API key for the [Claude API](https://www.anthropic.com/api) (recommended) or another supported LLM service
 


### PR DESCRIPTION
Added a note in the resolver README about the need to configure organizational token policies when working with organizational repositories. This helps users understand that they may need to set up additional permissions at the organization level before personal access tokens will work.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fd3a87e-nikolaik   --name openhands-app-fd3a87e   docker.all-hands.dev/all-hands-ai/openhands:fd3a87e
```