### PR TITLE
fix: Update frontend tests to support Node.js 22.x

### DIFF
--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [20, 22]
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,7 @@
 /** @type {import('tailwindcss').Config} */
-const { nextui } = require("@nextui-org/react");
+import { nextui } from "@nextui-org/react";
+import typography from '@tailwindcss/typography';
+
 export default {
   content: [
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -33,6 +35,6 @@ export default {
         }
       }
     }),
-    require('@tailwindcss/typography'),
+    typography,
   ],
 };


### PR DESCRIPTION
I was encountering errors when running "make build" when compiling the frontend on both node 22 and node 23.

```
vite v5.4.11 building for production...
file:///Users/gneubig/work/OpenHands/frontend/tailwind.config.js:2
const { nextui } = require("@nextui-org/react");
                   ^

ReferenceError: require is not defined
    at file:///Users/gneubig/work/OpenHands/frontend/tailwind.config.js:2:20
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:395:35)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:329:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1376:24)
    at Module._compile (node:internal/modules/cjs/loader:1528:5)
    at Object..js (node:internal/modules/cjs/loader:1698:10)
    at Module.load (node:internal/modules/cjs/loader:1303:32)
    at Function._load (node:internal/modules/cjs/loader:1117:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
```

This PR fixes frontend test failures in Node.js 22.x environments and improves test coverage:

- Convert Tailwind config to use ESM imports consistently
- Add Node.js 22.x to frontend test workflow matrix
- Add fail-fast strategy to catch test failures early

The changes ensure that frontend tests work correctly in both Node.js 20.x and 22.x environments, and the workflow will fail early if tests fail on either version.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:780707c-nikolaik   --name openhands-app-780707c   docker.all-hands.dev/all-hands-ai/openhands:780707c
```