### PR TITLE
Fix: Making the logs quieter

### DIFF
--- a/openhands/utils/shutdown_listener.py
+++ b/openhands/utils/shutdown_listener.py
@@ -19,7 +19,7 @@ def _register_signal_handler(sig: signal.Signals):
     original_handler = None
 
     def handler(sig_: int, frame: FrameType | None):
-        logger.info(f'shutdown_signal:{sig_}')
+        logger.debug(f'shutdown_signal:{sig_}')
         global _should_exit
         _should_exit = True
         if original_handler:
@@ -34,15 +34,15 @@ def _register_signal_handlers():
         return
     _should_exit = False
 
-    logger.info('_register_signal_handlers')
+    logger.debug('_register_signal_handlers')
 
     # Check if we're in the main thread of the main interpreter
     if threading.current_thread() is threading.main_thread():
-        logger.info('_register_signal_handlers:main_thread')
+        logger.debug('_register_signal_handlers:main_thread')
         for sig in HANDLED_SIGNALS:
             _register_signal_handler(sig)
     else:
-        logger.info('_register_signal_handlers:not_main_thread')
+        logger.debug('_register_signal_handlers:not_main_thread')
 
 
 def should_exit() -> bool:


### PR DESCRIPTION
**Some of these log messages can be turned down to debug now this feature is bedded in**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Simple change : info -> debug


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2707687-nikolaik   --name openhands-app-2707687   docker.all-hands.dev/all-hands-ai/openhands:2707687
```