### PR TITLE
Add fn call in response debug logging

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -12,6 +12,7 @@ from openhands.core.config import LLMConfig
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
     import litellm
+
 from litellm import Message as LiteLLMMessage
 from litellm import ModelInfo, PromptTokensDetails
 from litellm import completion as litellm_completion
@@ -244,6 +245,12 @@ class LLM(RetryMixin, DebugMixin):
                         f.write(json.dumps(_d))
 
                 message_back: str = resp['choices'][0]['message']['content']
+                tool_calls = resp['choices'][0]['message'].get('tool_calls', [])
+                if tool_calls:
+                    for tool_call in tool_calls:
+                        fn_name = tool_call.function.name
+                        fn_args = tool_call.function.arguments
+                        message_back += f'\nFunction call: {fn_name}({fn_args})'
 
                 # log the LLM response
                 self.log_response(message_back)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR is to:
- Add logging for function call in debugging mode. Currently it only logs message content.

Example output:
```
I'll help you navigate to All Hands AI's GitHub profile using the browser tool.
Function call: browser({"code": "goto('https://github.com/All-Hands-AI')"})
```
---
**Link of any specific issues this addresses**
