### PR TITLE
Fix: Only send the last agent state changed event

### DIFF
--- a/openhands/__init__.py
+++ b/openhands/__init__.py
@@ -4,6 +4,16 @@ __package_name__ = 'openhands_ai'
 
 
 def get_version():
+    # Try getting the version from pyproject.toml
+    try:
+        root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        with open(os.path.join(root_dir, 'pyproject.toml'), 'r') as f:
+            for line in f:
+                if line.startswith('version ='):
+                    return line.split('=')[1].strip().strip('"')
+    except FileNotFoundError:
+        pass
+
     try:
         from importlib.metadata import PackageNotFoundError, version
 
@@ -16,16 +26,6 @@ def get_version():
 
         return get_distribution(__package_name__).version
     except (ImportError, DistributionNotFound):
-        pass
-
-    # Try getting the version from pyproject.toml
-    try:
-        root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        with open(os.path.join(root_dir, 'pyproject.toml'), 'r') as f:
-            for line in f:
-                if line.startswith('version ='):
-                    return line.split('=')[1].strip().strip('"')
-    except FileNotFoundError:
         pass
 
     return 'unknown'

--- a/openhands/__init__.py
+++ b/openhands/__init__.py
@@ -4,16 +4,6 @@ __package_name__ = 'openhands_ai'
 
 
 def get_version():
-    # Try getting the version from pyproject.toml
-    try:
-        root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        with open(os.path.join(root_dir, 'pyproject.toml'), 'r') as f:
-            for line in f:
-                if line.startswith('version ='):
-                    return line.split('=')[1].strip().strip('"')
-    except FileNotFoundError:
-        pass
-
     try:
         from importlib.metadata import PackageNotFoundError, version
 
@@ -26,6 +16,16 @@ def get_version():
 
         return get_distribution(__package_name__).version
     except (ImportError, DistributionNotFound):
+        pass
+
+    # Try getting the version from pyproject.toml
+    try:
+        root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        with open(os.path.join(root_dir, 'pyproject.toml'), 'r') as f:
+            for line in f:
+                if line.startswith('version ='):
+                    return line.split('=')[1].strip().strip('"')
+    except FileNotFoundError:
         pass
 
     return 'unknown'


### PR DESCRIPTION
**Only send the last agent state changed event on init**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Rather than having a stream which includes multiple agent state changed events - send only the last one. This should result in less jarring blinks in the frontend as the state seems to rapidly cycle between previous states.


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4716917-nikolaik   --name openhands-app-4716917   docker.all-hands.dev/all-hands-ai/openhands:4716917
```