### PR TITLE
Fix: Redis listener attached at startup

### DIFF
--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -1,4 +1,5 @@
 import warnings
+from contextlib import asynccontextmanager
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
@@ -21,10 +22,17 @@ from openhands.server.routes.feedback import app as feedback_api_router
 from openhands.server.routes.files import app as files_api_router
 from openhands.server.routes.public import app as public_api_router
 from openhands.server.routes.security import app as security_api_router
-from openhands.server.shared import config
+from openhands.server.shared import config, session_manager
 from openhands.utils.import_utils import get_impl
 
-app = FastAPI()
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    async with session_manager:
+        yield
+
+
+app = FastAPI(lifespan=_lifespan)
 app.add_middleware(
     LocalhostCORSMiddleware,
     allow_credentials=True,

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -53,6 +53,7 @@ class SessionManager:
         """
         We use a redis backchannel to send actions between server nodes
         """
+        logger.debug('_redis_subscribe')
         redis_client = self._get_redis_client()
         pubsub = redis_client.pubsub()
         await pubsub.subscribe('oh_event')
@@ -76,7 +77,7 @@ class SessionManager:
 
     async def _process_message(self, message: dict):
         data = json.loads(message['data'])
-        logger.info(f'got_published_message:{message}')
+        logger.debug(f'got_published_message:{message}')
         sid = data['sid']
         message_type = data['message_type']
         if message_type == 'event':
@@ -113,7 +114,7 @@ class SessionManager:
         elif message_type == 'session_closing':
             # Session closing event - We only get this in the event of graceful shutdown,
             # which can't be guaranteed - nodes can simply vanish unexpectedly!
-            logger.info(f'session_closing:{sid}')
+            logger.debug(f'session_closing:{sid}')
             for (
                 connection_id,
                 local_sid,
@@ -166,11 +167,11 @@ class SessionManager:
     async def _is_session_running_in_cluster(self, sid: str) -> bool:
         """As the rest of the cluster if a session is running. Wait a for a short timeout for a reply"""
         # Create a flag for the callback
-        logger.info('_is_session_running_in_cluster')
+        logger.debug('_is_session_running_in_cluster')
         flag = asyncio.Event()
         self._session_is_running_flags[sid] = flag
         try:
-            logger.info(f'publish:is_session_running:{sid}')
+            logger.debug(f'publish:is_session_running:{sid}')
             await self._get_redis_client().publish(
                 'oh_event',
                 json.dumps(

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -46,7 +46,6 @@ class SessionManager:
 
     def _get_redis_client(self):
         redis_client = getattr(self.sio.manager, 'redis', None)
-        logger.info(f'_get_redis_client:{bool(redis_client)}')
         return redis_client
 
     async def _redis_subscribe(self):
@@ -157,7 +156,6 @@ class SessionManager:
             return session.agent_session.event_stream
 
         # If there is a remote session running, retrieve existing events for that
-        # We need more debug logging here - is there actually a redis client specified???
         redis_client = self._get_redis_client()
         if redis_client and await self._is_session_running_in_cluster(sid):
             return EventStream(sid, self.file_store)
@@ -167,7 +165,6 @@ class SessionManager:
     async def _is_session_running_in_cluster(self, sid: str) -> bool:
         """As the rest of the cluster if a session is running. Wait a for a short timeout for a reply"""
         # Create a flag for the callback
-        logger.debug('_is_session_running_in_cluster')
         flag = asyncio.Event()
         self._session_is_running_flags[sid] = flag
         try:


### PR DESCRIPTION
**Fix for issue where redis listener is not attached on server startup**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
I think this regression must have happened when `listen.py` was refactored. The lifespan listener was removed from the FastAPI app, so we were not listening on redis events.

I also added some log messages, and turned some down from `info` to `debug`.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:12786a0-nikolaik   --name openhands-app-12786a0   docker.all-hands.dev/all-hands-ai/openhands:12786a0
```