### PR TITLE
Parallize Python Unit tests

### DIFF
--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build Environment
         run: make build
       - name: Run Tests
-        run: poetry run pytest --forked --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
+        run: poetry run pytest --forked -n auto --cov=openhands --cov-report=xml -svv ./tests/unit --ignore=tests/unit/test_memory.py
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Python Unit Tests take a pretty long time to execute. This will use all the cores on the github actions worker to try to accelerate tests by parallelizing.

==== Before this PR

Example run: https://github.com/All-Hands-AI/OpenHands/actions/runs/12248390242/job/34167909826?pr=5488
```
397 passed in 320.14s (0:05:20)
```

==== After this PR

Example run: https://github.com/All-Hands-AI/OpenHands/actions/runs/12249262896/job/34170279872?pr=5499
```
397 passed in 193.19s (0:03:13)
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fac9b78-nikolaik   --name openhands-app-fac9b78   docker.all-hands.dev/all-hands-ai/openhands:fac9b78
```