### PR TITLE
fix(frontend): Display user-submitted images in the chat interface

### DIFF
--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -16,6 +16,7 @@ import {
   StatusMessage,
 } from "#/types/message";
 import { handleObservationMessage } from "./observations";
+import { UserMessageAction } from "#/types/core/actions";
 
 const messageActions = {
   [ActionType.BROWSE]: (message: ActionMessage) => {
@@ -33,12 +34,12 @@ const messageActions = {
     store.dispatch(setActiveFilepath(path));
     store.dispatch(setCode(content));
   },
-  [ActionType.MESSAGE]: (message: ActionMessage) => {
+  [ActionType.MESSAGE]: (message: UserMessageAction) => {
     if (message.source === "user") {
       store.dispatch(
         addUserMessage({
           content: message.args.content,
-          imageUrls: [],
+          imageUrls: message.args.image_urls,
           timestamp: message.timestamp,
           pending: false,
         }),

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -16,7 +16,6 @@ import {
   StatusMessage,
 } from "#/types/message";
 import { handleObservationMessage } from "./observations";
-import { UserMessageAction } from "#/types/core/actions";
 
 const messageActions = {
   [ActionType.BROWSE]: (message: ActionMessage) => {
@@ -34,12 +33,15 @@ const messageActions = {
     store.dispatch(setActiveFilepath(path));
     store.dispatch(setCode(content));
   },
-  [ActionType.MESSAGE]: (message: UserMessageAction) => {
+  [ActionType.MESSAGE]: (message: ActionMessage) => {
     if (message.source === "user") {
       store.dispatch(
         addUserMessage({
           content: message.args.content,
-          imageUrls: message.args.image_urls,
+          imageUrls:
+            typeof message.args.image_urls === "string"
+              ? [message.args.image_urls]
+              : message.args.image_urls,
           timestamp: message.timestamp,
           pending: false,
         }),


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- Images were not rendered in the chat interface

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Set server-received image urls to messages


---
**Link of any specific issues this addresses**
Resolves #5512

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:405fda6-nikolaik   --name openhands-app-405fda6   docker.all-hands.dev/all-hands-ai/openhands:405fda6
```