### PR TITLE
feat(runtime): Set server process to run with highest system priority

### DIFF
--- a/openhands/runtime/impl/modal/modal_runtime.py
+++ b/openhands/runtime/impl/modal/modal_runtime.py
@@ -252,6 +252,7 @@ echo 'export INPUTRC=/etc/inputrc' >> /etc/bash.bashrc
                 self.config.sandbox.user_id,
                 plugin_args,
                 browsergym_args,
+                is_root=not self.config.run_as_openhands,  # is_root=True when running as root
             )
             self.log('debug', f'Starting container with command: {sandbox_start_cmd}')
             self.sandbox = modal.Sandbox.create(

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -235,6 +235,7 @@ class RemoteRuntime(Runtime):
             self.config.sandbox.user_id,
             plugin_args,
             browsergym_args,
+            is_root=not self.config.run_as_openhands,  # is_root=True when running as root
         )
         start_request = {
             'image': self.container_image,

--- a/openhands/runtime/impl/runloop/runloop_runtime.py
+++ b/openhands/runtime/impl/runloop/runloop_runtime.py
@@ -171,6 +171,7 @@ class RunloopRuntime(EventStreamRuntime):
             self.config.sandbox.user_id,
             plugin_args,
             browsergym_args,
+            is_root=not self.config.run_as_openhands,  # is_root=True when running as root
         )
 
         # Add some additional commands based on our image

--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -5,14 +5,41 @@ def get_remote_startup_command(
     user_id: int,
     plugin_args: list[str],
     browsergym_args: list[str],
+    is_root: bool = False,
 ):
-    cmd = f'/openhands/micromamba/bin/micromamba run -n openhands poetry run python -u -m openhands.runtime.action_execution_server {port} --working-dir {sandbox_workspace_dir} {" ".join(plugin_args)} --username {username} --user-id {user_id} {" ".join(browsergym_args)}'
-    return [
-        'sudo',  # Needed for nice -20
-        'nice',
+    base_cmd = [
+        '/openhands/micromamba/bin/micromamba',
+        'run',
         '-n',
-        '-20',  # Highest priority
-        'sh',
-        '-c',
-        f'echo -1000 > /proc/self/oom_score_adj && exec {cmd}'
+        'openhands',
+        'poetry',
+        'run',
+        'python',
+        '-u',
+        '-m',
+        'openhands.runtime.action_execution_server',
+        str(port),
+        '--working-dir',
+        sandbox_workspace_dir,
+        *plugin_args,
+        '--username',
+        username,
+        '--user-id',
+        str(user_id),
+        *browsergym_args,
     ]
+
+    if is_root:
+        # If running as root, set highest priority and lowest OOM score
+        cmd_str = ' '.join(base_cmd)
+        return [
+            'nice',
+            '-n',
+            '-20',  # Highest priority
+            'sh',
+            '-c',
+            f'echo -1000 > /proc/self/oom_score_adj && exec {cmd_str}'
+        ]
+    else:
+        # If not root, run with normal priority
+        return base_cmd

--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -6,24 +6,13 @@ def get_remote_startup_command(
     plugin_args: list[str],
     browsergym_args: list[str],
 ):
+    cmd = f'/openhands/micromamba/bin/micromamba run -n openhands poetry run python -u -m openhands.runtime.action_execution_server {port} --working-dir {sandbox_workspace_dir} {" ".join(plugin_args)} --username {username} --user-id {user_id} {" ".join(browsergym_args)}'
     return [
-        '/openhands/micromamba/bin/micromamba',
-        'run',
+        'sudo',  # Needed for nice -20
+        'nice',
         '-n',
-        'openhands',
-        'poetry',
-        'run',
-        'python',
-        '-u',
-        '-m',
-        'openhands.runtime.action_execution_server',
-        str(port),
-        '--working-dir',
-        sandbox_workspace_dir,
-        *plugin_args,
-        '--username',
-        username,
-        '--user-id',
-        str(user_id),
-        *browsergym_args,
+        '-20',  # Highest priority
+        'sh',
+        '-c',
+        f'echo -1000 > /proc/self/oom_score_adj && exec {cmd}'
     ]


### PR DESCRIPTION
This PR modifies the server startup command to:

- Use nice -n -20 to set highest CPU scheduling priority
- Set OOM score to -1000 to make it one of the last processes to be killed
- Use sudo for elevated privileges needed for these settings

This ensures the server process runs with maximum priority and is one of the last processes to be killed by the OOM killer.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7bd12a9-nikolaik   --name openhands-app-7bd12a9   docker.all-hands.dev/all-hands-ai/openhands:7bd12a9
```