### PR TITLE
minor fixes for when commands time out

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -184,7 +184,7 @@ class AgentController:
         self.state.local_iteration += 1
 
     async def update_state_after_step(self):
-        # update metrics especially for cost. Use deepcopy to avoid it being modified by agent.reset()
+        # update metrics especially for cost. Use deepcopy to avoid it being modified by agent._reset()
         self.state.local_metrics = copy.deepcopy(self.agent.llm.metrics)
 
     async def _react_to_exception(
@@ -317,9 +317,10 @@ class AgentController:
         elif action.source == EventSource.AGENT and action.wait_for_response:
             await self.set_agent_state_to(AgentState.AWAITING_USER_INPUT)
 
-    def reset_task(self) -> None:
+    def _reset(self) -> None:
         """Resets the agent's task."""
         self.almost_stuck = 0
+        self._pending_action = None
         self.agent.reset()
 
     async def set_agent_state_to(self, new_state: AgentState) -> None:
@@ -337,7 +338,7 @@ class AgentController:
             return
 
         if new_state in (AgentState.STOPPED, AgentState.ERROR):
-            self.reset_task()
+            self._reset()
         elif (
             new_state == AgentState.RUNNING
             and self.state.agent_state == AgentState.PAUSED

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -318,7 +318,7 @@ class AgentController:
             await self.set_agent_state_to(AgentState.AWAITING_USER_INPUT)
 
     def _reset(self) -> None:
-        """Resets the agent's task."""
+        """Resets the agent controller"""
         self.almost_stuck = 0
         self._pending_action = None
         self.agent.reset()

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -24,7 +24,7 @@ def send_request(
     timeout: int = 10,
     **kwargs: Any,
 ) -> requests.Response:
-    response = session.request(method, url, **kwargs)
+    response = session.request(method, url, timeout=timeout, **kwargs)
     try:
         response.raise_for_status()
     except requests.HTTPError as e:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
CHANGELOG: better error handling for commands that timeout or kill the runtime

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

* We lost `timeout` for runtime requests (probably my fault 🤦)
* `_pending_action` seems to get stuck in place sometimes, this clears it if agent state hits STOP or ERROR

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:03a3ba7-nikolaik   --name openhands-app-03a3ba7   docker.all-hands.dev/all-hands-ai/openhands:03a3ba7
```