### PR TITLE
Remove symlink use for swebench setup

### DIFF
--- a/evaluation/benchmarks/swe_bench/eval_infer.py
+++ b/evaluation/benchmarks/swe_bench/eval_infer.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 import time
 from functools import partial
@@ -170,8 +171,9 @@ def process_instance(
     assert obs.exit_code == 0
 
     # Apply patch
+    workspace_name = re.sub(r'/', '__', f"{instance['repo']}__{instance['version']}")
     exec_command = (
-        'cd /testbed && '
+        f'cd /workspace/${workspace_name} && '
         "(git apply -v /tmp/patch.diff && echo 'APPLY_PATCH_PASS' || "
         "(echo 'Failed to apply patch with git apply, trying with patch command...' && "
         "(patch --batch --fuzz=5 -p1 -i /tmp/patch.diff && echo 'APPLY_PATCH_PASS' || "

--- a/evaluation/benchmarks/swe_bench/eval_infer.py
+++ b/evaluation/benchmarks/swe_bench/eval_infer.py
@@ -1,5 +1,4 @@
 import os
-import re
 import tempfile
 import time
 from functools import partial
@@ -171,9 +170,8 @@ def process_instance(
     assert obs.exit_code == 0
 
     # Apply patch
-    workspace_name = re.sub(r'/', '__', f"{instance['repo']}__{instance['version']}")
     exec_command = (
-        f'cd /workspace/${workspace_name} && '
+        'cd /testbed && '
         "(git apply -v /tmp/patch.diff && echo 'APPLY_PATCH_PASS' || "
         "(echo 'Failed to apply patch with git apply, trying with patch command...' && "
         "(patch --batch --fuzz=5 -p1 -i /tmp/patch.diff && echo 'APPLY_PATCH_PASS' || "

--- a/evaluation/benchmarks/swe_bench/scripts/setup/instance_swe_entry.sh
+++ b/evaluation/benchmarks/swe_bench/scripts/setup/instance_swe_entry.sh
@@ -33,7 +33,7 @@ if [ -d /workspace/$WORKSPACE_NAME ]; then
     rm -rf /workspace/$WORKSPACE_NAME
 fi
 mkdir -p /workspace
-ln -s /testbed /workspace/$WORKSPACE_NAME
+mv /testbed /workspace/$WORKSPACE_NAME
 
 # Activate instance-specific environment
 . /opt/miniconda3/etc/profile.d/conda.sh


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR is to replace `ln -s` with `mv` from `/testbed` to `/workspace`.
- We only need to do this in `run_infer.py` to grab the diff. In `eval_infer.py` we can still use the original `/testbed` and apply the generated patch there.

I ran on 3 instances and it seemed to work fine out of the box. CC: @xingyaoww 


---
**Link of any specific issues this addresses**

Fix #5526
