### PR TITLE
runtime(eval): increase runtime status request timeout for sessions

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -149,7 +149,7 @@ class RemoteRuntime(Runtime):
                 'GET',
                 f'{self.config.sandbox.remote_runtime_api_url}/sessions/{self.sid}',
                 is_retry=False,
-                timeout=5,
+                timeout=30,
             ) as response:
                 data = response.json()
                 status = data.get('status')


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Occasionally, when remote runtime cluster is busy, the runtime status request will take more than 5 seconds to finish. This PR increases timeout from 5 to 30 to avoid crashing when cluster is busy.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:936fd4d-nikolaik   --name openhands-app-936fd4d   docker.all-hands.dev/all-hands-ai/openhands:936fd4d
```