### PR TITLE
[Bug][Resolver]: Skip bot comment when PR is updated

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -278,6 +278,12 @@ jobs:
               console.error('Error reading results file:', error);
             }
 
+            if (logContent.includes("Updated pull request")) {
+              console.log("Updated pull request found. Skipping comment.");
+              return;
+            }
+
+
             try {
               if (success) {
                 prNumber = fs.readFileSync('/tmp/pr_number.txt', 'utf8').trim();

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -254,7 +254,7 @@ jobs:
           fi
 
       # Step leaves comment for when agent is invoked on PR
-      - name: Analyze Push Logs (Updated PR or No Changes) # Skip comment if PR update was successful OR leave comment is agent made no code changes
+      - name: Analyze Push Logs (Updated PR or No Changes) # Skip comment if PR update was successful OR leave comment if the agent made no code changes
         uses: actions/github-script@v7
         if: always()
         env:

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -258,7 +258,7 @@ jobs:
         uses: actions/github-script@v7
         if: always()
         env:
-          CONDITIONAL_EXECUTED: ${{ env.CONDITIONAL_EXECUTED || 'false' }}
+          AGENT_RESPONDED: ${{ env.AGENT_RESPONDED || 'false' }}
         with:
           github-token: ${{ secrets.PAT_TOKEN || github.token }}
           script: |
@@ -277,7 +277,7 @@ jobs:
             // Check logs from send_pull_request.py (pushes code to GitHub)
             if (logContent.includes("Updated pull request")) {
               console.log("Updated pull request found. Skipping comment.");
-              process.env.CONDITIONAL_EXECUTED = 'true';
+              process.env.AGENT_RESPONDED = 'true';
             } else if (logContent.includes(noChangesMessage)) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
@@ -285,7 +285,7 @@ jobs:
                 repo: context.repo.repo,
                 body: `The workflow to fix this issue encountered an error. Openhands failed to create any code changes.`
               });
-              process.env.CONDITIONAL_EXECUTED = 'true';
+              process.env.AGENT_RESPONDED = 'true';
             }
 
       # Step leaves comment for when agent is invoked on issue
@@ -293,7 +293,7 @@ jobs:
         uses: actions/github-script@v7
         if: always() # Comment on issue even if the previous steps fail
         env:
-          CONDITIONAL_EXECUTED: ${{ env.CONDITIONAL_EXECUTED || 'false' }}
+          AGENT_RESPONDED: ${{ env.AGENT_RESPONDED || 'false' }}
         with:
           github-token: ${{ secrets.PAT_TOKEN || github.token }}
           script: |
@@ -323,7 +323,7 @@ jobs:
                 repo: context.repo.repo,
                 body: `A potential fix has been generated and a draft PR #${prNumber} has been created. Please review the changes.`
               });
-              process.env.CONDITIONAL_EXECUTED = 'true';
+              process.env.AGENT_RESPONDED = 'true';
             } else if (!success && branchName) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
@@ -331,13 +331,13 @@ jobs:
                 repo: context.repo.repo,
                 body: `An attempt was made to automatically fix this issue, but it was unsuccessful. A branch named '${branchName}' has been created with the attempted changes. You can view the branch [here](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}). Manual intervention may be required.`
               });
-              process.env.CONDITIONAL_EXECUTED = 'true';
+              process.env.AGENT_RESPONDED = 'true';
             }
 
       # Leave error comment when both PR/Issue comment handling fail
       - name: Fallback Error Comment
         uses: actions/github-script@v7
-        if: ${{ env.CONDITIONAL_EXECUTED == 'false' }} # Only run if no conditions were met in previous steps
+        if: ${{ env.AGENT_RESPONDED == 'false' }} # Only run if no conditions were met in previous steps
         with:
           github-token: ${{ secrets.PAT_TOKEN || github.token }}
           script: |

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -253,9 +253,47 @@ jobs:
               grep "branch created" branch_result.txt | sed 's/.*\///g; s/.expand=1//g' > branch_name.txt
           fi
 
