### PR TITLE
Fix: Agent gets stuck in closing and server won't die

### DIFF
--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -15,6 +15,7 @@ from openhands.runtime.base import Runtime, RuntimeUnavailableError
 from openhands.security import SecurityAnalyzer, options
 from openhands.storage.files import FileStore
 from openhands.utils.async_utils import call_async_from_sync
+from openhands.utils.shutdown_listener import should_continue
 
 WAIT_TIME_BEFORE_CLOSE = 300
 WAIT_TIME_BEFORE_CLOSE_INTERVAL = 5
@@ -152,7 +153,7 @@ class AgentSession:
 
     async def _close(self):
         seconds_waited = 0
-        while self._initializing:
+        while self._initializing and should_continue():
             logger.debug(
                 f'Waiting for initialization to finish before closing session {self.sid}'
             )


### PR DESCRIPTION
**Fix: Agent gets stuck in closing and server won't die**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
This is a fix for a regression in main from 2024-12-18.
We no longer wait for the session to finish initializing if the server is shutting down.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:12d890d-nikolaik   --name openhands-app-12d890d   docker.all-hands.dev/all-hands-ai/openhands:12d890d
```