### PR TITLE
Prioritize version from pyproject.toml

### DIFF
--- a/openhands/__init__.py
+++ b/openhands/__init__.py
@@ -4,6 +4,16 @@ __package_name__ = 'openhands_ai'
 
 
 def get_version():
+    # Try getting the version from pyproject.toml
+    try:
+        root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        with open(os.path.join(root_dir, 'pyproject.toml'), 'r') as f:
+            for line in f:
+                if line.startswith('version ='):
+                    return line.split('=')[1].strip().strip('"')
+    except FileNotFoundError:
+        pass
+
     try:
         from importlib.metadata import PackageNotFoundError, version
 
@@ -16,16 +26,6 @@ def get_version():
 
         return get_distribution(__package_name__).version
     except (ImportError, DistributionNotFound):
-        pass
-
-    # Try getting the version from pyproject.toml
-    try:
-        root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        with open(os.path.join(root_dir, 'pyproject.toml'), 'r') as f:
-            for line in f:
-                if line.startswith('version ='):
-                    return line.split('=')[1].strip().strip('"')
-    except FileNotFoundError:
         pass
 
     return 'unknown'


### PR DESCRIPTION
**Prioritize version from pyproject.toml over importlib**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
When running directly from poetry, I get the following:
```
>>> from openhands import get_version
>>> get_version()
'0.0.0.post2755+c5117bc48'
```

Which leads to...
docker.errors.NotFound: 404 Client Error for http+docker://localhost/v1.47/containers/openhands-runtime-vvLDWakILRMQYcw_AAAB/json: Not Found ("No such container: openhands-runtime-vvLDWakILRMQYcw_AAAB")

This PR prioritizes the version from the pyproject.toml so that runtime images can be built.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:310ddce-nikolaik   --name openhands-app-310ddce   docker.all-hands.dev/all-hands-ai/openhands:310ddce
```