### PR TITLE
Remove Beta label from Browser tab

### DIFF
--- a/frontend/__tests__/components/browser.test.tsx
+++ b/frontend/__tests__/components/browser.test.tsx
@@ -11,6 +11,7 @@ describe("Browser", () => {
         browser: {
           url: "https://example.com",
           screenshotSrc: "",
+          updateCount: 0,
         },
       },
     });
@@ -26,6 +27,7 @@ describe("Browser", () => {
           url: "https://example.com",
           screenshotSrc:
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN0uGvyHwAFCAJS091fQwAAAABJRU5ErkJggg==",
+          updateCount: 0,
         },
       },
     });

--- a/frontend/src/components/layout/container.tsx
+++ b/frontend/src/components/layout/container.tsx
@@ -5,7 +5,7 @@ import { NavTab } from "./nav-tab";
 interface ContainerProps {
   label?: string;
   labels?: {
-    label: string;
+    label: string | React.ReactNode;
     to: string;
     icon?: React.ReactNode;
     isBeta?: boolean;

--- a/frontend/src/components/layout/count-badge.tsx
+++ b/frontend/src/components/layout/count-badge.tsx
@@ -1,0 +1,7 @@
+export function CountBadge({ count }: { count: number }) {
+  return (
+    <span className="text-[11px] leading-5 text-root-primary bg-neutral-400 px-1 rounded-xl">
+      {count}
+    </span>
+  );
+}

--- a/frontend/src/components/layout/nav-tab.tsx
+++ b/frontend/src/components/layout/nav-tab.tsx
@@ -4,7 +4,7 @@ import { BetaBadge } from "./beta-badge";
 
 interface NavTabProps {
   to: string;
-  label: string;
+  label: string | React.ReactNode;
   icon: React.ReactNode;
   isBeta?: boolean;
 }

--- a/frontend/src/routes/_oh.app/route.tsx
+++ b/frontend/src/routes/_oh.app/route.tsx
@@ -33,6 +33,8 @@ function App() {
     (state: RootState) => state.initalQuery,
   );
 
+  const { updateCount } = useSelector((state: RootState) => state.browser);
+
   const { data: latestGitHubCommit } = useLatestRepoCommit({
     repository: selectedRepository,
   });
@@ -81,9 +83,10 @@ function App() {
                   { label: "Workspace", to: "", icon: <CodeIcon /> },
                   { label: "Jupyter", to: "jupyter", icon: <ListIcon /> },
                   {
-                    label: "Browser",
+                    label:
+                      updateCount > 0 ? `Browser (${updateCount})` : "Browser",
                     to: "browser",
-                    icon: <GlobeIcon />
+                    icon: <GlobeIcon />,
                   },
                 ]}
               >

--- a/frontend/src/routes/_oh.app/route.tsx
+++ b/frontend/src/routes/_oh.app/route.tsx
@@ -83,8 +83,7 @@ function App() {
                   {
                     label: "Browser",
                     to: "browser",
-                    icon: <GlobeIcon />,
-                    isBeta: true,
+                    icon: <GlobeIcon />
                   },
                 ]}
               >

--- a/frontend/src/routes/_oh.app/route.tsx
+++ b/frontend/src/routes/_oh.app/route.tsx
@@ -21,6 +21,7 @@ import { useUserPrefs } from "#/context/user-prefs-context";
 import { useConversationConfig } from "#/hooks/query/use-conversation-config";
 import { Container } from "#/components/layout/container";
 import Security from "#/components/shared/modals/security/security";
+import { CountBadge } from "#/components/layout/count-badge";
 
 function App() {
   const { token, gitHubToken } = useAuth();
@@ -83,8 +84,12 @@ function App() {
                   { label: "Workspace", to: "", icon: <CodeIcon /> },
                   { label: "Jupyter", to: "jupyter", icon: <ListIcon /> },
                   {
-                    label:
-                      updateCount > 0 ? `Browser (${updateCount})` : "Browser",
+                    label: (
+                      <div className="flex items-center gap-1">
+                        Browser
+                        {updateCount > 0 && <CountBadge count={updateCount} />}
+                      </div>
+                    ),
                     to: "browser",
                     icon: <GlobeIcon />,
                   },

--- a/frontend/src/state/browser-slice.ts
+++ b/frontend/src/state/browser-slice.ts
@@ -5,6 +5,8 @@ export const initialState = {
   url: "https://github.com/All-Hands-AI/OpenHands",
   // Base64-encoded screenshot of browser window (placeholder for now, will be replaced with the actual screenshot later)
   screenshotSrc: "",
+  // Counter for browser updates
+  updateCount: 0,
 };
 
 export const browserSlice = createSlice({
@@ -16,6 +18,7 @@ export const browserSlice = createSlice({
     },
     setScreenshotSrc: (state, action) => {
       state.screenshotSrc = action.payload;
+      state.updateCount += 1;
     },
   },
 });


### PR DESCRIPTION
This PR removes the Beta label from the Browser tab in the frontend interface.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0df0ea7-nikolaik   --name openhands-app-0df0ea7   docker.all-hands.dev/all-hands-ai/openhands:0df0ea7
```