### PR TITLE
docs: improve custom sandbox guide with more configuration options

### DIFF
--- a/docs/modules/usage/how-to/custom-sandbox-guide.md
+++ b/docs/modules/usage/how-to/custom-sandbox-guide.md
@@ -16,7 +16,7 @@ If you choose the first option, you can skip the `Create Your Docker Image` sect
 
 ## Create Your Docker Image
 
-To create a custom Docker image, you can use any base image that supports your requirements. While Debian-based images are common, they're not strictly required.
+To create a custom Docker image, it must be Debian based.
 
 For example, if you want OpenHands to have `ruby` installed, you could create a `Dockerfile` with the following content:
 
@@ -67,9 +67,9 @@ The `config.toml` file supports several other options for customizing your sandb
 
 ```toml
 [core]
-# Install additional dependencies at runtime build time
+# Install additional dependencies when the runtime is built
 # Can contain any valid shell commands
-# $OH_INTERPRETER_PATH is available as the path to the OH-specific Python interpreter
+# If you need the path to the Python interpreter in any of these commands, you can use the $OH_INTERPRETER_PATH variable
 runtime_extra_deps = """
 pip install numpy pandas
 apt-get update && apt-get install -y ffmpeg

--- a/docs/modules/usage/how-to/custom-sandbox-guide.md
+++ b/docs/modules/usage/how-to/custom-sandbox-guide.md
@@ -16,15 +16,21 @@ If you choose the first option, you can skip the `Create Your Docker Image` sect
 
 ## Create Your Docker Image
 
-To create a custom Docker image, it must be Debian based.
+To create a custom Docker image, you can use any base image that supports your requirements. While Debian-based images are common, they're not strictly required.
 
-For example, if you want OpenHands to have `ruby` installed, create a `Dockerfile` with the following content:
+For example, if you want OpenHands to have `ruby` installed, you could create a `Dockerfile` with the following content:
 
 ```dockerfile
-FROM debian:latest
+FROM nikolaik/python-nodejs:python3.12-nodejs22
 
 # Install required packages
 RUN apt-get update && apt-get install -y ruby
+```
+
+Or you could use a Ruby-specific base image:
+
+```dockerfile
+FROM ruby:latest
 ```
 
 Save this file in a folder. Then, build your Docker image (e.g., named custom-image) by navigating to the folder in
@@ -53,6 +59,28 @@ This can be an image you’ve already pulled or one you’ve built:
 [core]
 ...
 sandbox_base_container_image="custom-image"
+```
+
+### Additional Configuration Options
+
+The `config.toml` file supports several other options for customizing your sandbox:
+
+```toml
+[core]
+# Install additional dependencies at runtime build time
+# Can contain any valid shell commands
+# $OH_INTERPRETER_PATH is available as the path to the OH-specific Python interpreter
+runtime_extra_deps = """
+pip install numpy pandas
+apt-get update && apt-get install -y ffmpeg
+"""
+
+# Set environment variables for the runtime
+# Useful for configuration that needs to be available at runtime
+runtime_startup_env_vars = { DATABASE_URL = "postgresql://user:pass@localhost/db" }
+
+# Specify platform for multi-architecture builds (e.g., "linux/amd64" or "linux/arm64")
+platform = "linux/amd64"
 ```
 
 ### Run


### PR DESCRIPTION
This PR improves the custom sandbox guide by:

1. Clarifying that any base image can be used, not just Debian-based ones
2. Adding examples using both the default nikolaik/python-nodejs image and a Ruby-specific image
3. Adding a new section "Additional Configuration Options" that documents:
   - runtime_extra_deps for installing additional dependencies
   - runtime_startup_env_vars for setting environment variables
   - platform for multi-architecture builds

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b8beaf6-nikolaik   --name openhands-app-b8beaf6   docker.all-hands.dev/all-hands-ai/openhands:b8beaf6
```