### PR TITLE
fix(frontend): Prevent VSCode from opening when remounting

### DIFF
--- a/frontend/src/hooks/query/use-vscode-url.ts
+++ b/frontend/src/hooks/query/use-vscode-url.ts
@@ -1,43 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import React from "react";
-import { useTranslation } from "react-i18next";
-import { useDispatch } from "react-redux";
-import toast from "#/utils/toast";
-import { addAssistantMessage } from "#/state/chat-slice";
-import { I18nKey } from "#/i18n/declaration";
 import OpenHands from "#/api/open-hands";
 
-export const useVSCodeUrl = () => {
-  const { t } = useTranslation();
-  const dispatch = useDispatch();
-
+export const useVSCodeUrl = (config: { enabled: boolean }) => {
   const data = useQuery({
     queryKey: ["vscode_url"],
     queryFn: OpenHands.getVSCodeUrl,
-    enabled: false,
+    enabled: config.enabled,
+    refetchOnMount: false,
   });
-
-  const { data: vscodeUrlObject, isFetching } = data;
-
-  React.useEffect(() => {
-    if (isFetching) return;
-
-    if (vscodeUrlObject?.vscode_url) {
-      dispatch(
-        addAssistantMessage(
-          "You opened VS Code. Please inform the agent of any changes you made to the workspace or environment. To avoid conflicts, it's best to pause the agent before making any changes.",
-        ),
-      );
-      window.open(vscodeUrlObject.vscode_url, "_blank");
-    } else if (vscodeUrlObject?.error) {
-      toast.error(
-        `open-vscode-error-${new Date().getTime()}`,
-        t(I18nKey.EXPLORER$VSCODE_SWITCHING_ERROR_MESSAGE, {
-          error: vscodeUrlObject.error,
-        }),
-      );
-    }
-  }, [vscodeUrlObject, isFetching]);
 
   return data;
 };


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- VSCode URL would forcefully open in certain cases such as when the query handler is remounted (due to the use effect logic)

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Fetches the URL when necessary, but only open the URL when the user explicitly clicks the handler


---
**Link of any specific issues this addresses**
Resolves #5519

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d848ea0-nikolaik   --name openhands-app-d848ea0   docker.all-hands.dev/all-hands-ai/openhands:d848ea0
```