### PR TITLE
add cost to summary

### DIFF
--- a/evaluation/benchmarks/swe_bench/scripts/eval/summarize_outputs.py
+++ b/evaluation/benchmarks/swe_bench/scripts/eval/summarize_outputs.py
@@ -128,6 +128,11 @@ def process_file(file_path):
                 for error, count in error_counter.items()
             },
         },
+        'costs': {
+            'main_agent': sum(main_agent_cost),
+            'editor': sum(editor_cost),
+            'total': sum(main_agent_cost) + sum(editor_cost),
+        },
         'statistics': {
             'avg_turns': sum(num_turns) / num_lines if num_lines > 0 else 0,
             'costs': {
@@ -251,6 +256,7 @@ if __name__ == '__main__':
             print(
                 f"Number of unfinished runs: {result['unfinished_runs']['count']} / {result['total_instances']} ({result['unfinished_runs']['percentage']:.2f}%)"
             )
+            print(f"Total cost: {result['costs']['total']:.2f} USD")
             print('## Statistics')
             print(
                 f"Avg. num of turns per instance: {result['statistics']['avg_turns']:.2f}"


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR adds total cost to the eval summary.

Cc @mamoodi I understand we need it for the the remote evals and, I assume, this is the script being run?

e.g.
```
Number of resolved: ...
Total cost: 35.88 USD
## Statistics
Avg. num of turns per instance: 31.65
Avg. agent cost per instance: 1.46 USD...
## Detailed error breakdown:
Agent reached maximum iteration in headless mode. Current iteration: 100.00, max iteration: 100.00: 6 (6.45%)
```

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2737b0f-nikolaik   --name openhands-app-2737b0f   docker.all-hands.dev/all-hands-ai/openhands:2737b0f
```