### PR TITLE
Fix: Auto-refresh file content when selected file changes

### DIFF
--- a/frontend/src/components/features/file-explorer/tree-node.tsx
+++ b/frontend/src/components/features/file-explorer/tree-node.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
 import { useFiles } from "#/context/files";
 import { cn } from "#/utils/utils";
 import { useListFiles } from "#/hooks/query/use-list-files";
 import { useListFile } from "#/hooks/query/use-list-file";
 import { Filename } from "./filename";
+import { RootState } from "#/store";
 
 interface TreeNodeProps {
   path: string;
@@ -20,6 +22,7 @@ function TreeNode({ path, defaultOpen = false }: TreeNodeProps) {
     selectedPath,
   } = useFiles();
   const [isOpen, setIsOpen] = React.useState(defaultOpen);
+  const { curAgentState } = useSelector((state: RootState) => state.agent);
 
   const isDirectory = path.endsWith("/");
 
@@ -38,6 +41,12 @@ function TreeNode({ path, defaultOpen = false }: TreeNodeProps) {
       }
     }
   }, [fileContent, path]);
+
+  React.useEffect(() => {
+    if (selectedPath === path && !isDirectory) {
+      refetch();
+    }
+  }, [curAgentState, selectedPath, path, isDirectory]);
 
   const fileParts = path.split("/");
   const filename =


### PR DESCRIPTION
This PR fixes the issue where the file content in the workspace panel does not automatically refresh when the selected file changes externally. Now, when a file is selected and its content changes, it will automatically update without requiring the user to click on the file again.

Changes:
- Added Redux store selector to get current agent state in TreeNode component
- Added useEffect hook to trigger file content refetch when:
  - File is currently selected
  - File is not a directory
  - Agent state changes

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:217f8d3-nikolaik   --name openhands-app-217f8d3   docker.all-hands.dev/all-hands-ai/openhands:217f8d3
```