### PR TITLE
fix: Update frontend workflows to catch TypeScript errors

### DIFF
--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         working-directory: ./frontend
         run: npm ci
+      - name: Run TypeScript compilation
+        working-directory: ./frontend
+        run: npm run make-i18n && tsc
       - name: Run tests and collect coverage
         working-directory: ./frontend
         run: npm run test:coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,10 +30,11 @@ jobs:
         run: |
           cd frontend
           npm install --frozen-lockfile
-      - name: Lint
+      - name: Lint and TypeScript compilation
         run: |
           cd frontend
           npm run lint
+          npm run make-i18n && tsc
 
   # Run lint on the python code
   lint-python:

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -82,10 +82,9 @@ export function ChatInput({
   };
 
   const handleSubmitMessage = () => {
-    if (textareaRef.current?.value) {
-      onSubmit(textareaRef.current.value);
-      textareaRef.current.value = "";
-    }
+    // Introducing the same TypeScript error by not checking if current is null
+    onSubmit(textareaRef.current.value);
+    textareaRef.current.value = "";
   };
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/components/chat-input.tsx
+++ b/frontend/src/components/chat-input.tsx
@@ -82,9 +82,10 @@ export function ChatInput({
   };
 
   const handleSubmitMessage = () => {
-    // Introducing the same TypeScript error by not checking if current is null
-    onSubmit(textareaRef.current.value);
-    textareaRef.current.value = "";
+    if (textareaRef.current?.value) {
+      onSubmit(textareaRef.current.value);
+      textareaRef.current.value = "";
+    }
   };
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
This PR fixes issue #5343 where frontend TypeScript errors cause Python unit tests to fail but not frontend workflows.

Changes:

1. First commit: Introduced a TypeScript error to reproduce the issue
   - Removed null check from `textareaRef.current` to trigger TypeScript error
   - Verified that Python tests fail but frontend tests pass

2. Second commit: Added TypeScript compilation to frontend workflows
   - Added `npm run make-i18n && tsc` to frontend unit tests workflow
   - Added TypeScript compilation to lint workflow
   - This ensures TypeScript errors are caught by frontend-specific workflows

3. Third commit: Fixed the TypeScript error
   - Added proper null check for `textareaRef.current`
   - Verified all workflows pass

These changes ensure that:
1. TypeScript errors are caught by frontend-specific workflows
2. Frontend issues do not cause Python tests to fail while frontend tests pass
3. All workflows properly validate their respective areas of code

Fixes #5343

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f985eb4-nikolaik   --name openhands-app-f985eb4   docker.all-hands.dev/all-hands-ai/openhands:f985eb4
```