### PR TITLE
Fix error message on invalid token

### DIFF
--- a/openhands/server/socket.py
+++ b/openhands/server/socket.py
@@ -44,11 +44,11 @@ async def init_connection(connection_id: str, data: dict):
         if sid == '':
             await sio.emit(
                 'oh_event',
-                 event_to_dict(
-                     ErrorObservation(
-                         content='Invalid token! (Maybe you need to specify a static jwt_secret?)'
-                     )
-                 ),
+                event_to_dict(
+                    ErrorObservation(
+                        content='Invalid token! (Maybe you need to specify a static jwt_secret?)'
+                    )
+                ),
             )
             return
         logger.info(f'Existing session: {sid}')

--- a/openhands/server/socket.py
+++ b/openhands/server/socket.py
@@ -8,6 +8,7 @@ from openhands.events.action import (
 from openhands.events.observation import (
     NullObservation,
 )
+from openhands.events.observation.error import ErrorObservation
 from openhands.events.serialization import event_to_dict
 from openhands.events.stream import AsyncEventStreamWrapper
 from openhands.server.auth import get_sid_from_token, sign_token
@@ -41,7 +42,7 @@ async def init_connection(connection_id: str, data: dict):
     if token:
         sid = get_sid_from_token(token, config.jwt_secret)
         if sid == '':
-            await sio.send({'error': 'Invalid token', 'error_code': 401})
+            await sio.emit('oh_event', event_to_dict(ErrorObservation(content='Invalid token! (Maybe you need to specify a static jwt_secret?)')))
             return
         logger.info(f'Existing session: {sid}')
     else:

--- a/openhands/server/socket.py
+++ b/openhands/server/socket.py
@@ -42,7 +42,14 @@ async def init_connection(connection_id: str, data: dict):
     if token:
         sid = get_sid_from_token(token, config.jwt_secret)
         if sid == '':
-            await sio.emit('oh_event', event_to_dict(ErrorObservation(content='Invalid token! (Maybe you need to specify a static jwt_secret?)')))
+            await sio.emit(
+                'oh_event',
+                 event_to_dict(
+                     ErrorObservation(
+                         content='Invalid token! (Maybe you need to specify a static jwt_secret?)'
+                     )
+                 ),
+            )
             return
         logger.info(f'Existing session: {sid}')
     else:


### PR DESCRIPTION
**When an invalid token error occurs, a message is displayed in the UI.**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
This error occurs when you restart your server and have not specified a `JWT_SECRET` in either your environment or config.toml

Before this the agent would just stop inexplicably.
<img width="462" alt="image" src="https://github.com/user-attachments/assets/b2a8d25b-96fc-48fe-ab52-18b5ecd7975f">

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9a7761e-nikolaik   --name openhands-app-9a7761e   docker.all-hands.dev/all-hands-ai/openhands:9a7761e
```