### PR TITLE
Fix: Session expired

### DIFF
--- a/openhands/server/socket.py
+++ b/openhands/server/socket.py
@@ -8,7 +8,6 @@ from openhands.events.action import (
 from openhands.events.observation import (
     NullObservation,
 )
-from openhands.events.observation.error import ErrorObservation
 from openhands.events.serialization import event_to_dict
 from openhands.events.stream import AsyncEventStreamWrapper
 from openhands.server.auth import get_sid_from_token, sign_token
@@ -42,14 +41,7 @@ async def init_connection(connection_id: str, data: dict):
     if token:
         sid = get_sid_from_token(token, config.jwt_secret)
         if sid == '':
-            await sio.emit(
-                'oh_event',
-                event_to_dict(
-                    ErrorObservation(
-                        content='Invalid token! Please ensure a valid jwt_secret is specified or use -e JWT_TOKEN when running with Docker.'
-                    )
-                ),
-            )
+            await sio.emit('oh_event', {'error': 'Invalid token', 'error_code': 401})
             return
         logger.info(f'Existing session: {sid}')
     else:


### PR DESCRIPTION
**Rather than the message about the JWT_SECRET, we now add a session expired message and redirect to the splash screen again**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

<img width="918" alt="image" src="https://github.com/user-attachments/assets/12a52719-d0b2-4f13-bc5e-27cd5b5f45a5">

---

**Background Info**

We face the fairly common situation where we need to sign a JWT tokens so that it can be verified that only the server could have produced it and it is not from another source - this adds a level of security against somebody trying to hijack a session from another user.

In order to sign tokens, a secret key is required. If this key were in the github repo, it would not be secret, so it is specified either in the environment variables or config.toml. In the event that no key is specified, a new random one is generated every time the server restarts. This means that if your config does not include a key, sessions will not persist between server restarts. (https://github.com/All-Hands-AI/OpenHands/blob/ea994b6209d11e32710d4b5ed223b87a149f78ed/docs/modules/usage/troubleshooting/troubleshooting.md?plain=1#L127)

Given that this is a fairly common error case, we have specific code to handle it on the frontend - we display a toast that says "Session Expired" and take the user back to the splash screen. Unfortunately, when introducing SocketIO I also inadvertently introduced a regression that meant this code no longer worked as expected.

This PR fixes the regression.


To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d0864cf-nikolaik   --name openhands-app-d0864cf   docker.all-hands.dev/all-hands-ai/openhands:d0864cf
```