### PR TITLE
Dependabot config for any browsergym-* package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - "chromadb"
       browsergym:
         patterns:
-          - "browsergym"
+          - "browsergym*"
       security-all:
         applies-to: "security-updates"
         patterns:


### PR DESCRIPTION

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Dependabot is [unhappy](https://github.com/All-Hands-AI/OpenHands/pull/5313#issuecomment-2511605946) with "browsergym" category now, since we have only `browsergym-stuff`, so this PR proposes to tweak the category to apply to all of them.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5e579db-nikolaik   --name openhands-app-5e579db   docker.all-hands.dev/all-hands-ai/openhands:5e579db
```