### PR TITLE
fix(frontend): Trim settings data when setting to storage

### DIFF
--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -93,7 +93,7 @@ export const saveSettings = (settings: Partial<Settings>) => {
     if (!isValid) return;
     let value = settings[key as keyof Settings];
     if (value === undefined || value === null) value = "";
-    localStorage.setItem(key, value.toString());
+    localStorage.setItem(key, value.toString().trim());
   });
   localStorage.setItem("SETTINGS_VERSION", LATEST_SETTINGS_VERSION.toString());
 };


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- User can set empty data

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Trim data when setting storage


---
**Link of any specific issues this addresses**
Resolves #5377

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:70503a1-nikolaik   --name openhands-app-70503a1   docker.all-hands.dev/all-hands-ai/openhands:70503a1
```