### PR TITLE
chore: cleanup log - make "cannot restore state" a debug message

### DIFF
--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -118,7 +118,7 @@ class State:
             pickled = base64.b64decode(encoded)
             state = pickle.loads(pickled)
         except Exception as e:
-            logger.warning(f'Could not restore state from session: {e}')
+            logger.debug(f'Could not restore state from session: {e}')
             raise e
 
         # update state


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

I've been seeing a lot of these "cannot restore state" warning during eval, which is kinda annoying:

```
b0c300eb-ccdddea5fd674598/agent_state.pkl
Instance scikit-learn__scikit-learn-15512 - 2024-12-18 18:10:47,854 - WARNING - Could not restore state from session: sessions/81746d32-1c57-42f3-bf4a-587a772d79ad-98702b062bafe0ac/agent_state.pkl
Instance scikit-learn__scikit-learn-14092 - 2024-12-18 18:10:47,975 - WARNING - Could not restore state from session: sessions/53fff775-a2eb-457e-9880-690ac4fb545b-29a133eec9609f3c/agent_state.pkl
Instance sympy__sympy-18189 - 2024-12-18 18:10:48,022 - WARNING - Could not restore state from session: sessions/2de7ead0-aa35-4858-af17-f901316faf79-94b5fa567eb5a9e6/agent_state.pkl
Instance scikit-learn__scikit-learn-25570 - 2024-12-18 18:10:50,312 - WARNING - Could not restore state from session: sessions/306be277-7156-46fd-b88e-a57f4049c456-daaa6420da45de7d/agent_state.pkl
Instance matplotlib__matplotlib-25079 - 2024-12-18 18:10:50,487 - WARNING - Could not restore state from session: sessions/b5e76fbf-61a3-4494-92dc-c2e1e72d2b1f-84e04669acc8caa9/agent_state.pkl
Instance sympy__sympy-12236 - 2024-12-18 18:10:53,714 - WARNING - Could not restore state from session: sessions/38264486-9f91-4364-8d39-0afe90fba465-7b6573a18a42db52/agent_state.pkl
Instance scikit-learn__scikit-learn-13142 - 2024-12-18 18:10:56,697 - WARNING - Could not restore state from session: sessions/20971a7b-8303-42f8-94c6-2f611555ca29-da0082f9330a3c3f/agent_state.pkl
Instance scikit-learn__scikit-learn-10297 - 2024-12-18 18:10:58,822 - WARNING - Could not restore state from session: sessions/cb29e8ea-35bc-460c-81ea-e7526cd08bab-489be2d7843d8890/agent_state.pkl
Instance scikit-learn__scikit-learn-10508 - 2024-12-18 18:10:59,199 - WARNING - Could not restore state from session: sessions/120544fa-c8e0-4105-a5ec-646c1813a83b-36f2d024e01ed4cc/agent_state.pkl
Instance scikit-learn__scikit-learn-15535 - 2024-12-18 18:10:59,215 - WARNING - Could not restore state from session: sessions/63061369-f521-4e70-aa96-8ba327e7ad9b-c1baf845e2b23ebc/agent_state.pkl
Instance sympy__sympy-16988 - 2024-12-18 18:10:59,782 - WARNING - Could not restore state from session: sessions/f6ae6461-db7f-44fe-a342-94f62b89758d-a05a3f581c0fea49/agent_state.pkl
Instance django__django-16910 - 2024-12-18 18:11:00,083 - WARNING - Could not restore state from session: sessions/d059c66a-5e53-453e-9b8f-65069c75c2d0-d085ab3a3fb0c145/agent_state.pkl
Instance sympy__sympy-21847 - 2024-12-18 18:11:13,067 - WARNING - Could not restore state from session: sessions/0df7afc2-2461-452a-b568-f51aa3defb0a-2b96c5b21b0abfe3/agent_state.pkl
Instance sympy__sympy-24066 - 2024-12-18 18:11:15,306 - WARNING - Could not restore state from session: sessions/1f814c4a-0752-4415-ad82-c5e963833b20-ccce4134f51bf1ee/agent_state.pkl
Instance sympy__sympy-15011 - 2024-12-18 18:11:16,270 - WARNING - Could not restore state from session: sessions/c825df87-a33d-489d-a070-9a4437b56169-17bdbc1cac1409f9/agent_state.pkl
Instance astropy__astropy-14995 - 2024-12-18 18:11:17,264 - WARNING - Could not restore state from session: sessions/2ebb4b9f-38c6-4d51-a921-3923a974c291-ac6184fae8ce548f/agent_state.pkl
```

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1a45a61-nikolaik   --name openhands-app-1a45a61   docker.all-hands.dev/all-hands-ai/openhands:1a45a61
```