### PR TITLE
Support multiline and default user messages

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -376,6 +376,11 @@ def get_parser() -> argparse.ArgumentParser:
         type=str,
         help='The comma-separated list (in quotes) of IDs of the instances to evaluate',
     )
+    parser.add_argument(
+        '--no-auto-continue',
+        action='store_true',
+        help='Disable automatic "continue" responses. Will read from stdin instead.',
+    )
     return parser
 
 

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -188,7 +188,9 @@ async def run_controller(
                 if exit_on_message:
                     message = '/exit'
                 elif fake_user_response_fn is None:
-                    message = input('Request user input >> ')
+                    # read until EOF (Ctrl+D on Unix, Ctrl+Z on Windows)
+                    print('Request user input (press Ctrl+D/Z when done) >> ')
+                    message = sys.stdin.read().rstrip()
                 else:
                     message = fake_user_response_fn(controller.get_state())
                 action = MessageAction(content=message)

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -243,6 +243,17 @@ def generate_sid(config: AppConfig, session_name: str | None = None) -> str:
     return f'{session_name}-{hash_str[:16]}'
 
 
+def auto_continue_response(
+    state: State,
+    encapsulate_solution: bool = False,
+    try_parse: Callable[[Action | None], str] | None = None,
+) -> str:
+    """Default function to generate user responses.
+    Returns 'continue' to tell the agent to proceed without asking for more input.
+    """
+    return 'continue'
+
+
 if __name__ == '__main__':
     args = parse_arguments()
 
@@ -286,5 +297,8 @@ if __name__ == '__main__':
             config=config,
             initial_user_action=initial_user_action,
             sid=sid,
+            fake_user_response_fn=None
+            if args.no_auto_continue
+            else auto_continue_response,
         )
     )

--- a/tests/unit/test_arg_parser.py
+++ b/tests/unit/test_arg_parser.py
@@ -19,6 +19,7 @@ def test_parser_default_values():
     assert args.eval_note is None
     assert args.llm_config is None
     assert args.name == 'default'
+    assert not args.no_auto_continue
 
 
 def test_parser_custom_values():
@@ -49,6 +50,7 @@ def test_parser_custom_values():
             'gpt4',
             '-n',
             'test_session',
+            '--no-auto-continue',
         ]
     )
 
@@ -64,6 +66,7 @@ def test_parser_custom_values():
     assert args.eval_note == 'Test run'
     assert args.llm_config == 'gpt4'
     assert args.name == 'test_session'
+    assert args.no_auto_continue
 
 
 def test_parser_file_overrides_task():
@@ -124,10 +127,11 @@ def test_help_message(capsys):
         '-l LLM_CONFIG, --llm-config LLM_CONFIG',
         '-n NAME, --name NAME',
         '--config-file CONFIG_FILE',
+        '--no-auto-continue',
     ]
 
     for element in expected_elements:
         assert element in help_output, f"Expected '{element}' to be in the help message"
 
     option_count = help_output.count('  -')
-    assert option_count == 15, f'Expected 15 options, found {option_count}'
+    assert option_count == 16, f'Expected 16 options, found {option_count}'


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Add support for multiline user messages, and default user message when running headless.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes a couple of additions for user messages in headless mode
- read multiline input (fixes an issue where the messages were split and fail on bedrock because "\n" ends up empty)
- send a default user message ("continue") in headless mode
- can be disabled with `--no-auto-continue`

---
**Link of any specific issues this addresses**
Fix #5339 
Fix #5015

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:39247db-nikolaik   --name openhands-app-39247db   docker.all-hands.dev/all-hands-ai/openhands:39247db
```