### PR TITLE
Add browser observations to chat interface

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -2017,6 +2017,9 @@
   "ACTION_MESSAGE$WRITE": {
     "en": "Writing to a file"
   },
+  "ACTION_MESSAGE$BROWSE": {
+    "en": "Browsing the web"
+  },
   "OBSERVATION_MESSAGE$RUN": {
     "en": "Ran a bash command"
   },
@@ -2028,6 +2031,9 @@
   },
   "OBSERVATION_MESSAGE$WRITE": {
     "en": "Wrote to a file"
+  },
+  "OBSERVATION_MESSAGE$BROWSE": {
+    "en": "Browsing completed"
   },
   "EXPANDABLE_MESSAGE$SHOW_DETAILS": {
     "en": "Show details"

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -139,11 +139,11 @@ export const chatSlice = createSlice({
         content = `\`\`\`\n${content}\n\`\`\``;
         causeMessage.content = content; // Observation content includes the action
       } else if (observationID === "browse") {
-        let content = `**Current URL:** \`\`\`\n${observation.payload.extras.url}\`\`\`\n`;
+        let content = `**URL:** ${observation.payload.extras.url}\n`;
         if (observation.payload.extras.error) {
-          content += `**Error:** \`\`\`\n${observation.payload.extras.error}\`\`\`\n\n`;
+          content += `**Error:**\n\`\`\`\n${observation.payload.extras.error}\`\`\`\n\n`;
         }
-        content += `**Output:** \`\`\`\n${observation.payload.content}\`\`\``;
+        content += `**Output:**\n\`\`\`\n${observation.payload.content}\`\`\``;
         if (content.length > MAX_CONTENT_LENGTH) {
           content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
         }

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -141,9 +141,9 @@ export const chatSlice = createSlice({
       } else if (observationID === "browse") {
         let content = `**URL:** ${observation.payload.extras.url}\n`;
         if (observation.payload.extras.error) {
-          content += `**Error:**\n\`\`\`\n${observation.payload.extras.error}\`\`\`\n\n`;
+          content += `**Error:**\n${observation.payload.extras.error}\n`;
         }
-        content += `**Output:**\n\`\`\`\n${observation.payload.content}\`\`\``;
+        content += `**Output:**\n${observation.payload.content}`;
         if (content.length > MAX_CONTENT_LENGTH) {
           content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
         }

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -93,7 +93,11 @@ export const chatSlice = createSlice({
       } else if (actionID === "read") {
         text = action.payload.args.path;
       } else if (actionID === "browse") {
-        text = `\`\`\`\n${action.payload.args.code}\n\`\`\``;
+        text = `Current URL: ${action.payload.args.url}\n`;
+        if (action.payload.args.error) {
+          text += `Error: ${action.payload.args.error}\n\n`;
+        }
+        text += `${action.payload.args.code}`;
       }
       if (actionID === "run" || actionID === "run_ipython") {
         if (

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -139,11 +139,11 @@ export const chatSlice = createSlice({
         content = `\`\`\`\n${content}\n\`\`\``;
         causeMessage.content = content; // Observation content includes the action
       } else if (observationID === "browse") {
-        let content = `Current URL: ${observation.payload.extras.url}\n`;
+        let content = `**Current URL:** \`\`\`\n${observation.payload.extras.url}\`\`\`\n`;
         if (observation.payload.extras.error) {
-          content += `Error: ${observation.payload.extras.error}\n\n`;
+          content += `**Error:** \`\`\`\n${observation.payload.extras.error}\`\`\`\n\n`;
         }
-        content += observation.payload.content;
+        content += `**Output:** \`\`\`\n${observation.payload.content}\`\`\``;
         if (content.length > MAX_CONTENT_LENGTH) {
           content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
         }

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -135,7 +135,11 @@ export const chatSlice = createSlice({
         return;
       }
       causeMessage.translationID = translationID;
-      if (observationID === "run" || observationID === "run_ipython" || observationID === "browse") {
+      if (
+        observationID === "run" ||
+        observationID === "run_ipython" ||
+        observationID === "browse"
+      ) {
         let { content } = observation.payload;
         if (content.length > MAX_CONTENT_LENGTH) {
           content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -8,7 +8,7 @@ type SliceState = { messages: Message[] };
 
 const MAX_CONTENT_LENGTH = 1000;
 
-const HANDLED_ACTIONS = ["run", "run_ipython", "write", "read"];
+const HANDLED_ACTIONS = ["run", "run_ipython", "write", "read", "browse"];
 
 function getRiskText(risk: ActionSecurityRisk) {
   switch (risk) {
@@ -92,6 +92,8 @@ export const chatSlice = createSlice({
         text = `${action.payload.args.path}\n${content}`;
       } else if (actionID === "read") {
         text = action.payload.args.path;
+      } else if (actionID === "browse") {
+        text = `\`\`\`\n${action.payload.args.code}\n\`\`\``;
       }
       if (actionID === "run" || actionID === "run_ipython") {
         if (
@@ -129,7 +131,7 @@ export const chatSlice = createSlice({
         return;
       }
       causeMessage.translationID = translationID;
-      if (observationID === "run" || observationID === "run_ipython") {
+      if (observationID === "run" || observationID === "run_ipython" || observationID === "browse") {
         let { content } = observation.payload;
         if (content.length > MAX_CONTENT_LENGTH) {
           content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -93,7 +93,7 @@ export const chatSlice = createSlice({
       } else if (actionID === "read") {
         text = action.payload.args.path;
       } else if (actionID === "browse") {
-        text = `\`\`\`\n${action.payload.args.code}\n\`\`\``;
+        text = `Browsing ${action.payload.args.url}`;
       }
       if (actionID === "run" || actionID === "run_ipython") {
         if (

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -93,11 +93,7 @@ export const chatSlice = createSlice({
       } else if (actionID === "read") {
         text = action.payload.args.path;
       } else if (actionID === "browse") {
-        text = `Current URL: ${action.payload.args.url}\n`;
-        if (action.payload.args.error) {
-          text += `Error: ${action.payload.args.error}\n\n`;
-        }
-        text += `${action.payload.args.code}`;
+        text = `\`\`\`\n${action.payload.args.code}\n\`\`\``;
       }
       if (actionID === "run" || actionID === "run_ipython") {
         if (
@@ -135,17 +131,23 @@ export const chatSlice = createSlice({
         return;
       }
       causeMessage.translationID = translationID;
-      if (
-        observationID === "run" ||
-        observationID === "run_ipython" ||
-        observationID === "browse"
-      ) {
+      if (observationID === "run" || observationID === "run_ipython") {
         let { content } = observation.payload;
         if (content.length > MAX_CONTENT_LENGTH) {
           content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
         }
         content = `\`\`\`\n${content}\n\`\`\``;
         causeMessage.content = content; // Observation content includes the action
+      } else if (observationID === "browse") {
+        let content = `Current URL: ${observation.payload.args.url}\n`;
+        if (observation.payload.args.error) {
+          content += `Error: ${observation.payload.args.error}\n\n`;
+        }
+        content += observation.payload.content;
+        if (content.length > MAX_CONTENT_LENGTH) {
+          content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
+        }
+        causeMessage.content = content;
       }
     },
 

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -139,9 +139,9 @@ export const chatSlice = createSlice({
         content = `\`\`\`\n${content}\n\`\`\``;
         causeMessage.content = content; // Observation content includes the action
       } else if (observationID === "browse") {
-        let content = `Current URL: ${observation.payload.args.url}\n`;
-        if (observation.payload.args.error) {
-          content += `Error: ${observation.payload.args.error}\n\n`;
+        let content = `Current URL: ${observation.payload.extras.url}\n`;
+        if (observation.payload.extras.error) {
+          content += `Error: ${observation.payload.extras.error}\n\n`;
         }
         content += observation.payload.content;
         if (content.length > MAX_CONTENT_LENGTH) {


### PR DESCRIPTION
This PR adds support for browser observations in the chat interface, similar to how run observations work. Changes include:

- Added "browse" to HANDLED_ACTIONS array
- Updated addAssistantAction to handle browser actions
- Updated addAssistantObservation to handle browser observations

Browser actions and their outputs will now be displayed in collapsible sections using the OBSERVATION_MESSAGE$BROWSE translation key.

Before expansion:
<img width="401" alt="image" src="https://github.com/user-attachments/assets/c4bfa34c-c481-45c8-975b-bd8da67c681d">


Expanded:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/7a8e5212-7bff-43af-aea4-f7c20108e898">


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:52d6f81-nikolaik   --name openhands-app-52d6f81   docker.all-hands.dev/all-hands-ai/openhands:52d6f81
```