### PR TITLE
hotfix: Revert cache steps in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,6 @@ test:
 	@$(MAKE) -s test-frontend
 
 build-frontend:
-	@echo "$(YELLOW)Cleaning TypeScript build cache...$(RESET)"
-	@cd frontend && npx tsc --build --clean
-	@echo "$(YELLOW)Cleaning Git cache for casing issues...$(RESET)"
-	@cd frontend && git rm -r --cached . && git add . && git commit -m "Fix Git cache" || echo "No changes to commit"
 	@echo "$(YELLOW)Building frontend...$(RESET)"
 	@cd frontend && npm run build
 


### PR DESCRIPTION
This was originally added to address the case of case sensitive file changes that were ignored by Git.

Details in #5209

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:05a41bc-nikolaik   --name openhands-app-05a41bc   docker.all-hands.dev/all-hands-ai/openhands:05a41bc
```