### PR TITLE
Fix not initialized response latencies

### DIFF
--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -46,7 +46,13 @@ class Metrics:
 
     @property
     def response_latencies(self) -> list[ResponseLatency]:
+        if not hasattr(self, '_response_latencies'):
+            self._response_latencies = []
         return self._response_latencies
+
+    @response_latencies.setter
+    def response_latencies(self, value: list[ResponseLatency]) -> None:
+        self._response_latencies = value
 
     def add_cost(self, value: float) -> None:
         if value < 0:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

I sometimes saw:
```
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-46' coro=<AgentController.on_event() done, defined at /Users/enyst/repos/odie/openhands/controller/agent_controller.py:221> exception=AttributeError("'Metrics' object has no attribute '_response_latencies'")>
Traceback (most recent call last):
  File "/Users/enyst/repos/odie/openhands/controller/agent_controller.py", line 237, in on_event
    await self._handle_observation(event)
  File "/Users/enyst/repos/odie/openhands/controller/agent_controller.py", line 297, in _handle_observation
    self.state.metrics.merge(self.state.local_metrics)
  File "/Users/enyst/repos/odie/openhands/llm/metrics.py", line 69, in merge
    def get(self) -> dict:
        ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Metrics' object has no attribute '_response_latencies'. Did you mean: 'response_latencies'?
```

I think it was a session started just before response latencies were introduced, so the state [was pickled](https://github.com/All-Hands-AI/OpenHands/blob/5498ca1f8bb71fbb72913aacac3c5457c44736a9/openhands/controller/state/state.py#L119) without it.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:44688a5-nikolaik   --name openhands-app-44688a5   docker.all-hands.dev/all-hands-ai/openhands:44688a5
```