### PR TITLE
chore(frontend): Update `msw`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -79,7 +79,7 @@
         "husky": "^9.1.6",
         "jsdom": "^25.0.1",
         "lint-staged": "^15.2.10",
-        "msw": "^2.3.0-ws.rc-12",
+        "msw": "^2.6.6",
         "postcss": "^8.4.47",
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,7 @@
     "husky": "^9.1.6",
     "jsdom": "^25.0.1",
     "lint-staged": "^15.2.10",
-    "msw": "^2.3.0-ws.rc-12",
+    "msw": "^2.6.6",
     "postcss": "^8.4.47",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.14",


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
We were using the beta version of `msw` to mock WebSocket events

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Mocking WebSocket events with `msw` is out of beta


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ff49cf8-nikolaik   --name openhands-app-ff49cf8   docker.all-hands.dev/all-hands-ai/openhands:ff49cf8
```