### PR TITLE
fix: allow to continue when the agent is stuck in interactive mode

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -902,17 +902,20 @@ class AgentController:
 
         return kept_events
 
-    def _is_stuck(self) -> bool:
+    def _is_stuck(self, ui_mode: bool | None = None) -> bool:
         """Checks if the agent or its delegate is stuck in a loop.
+
+        Args:
+            ui_mode: Optional override for UI mode. If not provided, uses not self.headless_mode.
 
         Returns:
             bool: True if the agent is stuck, False otherwise.
         """
         # check if delegate stuck
-        if self.delegate and self.delegate._is_stuck():
+        if self.delegate and self.delegate._is_stuck(ui_mode):
             return True
 
-        return self._stuck_detector.is_stuck()
+        return self._stuck_detector.is_stuck(ui_mode if ui_mode is not None else not self.headless_mode)
 
     def __repr__(self):
         return (

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -319,7 +319,7 @@ class AgentController:
 
     def _reset(self) -> None:
         """Resets the agent controller"""
-        self.almost_stuck = 0
+
         self._pending_action = None
         self.agent.reset()
 

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -912,7 +912,7 @@ class AgentController:
         if self.delegate and self.delegate._is_stuck():
             return True
 
-        return self._stuck_detector.is_stuck(not self.headless_mode)
+        return self._stuck_detector.is_stuck(self.headless_mode)
 
     def __repr__(self):
         return (

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -902,20 +902,17 @@ class AgentController:
 
         return kept_events
 
-    def _is_stuck(self, ui_mode: bool | None = None) -> bool:
+    def _is_stuck(self) -> bool:
         """Checks if the agent or its delegate is stuck in a loop.
-
-        Args:
-            ui_mode: Optional override for UI mode. If not provided, uses not self.headless_mode.
 
         Returns:
             bool: True if the agent is stuck, False otherwise.
         """
         # check if delegate stuck
-        if self.delegate and self.delegate._is_stuck(ui_mode):
+        if self.delegate and self.delegate._is_stuck():
             return True
 
-        return self._stuck_detector.is_stuck(ui_mode if ui_mode is not None else not self.headless_mode)
+        return self._stuck_detector.is_stuck(not self.headless_mode)
 
     def __repr__(self):
         return (

--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -94,7 +94,7 @@ class State:
     end_id: int = -1
     # truncation_id tracks where to load history after context window truncation
     truncation_id: int = -1
-    almost_stuck: int = 0
+
     delegates: dict[tuple[int, int], tuple[str, str]] = field(default_factory=dict)
     # NOTE: This will never be used by the controller, but it can be used by different
     # evaluation tasks to store extra data needed to track the progress/state of the task.

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -24,17 +24,18 @@ class StuckDetector:
     def __init__(self, state: State):
         self.state = state
 
-    def is_stuck(self, interactive_mode: bool = False):
+    def is_stuck(self, not_headless: bool = False):
         """Checks if the agent is stuck in a loop.
 
         Args:
-            interactive_mode: If True (not headless), only consider history after last user message.
-                           If False (headless), consider all history.
+            not_headless: Matches AgentController's not headless_mode.
+                         If True: Consider only history after last user message
+                         If False: Consider all history (headless mode)
 
         Returns:
             bool: True if the agent is stuck in a loop, False otherwise.
         """
-        if interactive_mode:
+        if not_headless:
             # In interactive mode, only look at history after the last user message
             last_user_msg_idx = -1
             for i, event in enumerate(self.state.history):

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -24,18 +24,18 @@ class StuckDetector:
     def __init__(self, state: State):
         self.state = state
 
-    def is_stuck(self, not_headless: bool = False):
+    def is_stuck(self, headless_mode: bool = True):
         """Checks if the agent is stuck in a loop.
 
         Args:
-            not_headless: Matches AgentController's not headless_mode.
-                         If True: Consider only history after last user message
-                         If False: Consider all history (headless mode)
+            headless_mode: Matches AgentController's headless_mode.
+                          If True: Consider all history (automated/testing)
+                          If False: Consider only history after last user message (interactive)
 
         Returns:
             bool: True if the agent is stuck in a loop, False otherwise.
         """
-        if not_headless:
+        if not headless_mode:
             # In interactive mode, only look at history after the last user message
             last_user_msg_idx = -1
             for i, event in enumerate(self.state.history):

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -38,9 +38,10 @@ class StuckDetector:
         if not headless_mode:
             # In interactive mode, only look at history after the last user message
             last_user_msg_idx = -1
-            for i, event in enumerate(self.state.history):
+            for i, event in enumerate(reversed(self.state.history)):
                 if isinstance(event, MessageAction) and event.source == EventSource.USER:
-                    last_user_msg_idx = i
+                    last_user_msg_idx = len(self.state.history) - i - 1
+                    break
 
             history_to_check = self.state.history[last_user_msg_idx + 1:]
         else:

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -39,11 +39,14 @@ class StuckDetector:
             # In interactive mode, only look at history after the last user message
             last_user_msg_idx = -1
             for i, event in enumerate(reversed(self.state.history)):
-                if isinstance(event, MessageAction) and event.source == EventSource.USER:
+                if (
+                    isinstance(event, MessageAction)
+                    and event.source == EventSource.USER
+                ):
                     last_user_msg_idx = len(self.state.history) - i - 1
                     break
 
-            history_to_check = self.state.history[last_user_msg_idx + 1:]
+            history_to_check = self.state.history[last_user_msg_idx + 1 :]
         else:
             # In headless mode, look at all history
             history_to_check = self.state.history

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -52,6 +52,7 @@ class StuckDetector:
             event
             for event in history_to_check
             if not (
+                # this is a problem! in headless mode we ignore these, but will this work with UI?
                 (isinstance(event, MessageAction) and event.source == EventSource.USER)
                 # there might be some NullAction or NullObservation in the history at least for now
                 or isinstance(event, (NullAction, NullObservation))

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -53,6 +53,7 @@ class StuckDetector:
             for event in history_to_check
             if not (
                 (isinstance(event, MessageAction) and event.source == EventSource.USER)
+                # there might be some NullAction or NullObservation in the history at least for now
                 or isinstance(event, (NullAction, NullObservation))
             )
         ]

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -81,43 +81,19 @@ class StuckDetector:
         # it takes 4 actions and 4 observations to detect a loop
         # assert len(last_actions) == 4 and len(last_observations) == 4
 
-        # reset almost_stuck reminder
-        self.state.almost_stuck = 0
-
-        # almost stuck? if two actions, obs are the same, we're almost stuck
-        if len(last_actions) >= 2 and len(last_observations) >= 2:
+        # Check for a loop of 4 identical action-observation pairs
+        if len(last_actions) == 4 and len(last_observations) == 4:
             actions_equal = all(
-                self._eq_no_pid(last_actions[0], action) for action in last_actions[:2]
+                self._eq_no_pid(last_actions[0], action) for action in last_actions
             )
             observations_equal = all(
                 self._eq_no_pid(last_observations[0], observation)
-                for observation in last_observations[:2]
+                for observation in last_observations
             )
 
-            # the last two actions and obs are the same?
             if actions_equal and observations_equal:
-                self.state.almost_stuck = 2
-
-            # the last three actions and observations are the same?
-            if len(last_actions) >= 3 and len(last_observations) >= 3:
-                if (
-                    actions_equal
-                    and observations_equal
-                    and self._eq_no_pid(last_actions[0], last_actions[2])
-                    and self._eq_no_pid(last_observations[0], last_observations[2])
-                ):
-                    self.state.almost_stuck = 1
-
-            if len(last_actions) == 4 and len(last_observations) == 4:
-                if (
-                    actions_equal
-                    and observations_equal
-                    and self._eq_no_pid(last_actions[0], last_actions[3])
-                    and self._eq_no_pid(last_observations[0], last_observations[3])
-                ):
-                    logger.warning('Action, Observation loop detected')
-                    self.state.almost_stuck = 0
-                    return True
+                logger.warning('Action, Observation loop detected')
+                return True
 
         return False
 

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -53,7 +53,9 @@ class StuckDetector:
             event
             for event in history_to_check
             if not (
-                # this is a problem! in headless mode we ignore these, but will this work with UI?
+                # Filter works elegantly in both modes:
+                # - In headless: actively filters out user messages from full history
+                # - In non-headless: no-op since we already sliced after last user message
                 (isinstance(event, MessageAction) and event.source == EventSource.USER)
                 # there might be some NullAction or NullObservation in the history at least for now
                 or isinstance(event, (NullAction, NullObservation))

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -24,9 +24,18 @@ class StuckDetector:
     def __init__(self, state: State):
         self.state = state
 
-    def is_stuck(self, ui_mode: bool = False):
-        if ui_mode:
-            # In UI mode, only look at history after the last user message
+    def is_stuck(self, interactive_mode: bool = False):
+        """Checks if the agent is stuck in a loop.
+
+        Args:
+            interactive_mode: If True (not headless), only consider history after last user message.
+                           If False (headless), consider all history.
+
+        Returns:
+            bool: True if the agent is stuck in a loop, False otherwise.
+        """
+        if interactive_mode:
+            # In interactive mode, only look at history after the last user message
             last_user_msg_idx = -1
             for i, event in enumerate(self.state.history):
                 if isinstance(event, MessageAction) and event.source == EventSource.USER:

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -128,7 +128,8 @@ class TestStuckDetector:
         
         # In headless mode, this should be stuck
         assert stuck_detector.is_stuck(headless_mode=True) is True
-        
+        # with the UI, it will ALSO be stuck initially
+        assert stuck_detector.is_stuck(headless_mode=False) is True
         # Add a user message
         message_action = MessageAction(content='Hello', wait_for_response=False)
         message_action._source = EventSource.USER

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -114,18 +114,22 @@ class TestStuckDetector:
 
         assert stuck_detector.is_stuck(headless_mode=True) is False
 
-    def test_interactive_mode_resets_after_user_message(self, stuck_detector: StuckDetector):
+    def test_interactive_mode_resets_after_user_message(
+        self, stuck_detector: StuckDetector
+    ):
         state = stuck_detector.state
-        
+
         # First add some actions that would be stuck in non-UI mode
         for i in range(4):
             cmd_action = CmdRunAction(command='ls')
             cmd_action._id = i
             state.history.append(cmd_action)
-            cmd_observation = CmdOutputObservation(content='', command='ls', command_id=i)
+            cmd_observation = CmdOutputObservation(
+                content='', command='ls', command_id=i
+            )
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
-        
+
         # In headless mode, this should be stuck
         assert stuck_detector.is_stuck(headless_mode=True) is True
         # with the UI, it will ALSO be stuck initially
@@ -134,11 +138,11 @@ class TestStuckDetector:
         message_action = MessageAction(content='Hello', wait_for_response=False)
         message_action._source = EventSource.USER
         state.history.append(message_action)
-        
+
         # In not-headless mode, this should not be stuck because we ignore history before user message
         assert stuck_detector.is_stuck(headless_mode=False) is False
 
-         # But in headless mode, this should be still stuck because user messages do not count
+        # But in headless mode, this should be still stuck because user messages do not count
         assert stuck_detector.is_stuck(headless_mode=True) is True
 
         # Add two more identical actions - still not stuck because we need at least 3
@@ -146,21 +150,25 @@ class TestStuckDetector:
             cmd_action = CmdRunAction(command='ls')
             cmd_action._id = i + 4
             state.history.append(cmd_action)
-            cmd_observation = CmdOutputObservation(content='', command='ls', command_id=i + 4)
+            cmd_observation = CmdOutputObservation(
+                content='', command='ls', command_id=i + 4
+            )
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
-        
+
         assert stuck_detector.is_stuck(headless_mode=False) is False
-        
+
         # Add two more identical actions - now it should be stuck
         for i in range(2):
             cmd_action = CmdRunAction(command='ls')
             cmd_action._id = i + 6
             state.history.append(cmd_action)
-            cmd_observation = CmdOutputObservation(content='', command='ls', command_id=i + 6)
+            cmd_observation = CmdOutputObservation(
+                content='', command='ls', command_id=i + 6
+            )
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
-        
+
         assert stuck_detector.is_stuck(headless_mode=False) is True
 
     def test_is_stuck_repeating_action_observation(self, stuck_detector: StuckDetector):

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -137,7 +137,10 @@ class TestStuckDetector:
         
         # In not-headless mode, this should not be stuck because we ignore history before user message
         assert stuck_detector.is_stuck(headless_mode=False) is False
-        
+
+         # But in headless mode, this should be still stuck because user messages do not count
+        assert stuck_detector.is_stuck(headless_mode=True) is True
+
         # Add two more identical actions - still not stuck because we need at least 3
         for i in range(2):
             cmd_action = CmdRunAction(command='ls')

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -135,6 +135,7 @@ class TestStuckDetector:
 
         # with the UI, it will ALSO be stuck initially
         assert stuck_detector.is_stuck(headless_mode=False) is True
+
         # Add a user message
         message_action = MessageAction(content='Hello', wait_for_response=False)
         message_action._source = EventSource.USER

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -112,10 +112,10 @@ class TestStuckDetector:
         # cmd_observation._cause = cmd_action._id
         state.history.append(cmd_observation)
 
-        assert stuck_detector.is_stuck(interactive_mode=False) is False
-        assert stuck_detector.is_stuck(interactive_mode=True) is False
+        assert stuck_detector.is_stuck(not_headless=False) is False
+        assert stuck_detector.is_stuck(not_headless=True) is False
 
-    def test_interactive_mode_resets_after_user_message(self, stuck_detector: StuckDetector):
+    def test_not_headless_resets_after_user_message(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
         
         # First add some actions that would be stuck in non-UI mode
@@ -127,16 +127,16 @@ class TestStuckDetector:
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
         
-        # In non-UI mode, this should be stuck
-        assert stuck_detector.is_stuck(interactive_mode=False) is True
+        # In headless mode, this should be stuck
+        assert stuck_detector.is_stuck(not_headless=False) is True
         
         # Add a user message
         message_action = MessageAction(content='Hello', wait_for_response=False)
         message_action._source = EventSource.USER
         state.history.append(message_action)
         
-        # In interactive mode, this should not be stuck because we ignore history before user message
-        assert stuck_detector.is_stuck(interactive_mode=True) is False
+        # In not-headless mode, this should not be stuck because we ignore history before user message
+        assert stuck_detector.is_stuck(not_headless=True) is False
         
         # Add two more identical actions - still not stuck because we need at least 3
         for i in range(2):
@@ -147,7 +147,7 @@ class TestStuckDetector:
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
         
-        assert stuck_detector.is_stuck(interactive_mode=True) is False
+        assert stuck_detector.is_stuck(not_headless=True) is False
         
         # Add two more identical actions - now it should be stuck
         for i in range(2):
@@ -158,7 +158,7 @@ class TestStuckDetector:
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
         
-        assert stuck_detector.is_stuck(interactive_mode=True) is True
+        assert stuck_detector.is_stuck(not_headless=True) is True
 
     def test_is_stuck_repeating_action_observation(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -194,7 +194,7 @@ class TestStuckDetector:
         state.history.append(message_null_observation)
         # 8 events
 
-        assert stuck_detector.is_stuck(interactive_mode=False) is False
+        assert stuck_detector.is_stuck(not_headless=False) is False
 
         cmd_action_3 = CmdRunAction(command='ls')
         cmd_action_3._id = 3
@@ -205,7 +205,7 @@ class TestStuckDetector:
         # 10 events
 
         assert len(state.history) == 10
-        assert stuck_detector.is_stuck(interactive_mode=False) is False
+        assert stuck_detector.is_stuck(not_headless=False) is False
 
         cmd_action_4 = CmdRunAction(command='ls')
         cmd_action_4._id = 4
@@ -218,7 +218,7 @@ class TestStuckDetector:
         assert len(state.history) == 12
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(interactive_mode=False) is True
+            assert stuck_detector.is_stuck(not_headless=False) is True
             mock_warning.assert_called_once_with('Action, Observation loop detected')
 
     def test_is_stuck_repeating_action_error(self, stuck_detector: StuckDetector):
@@ -270,7 +270,7 @@ class TestStuckDetector:
         # 12 events
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(interactive_mode=False) is True
+            assert stuck_detector.is_stuck(not_headless=False) is True
             mock_warning.assert_called_once_with(
                 'Action, ErrorObservation loop detected'
             )
@@ -284,7 +284,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is True
+            assert stuck_detector.is_stuck(not_headless=False) is True
 
     def test_is_not_stuck_invalid_syntax_error_random_lines(
         self, stuck_detector: StuckDetector
@@ -297,7 +297,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is False
+            assert stuck_detector.is_stuck(not_headless=False) is False
 
     def test_is_not_stuck_invalid_syntax_error_only_three_incidents(
         self, stuck_detector: StuckDetector
@@ -311,7 +311,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is False
+            assert stuck_detector.is_stuck(not_headless=False) is False
 
     def test_is_stuck_incomplete_input_error(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -322,7 +322,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is True
+            assert stuck_detector.is_stuck(not_headless=False) is True
 
     def test_is_not_stuck_incomplete_input_error(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -333,7 +333,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is False
+            assert stuck_detector.is_stuck(not_headless=False) is False
 
     def test_is_not_stuck_ipython_unterminated_string_error_random_lines(
         self, stuck_detector: StuckDetector
@@ -342,7 +342,7 @@ class TestStuckDetector:
         self._impl_unterminated_string_error_events(state, random_line=True)
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is False
+            assert stuck_detector.is_stuck(not_headless=False) is False
 
     def test_is_not_stuck_ipython_unterminated_string_error_only_three_incidents(
         self, stuck_detector: StuckDetector
@@ -353,7 +353,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is False
+            assert stuck_detector.is_stuck(not_headless=False) is False
 
     def test_is_stuck_ipython_unterminated_string_error(
         self, stuck_detector: StuckDetector
@@ -362,7 +362,7 @@ class TestStuckDetector:
         self._impl_unterminated_string_error_events(state, random_line=False)
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(interactive_mode=False) is True
+            assert stuck_detector.is_stuck(not_headless=False) is True
 
     def test_is_not_stuck_ipython_syntax_error_not_at_end(
         self, stuck_detector: StuckDetector
@@ -407,7 +407,7 @@ class TestStuckDetector:
         state.history.append(ipython_observation_4)
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(interactive_mode=False) is False
+            assert stuck_detector.is_stuck(not_headless=False) is False
             mock_warning.assert_not_called()
 
     def test_is_stuck_repeating_action_observation_pattern(
@@ -476,7 +476,7 @@ class TestStuckDetector:
         state.history.append(read_observation_3)
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(interactive_mode=False) is True
+            assert stuck_detector.is_stuck(not_headless=False) is True
             mock_warning.assert_called_once_with('Action, Observation pattern detected')
 
     def test_is_stuck_not_stuck(self, stuck_detector: StuckDetector):
@@ -542,7 +542,7 @@ class TestStuckDetector:
         # read_observation_3._cause = read_action_3._id
         state.history.append(read_observation_3)
 
-        assert stuck_detector.is_stuck(interactive_mode=False) is False
+        assert stuck_detector.is_stuck(not_headless=False) is False
 
     def test_is_stuck_monologue(self, stuck_detector):
         state = stuck_detector.state
@@ -572,7 +572,7 @@ class TestStuckDetector:
         message_action_6._source = EventSource.AGENT
         state.history.append(message_action_6)
 
-        assert stuck_detector.is_stuck(interactive_mode=False)
+        assert stuck_detector.is_stuck(not_headless=False)
 
         # Add an observation event between the repeated message actions
         cmd_output_observation = CmdOutputObservation(
@@ -592,7 +592,7 @@ class TestStuckDetector:
         state.history.append(message_action_8)
 
         with patch('logging.Logger.warning'):
-            assert not stuck_detector.is_stuck(interactive_mode=False)
+            assert not stuck_detector.is_stuck(not_headless=False)
 
 
 class TestAgentController:

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -132,6 +132,7 @@ class TestStuckDetector:
 
         # In headless mode, this should be stuck
         assert stuck_detector.is_stuck(headless_mode=True) is True
+
         # with the UI, it will ALSO be stuck initially
         assert stuck_detector.is_stuck(headless_mode=False) is True
         # Add a user message

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -112,10 +112,10 @@ class TestStuckDetector:
         # cmd_observation._cause = cmd_action._id
         state.history.append(cmd_observation)
 
-        assert stuck_detector.is_stuck(ui_mode=False) is False
-        assert stuck_detector.is_stuck(ui_mode=True) is False
+        assert stuck_detector.is_stuck(interactive_mode=False) is False
+        assert stuck_detector.is_stuck(interactive_mode=True) is False
 
-    def test_ui_mode_resets_after_user_message(self, stuck_detector: StuckDetector):
+    def test_interactive_mode_resets_after_user_message(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
         
         # First add some actions that would be stuck in non-UI mode
@@ -128,15 +128,15 @@ class TestStuckDetector:
             state.history.append(cmd_observation)
         
         # In non-UI mode, this should be stuck
-        assert stuck_detector.is_stuck(ui_mode=False) is True
+        assert stuck_detector.is_stuck(interactive_mode=False) is True
         
         # Add a user message
         message_action = MessageAction(content='Hello', wait_for_response=False)
         message_action._source = EventSource.USER
         state.history.append(message_action)
         
-        # In UI mode, this should not be stuck because we ignore history before user message
-        assert stuck_detector.is_stuck(ui_mode=True) is False
+        # In interactive mode, this should not be stuck because we ignore history before user message
+        assert stuck_detector.is_stuck(interactive_mode=True) is False
         
         # Add two more identical actions - still not stuck because we need at least 3
         for i in range(2):
@@ -147,7 +147,7 @@ class TestStuckDetector:
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
         
-        assert stuck_detector.is_stuck(ui_mode=True) is False
+        assert stuck_detector.is_stuck(interactive_mode=True) is False
         
         # Add two more identical actions - now it should be stuck
         for i in range(2):
@@ -158,7 +158,7 @@ class TestStuckDetector:
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
         
-        assert stuck_detector.is_stuck(ui_mode=True) is True
+        assert stuck_detector.is_stuck(interactive_mode=True) is True
 
     def test_is_stuck_repeating_action_observation(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -194,7 +194,7 @@ class TestStuckDetector:
         state.history.append(message_null_observation)
         # 8 events
 
-        assert stuck_detector.is_stuck(ui_mode=False) is False
+        assert stuck_detector.is_stuck(interactive_mode=False) is False
 
         cmd_action_3 = CmdRunAction(command='ls')
         cmd_action_3._id = 3
@@ -205,7 +205,7 @@ class TestStuckDetector:
         # 10 events
 
         assert len(state.history) == 10
-        assert stuck_detector.is_stuck(ui_mode=False) is False
+        assert stuck_detector.is_stuck(interactive_mode=False) is False
 
         cmd_action_4 = CmdRunAction(command='ls')
         cmd_action_4._id = 4
@@ -218,7 +218,7 @@ class TestStuckDetector:
         assert len(state.history) == 12
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(ui_mode=False) is True
+            assert stuck_detector.is_stuck(interactive_mode=False) is True
             mock_warning.assert_called_once_with('Action, Observation loop detected')
 
     def test_is_stuck_repeating_action_error(self, stuck_detector: StuckDetector):
@@ -270,7 +270,7 @@ class TestStuckDetector:
         # 12 events
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(ui_mode=False) is True
+            assert stuck_detector.is_stuck(interactive_mode=False) is True
             mock_warning.assert_called_once_with(
                 'Action, ErrorObservation loop detected'
             )
@@ -284,7 +284,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is True
+            assert stuck_detector.is_stuck(interactive_mode=False) is True
 
     def test_is_not_stuck_invalid_syntax_error_random_lines(
         self, stuck_detector: StuckDetector
@@ -297,7 +297,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is False
+            assert stuck_detector.is_stuck(interactive_mode=False) is False
 
     def test_is_not_stuck_invalid_syntax_error_only_three_incidents(
         self, stuck_detector: StuckDetector
@@ -311,7 +311,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is False
+            assert stuck_detector.is_stuck(interactive_mode=False) is False
 
     def test_is_stuck_incomplete_input_error(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -322,7 +322,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is True
+            assert stuck_detector.is_stuck(interactive_mode=False) is True
 
     def test_is_not_stuck_incomplete_input_error(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -333,7 +333,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is False
+            assert stuck_detector.is_stuck(interactive_mode=False) is False
 
     def test_is_not_stuck_ipython_unterminated_string_error_random_lines(
         self, stuck_detector: StuckDetector
@@ -342,7 +342,7 @@ class TestStuckDetector:
         self._impl_unterminated_string_error_events(state, random_line=True)
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is False
+            assert stuck_detector.is_stuck(interactive_mode=False) is False
 
     def test_is_not_stuck_ipython_unterminated_string_error_only_three_incidents(
         self, stuck_detector: StuckDetector
@@ -353,7 +353,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is False
+            assert stuck_detector.is_stuck(interactive_mode=False) is False
 
     def test_is_stuck_ipython_unterminated_string_error(
         self, stuck_detector: StuckDetector
@@ -362,7 +362,7 @@ class TestStuckDetector:
         self._impl_unterminated_string_error_events(state, random_line=False)
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(ui_mode=False) is True
+            assert stuck_detector.is_stuck(interactive_mode=False) is True
 
     def test_is_not_stuck_ipython_syntax_error_not_at_end(
         self, stuck_detector: StuckDetector
@@ -407,7 +407,7 @@ class TestStuckDetector:
         state.history.append(ipython_observation_4)
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(ui_mode=False) is False
+            assert stuck_detector.is_stuck(interactive_mode=False) is False
             mock_warning.assert_not_called()
 
     def test_is_stuck_repeating_action_observation_pattern(
@@ -476,7 +476,7 @@ class TestStuckDetector:
         state.history.append(read_observation_3)
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(ui_mode=False) is True
+            assert stuck_detector.is_stuck(interactive_mode=False) is True
             mock_warning.assert_called_once_with('Action, Observation pattern detected')
 
     def test_is_stuck_not_stuck(self, stuck_detector: StuckDetector):
@@ -542,7 +542,7 @@ class TestStuckDetector:
         # read_observation_3._cause = read_action_3._id
         state.history.append(read_observation_3)
 
-        assert stuck_detector.is_stuck(ui_mode=False) is False
+        assert stuck_detector.is_stuck(interactive_mode=False) is False
 
     def test_is_stuck_monologue(self, stuck_detector):
         state = stuck_detector.state
@@ -572,7 +572,7 @@ class TestStuckDetector:
         message_action_6._source = EventSource.AGENT
         state.history.append(message_action_6)
 
-        assert stuck_detector.is_stuck(ui_mode=False)
+        assert stuck_detector.is_stuck(interactive_mode=False)
 
         # Add an observation event between the repeated message actions
         cmd_output_observation = CmdOutputObservation(
@@ -592,7 +592,7 @@ class TestStuckDetector:
         state.history.append(message_action_8)
 
         with patch('logging.Logger.warning'):
-            assert not stuck_detector.is_stuck(ui_mode=False)
+            assert not stuck_detector.is_stuck(interactive_mode=False)
 
 
 class TestAgentController:
@@ -609,4 +609,4 @@ class TestAgentController:
     def test_is_stuck_delegate_stuck(self, controller: AgentController):
         controller.delegate = Mock()
         controller.delegate._is_stuck.return_value = True
-        assert controller._is_stuck(ui_mode=False) is True
+        assert controller._is_stuck() is True

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -113,7 +113,6 @@ class TestStuckDetector:
         state.history.append(cmd_observation)
 
         assert stuck_detector.is_stuck(headless_mode=True) is False
-        assert stuck_detector.is_stuck(headless_mode=False) is False
 
     def test_interactive_mode_resets_after_user_message(self, stuck_detector: StuckDetector):
         state = stuck_detector.state

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -112,10 +112,10 @@ class TestStuckDetector:
         # cmd_observation._cause = cmd_action._id
         state.history.append(cmd_observation)
 
-        assert stuck_detector.is_stuck(not_headless=False) is False
-        assert stuck_detector.is_stuck(not_headless=True) is False
+        assert stuck_detector.is_stuck(headless_mode=True) is False
+        assert stuck_detector.is_stuck(headless_mode=False) is False
 
-    def test_not_headless_resets_after_user_message(self, stuck_detector: StuckDetector):
+    def test_interactive_mode_resets_after_user_message(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
         
         # First add some actions that would be stuck in non-UI mode
@@ -128,7 +128,7 @@ class TestStuckDetector:
             state.history.append(cmd_observation)
         
         # In headless mode, this should be stuck
-        assert stuck_detector.is_stuck(not_headless=False) is True
+        assert stuck_detector.is_stuck(headless_mode=True) is True
         
         # Add a user message
         message_action = MessageAction(content='Hello', wait_for_response=False)
@@ -136,7 +136,7 @@ class TestStuckDetector:
         state.history.append(message_action)
         
         # In not-headless mode, this should not be stuck because we ignore history before user message
-        assert stuck_detector.is_stuck(not_headless=True) is False
+        assert stuck_detector.is_stuck(headless_mode=False) is False
         
         # Add two more identical actions - still not stuck because we need at least 3
         for i in range(2):
@@ -147,7 +147,7 @@ class TestStuckDetector:
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
         
-        assert stuck_detector.is_stuck(not_headless=True) is False
+        assert stuck_detector.is_stuck(headless_mode=False) is False
         
         # Add two more identical actions - now it should be stuck
         for i in range(2):
@@ -158,7 +158,7 @@ class TestStuckDetector:
             cmd_observation._cause = cmd_action._id
             state.history.append(cmd_observation)
         
-        assert stuck_detector.is_stuck(not_headless=True) is True
+        assert stuck_detector.is_stuck(headless_mode=False) is True
 
     def test_is_stuck_repeating_action_observation(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -194,7 +194,7 @@ class TestStuckDetector:
         state.history.append(message_null_observation)
         # 8 events
 
-        assert stuck_detector.is_stuck(not_headless=False) is False
+        assert stuck_detector.is_stuck(headless_mode=True) is False
 
         cmd_action_3 = CmdRunAction(command='ls')
         cmd_action_3._id = 3
@@ -205,7 +205,7 @@ class TestStuckDetector:
         # 10 events
 
         assert len(state.history) == 10
-        assert stuck_detector.is_stuck(not_headless=False) is False
+        assert stuck_detector.is_stuck(headless_mode=True) is False
 
         cmd_action_4 = CmdRunAction(command='ls')
         cmd_action_4._id = 4
@@ -218,7 +218,7 @@ class TestStuckDetector:
         assert len(state.history) == 12
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(not_headless=False) is True
+            assert stuck_detector.is_stuck(headless_mode=True) is True
             mock_warning.assert_called_once_with('Action, Observation loop detected')
 
     def test_is_stuck_repeating_action_error(self, stuck_detector: StuckDetector):
@@ -270,7 +270,7 @@ class TestStuckDetector:
         # 12 events
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(not_headless=False) is True
+            assert stuck_detector.is_stuck(headless_mode=True) is True
             mock_warning.assert_called_once_with(
                 'Action, ErrorObservation loop detected'
             )
@@ -284,7 +284,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is True
+            assert stuck_detector.is_stuck(headless_mode=True) is True
 
     def test_is_not_stuck_invalid_syntax_error_random_lines(
         self, stuck_detector: StuckDetector
@@ -297,7 +297,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is False
+            assert stuck_detector.is_stuck(headless_mode=True) is False
 
     def test_is_not_stuck_invalid_syntax_error_only_three_incidents(
         self, stuck_detector: StuckDetector
@@ -311,7 +311,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is False
+            assert stuck_detector.is_stuck(headless_mode=True) is False
 
     def test_is_stuck_incomplete_input_error(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -322,7 +322,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is True
+            assert stuck_detector.is_stuck(headless_mode=True) is True
 
     def test_is_not_stuck_incomplete_input_error(self, stuck_detector: StuckDetector):
         state = stuck_detector.state
@@ -333,7 +333,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is False
+            assert stuck_detector.is_stuck(headless_mode=True) is False
 
     def test_is_not_stuck_ipython_unterminated_string_error_random_lines(
         self, stuck_detector: StuckDetector
@@ -342,7 +342,7 @@ class TestStuckDetector:
         self._impl_unterminated_string_error_events(state, random_line=True)
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is False
+            assert stuck_detector.is_stuck(headless_mode=True) is False
 
     def test_is_not_stuck_ipython_unterminated_string_error_only_three_incidents(
         self, stuck_detector: StuckDetector
@@ -353,7 +353,7 @@ class TestStuckDetector:
         )
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is False
+            assert stuck_detector.is_stuck(headless_mode=True) is False
 
     def test_is_stuck_ipython_unterminated_string_error(
         self, stuck_detector: StuckDetector
@@ -362,7 +362,7 @@ class TestStuckDetector:
         self._impl_unterminated_string_error_events(state, random_line=False)
 
         with patch('logging.Logger.warning'):
-            assert stuck_detector.is_stuck(not_headless=False) is True
+            assert stuck_detector.is_stuck(headless_mode=True) is True
 
     def test_is_not_stuck_ipython_syntax_error_not_at_end(
         self, stuck_detector: StuckDetector
@@ -407,7 +407,7 @@ class TestStuckDetector:
         state.history.append(ipython_observation_4)
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(not_headless=False) is False
+            assert stuck_detector.is_stuck(headless_mode=True) is False
             mock_warning.assert_not_called()
 
     def test_is_stuck_repeating_action_observation_pattern(
@@ -476,7 +476,7 @@ class TestStuckDetector:
         state.history.append(read_observation_3)
 
         with patch('logging.Logger.warning') as mock_warning:
-            assert stuck_detector.is_stuck(not_headless=False) is True
+            assert stuck_detector.is_stuck(headless_mode=True) is True
             mock_warning.assert_called_once_with('Action, Observation pattern detected')
 
     def test_is_stuck_not_stuck(self, stuck_detector: StuckDetector):
@@ -542,7 +542,7 @@ class TestStuckDetector:
         # read_observation_3._cause = read_action_3._id
         state.history.append(read_observation_3)
 
-        assert stuck_detector.is_stuck(not_headless=False) is False
+        assert stuck_detector.is_stuck(headless_mode=True) is False
 
     def test_is_stuck_monologue(self, stuck_detector):
         state = stuck_detector.state
@@ -572,7 +572,7 @@ class TestStuckDetector:
         message_action_6._source = EventSource.AGENT
         state.history.append(message_action_6)
 
-        assert stuck_detector.is_stuck(not_headless=False)
+        assert stuck_detector.is_stuck(headless_mode=True)
 
         # Add an observation event between the repeated message actions
         cmd_output_observation = CmdOutputObservation(
@@ -592,7 +592,7 @@ class TestStuckDetector:
         state.history.append(message_action_8)
 
         with patch('logging.Logger.warning'):
-            assert not stuck_detector.is_stuck(not_headless=False)
+            assert not stuck_detector.is_stuck(headless_mode=True)
 
 
 class TestAgentController:

--- a/tests/unit/test_is_stuck.py
+++ b/tests/unit/test_is_stuck.py
@@ -149,7 +149,6 @@ class TestStuckDetector:
         # 8 events
 
         assert stuck_detector.is_stuck() is False
-        assert stuck_detector.state.almost_stuck == 2
 
         cmd_action_3 = CmdRunAction(command='ls')
         cmd_action_3._id = 3
@@ -160,20 +159,7 @@ class TestStuckDetector:
         # 10 events
 
         assert len(state.history) == 10
-        assert (
-            len(state.history) == 10
-        )  # Adjusted since history is a list and the controller is not running
-
-        # FIXME are we still testing this without this test?
-        # assert (
-        #    len(
-        #        get_pairs_from_events(state.history)
-        #    )
-        #    == 5
-        # )
-
         assert stuck_detector.is_stuck() is False
-        assert stuck_detector.state.almost_stuck == 1
 
         cmd_action_4 = CmdRunAction(command='ls')
         cmd_action_4._id = 4
@@ -184,16 +170,9 @@ class TestStuckDetector:
         # 12 events
 
         assert len(state.history) == 12
-        # assert (
-        #    len(
-        #        get_pairs_from_events(state.history)
-        #    )
-        #    == 6
-        # )
 
         with patch('logging.Logger.warning') as mock_warning:
             assert stuck_detector.is_stuck() is True
-            assert stuck_detector.state.almost_stuck == 0
             mock_warning.assert_called_once_with('Action, Observation loop detected')
 
     def test_is_stuck_repeating_action_error(self, stuck_detector: StuckDetector):


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Let user continue when the agent gets stuck in the UI.

---

Changes:
1. Clean up:
   - Remove unused `almost_stuck` field and related code
   - Simplify stuck detection logic

2. Improve stuck detection:
   - Use `headless_mode` to determine behavior
   - In interactive mode: only consider history after last user message
   - In headless mode: keep existing behavior (full history)

3. Optimizations:
   - Use `reversed()` to find last user message
   - Elegant filtering that works in both modes:
     * In headless: actively filters user messages
     * In interactive: no-op (already sliced after last user message)

4. Tests:
   - Add tests for both modes
   - Verify behavior before/after user messages
   - Maintain backward compatibility

Fix: #5480

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:63cb544-nikolaik   --name openhands-app-63cb544   docker.all-hands.dev/all-hands-ai/openhands:63cb544
```