### PR TITLE
fix: Avoid duplicate messages during browser search operations

### DIFF
--- a/openhands/agenthub/browsing_agent/response_parser.py
+++ b/openhands/agenthub/browsing_agent/response_parser.py
@@ -53,7 +53,8 @@ class BrowsingActionParserMessage(ActionParser):
         pass
 
     def check_condition(self, action_str: str) -> bool:
-        return '```' not in action_str
+        # Only treat as message if it doesn't contain code blocks and isn't about searching
+        return '```' not in action_str and 'search' not in action_str.lower()
 
     def parse(self, action_str: str) -> Action:
         msg = f'send_msg_to_user("""{action_str}""")'


### PR DESCRIPTION
Fixes #5423

When performing browser operations, the message "Let me search for this information" was being repeated twice before the actual answer was received. This was happening because the browsing agent was sending intermediate messages during the search process.

This PR modifies the `BrowsingActionParserMessage` class to avoid treating search-related messages as user-facing messages, so they won't be sent to the user. Now only the final result will be shown.