### PR TITLE
fix(frontend): Trigger VSCode URL query only when runtime is active

### DIFF
--- a/frontend/src/components/features/file-explorer/file-explorer.tsx
+++ b/frontend/src/components/features/file-explorer/file-explorer.tsx
@@ -15,6 +15,10 @@ import { FileExplorerHeader } from "./file-explorer-header";
 import { useVSCodeUrl } from "#/hooks/query/use-vscode-url";
 import { OpenVSCodeButton } from "#/components/shared/buttons/open-vscode-button";
 import { addAssistantMessage } from "#/state/chat-slice";
+import {
+  useWsClient,
+  WsClientProviderStatus,
+} from "#/context/ws-client-provider";
 
 interface FileExplorerProps {
   isOpen: boolean;
@@ -22,6 +26,7 @@ interface FileExplorerProps {
 }
 
 export function FileExplorer({ isOpen, onToggle }: FileExplorerProps) {
+  const { status } = useWsClient();
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
@@ -30,12 +35,11 @@ export function FileExplorer({ isOpen, onToggle }: FileExplorerProps) {
 
   const { curAgentState } = useSelector((state: RootState) => state.agent);
 
-  const agentIsReady =
-    curAgentState !== AgentState.INIT && curAgentState !== AgentState.LOADING;
-
   const { data: paths, refetch, error } = useListFiles();
   const { mutate: uploadFiles } = useUploadFiles();
-  const { data: vscodeUrl } = useVSCodeUrl({ enabled: agentIsReady });
+  const { data: vscodeUrl } = useVSCodeUrl({
+    enabled: status === WsClientProviderStatus.ACTIVE,
+  });
 
   const handleOpenVSCode = () => {
     if (vscodeUrl?.vscode_url) {
@@ -166,7 +170,7 @@ export function FileExplorer({ isOpen, onToggle }: FileExplorerProps) {
           {isOpen && (
             <OpenVSCodeButton
               onClick={handleOpenVSCode}
-              isDisabled={!agentIsReady}
+              isDisabled={status !== WsClientProviderStatus.ACTIVE}
             />
           )}
         </div>

--- a/frontend/src/components/features/file-explorer/file-explorer.tsx
+++ b/frontend/src/components/features/file-explorer/file-explorer.tsx
@@ -170,7 +170,7 @@ export function FileExplorer({ isOpen, onToggle }: FileExplorerProps) {
           {isOpen && (
             <OpenVSCodeButton
               onClick={handleOpenVSCode}
-              isDisabled={status !== WsClientProviderStatus.ACTIVE}
+              isDisabled={status === WsClientProviderStatus.OPENING}
             />
           )}
         </div>

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -4,7 +4,6 @@ import { io, Socket } from "socket.io-client";
 import { Settings } from "#/services/settings";
 import ActionType from "#/types/action-type";
 import EventLogger from "#/utils/event-logger";
-import AgentState from "#/types/agent-state";
 import { handleAssistantMessage } from "#/services/actions";
 import { useRate } from "#/hooks/use-rate";
 
@@ -102,16 +101,17 @@ export function WsClientProvider({
     if (!Number.isNaN(parseInt(event.id as string, 10))) {
       lastEventRef.current = event;
     }
-    const extras = event.extras as Record<string, unknown>;
-    if (extras?.agent_state === AgentState.INIT) {
-      setStatus(WsClientProviderStatus.ACTIVE);
-    }
+
     if (
       status !== WsClientProviderStatus.ACTIVE &&
       event?.observation === "error"
     ) {
       setStatus(WsClientProviderStatus.ERROR);
       return;
+    }
+
+    if (status !== WsClientProviderStatus.ACTIVE) {
+      setStatus(WsClientProviderStatus.ACTIVE);
     }
 
     if (!event.token) {


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- The query responsible for fetching the VSCode URL would run before the runtime is active, resulting in an error thrown in the terminal

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Only query when runtime is active


---
**Link of any specific issues this addresses**
Resolves #5606

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b5d38cb-nikolaik   --name openhands-app-b5d38cb   docker.all-hands.dev/all-hands-ai/openhands:b5d38cb
```