### PR TITLE
Fix issue #5154: [Bug]: FinishTool doesn't have a tool response so the agent loses its content

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -153,7 +153,7 @@ class CodeActAgent(Agent):
                 BrowseInteractiveAction,
             ),
         ) or (
-            isinstance(action, (AgentFinishAction, CmdRunAction))
+            isinstance(action, CmdRunAction)
             and action.source == 'agent'
         ):
             tool_metadata = action.tool_call_metadata
@@ -192,6 +192,22 @@ class CodeActAgent(Agent):
                 Message(
                     role='user',
                     content=content,
+                )
+            ]
+        elif isinstance(action, AgentFinishAction) and action.source == 'agent':
+            # For agent-sourced FinishAction, treat it as a message action
+            # This way it won't expect a tool response
+            tool_metadata = action.tool_call_metadata
+            assert tool_metadata is not None, (
+                'Tool call metadata should NOT be None when function calling is enabled. Action: '
+                + str(action)
+            )
+            llm_response: ModelResponse = tool_metadata.model_response
+            assistant_msg = llm_response.choices[0].message
+            return [
+                Message(
+                    role=assistant_msg.role,
+                    content=[TextContent(text=assistant_msg.content or '')],
                 )
             ]
         return []


### PR DESCRIPTION
This pull request fixes #5154.

The issue has been successfully resolved. The PR fixes the core problem where FinishAction with source='agent' was being treated incorrectly in the conversation flow. Here's a summary for the reviewer:

This PR fixes a regression in function calling where FinishAction with source='agent' wasn't being properly handled. The changes:

1. Removes AgentFinishAction from the list of actions treated as tool calls in get_action_message, preventing it from being stored in pending_tool_call_action_messages
2. Adds specific handling for AgentFinishAction (source='agent') by treating it as a regular message action:
   - Extracts the original LLM response from tool_call_metadata
   - Creates a new Message with matching role and content
   - Preserves the agent's finishing thought in conversation history

The solution maintains proper conversation flow while ensuring:
- FinishAction (source='user') continues to work as intended
- FinishAction (source='agent') is properly handled without requiring tool responses
- Agent's reasoning for finishing is preserved in the conversation history

These changes align with LLM API requirements while fixing the regression in function calling behavior.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