### PR TITLE
fix issue where message is none

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -245,7 +245,7 @@ class LLM(RetryMixin, DebugMixin):
                     with open(log_file, 'w') as f:
                         f.write(json.dumps(_d))
 
-                message_back: str = resp['choices'][0]['message']['content']
+                message_back: str = resp['choices'][0]['message']['content'] or ''
                 tool_calls = resp['choices'][0]['message'].get('tool_calls', [])
                 if tool_calls:
                     for tool_call in tool_calls:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

if `content` is none you end up with an error like this
```
openhands-56bd55d9f8-rjngn openhands   File "/app/openhands/llm/llm.py", line 254, in wrapper
openhands-56bd55d9f8-rjngn openhands     message_back += f'\nFunction call: {fn_name}({fn_args})'
openhands-56bd55d9f8-rjngn openhands TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'

```

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7cb9203-nikolaik   --name openhands-app-7cb9203   docker.all-hands.dev/all-hands-ai/openhands:7cb9203
```