### PR TITLE
Improve error message when issue/PR not found in resolver

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "openhands-frontend",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@nextui-org/react": "^2.4.8",

--- a/openhands/resolver/resolve_issue.py
+++ b/openhands/resolver/resolve_issue.py
@@ -349,7 +349,7 @@ async def resolve_issue(
             f'No issues found for issue number {issue_number}. Please verify that:\n'
             f'1. The issue/PR #{issue_number} exists in the repository {owner}/{repo}\n'
             f'2. You have the correct permissions to access it\n'
-            f'3. The repository name is spelled correctly (case-sensitive)'
+            f'3. The repository name is spelled correctly'
         )
 
     issue = issues[0]

--- a/openhands/resolver/resolve_issue.py
+++ b/openhands/resolver/resolve_issue.py
@@ -344,6 +344,14 @@ async def resolve_issue(
         issue_numbers=[issue_number], comment_id=comment_id
     )
 
+    if not issues:
+        raise ValueError(
+            f'No issues found for issue number {issue_number}. Please verify that:\n'
+            f'1. The issue/PR #{issue_number} exists in the repository {owner}/{repo}\n'
+            f'2. You have the correct permissions to access it\n'
+            f'3. The repository name is spelled correctly (case-sensitive)'
+        )
+
     issue = issues[0]
 
     if comment_id is not None:

--- a/tests/unit/resolver/test_resolve_issues.py
+++ b/tests/unit/resolver/test_resolve_issues.py
@@ -117,7 +117,6 @@ async def test_resolve_issue_no_issues_found():
         assert 'test-owner/test-repo' in str(exc_info.value)
         assert 'exists in the repository' in str(exc_info.value)
         assert 'correct permissions' in str(exc_info.value)
-        assert 'case-sensitive' in str(exc_info.value)
 
 
 def test_download_issues_from_github():

--- a/tests/unit/resolver/test_resolve_issues.py
+++ b/tests/unit/resolver/test_resolve_issues.py
@@ -84,6 +84,42 @@ def test_initialize_runtime():
     )
 
 
+@pytest.mark.asyncio
+async def test_resolve_issue_no_issues_found():
+    from openhands.resolver.resolve_issue import resolve_issue
+
+    # Mock dependencies
+    mock_handler = MagicMock()
+    mock_handler.get_converted_issues.return_value = []  # Return empty list
+
+    with patch(
+        'openhands.resolver.resolve_issue.issue_handler_factory',
+        return_value=mock_handler,
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            await resolve_issue(
+                owner='test-owner',
+                repo='test-repo',
+                token='test-token',
+                username='test-user',
+                max_iterations=5,
+                output_dir='/tmp',
+                llm_config=LLMConfig(model='test', api_key='test'),
+                runtime_container_image='test-image',
+                prompt_template='test-template',
+                issue_type='pr',
+                repo_instruction=None,
+                issue_number=5432,
+                comment_id=None,
+            )
+
+        assert 'No issues found for issue number 5432' in str(exc_info.value)
+        assert 'test-owner/test-repo' in str(exc_info.value)
+        assert 'exists in the repository' in str(exc_info.value)
+        assert 'correct permissions' in str(exc_info.value)
+        assert 'case-sensitive' in str(exc_info.value)
+
+
 def test_download_issues_from_github():
     llm_config = LLMConfig(model='test', api_key='test')
     handler = IssueHandler('owner', 'repo', 'token', llm_config)


### PR DESCRIPTION
When trying to resolve an issue or PR that does not exist, the resolver previously failed with a cryptic "list index out of range" error. This PR improves the error message to be more descriptive and helpful.

Changes:
- Added a check before accessing `issues[0]` to verify the list is not empty
- Added a descriptive error message that explains:
  1. What went wrong (no issues found)
  2. The issue number that was searched for
  3. Common reasons for the error (non-existent issue, permissions, case-sensitive repo name)
- Added a new test case `test_resolve_issue_no_issues_found` to verify the error handling

All tests pass.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:72f591c-nikolaik   --name openhands-app-72f591c   docker.all-hands.dev/all-hands-ai/openhands:72f591c
```