### PR TITLE
Fix duplicate events on reinit

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -82,7 +82,7 @@ export function WsClientProvider({
       initEvent.github_token = ghToken;
     }
     const lastEvent = lastEventRef.current;
-    if (lastEvent && !Number.isNaN(parseInt(lastEvent.id as string, 10))) {
+    if (lastEvent) {
       initEvent.latest_event_id = lastEvent.id;
     }
     send(initEvent);
@@ -93,7 +93,9 @@ export function WsClientProvider({
       messageRateHandler.record(new Date().getTime());
     }
     setEvents((prevEvents) => [...prevEvents, event]);
-    lastEventRef.current = event;
+    if (!Number.isNaN(parseInt(event.id as string, 10))) {
+      lastEventRef.current = event;
+    }
     const extras = event.extras as Record<string, unknown>;
     if (extras?.agent_state === AgentState.INIT) {
       setStatus(WsClientProviderStatus.ACTIVE);


### PR DESCRIPTION
**Fix duplicate events on re-initialize**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---

The frontend code maintains a variable containing the last event from the event stream on the server received over the socket. It uses this when a reinitialization occurs to make sure that the full event stream is not sent over the socket again.

 However, the socket does not just contain events from the event stream - it also contains other pseudo events that do not have an ID - for example:
* `{token: "******", status: "ok"}`
* `{status_update: true, type: "info", id: "STATUS$CONTAINER_STARTED", message: "Container started"}`

If one of these happened to be the last event received, then the stream was duplicated. 

This PR updates the stream to only store a last event if it has a numeric id.

---
https://github.com/All-Hands-AI/OpenHands/issues/5358

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:139ba40-nikolaik   --name openhands-app-139ba40   docker.all-hands.dev/all-hands-ai/openhands:139ba40
```