### PR TITLE
[Resolver]: Removing target branch param from resolve_issue.py in workflow definition

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
         default: "main"
-        description: 'Target branch to pull and create PR against'
+        description: "Target branch to pull and create PR against"
     secrets:
       LLM_MODEL:
         required: true
@@ -184,7 +184,6 @@ jobs:
             --issue-type ${{ env.ISSUE_TYPE }} \
             --max-iterations ${{ env.MAX_ITERATIONS }} \
             --comment-id ${{ env.COMMENT_ID }} \
-            --target-branch ${{ env.TARGET_BRANCH }}
 
       - name: Check resolution result
         id: check_result


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
In #5075 a new parameter `target_branch` was introduced to `.github/workflows/openhands-resolver.yml`. This parameter is passed into the resolver.

This parameter, as of right now, works with the latest version of resolver on `main` which hasn't been released yet. This PR reverts the parameter in the workflow definition.

---
**Link of any specific issues this addresses**
#5216