### PR TITLE
Fix markdown code block formatting in chat window

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -27,7 +27,7 @@ code {
     monospace;
 }
 
-.markdown-body code {
+.markdown-body :not(pre) > code {
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
@@ -39,9 +39,25 @@ code {
   letter-spacing: -0.2px;
 }
 
+.markdown-body pre {
+  background-color: #2a3038;
+  border-radius: 6px;
+  padding: 16px;
+  border: 1px solid #30363d;
+  overflow: auto;
+}
+
 .markdown-body pre code {
   padding: 0;
-  background-color: inherit;
+  margin: 0;
+  font-size: 85%;
+  white-space: pre;
+  background-color: transparent;
+  border: 0;
+  display: block;
+  color: #e6edf3;
+  overflow: visible;
+  line-height: inherit;
 }
 
 .markdown-body {


### PR DESCRIPTION
This PR fixes the code block formatting in the chat window by:

- Properly differentiating between inline code and code blocks
- Adding proper styling for code blocks with background, border, and padding
- Preserving whitespace and formatting in code blocks
- Maintaining inline code styling for single-line code snippets

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:81c5c20-nikolaik   --name openhands-app-81c5c20   docker.all-hands.dev/all-hands-ai/openhands:81c5c20
```