### PR TITLE
Skip pre-commit hooks in lint-fix workflow

### DIFF
--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -57,6 +57,6 @@ jobs:
         run: |
           git config --local user.email "openhands@all-hands.dev"
           git config --local user.name "OpenHands Bot"
-          git add -A
-          git commit -m "🤖 Auto-fix linting issues"
+          SKIP_PRE_COMMIT=1 git add -A
+          SKIP_PRE_COMMIT=1 git commit -m "🤖 Auto-fix linting issues"
           git push


### PR DESCRIPTION
Modified the lint-fix workflow to skip pre-commit hooks when committing changes. This ensures that linting fixes can be pushed even if other pre-commit checks would fail.