### PR TITLE
feat: Configure fallback LLMs for rate limit handling

### DIFF
--- a/tests/unit/test_llm_fallback.py
+++ b/tests/unit/test_llm_fallback.py
@@ -1,7 +1,8 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
+import pytest
 from litellm.exceptions import RateLimitError
+
 from openhands.core.config import LLMConfig
 from openhands.llm.llm import LLM
 
@@ -27,11 +28,13 @@ def test_llm_fallback_on_rate_limit():
     primary_config.fallback_llms = [fallback1]
 
     llm = LLM(primary_config)
-    
+
     # Mock the completion functions
     primary_error = RateLimitError('Please try again in 60.5s')
     llm._completion_unwrapped = MagicMock(side_effect=primary_error)
-    llm._fallback_llms[0]._completion_unwrapped = MagicMock(return_value={'choices': [{'message': {'content': 'success'}}]})
+    llm._fallback_llms[0]._completion_unwrapped = MagicMock(
+        return_value={'choices': [{'message': {'content': 'success'}}]}
+    )
 
     # Call completion and verify fallback is used
     result = llm.completion(messages=[{'role': 'user', 'content': 'test'}])
@@ -47,7 +50,7 @@ def test_llm_fallback_reset():
 
     llm = LLM(primary_config)
     llm._current_llm_index = 1  # Simulate using fallback
-    
+
     # Reset and verify
     llm.reset_fallback_index()
     assert llm.get_current_model() == 'model1'
@@ -60,7 +63,7 @@ def test_llm_no_more_fallbacks():
     primary_config.fallback_llms = [fallback1]
 
     llm = LLM(primary_config)
-    
+
     # Mock both LLMs to fail
     error = RateLimitError('Rate limit exceeded')
     llm._completion_unwrapped = MagicMock(side_effect=error)

--- a/tests/unit/test_llm_fallback.py
+++ b/tests/unit/test_llm_fallback.py
@@ -1,0 +1,71 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from litellm.exceptions import RateLimitError
+from openhands.core.config import LLMConfig
+from openhands.llm.llm import LLM
+
+
+def test_llm_fallback_init():
+    # Test that fallback LLMs are properly initialized
+    primary_config = LLMConfig(model='model1')
+    fallback1 = LLMConfig(model='model2')
+    fallback2 = LLMConfig(model='model3')
+    primary_config.fallback_llms = [fallback1, fallback2]
+
+    llm = LLM(primary_config)
+    assert llm.get_current_model() == 'model1'
+    assert len(llm._fallback_llms) == 2
+    assert llm._fallback_llms[0].config.model == 'model2'
+    assert llm._fallback_llms[1].config.model == 'model3'
+
+
+def test_llm_fallback_on_rate_limit():
+    # Test that LLM switches to fallback on rate limit error
+    primary_config = LLMConfig(model='model1')
+    fallback1 = LLMConfig(model='model2')
+    primary_config.fallback_llms = [fallback1]
+
+    llm = LLM(primary_config)
+    
+    # Mock the completion functions
+    primary_error = RateLimitError('Please try again in 60.5s')
+    llm._completion_unwrapped = MagicMock(side_effect=primary_error)
+    llm._fallback_llms[0]._completion_unwrapped = MagicMock(return_value={'choices': [{'message': {'content': 'success'}}]})
+
+    # Call completion and verify fallback is used
+    result = llm.completion(messages=[{'role': 'user', 'content': 'test'}])
+    assert result['choices'][0]['message']['content'] == 'success'
+    assert llm.get_current_model() == 'model2'
+
+
+def test_llm_fallback_reset():
+    # Test that LLM resets to primary after rate limit expires
+    primary_config = LLMConfig(model='model1')
+    fallback1 = LLMConfig(model='model2')
+    primary_config.fallback_llms = [fallback1]
+
+    llm = LLM(primary_config)
+    llm._current_llm_index = 1  # Simulate using fallback
+    
+    # Reset and verify
+    llm.reset_fallback_index()
+    assert llm.get_current_model() == 'model1'
+
+
+def test_llm_no_more_fallbacks():
+    # Test that error is re-raised when no more fallbacks are available
+    primary_config = LLMConfig(model='model1')
+    fallback1 = LLMConfig(model='model2')
+    primary_config.fallback_llms = [fallback1]
+
+    llm = LLM(primary_config)
+    
+    # Mock both LLMs to fail
+    error = RateLimitError('Rate limit exceeded')
+    llm._completion_unwrapped = MagicMock(side_effect=error)
+    llm._fallback_llms[0]._completion_unwrapped = MagicMock(side_effect=error)
+
+    # Verify error is raised when no more fallbacks
+    with pytest.raises(RateLimitError):
+        llm.completion(messages=[{'role': 'user', 'content': 'test'}])


### PR DESCRIPTION
This PR adds support for configuring fallback LLMs that are automatically used when rate limits are hit.

### Changes
- Add `fallback_llms` field to `LLMConfig` to support a list of fallback LLM configurations
- Implement automatic switching to fallback LLMs when rate limits are hit
- Add automatic reset to primary LLM when rate limit expires
- Add unit tests to verify the functionality

### Usage Example
```toml
[llm]
model = "claude-3-5-sonnet-20241022"
api_key = "..."

[[llm.fallback_llms]]
model = "gpt-4"
api_key = "..."

[[llm.fallback_llms]]
model = "llama2-70b"
api_key = "..."
```

The system will automatically switch between these LLMs when rate limits are hit, and return to the primary LLM when the rate limit expires.

Fixes #1263

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:da0d740-nikolaik   --name openhands-app-da0d740   docker.all-hands.dev/all-hands-ai/openhands:da0d740
```