### PR TITLE
chore(runtime): Add logging for /server_info endpoint

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -417,17 +417,18 @@ if __name__ == '__main__':
 
     @app.get('/server_info')
     async def get_server_info():
-        logger.info('Server info endpoint called')
         assert client is not None
         current_time = time.time()
         uptime = current_time - client.start_time
         idle_time = current_time - client.last_execution_time
 
-        return {
+        response = {
             'uptime': uptime,
             'idle_time': idle_time,
             'resources': get_system_stats(),
         }
+        logger.info('Server info endpoint response: %s', response)
+        return response
 
     @app.post('/execute_action')
     async def execute_action(action_request: ActionRequest):

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -417,6 +417,7 @@ if __name__ == '__main__':
 
     @app.get('/server_info')
     async def get_server_info():
+        logger.info('Server info endpoint called')
         assert client is not None
         current_time = time.time()
         uptime = current_time - client.start_time


### PR DESCRIPTION
Added INFO level logging when the /server_info endpoint is called to improve observability of server status requests.

This allow us to better debug cases where runtime dies - so we can know better if it is caused by OOM or something else.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f8c994d-nikolaik   --name openhands-app-f8c994d   docker.all-hands.dev/all-hands-ai/openhands:f8c994d
```