### PR TITLE
Fix issue #5563: [Bug]: Prompt is not deleted when the user sends a message

### DIFF
--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -83,11 +83,11 @@ export function ChatInput({
   };
 
   const handleSubmitMessage = () => {
-    if (value || (textareaRef.current?.value && !value)) {
-      onSubmit(value || textareaRef.current?.value || "");
-      if (value) {
-        onChange?.("");
-      } else if (textareaRef.current) {
+    const message = value || textareaRef.current?.value || "";
+    if (message) {
+      onSubmit(message);
+      onChange?.("");
+      if (textareaRef.current) {
         textareaRef.current.value = "";
       }
     }


### PR DESCRIPTION
This pull request fixes #5563.

The issue has been successfully resolved. The PR fixes the regression where the prompt wasn't being cleared after text-only message submissions. The key changes include:

1. Simplified the input clearing logic by consolidating the message handling into a single flow
2. Ensuring both controlled and uncontrolled input states are cleared consistently after submission
3. Removing the conditional clearing behavior that was causing the regression

The changes have been verified through passing ChatInput tests, and the new implementation guarantees that the prompt will be cleared every time a user submits a message, regardless of whether it contains only text or includes images.

This fix directly addresses the reported bug while maintaining the expected functionality. The unrelated i18n test failures do not impact the effectiveness of this solution.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9d0cc5c-nikolaik   --name openhands-app-9d0cc5c   docker.all-hands.dev/all-hands-ai/openhands:9d0cc5c
```