### PR TITLE
fix: wrap multi-line code blocks in pre tag

### DIFF
--- a/frontend/src/components/features/markdown/code.tsx
+++ b/frontend/src/components/features/markdown/code.tsx
@@ -17,8 +17,8 @@ export function code({
   const match = /language-(\w+)/.exec(className || ""); // get the language
 
   if (!match) {
-    const isMultiline = String(children).includes('\n');
-    
+    const isMultiline = String(children).includes("\n");
+
     if (!isMultiline) {
       return (
         <code
@@ -47,9 +47,7 @@ export function code({
           overflow: "auto",
         }}
       >
-        <code className={className}>
-          {String(children).replace(/\n$/, "")}
-        </code>
+        <code className={className}>{String(children).replace(/\n$/, "")}</code>
       </pre>
     );
   }

--- a/frontend/src/components/features/markdown/code.tsx
+++ b/frontend/src/components/features/markdown/code.tsx
@@ -17,19 +17,40 @@ export function code({
   const match = /language-(\w+)/.exec(className || ""); // get the language
 
   if (!match) {
+    const isMultiline = String(children).includes('\n');
+    
+    if (!isMultiline) {
+      return (
+        <code
+          className={className}
+          style={{
+            backgroundColor: "#2a3038",
+            padding: "0.2em 0.4em",
+            borderRadius: "4px",
+            color: "#e6edf3",
+            border: "1px solid #30363d",
+          }}
+        >
+          {children}
+        </code>
+      );
+    }
+
     return (
-      <code
-        className={className}
+      <pre
         style={{
           backgroundColor: "#2a3038",
-          padding: "0.2em 0.4em",
+          padding: "1em",
           borderRadius: "4px",
           color: "#e6edf3",
           border: "1px solid #30363d",
+          overflow: "auto",
         }}
       >
-        {children}
-      </code>
+        <code className={className}>
+          {String(children).replace(/\n$/, "")}
+        </code>
+      </pre>
     );
   }
 


### PR DESCRIPTION
This PR fixes the rendering of multi-line code blocks in the chat window by:

- Detecting multi-line code blocks
- Wrapping them in pre tags with proper styling
- Maintaining consistent newline handling

Fixes #5186

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c10dd6b-nikolaik   --name openhands-app-c10dd6b   docker.all-hands.dev/all-hands-ai/openhands:c10dd6b
```