### PR TITLE
Separate browsergym updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       chromadb:
         patterns:
           - "chromadb"
+      browsergym:
+        patterns:
+          - "browsergym"
       security-all:
         applies-to: "security-updates"
         patterns:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes to put `browsergym` updates in their own group, to be reviewed separately from the rest.

The reason is that newer versions [install nvidia-CUDA](https://github.com/All-Hands-AI/OpenHands/actions/runs/11998542625/job/33445417697?pr=5237#step:7:151) via a `libvisualwebarena` dependency
- this has lead to failed CI because of out of space errors
- we have torch and similar, set as optional deps under the `evaluation` poetry group (used for local embeddings), but I suppose we won't do that with `browsergym`

I seem to understand we will want visual web arena, so we may need to look into this. In any case, we have generally separated deps that are likely to break things, and this one looks like it needs its own.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:273f8b9-nikolaik   --name openhands-app-273f8b9   docker.all-hands.dev/all-hands-ai/openhands:273f8b9
```