### PR TITLE
Use LLM APIs responses in token counting

### DIFF
--- a/openhands/core/message_utils.py
+++ b/openhands/core/message_utils.py
@@ -29,6 +29,7 @@ from openhands.events.observation import (
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.observation.observation import Observation
 from openhands.events.serialization.event import truncate_content
+from openhands.llm.metrics import Metrics, TokensUsage
 
 
 def events_to_messages(
@@ -362,3 +363,49 @@ def apply_prompt_caching(messages: list[Message]) -> None:
                 -1
             ].cache_prompt = True  # Last item inside the message content
             break
+
+
+def get_single_tokens_usage_for_event(
+    event: Event, metrics: Metrics
+) -> TokensUsage | None:
+    """
+    Returns at most one token usage record for the `model_response.id` in this event's
+    `tool_call_metadata`.
+
+    If no response_id is found, or none match in metrics.tokens_usages, returns [].
+    """
+    if event.tool_call_metadata and event.tool_call_metadata.model_response:
+        response_id = event.tool_call_metadata.model_response.get('id')
+        if response_id:
+            return next(
+                (
+                    usage
+                    for usage in metrics.tokens_usages
+                    if usage.response_id == response_id
+                ),
+                None,
+            )
+    return None
+
+
+def get_tokens_usage_for_event_id(
+    events: list[Event], event_id: int, metrics: Metrics
+) -> TokensUsage | None:
+    """
+    Starting from the event with .id == event_id and moving backwards in `events`,
+    find the first TokensUsage record (if any) associated with a response_id from
+    tool_call_metadata.model_response.id.
+
+    Returns the first match found, or None if none is found.
+    """
+    # find the index of the event with the given id
+    idx = next((i for i, e in enumerate(events) if e.id == event_id), None)
+    if idx is None:
+        return None
+
+    # search backward from idx down to 0
+    for i in range(idx, -1, -1):
+        usage = get_single_tokens_usage_for_event(events[i], metrics)
+        if usage is not None:
+            return usage
+    return None

--- a/openhands/core/message_utils.py
+++ b/openhands/core/message_utils.py
@@ -29,7 +29,7 @@ from openhands.events.observation import (
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.observation.observation import Observation
 from openhands.events.serialization.event import truncate_content
-from openhands.llm.metrics import Metrics, TokensUsage
+from openhands.llm.metrics import Metrics, TokenUsage
 
 
 def events_to_messages(
@@ -365,14 +365,12 @@ def apply_prompt_caching(messages: list[Message]) -> None:
             break
 
 
-def get_single_tokens_usage_for_event(
-    event: Event, metrics: Metrics
-) -> TokensUsage | None:
+def get_token_usage_for_event(event: Event, metrics: Metrics) -> TokenUsage | None:
     """
     Returns at most one token usage record for the `model_response.id` in this event's
     `tool_call_metadata`.
 
-    If no response_id is found, or none match in metrics.tokens_usages, returns [].
+    If no response_id is found, or none match in metrics.token_usages, returns [].
     """
     if event.tool_call_metadata and event.tool_call_metadata.model_response:
         response_id = event.tool_call_metadata.model_response.get('id')
@@ -380,7 +378,7 @@ def get_single_tokens_usage_for_event(
             return next(
                 (
                     usage
-                    for usage in metrics.tokens_usages
+                    for usage in metrics.token_usages
                     if usage.response_id == response_id
                 ),
                 None,
@@ -388,12 +386,12 @@ def get_single_tokens_usage_for_event(
     return None
 
 
-def get_tokens_usage_for_event_id(
+def get_token_usage_for_event_id(
     events: list[Event], event_id: int, metrics: Metrics
-) -> TokensUsage | None:
+) -> TokenUsage | None:
     """
     Starting from the event with .id == event_id and moving backwards in `events`,
-    find the first TokensUsage record (if any) associated with a response_id from
+    find the first TokenUsage record (if any) associated with a response_id from
     tool_call_metadata.model_response.id.
 
     Returns the first match found, or None if none is found.
@@ -405,7 +403,7 @@ def get_tokens_usage_for_event_id(
 
     # search backward from idx down to 0
     for i in range(idx, -1, -1):
-        usage = get_single_tokens_usage_for_event(events[i], metrics)
+        usage = get_token_usage_for_event(events[i], metrics)
         if usage is not None:
             return usage
     return None

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -497,6 +497,7 @@ class LLM(RetryMixin, DebugMixin):
             stats += 'Response Latency: %.3f seconds\n' % latest_latency.latency
 
         usage: Usage | None = response.get('usage')
+        response_id = response.get('id', 'unknown')
 
         if usage:
             # keep track of the input and output tokens
@@ -539,6 +540,7 @@ class LLM(RetryMixin, DebugMixin):
                 completion_tokens=completion_tokens,
                 cache_read_tokens=cache_hit_tokens,
                 cache_write_tokens=cache_write_tokens,
+                response_id=response_id,
             )
 
         # log the stats

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -535,7 +535,7 @@ class LLM(RetryMixin, DebugMixin):
 
             # Record in metrics
             # We'll treat cache_hit_tokens as "cache read" and cache_write_tokens as "cache write"
-            self.metrics.add_tokens_usage(
+            self.metrics.add_token_usage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 cache_read_tokens=cache_hit_tokens,

--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -67,6 +67,16 @@ class Metrics:
     def response_latencies(self, value: list[ResponseLatency]) -> None:
         self._response_latencies = value
 
+    @property
+    def tokens_usages(self) -> list[TokensUsage]:
+        if not hasattr(self, '_tokens_usages'):
+            self._tokens_usages = []
+        return self._tokens_usages
+
+    @tokens_usages.setter
+    def tokens_usages(self, value: list[TokensUsage]) -> None:
+        self._tokens_usages = value
+
     def add_cost(self, value: float) -> None:
         if value < 0:
             raise ValueError('Added cost cannot be negative.')
@@ -104,8 +114,9 @@ class Metrics:
         """Merge 'other' metrics into this one."""
         self._accumulated_cost += other.accumulated_cost
         self._costs += other._costs
-        self._response_latencies += other._response_latencies
-        self._tokens_usages += other._tokens_usages
+        # use the property so older picked objects that lack the field won't crash
+        self.tokens_usages += other.tokens_usages
+        self.response_latencies += other.response_latencies
 
     def get(self) -> dict:
         """Return the metrics in a dictionary."""

--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -17,11 +17,23 @@ class ResponseLatency(BaseModel):
     response_id: str
 
 
+class TokensUsage(BaseModel):
+    """Metric tracking detailed token usage per completion call."""
+
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    timestamp: float = Field(default_factory=time.time)
+
+
 class Metrics:
     """Metrics class can record various metrics during running and evaluation.
     Currently, we define the following metrics:
         accumulated_cost: the total cost (USD $) of the current LLM.
         response_latency: the time taken for each LLM completion call.
+        accrued token usage: the total tokens used across all completions.
     """
 
     def __init__(self, model_name: str = 'default') -> None:
@@ -29,6 +41,11 @@ class Metrics:
         self._costs: list[Cost] = []
         self._response_latencies: list[ResponseLatency] = []
         self.model_name = model_name
+        self._accumulated_prompt_tokens = 0
+        self._accumulated_completion_tokens = 0
+        self._accumulated_cache_read_tokens = 0
+        self._accumulated_cache_write_tokens = 0
+        self._tokens_usages: list[TokensUsage] = []
 
     @property
     def accumulated_cost(self) -> float:
@@ -67,16 +84,50 @@ class Metrics:
             )
         )
 
+    def add_tokens_usage(
+        self,
+        prompt_tokens: int,
+        completion_tokens: int,
+        cache_read_tokens: int,
+        cache_write_tokens: int,
+    ) -> None:
+        # accumulate
+        self._accumulated_prompt_tokens += prompt_tokens
+        self._accumulated_completion_tokens += completion_tokens
+        self._accumulated_cache_read_tokens += cache_read_tokens
+        self._accumulated_cache_write_tokens += cache_write_tokens
+
+        # record this individual usage
+        self._tokens_usages.append(
+            TokensUsage(
+                model=self.model_name,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            )
+        )
+
     def merge(self, other: 'Metrics') -> None:
         self._accumulated_cost += other.accumulated_cost
         self._costs += other._costs
         self._response_latencies += other._response_latencies
+        self._accumulated_prompt_tokens += other._accumulated_prompt_tokens
+        self._accumulated_completion_tokens += other._accumulated_completion_tokens
+        self._accumulated_cache_read_tokens += other._accumulated_cache_read_tokens
+        self._accumulated_cache_write_tokens += other._accumulated_cache_write_tokens
+        self._tokens_usages += other._tokens_usages
 
     def get(self) -> dict:
         """Return the metrics in a dictionary."""
         return {
             'accumulated_cost': self._accumulated_cost,
             'costs': [cost.model_dump() for cost in self._costs],
+            'accumulated_prompt_tokens': self._accumulated_prompt_tokens,
+            'accumulated_completion_tokens': self._accumulated_completion_tokens,
+            'accumulated_cache_read_tokens': self._accumulated_cache_read_tokens,
+            'accumulated_cache_write_tokens': self._accumulated_cache_write_tokens,
+            'tokens_usages': [usage.model_dump() for usage in self._tokens_usages],
             'response_latencies': [
                 latency.model_dump() for latency in self._response_latencies
             ],
@@ -86,6 +137,11 @@ class Metrics:
         self._accumulated_cost = 0.0
         self._costs = []
         self._response_latencies = []
+        self._accumulated_prompt_tokens = 0
+        self._accumulated_completion_tokens = 0
+        self._accumulated_cache_read_tokens = 0
+        self._accumulated_cache_write_tokens = 0
+        self._tokens_usages = []
 
     def log(self):
         """Log the metrics."""

--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -17,7 +17,7 @@ class ResponseLatency(BaseModel):
     response_id: str
 
 
-class TokensUsage(BaseModel):
+class TokenUsage(BaseModel):
     """Metric tracking detailed token usage per completion call."""
 
     model: str
@@ -33,7 +33,7 @@ class Metrics:
     We track:
       - accumulated_cost and costs
       - A list of ResponseLatency
-      - A list of TokensUsage (one per call).
+      - A list of TokenUsage (one per call).
     """
 
     def __init__(self, model_name: str = 'default') -> None:
@@ -41,7 +41,7 @@ class Metrics:
         self._costs: list[Cost] = []
         self._response_latencies: list[ResponseLatency] = []
         self.model_name = model_name
-        self._tokens_usages: list[TokensUsage] = []
+        self._token_usages: list[TokenUsage] = []
 
     @property
     def accumulated_cost(self) -> float:
@@ -68,14 +68,14 @@ class Metrics:
         self._response_latencies = value
 
     @property
-    def tokens_usages(self) -> list[TokensUsage]:
-        if not hasattr(self, '_tokens_usages'):
-            self._tokens_usages = []
-        return self._tokens_usages
+    def token_usages(self) -> list[TokenUsage]:
+        if not hasattr(self, '_token_usages'):
+            self._token_usages = []
+        return self._token_usages
 
-    @tokens_usages.setter
-    def tokens_usages(self, value: list[TokensUsage]) -> None:
-        self._tokens_usages = value
+    @token_usages.setter
+    def token_usages(self, value: list[TokenUsage]) -> None:
+        self._token_usages = value
 
     def add_cost(self, value: float) -> None:
         if value < 0:
@@ -90,7 +90,7 @@ class Metrics:
             )
         )
 
-    def add_tokens_usage(
+    def add_token_usage(
         self,
         prompt_tokens: int,
         completion_tokens: int,
@@ -99,8 +99,8 @@ class Metrics:
         response_id: str,
     ) -> None:
         """Add a single usage record."""
-        self._tokens_usages.append(
-            TokensUsage(
+        self._token_usages.append(
+            TokenUsage(
                 model=self.model_name,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
@@ -115,7 +115,7 @@ class Metrics:
         self._accumulated_cost += other.accumulated_cost
         self._costs += other._costs
         # use the property so older picked objects that lack the field won't crash
-        self.tokens_usages += other.tokens_usages
+        self.token_usages += other.token_usages
         self.response_latencies += other.response_latencies
 
     def get(self) -> dict:
@@ -126,14 +126,14 @@ class Metrics:
             'response_latencies': [
                 latency.model_dump() for latency in self._response_latencies
             ],
-            'tokens_usages': [usage.model_dump() for usage in self._tokens_usages],
+            'token_usages': [usage.model_dump() for usage in self._token_usages],
         }
 
     def reset(self):
         self._accumulated_cost = 0.0
         self._costs = []
         self._response_latencies = []
-        self._tokens_usages = []
+        self._token_usages = []
 
     def log(self):
         """Log the metrics."""

--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -25,7 +25,7 @@ class TokensUsage(BaseModel):
     completion_tokens: int
     cache_read_tokens: int
     cache_write_tokens: int
-    timestamp: float = Field(default_factory=time.time)
+    response_id: str
 
 
 class Metrics:
@@ -90,6 +90,7 @@ class Metrics:
         completion_tokens: int,
         cache_read_tokens: int,
         cache_write_tokens: int,
+        response_id: str,
     ) -> None:
         # accumulate
         self._accumulated_prompt_tokens += prompt_tokens
@@ -105,6 +106,7 @@ class Metrics:
                 completion_tokens=completion_tokens,
                 cache_read_tokens=cache_read_tokens,
                 cache_write_tokens=cache_write_tokens,
+                response_id=response_id,
             )
         )
 

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -2,6 +2,7 @@ import copy
 from unittest.mock import MagicMock, patch
 
 import pytest
+from litellm import PromptTokensDetails
 from litellm.exceptions import (
     RateLimitError,
 )
@@ -441,7 +442,7 @@ def test_llm_token_usage(mock_litellm_completion, default_config):
         'usage': {
             'prompt_tokens': 12,
             'completion_tokens': 3,
-            'prompt_tokens_details': {'cached_tokens': 2},
+            'prompt_tokens_details': PromptTokensDetails(cached_tokens=2),
             'model_extra': {'cache_creation_input_tokens': 5},
         },
     }
@@ -453,7 +454,7 @@ def test_llm_token_usage(mock_litellm_completion, default_config):
         'usage': {
             'prompt_tokens': 7,
             'completion_tokens': 2,
-            'prompt_tokens_details': {'cached_tokens': 1},
+            'prompt_tokens_details': PromptTokensDetails(cached_tokens=1),
             'model_extra': {'cache_creation_input_tokens': 3},
         },
     }

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -468,9 +468,9 @@ def test_llm_token_usage(mock_litellm_completion, default_config):
     llm.completion(messages=[{'role': 'user', 'content': 'Hello usage!'}])
 
     # Verify we have exactly one usage record after first call
-    tokens_usage_list = llm.metrics.get()['tokens_usages']
-    assert len(tokens_usage_list) == 1
-    usage_entry_1 = tokens_usage_list[0]
+    token_usage_list = llm.metrics.get()['token_usages']
+    assert len(token_usage_list) == 1
+    usage_entry_1 = token_usage_list[0]
     assert usage_entry_1['prompt_tokens'] == 12
     assert usage_entry_1['completion_tokens'] == 3
     assert usage_entry_1['cache_read_tokens'] == 2
@@ -481,9 +481,9 @@ def test_llm_token_usage(mock_litellm_completion, default_config):
     llm.completion(messages=[{'role': 'user', 'content': 'Hello again!'}])
 
     # Now we expect two usage records total
-    tokens_usage_list = llm.metrics.get()['tokens_usages']
-    assert len(tokens_usage_list) == 2
-    usage_entry_2 = tokens_usage_list[-1]
+    token_usage_list = llm.metrics.get()['token_usages']
+    assert len(token_usage_list) == 2
+    usage_entry_2 = token_usage_list[-1]
     assert usage_entry_2['prompt_tokens'] == 7
     assert usage_entry_2['completion_tokens'] == 2
     assert usage_entry_2['cache_read_tokens'] == 1

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -463,46 +463,28 @@ def test_llm_token_usage(mock_litellm_completion, default_config):
 
     llm = LLM(config=default_config)
 
-    # First call: usage_1
-    _ = llm.completion(messages=[{'role': 'user', 'content': 'Hello usage!'}])
+    # First call
+    llm.completion(messages=[{'role': 'user', 'content': 'Hello usage!'}])
 
-    # Check that the metrics tracked these tokens for the first response
-    assert llm.metrics.get()['accumulated_prompt_tokens'] == 12
-    assert llm.metrics.get()['accumulated_completion_tokens'] == 3
-    assert llm.metrics.get()['accumulated_cache_read_tokens'] == 2
-    assert llm.metrics.get()['accumulated_cache_write_tokens'] == 5
-
-    # Also verify tokens_usages has a single entry with the exact usage
+    # Verify we have exactly one usage record after first call
     tokens_usage_list = llm.metrics.get()['tokens_usages']
     assert len(tokens_usage_list) == 1
-    usage_entry = tokens_usage_list[0]
-    assert usage_entry['prompt_tokens'] == 12
-    assert usage_entry['completion_tokens'] == 3
-    assert usage_entry['cache_read_tokens'] == 2
-    assert usage_entry['cache_write_tokens'] == 5
-    # Check the response_id
-    assert usage_entry['response_id'] == 'test-response-usage'
+    usage_entry_1 = tokens_usage_list[0]
+    assert usage_entry_1['prompt_tokens'] == 12
+    assert usage_entry_1['completion_tokens'] == 3
+    assert usage_entry_1['cache_read_tokens'] == 2
+    assert usage_entry_1['cache_write_tokens'] == 5
+    assert usage_entry_1['response_id'] == 'test-response-usage'
 
-    # Second call: usage_2
-    _ = llm.completion(messages=[{'role': 'user', 'content': 'Hello again!'}])
+    # Second call
+    llm.completion(messages=[{'role': 'user', 'content': 'Hello again!'}])
 
-    # Now check accumulated totals
-    metrics_dict = llm.metrics.get()
-    # Prompt tokens = 12 + 7 = 19
-    assert metrics_dict['accumulated_prompt_tokens'] == 19
-    # Completion tokens = 3 + 2 = 5
-    assert metrics_dict['accumulated_completion_tokens'] == 5
-    # Cache read = 2 + 1 = 3
-    assert metrics_dict['accumulated_cache_read_tokens'] == 3
-    # Cache write = 5 + 3 = 8
-    assert metrics_dict['accumulated_cache_write_tokens'] == 8
-
-    # Also verify we have two usage records now
-    tokens_usage_list = metrics_dict['tokens_usages']
+    # Now we expect two usage records total
+    tokens_usage_list = llm.metrics.get()['tokens_usages']
     assert len(tokens_usage_list) == 2
-    latest_entry = tokens_usage_list[-1]
-    assert latest_entry['prompt_tokens'] == 7
-    assert latest_entry['completion_tokens'] == 2
-    assert latest_entry['cache_read_tokens'] == 1
-    assert latest_entry['cache_write_tokens'] == 3
-    assert latest_entry['response_id'] == 'test-response-usage-2'
+    usage_entry_2 = tokens_usage_list[-1]
+    assert usage_entry_2['prompt_tokens'] == 7
+    assert usage_entry_2['completion_tokens'] == 2
+    assert usage_entry_2['cache_read_tokens'] == 1
+    assert usage_entry_2['cache_write_tokens'] == 3
+    assert usage_entry_2['response_id'] == 'test-response-usage-2'

--- a/tests/unit/test_message_utils.py
+++ b/tests/unit/test_message_utils.py
@@ -3,13 +3,18 @@ from unittest.mock import Mock
 import pytest
 
 from openhands.core.message import ImageContent, TextContent
-from openhands.core.message_utils import get_action_message, get_observation_message
+from openhands.core.message_utils import (
+    get_action_message,
+    get_observation_message,
+    get_single_tokens_usage_for_event,
+    get_tokens_usage_for_event_id,
+)
 from openhands.events.action import (
     AgentFinishAction,
     CmdRunAction,
     MessageAction,
 )
-from openhands.events.event import EventSource, FileEditSource, FileReadSource
+from openhands.events.event import Event, EventSource, FileEditSource, FileReadSource
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (
     CmdOutputMetadata,
@@ -21,6 +26,7 @@ from openhands.events.observation.error import ErrorObservation
 from openhands.events.observation.files import FileEditObservation, FileReadObservation
 from openhands.events.observation.reject import UserRejectObservation
 from openhands.events.tool import ToolCallMetadata
+from openhands.llm.metrics import Metrics, TokensUsage
 
 
 def test_cmd_output_observation_message():
@@ -269,3 +275,113 @@ def test_agent_finish_action_with_tool_metadata():
     assert len(result.content) == 1
     assert isinstance(result.content[0], TextContent)
     assert 'Initial thought\nTask completed' in result.content[0].text
+
+
+def test_get_single_tokens_usage_for_event():
+    """Test that we get the single matching usage record (if any) based on the event's model_response.id."""
+    metrics = Metrics(model_name='test-model')
+    usage_record = TokensUsage(
+        model='test-model',
+        prompt_tokens=10,
+        completion_tokens=5,
+        cache_read_tokens=2,
+        cache_write_tokens=1,
+        response_id='test-response-id',
+    )
+    metrics.add_tokens_usage(
+        prompt_tokens=usage_record.prompt_tokens,
+        completion_tokens=usage_record.completion_tokens,
+        cache_read_tokens=usage_record.cache_read_tokens,
+        cache_write_tokens=usage_record.cache_write_tokens,
+        response_id=usage_record.response_id,
+    )
+
+    # Create an event referencing that response_id
+    event = Event()
+    mock_tool_call_metadata = ToolCallMetadata(
+        tool_call_id='test-tool-call',
+        function_name='fake_function',
+        model_response={'id': 'test-response-id'},
+        total_calls_in_response=1,
+    )
+    event._tool_call_metadata = (
+        mock_tool_call_metadata  # normally you'd do event.tool_call_metadata = ...
+    )
+
+    # We should find that usage record
+    found = get_single_tokens_usage_for_event(event, metrics)
+    assert found is not None
+    assert found.prompt_tokens == 10
+    assert found.response_id == 'test-response-id'
+
+    # If we change the event's response ID, we won't find anything
+    mock_tool_call_metadata.model_response['id'] = 'some-other-id'
+    found2 = get_single_tokens_usage_for_event(event, metrics)
+    assert found2 is None
+
+    # If the event has no tool_call_metadata, also returns None
+    event._tool_call_metadata = None
+    found3 = get_single_tokens_usage_for_event(event, metrics)
+    assert found3 is None
+
+
+def test_get_tokens_usage_for_event_id():
+    """
+    Test that we search backward from the event with the given id,
+    finding the first usage record that matches a response_id in that or previous events.
+    """
+    metrics = Metrics(model_name='test-model')
+    usage_1 = TokensUsage(
+        model='test-model',
+        prompt_tokens=12,
+        completion_tokens=3,
+        cache_read_tokens=2,
+        cache_write_tokens=5,
+        response_id='resp-1',
+    )
+    usage_2 = TokensUsage(
+        model='test-model',
+        prompt_tokens=7,
+        completion_tokens=2,
+        cache_read_tokens=1,
+        cache_write_tokens=3,
+        response_id='resp-2',
+    )
+    metrics._tokens_usages.append(usage_1)
+    metrics._tokens_usages.append(usage_2)
+
+    # Build a list of events
+    events = []
+    for i in range(5):
+        e = Event()
+        e._id = i
+        # We'll attach usage_1 to event 1, usage_2 to event 3
+        if i == 1:
+            e._tool_call_metadata = ToolCallMetadata(
+                tool_call_id='tid1',
+                function_name='fn1',
+                model_response={'id': 'resp-1'},
+                total_calls_in_response=1,
+            )
+        elif i == 3:
+            e._tool_call_metadata = ToolCallMetadata(
+                tool_call_id='tid2',
+                function_name='fn2',
+                model_response={'id': 'resp-2'},
+                total_calls_in_response=1,
+            )
+        events.append(e)
+
+    # If we ask for event_id=3, we find usage_2 immediately
+    found_3 = get_tokens_usage_for_event_id(events, 3, metrics)
+    assert found_3 is not None
+    assert found_3.response_id == 'resp-2'
+
+    # If we ask for event_id=2, no usage in event2, so we check event1 -> usage_1 found
+    found_2 = get_tokens_usage_for_event_id(events, 2, metrics)
+    assert found_2 is not None
+    assert found_2.response_id == 'resp-1'
+
+    # If we ask for event_id=0, no usage in event0 or earlier, so return None
+    found_0 = get_tokens_usage_for_event_id(events, 0, metrics)
+    assert found_0 is None

--- a/tests/unit/test_message_utils.py
+++ b/tests/unit/test_message_utils.py
@@ -315,7 +315,7 @@ def test_get_single_tokens_usage_for_event():
     assert found.response_id == 'test-response-id'
 
     # If we change the event's response ID, we won't find anything
-    mock_tool_call_metadata.model_response['id'] = 'some-other-id'
+    mock_tool_call_metadata.model_response.id = 'some-other-id'
     found2 = get_single_tokens_usage_for_event(event, metrics)
     assert found2 is None
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes to use the liteLLM token usage data explicitly.
- track it in Metrics
- add two utility methods to link it to events

Please note: technically we also have it in the `tool_call_metadata` optional field in Event, because we have the entire litellm ModelResponse there. This PR proposes to take it out of a ModelResponse, for a few reasons:
- it's not always there: MessageActions, some FinishActions, and user actions don't have a tool. We can fill the data for those from elsewhere (e.g. tokenizer on the corresponding message)
- it seems easier to work with, in a format we need, than the format that litellm returns, though I could be wrong
- we may want to remove the full ModelResponse from events sometime, it contains a lot we don't really need. Events are supposed to be sort of simple and higher level, while the technical details of an API response in litellm are quite complex and of a different nature.


---
Part of https://github.com/All-Hands-AI/OpenHands/issues/6707

Follow-up on https://github.com/All-Hands-AI/OpenHands/pull/5550

**Link of any specific issues this addresses**
Fix #2947 

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9d3f77f-nikolaik   --name openhands-app-9d3f77f   docker.all-hands.dev/all-hands-ai/openhands:9d3f77f
```