### PR TITLE
[Bug][Resolver]: Multiline comments crashing resolver

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -184,17 +184,32 @@ jobs:
             });
 
       - name: Install OpenHands
-        run: |
-          if [[ "${{ github.event.label.name }}" == "fix-me-experimental" ]] ||
-             ([[ "${{ github.event_name }}" == "issue_comment" || "${{ github.event_name }}" == "pull_request_review_comment" ]] &&
-              [[ "${{ github.event.comment.body }}" == "@openhands-agent-exp"* ]]) ||
-             ([[ "${{ github.event_name }}" == "pull_request_review" ]] &&
-              [[ "${{ github.event.review.body }}" == "@openhands-agent-exp"* ]]); then
-            python -m pip install --upgrade pip
-            pip install git+https://github.com/all-hands-ai/openhands.git
-          else
-            python -m pip install --upgrade -r requirements.txt
-          fi
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentBody = `${{ github.event.comment.body || '' }}`.trim();
+            const reviewBody = `${{ github.event.review.body || '' }}`.trim();
+            const labelName = `${{ github.event.label.name || '' }}`.trim();
+            const eventName = `${{ github.event_name }}`.trim();
+
+            // Check conditions
+            const isExperimentalLabel = labelName === "fix-me-experimental";
+            const isIssueCommentExperimental =
+              (eventName === "issue_comment" || eventName === "pull_request_review_comment") &&
+              commentBody.includes("@openhands-agent-exp");
+            const isReviewCommentExperimental =
+              eventName === "pull_request_review" && reviewBody.includes("@openhands-agent-exp");
+
+            // Perform package installation
+            if (isExperimentalLabel || isIssueCommentExperimental || isReviewCommentExperimental) {
+              console.log("Installing experimental OpenHands...");
+              await exec.exec("python -m pip install --upgrade pip");
+              await exec.exec("pip install git+https://github.com/all-hands-ai/openhands.git");
+            } else {
+              console.log("Installing from requirements.txt...");
+              await exec.exec("python -m pip install --upgrade pip");
+              await exec.exec("pip install -r requirements.txt");
+            }
 
       - name: Attempt to resolve issue
         env:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

### Summary
There is a bug where comments with quotations or multi-line comments caused the resolver to crash. This is because we were using bash to check the event body for "openhands-agent` macro, but the event body string was not properly escaped.


In this PR, we've opted to move away from bash and use javascript instead to implement the same functionality.


### Alternatives considered but opted against
1. Properly escape the string in bash (`if [[ "$(echo '${{ github.event.comment.body }}' | tr -d '\n' | sed "s/'/'\\\\''/g")" == "@openhands-agent-exp"* ]]; then`)
   a. Opted against this as readability becomes tough and the expression needs to be used in multiple places
2. Set the comment body as an ENV var in a previous step, then reference it in the conditional
   a. Opted against this as it would bloat the workflow with too many steps


### Sample Test
Example [workflow logs](https://github.com/malhotra5/test-repo/actions/runs/12364631042/job/34508207845
)

---
**Link of any specific issues this addresses**
#5230