### PR TITLE
fix: Gracefully handling negative response latencies

### DIFF
--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -2,6 +2,8 @@ import time
 
 from pydantic import BaseModel, Field
 
+from openhands.core.logger import openhands_logger as logger
+
 
 class Cost(BaseModel):
     model: str
@@ -56,7 +58,8 @@ class Metrics:
 
     def add_response_latency(self, value: float, response_id: str) -> None:
         if value < 0:
-            raise ValueError('Response latency cannot be negative.')
+            logger.warning(f'Response latency ({value}) cannot be negative.')
+            value = 0.0
         self._response_latencies.append(
             ResponseLatency(
                 latency=value, model=self.model_name, response_id=response_id

--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -2,8 +2,6 @@ import time
 
 from pydantic import BaseModel, Field
 
-from openhands.core.logger import openhands_logger as logger
-
 
 class Cost(BaseModel):
     model: str
@@ -57,12 +55,9 @@ class Metrics:
         self._costs.append(Cost(cost=value, model=self.model_name))
 
     def add_response_latency(self, value: float, response_id: str) -> None:
-        if value < 0:
-            logger.warning(f'Response latency ({value}) cannot be negative.')
-            value = 0.0
         self._response_latencies.append(
             ResponseLatency(
-                latency=value, model=self.model_name, response_id=response_id
+                latency=max(0.0, value), model=self.model_name, response_id=response_id
             )
         )
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When response latencies would be negative (possibly due to issues with system timing info), clips to 0 instead.

---
**Link of any specific issues this addresses**

#5658