### PR TITLE
Microagent to fix issues with npm

### DIFF
--- a/openhands/agenthub/codeact_agent/micro/npm.md
+++ b/openhands/agenthub/codeact_agent/micro/npm.md
@@ -1,0 +1,9 @@
+---
+name: npm
+agent: CodeActAgent
+triggers:
+- npm
+---
+
+When using npm to install packages, you will not be able to use an interactive shell, and it may be hard to confirm your actions.
+As an alternative, you can pipe in the output of the unix "yes" command to confirm your actions.


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When using `npm`, it confirms on the command line if we'd like to install packages, which results in a timeout.
This PR encourages the agent to auto-confirm these changes.

Note that I also tried adding the `--yes` command line argument to npm, but that doesn't work for things like the `create-vite` command, which is not confirmed by just adding `--yes`.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bb85aaa-nikolaik   --name openhands-app-bb85aaa   docker.all-hands.dev/all-hands-ai/openhands:bb85aaa
```