### PR TITLE
Clicking row should select file

### DIFF
--- a/frontend/src/components/file-explorer/tree-node.tsx
+++ b/frontend/src/components/file-explorer/tree-node.tsx
@@ -10,15 +10,11 @@ interface TitleProps {
   name: string;
   type: "folder" | "file";
   isOpen: boolean;
-  onClick: () => void;
 }
 
-function Title({ name, type, isOpen, onClick }: TitleProps) {
+function Title({ name, type, isOpen }: TitleProps) {
   return (
-    <div
-      onClick={onClick}
-      className="cursor-pointer text-nowrap rounded-[5px] p-1 nowrap flex items-center gap-2 aria-selected:bg-neutral-600 aria-selected:text-white hover:text-white"
-    >
+    <div className="cursor-pointer text-nowrap rounded-[5px] p-1 nowrap flex items-center gap-2 aria-selected:bg-neutral-600 aria-selected:text-white hover:text-white">
       <div className="flex-shrink-0">
         {type === "folder" && <FolderIcon isOpen={isOpen} />}
         {type === "file" && <FileIcon filename={name} />}
@@ -84,13 +80,13 @@ function TreeNode({ path, defaultOpen = false }: TreeNodeProps) {
         type={isDirectory ? "button" : "submit"}
         name="file"
         value={path}
+        onClick={handleClick}
         className="flex items-center justify-between w-full px-1"
       >
         <Title
           name={filename}
           type={isDirectory ? "folder" : "file"}
           isOpen={isOpen}
-          onClick={handleClick}
         />
 
         {modifiedFiles[path] && (


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Clicking row should select file

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Right now you have to select the actual file name for the file to be selected. This makes it so that you can select the row.

I asked OpenHands to fix this. I tested it and it works but need some eyes to make sure it's good.

---
**Link of any specific issues this addresses**
https://github.com/All-Hands-AI/OpenHands/issues/5299

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:730fecb-nikolaik   --name openhands-app-730fecb   docker.all-hands.dev/all-hands-ai/openhands:730fecb
```