### PR TITLE
Update resolver README.md to fix repo location

### DIFF
--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -61,7 +61,7 @@ Follow these steps to use this workflow in your own repository:
         2. Create a draft PR if successful, or push a branch if unsuccessful
         3. Comment on the issue with the results
 
-Need help? Feel free to [open an issue](https://github.com/all-hands-ai/openhands-resolver/issues) or email us at [contact@all-hands.dev](mailto:contact@all-hands.dev).
+Need help? Feel free to [open an issue](https://github.com/all-hands-ai/openhands/issues) or email us at [contact@all-hands.dev](mailto:contact@all-hands.dev).
 
 ## Manual Installation
 
@@ -111,7 +111,7 @@ python -m openhands.resolver.resolve_issue --repo [OWNER]/[REPO] --issue-number 
 For instance, if you want to resolve issue #100 in this repo, you would run:
 
 ```bash
-python -m openhands.resolver.resolve_issue --repo all-hands-ai/openhands-resolver --issue-number 100
+python -m openhands.resolver.resolve_issue --repo all-hands-ai/openhands --issue-number 100
 ```
 
 The output will be written to the `output/` directory.
@@ -119,7 +119,7 @@ The output will be written to the `output/` directory.
 If you've installed the package from source using poetry, you can use:
 
 ```bash
-poetry run python openhands/resolver/resolve_issue.py --repo all-hands-ai/openhands-resolver --issue-number 100
+poetry run python openhands/resolver/resolve_issue.py --repo all-hands-ai/openhands --issue-number 100
 ```
 
 For resolving multiple issues at once (e.g., in a batch process), you can use the `resolve_all_issues` command:
@@ -131,7 +131,7 @@ python -m openhands.resolver.resolve_all_issues --repo [OWNER]/[REPO] --issue-nu
 For example:
 
 ```bash
-python -m openhands.resolver.resolve_all_issues --repo all-hands-ai/openhands-resolver --issue-numbers 100,101,102
+python -m openhands.resolver.resolve_all_issues --repo all-hands-ai/openhands --issue-numbers 100,101,102
 ```
 
 ## Responding to PR Comments


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

There are still some vestiges of the old repo name in the resolver README.md. This fixes.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:95d1962-nikolaik   --name openhands-app-95d1962   docker.all-hands.dev/all-hands-ai/openhands:95d1962
```