### PR TITLE
Fix stuck execution flow

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -463,10 +463,6 @@ class AgentController:
                 await self._delegate_step()
             return
 
-        if self._is_stuck():
-            await self._react_to_exception(RuntimeError('Agent got stuck in a loop'))
-            return
-
         self.log(
             'info',
             f'LEVEL {self.state.delegate_level} LOCAL STEP {self.state.local_iteration} GLOBAL STEP {self.state.iteration}',
@@ -486,6 +482,10 @@ class AgentController:
                     'budget', current_cost, self.max_budget_per_task
                 )
         if stop_step:
+            return
+
+        if self._is_stuck():
+            await self._react_to_exception(RuntimeError('Agent got stuck in a loop'))
             return
 
         self.update_state_before_step()

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -454,16 +454,17 @@ class AgentController:
             await asyncio.sleep(1)
             return
 
-        if self._is_stuck():
-            await self._react_to_exception(RuntimeError('Agent got stuck in a loop'))
-            return
-
         if self.delegate is not None:
             assert self.delegate != self
             if self.delegate.get_agent_state() == AgentState.PAUSED:
+                # no need to check too often
                 await asyncio.sleep(1)
             else:
                 await self._delegate_step()
+            return
+
+        if self._is_stuck():
+            await self._react_to_exception(RuntimeError('Agent got stuck in a loop'))
             return
 
         self.log(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We check if the agent is stuck once per step: for repetitive patterns in the latest actions and observations of the agent.

When we changed the `is_stuck` check from the end of the step to the beginning of the step, it ended up before the delegate check in the parent. That can lead to a lot of unnecessary checks in the parent while the delegate is running.

This PR proposes to move it down in the execution flow. Also after checking for traffic control, which can lead to a stop of its own or a paused state in the UI.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ddf1dfb-nikolaik   --name openhands-app-ddf1dfb   docker.all-hands.dev/all-hands-ai/openhands:ddf1dfb
```