### PR TITLE
fix: properly serialize tool calls into dicts for token counting

### DIFF
--- a/openhands/core/message.py
+++ b/openhands/core/message.py
@@ -114,11 +114,23 @@ class Message(BaseModel):
     def _add_tool_call_keys(self, message_dict: dict) -> dict:
         """Add tool call keys if we have a tool call or response.
 
-        NOTE: this is necessary for both native and non-native tool calling"""
+        NOTE: this is necessary for both native and non-native tool calling.
+        Tool calls are converted to dicts for token counting, but can remain as objects
+        for API calls since litellm's ChatCompletionMessageToolCall accepts both."""
 
         # an assistant message calling a tool
         if self.tool_calls is not None:
-            message_dict['tool_calls'] = self.tool_calls
+            message_dict['tool_calls'] = [
+                {
+                    'id': tool_call.id,
+                    'type': 'function',
+                    'function': {
+                        'name': tool_call.function.name,
+                        'arguments': tool_call.function.arguments
+                    }
+                }
+                for tool_call in self.tool_calls
+            ]
 
         # an observation message with tool response
         if self.tool_call_id is not None:

--- a/tests/unit/test_message.py
+++ b/tests/unit/test_message.py
@@ -1,0 +1,58 @@
+from litellm import ChatCompletionMessageToolCall
+
+from openhands.core.message import Message, TextContent
+
+
+def test_message_tool_call_serialization():
+    """Test that tool calls are properly serialized into dicts for token counting."""
+    # Create a tool call
+    tool_call = ChatCompletionMessageToolCall(
+        id="call_123",
+        type="function",
+        function={
+            "name": "test_function",
+            "arguments": '{"arg1": "value1"}'
+        }
+    )
+
+    # Create a message with the tool call
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="Test message")],
+        tool_calls=[tool_call]
+    )
+
+    # Serialize the message
+    serialized = message.model_dump()
+
+    # Check that tool calls are properly serialized
+    assert 'tool_calls' in serialized
+    assert isinstance(serialized['tool_calls'], list)
+    assert len(serialized['tool_calls']) == 1
+    
+    tool_call_dict = serialized['tool_calls'][0]
+    assert isinstance(tool_call_dict, dict)
+    assert tool_call_dict['id'] == "call_123"
+    assert tool_call_dict['type'] == "function"
+    assert tool_call_dict['function']['name'] == "test_function"
+    assert tool_call_dict['function']['arguments'] == '{"arg1": "value1"}'
+
+
+def test_message_tool_response_serialization():
+    """Test that tool responses are properly serialized."""
+    # Create a message with tool response
+    message = Message(
+        role="tool",
+        content=[TextContent(text="Function result")],
+        tool_call_id="call_123",
+        name="test_function"
+    )
+
+    # Serialize the message
+    serialized = message.model_dump()
+
+    # Check that tool response fields are properly serialized
+    assert 'tool_call_id' in serialized
+    assert serialized['tool_call_id'] == "call_123"
+    assert 'name' in serialized
+    assert serialized['name'] == "test_function"


### PR DESCRIPTION
(That wasn't me! 😅)

---

Original `openhands` message:

Tool calls are now properly serialized into dictionaries for token counting, while still working with litellm's API calls which accept both dicts and objects.

The issue was that tool calls were being passed directly to litellm's token counter without being converted to dictionaries. While this worked for API calls (because litellm's `ChatCompletionMessageToolCall` accepts both dicts and objects), it caused undercounting in token counting.

Changes:
- Modified `_add_tool_call_keys` to properly serialize tool calls into dicts
- Added tests to verify the serialization
- Added documentation explaining why we need dict serialization for token counting

This fixes the issue where tool calls were not being properly counted in token calculations.