### PR TITLE
fix(eval): Use cp -r instead of mv for SWE-Bench Initialization

### DIFF
--- a/evaluation/benchmarks/swe_bench/scripts/setup/instance_swe_entry.sh
+++ b/evaluation/benchmarks/swe_bench/scripts/setup/instance_swe_entry.sh
@@ -33,7 +33,7 @@ if [ -d /workspace/$WORKSPACE_NAME ]; then
     rm -rf /workspace/$WORKSPACE_NAME
 fi
 mkdir -p /workspace
-mv /testbed /workspace/$WORKSPACE_NAME
+cp -r /testbed /workspace/$WORKSPACE_NAME
 
 # Activate instance-specific environment
 . /opt/miniconda3/etc/profile.d/conda.sh


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

For some reason, `mv /testbed` causes the conda environment to break (most likely because some packages are installed inside docker are based on the absolute path of `/testbed`)

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:568de64-nikolaik   --name openhands-app-568de64   docker.all-hands.dev/all-hands-ai/openhands:568de64
```