-      - name: Comment on issue
+      # Step leaves comment for when agent is invoked on PR
+      - name: Analyze Push Logs (Updated PR or No Changes) # Skip comment if PR update was successful OR leave comment is agent made no code changes
+        uses: actions/github-script@v7
+        if: always()
+        env:
+          CONDITIONAL_EXECUTED: ${{ env.CONDITIONAL_EXECUTED || 'false' }}
+        with:
+          github-token: ${{ secrets.PAT_TOKEN || github.token }}
+          script: |
+            const fs = require('fs');
+            const issueNumber = ${{ env.ISSUE_NUMBER }};
+            let logContent = '';
+
+            try {
+              logContent = fs.readFileSync('/tmp/pr_result.txt', 'utf8').trim();
+            } catch (error) {
+              console.error('Error reading pr_result.txt file:', error);
+            }
+
+            const noChangesMessage = `No changes to commit for issue #${issueNumber}. Skipping commit.`;
+
+            // Check logs from send_pull_request.py (pushes code to GitHub)
+            if (logContent.includes("Updated pull request")) {
+              console.log("Updated pull request found. Skipping comment.");
+              process.env.CONDITIONAL_EXECUTED = 'true';
+            } else if (logContent.includes(noChangesMessage)) {
+              github.rest.issues.createComment({
+                issue_number: issueNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `The workflow to fix this issue encountered an error. Openhands failed to create any code changes.`
+              });
+              process.env.CONDITIONAL_EXECUTED = 'true';
+            }
+
+      # Step leaves comment for when agent is invoked on issue
+      - name: Comment on issue # Comment link to either PR or branch created by agent
         uses: actions/github-script@v7
         if: always() # Comment on issue even if the previous steps fail
+        env:
+          CONDITIONAL_EXECUTED: ${{ env.CONDITIONAL_EXECUTED || 'false' }}
         with:
           github-token: ${{ secrets.PAT_TOKEN || github.token }}
           script: |
@@ -265,24 +303,6 @@ jobs:
 
             let prNumber = '';
             let branchName = '';
-            let logContent = '';
-            const noChangesMessage = `No changes to commit for issue #${issueNumber}. Skipping commit.`;
-
-            try {
-              if (success){
-                logContent = fs.readFileSync('/tmp/pr_result.txt', 'utf8').trim();
-              } else {
-                logContent = fs.readFileSync('/tmp/branch_result.txt', 'utf8').trim();
-              }
-            } catch (error) {
-              console.error('Error reading results file:', error);
-            }
-
-            if (logContent.includes("Updated pull request")) {
-              console.log("Updated pull request found. Skipping comment.");
-              return;
-            }
-
 
             try {
               if (success) {
@@ -294,20 +314,16 @@ jobs:
               console.error('Error reading file:', error);
             }
 
-            if (logContent.includes(noChangesMessage)) {
-              github.rest.issues.createComment({
-                issue_number: issueNumber,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `The workflow to fix this issue encountered an error. Openhands failed to create any code changes.`
-              });
-            } else if (success && prNumber) {
+
+            // Check "success" log from resolver output
+            if (success && prNumber) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: `A potential fix has been generated and a draft PR #${prNumber} has been created. Please review the changes.`
               });
+              process.env.CONDITIONAL_EXECUTED = 'true';
             } else if (!success && branchName) {
               github.rest.issues.createComment({
                 issue_number: issueNumber,
@@ -315,11 +331,21 @@ jobs:
                 repo: context.repo.repo,
                 body: `An attempt was made to automatically fix this issue, but it was unsuccessful. A branch named '${branchName}' has been created with the attempted changes. You can view the branch [here](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}). Manual intervention may be required.`
               });
-            } else {
-              github.rest.issues.createComment({
-                issue_number: issueNumber,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `The workflow to fix this issue encountered an error. Please check the [workflow logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for more information.`
-              });
+              process.env.CONDITIONAL_EXECUTED = 'true';
             }
+
+      # Leave error comment when both PR/Issue comment handling fail
+      - name: Fallback Error Comment
+        uses: actions/github-script@v7
+        if: ${{ env.CONDITIONAL_EXECUTED == 'false' }} # Only run if no conditions were met in previous steps
+        with:
+          github-token: ${{ secrets.PAT_TOKEN || github.token }}
+          script: |
+            const issueNumber = ${{ env.ISSUE_NUMBER }};
+
+            github.rest.issues.createComment({
+              issue_number: issueNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `The workflow to fix this issue encountered an error. Please check the [workflow logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for more information.`
+            });


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The final step in the workflow definition is leave a bot message. It handles three cases

1. A branch or PR has been created (success msg)
2. The agent didn't make an code changes (error msg)
3. Last resort, an unexpected failure occurred, and workflow logs need to be checked (error msg)

Step 3 was being invoked by default when the agent was called on PRs, because it didn't match the criteria for 1 or 2. 


This PR will skip the bot comment when a PR is being updated successfully and `openhands/resolver/send_pull_request.py` will leave a new comment with the success message.


---
**Link of any specific issues this addresses**
#5612

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:183c732-nikolaik   --name openhands-app-183c732   docker.all-hands.dev/all-hands-ai/openhands:183c732
```