### PR TITLE
[Bug]: Settings modal opens on every refresh

### DIFF
--- a/frontend/__tests__/routes/_oh.test.tsx
+++ b/frontend/__tests__/routes/_oh.test.tsx
@@ -39,12 +39,6 @@ describe("frontend/routes/_oh", () => {
     await screen.findByTestId("root-layout");
   });
 
-  it("should render the AI config modal if the user is authed", async () => {
-    // Our mock return value is true by default
-    renderWithProviders(<RouteStub />);
-    await screen.findByTestId("ai-config-modal");
-  });
-
   it("should render the AI config modal if settings are not up-to-date", async () => {
     settingsAreUpToDateMock.mockReturnValue(false);
     renderWithProviders(<RouteStub />);

--- a/frontend/src/routes/_oh/route.tsx
+++ b/frontend/src/routes/_oh/route.tsx
@@ -9,6 +9,7 @@ import { useConfig } from "#/hooks/query/use-config";
 import { Sidebar } from "#/components/features/sidebar/sidebar";
 import { WaitlistModal } from "#/components/features/waitlist/waitlist-modal";
 import { AnalyticsConsentFormModal } from "#/components/features/analytics/analytics-consent-form-modal";
+import { SettingsModal } from "#/components/shared/modals/settings/settings-modal";
 
 export function ErrorBoundary() {
   const error = useRouteError();
@@ -44,11 +45,14 @@ export function ErrorBoundary() {
 
 export default function MainApp() {
   const { gitHubToken, clearToken } = useAuth();
-  const { settings } = useUserPrefs();
+  const { settings, settingsAreUpToDate } = useUserPrefs();
 
   const [consentFormIsOpen, setConsentFormIsOpen] = React.useState(
     !localStorage.getItem("analytics-consent"),
   );
+
+  const [aiConfigModalIsOpen, setAiConfigModalIsOpen] =
+    React.useState(!settingsAreUpToDate);
 
   const config = useConfig();
   const {
@@ -94,6 +98,13 @@ export default function MainApp() {
       {config.data?.APP_MODE === "oss" && consentFormIsOpen && (
         <AnalyticsConsentFormModal
           onClose={() => setConsentFormIsOpen(false)}
+        />
+      )}
+
+      {aiConfigModalIsOpen && (
+        <SettingsModal
+          onClose={() => setAiConfigModalIsOpen(false)}
+          data-testid="ai-config-modal"
         />
       )}
     </div>

--- a/frontend/src/routes/_oh/route.tsx
+++ b/frontend/src/routes/_oh/route.tsx
@@ -9,7 +9,6 @@ import { useConfig } from "#/hooks/query/use-config";
 import { Sidebar } from "#/components/features/sidebar/sidebar";
 import { WaitlistModal } from "#/components/features/waitlist/waitlist-modal";
 import { AnalyticsConsentFormModal } from "#/components/features/analytics/analytics-consent-form-modal";
-import { SettingsModal } from "#/components/shared/modals/settings/settings-modal";
 
 export function ErrorBoundary() {
   const error = useRouteError();
@@ -77,9 +76,6 @@ export default function MainApp() {
   const isInWaitlist =
     !isFetchingAuth && !isAuthed && config.data?.APP_MODE === "saas";
 
-  const { settingsAreUpToDate } = useUserPrefs();
-  const [showAIConfig, setShowAIConfig] = React.useState(true);
-
   return (
     <div
       data-testid="root-layout"
@@ -99,10 +95,6 @@ export default function MainApp() {
         <AnalyticsConsentFormModal
           onClose={() => setConsentFormIsOpen(false)}
         />
-      )}
-
-      {(isAuthed || !settingsAreUpToDate) && showAIConfig && (
-        <SettingsModal onClose={() => setShowAIConfig(false)} />
       )}
     </div>
   );


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Removes logic that causes settings modal to open on every refresh; bug introduced in this [commit](https://github.com/All-Hands-AI/OpenHands/pull/5371/commits/8f5826a4d6b48f733b486c82d63184ba824fb271)


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e10ebb0-nikolaik   --name openhands-app-e10ebb0   docker.all-hands.dev/all-hands-ai/openhands:e10ebb0
```