### PR TITLE
Fix issue #5683: [Bug]: Repo picker does not show all org repos

### DIFF
--- a/frontend/src/__tests__/github-repo-selector.test.tsx
+++ b/frontend/src/__tests__/github-repo-selector.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
-import { GitHubRepositorySelector } from "../components/features/github/github-repo-selector";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import { AuthProvider } from "../context/auth-context";
+import { GitHubRepositorySelector } from "../components/features/github/github-repo-selector";
 
 vi.mock("../hooks/query/use-config", () => ({
   useConfig: () => ({
@@ -35,7 +35,7 @@ describe("GitHubRepositorySelector", () => {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     };
-    Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+    Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/__tests__/github-repo-selector.test.tsx
+++ b/frontend/src/__tests__/github-repo-selector.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { GitHubRepositorySelector } from "../components/features/github/github-repo-selector";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider } from "../context/auth-context";
+
+vi.mock("../hooks/query/use-config", () => ({
+  useConfig: () => ({
+    data: {
+      APP_MODE: "oss",
+    },
+  }),
+}));
+
+const store = configureStore({
+  reducer: {
+    initialQuery: (state = {}) => state,
+  },
+});
+
+const queryClient = new QueryClient();
+
+describe("GitHubRepositorySelector", () => {
+  const mockRepositories = Array.from({ length: 50 }, (_, i) => ({
+    id: i,
+    full_name: `repo-${i}`,
+  }));
+
+  it("should render all repositories", () => {
+    // Mock localStorage
+    const localStorageMock = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <AuthProvider>
+            <GitHubRepositorySelector
+              onSelect={() => {}}
+              repositories={mockRepositories}
+            />
+          </AuthProvider>
+        </Provider>
+      </QueryClientProvider>
+    );
+
+    // Open the dropdown by typing
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "repo" } });
+
+    // Check if all repositories are rendered
+    const items = screen.getAllByTestId("github-repo-item");
+    expect(items).toHaveLength(50);
+  });
+});

--- a/frontend/src/__tests__/use-user-repositories.test.tsx
+++ b/frontend/src/__tests__/use-user-repositories.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useUserRepositories } from "../hooks/query/use-user-repositories";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider } from "../context/auth-context";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+
+// Mock the auth context
+vi.mock("../context/auth-context", () => ({
+  useAuth: () => ({
+    gitHubToken: "mock-token",
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock the config hook
+vi.mock("../hooks/query/use-config", () => ({
+  useConfig: () => ({
+    data: {
+      APP_MODE: "oss",
+    },
+  }),
+}));
+
+// Mock the GitHub API response
+vi.mock("../api/github", () => ({
+  retrieveGitHubUserRepositories: vi.fn().mockImplementation((page) => {
+    const repos = Array.from({ length: 100 }, (_, i) => ({
+      id: i + (page - 1) * 100,
+      full_name: `repo-${i + (page - 1) * 100}`,
+    }));
+    return Promise.resolve({
+      data: repos,
+      nextPage: page < 3 ? page + 1 : undefined,
+    });
+  }),
+}));
+
+const store = configureStore({
+  reducer: {
+    initialQuery: (state = {}) => state,
+  },
+});
+
+describe("useUserRepositories", () => {
+  it("should fetch all repositories with pagination", async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <AuthProvider>{children}</AuthProvider>
+        </Provider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useUserRepositories(), { wrapper });
+
+    // Wait for all pages to be fetched
+    await waitFor(() => {
+      expect(result.current.data?.pages.length).toBe(3);
+    });
+
+    // Check that we have all repositories
+    const allRepos = result.current.data?.pages.flatMap((page) => page.data) ?? [];
+    expect(allRepos.length).toBe(300); // 3 pages * 100 repos per page
+  });
+});

--- a/frontend/src/__tests__/use-user-repositories.test.tsx
+++ b/frontend/src/__tests__/use-user-repositories.test.tsx
@@ -11,9 +11,7 @@ vi.mock("../context/auth-context", () => ({
   useAuth: () => ({
     gitHubToken: "mock-token",
   }),
-  AuthProvider: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 // Mock the config hook

--- a/frontend/src/__tests__/use-user-repositories.test.tsx
+++ b/frontend/src/__tests__/use-user-repositories.test.tsx
@@ -1,17 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import { useUserRepositories } from "../hooks/query/use-user-repositories";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AuthProvider } from "../context/auth-context";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AuthProvider } from "../context/auth-context";
+import { useUserRepositories } from "../hooks/query/use-user-repositories";
 
 // Mock the auth context
 vi.mock("../context/auth-context", () => ({
   useAuth: () => ({
     gitHubToken: "mock-token",
   }),
-  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AuthProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 // Mock the config hook

--- a/frontend/src/__tests__/utils/extract-next-page-from-link.test.ts
+++ b/frontend/src/__tests__/utils/extract-next-page-from-link.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { extractNextPageFromLink } from "../../utils/extract-next-page-from-link";
+
+describe("extractNextPageFromLink", () => {
+  it("should extract next page number from GitHub API link header", () => {
+    const link =
+      '<https://api.github.com/user/repos?page=2>; rel="next", <https://api.github.com/user/repos?page=3>; rel="last"';
+    expect(extractNextPageFromLink(link)).toBe(2);
+  });
+
+  it("should return null when there is no next page", () => {
+    const link =
+      '<https://api.github.com/user/repos?page=1>; rel="first", <https://api.github.com/user/repos?page=3>; rel="last"';
+    expect(extractNextPageFromLink(link)).toBe(null);
+  });
+
+  it("should handle empty link header", () => {
+    expect(extractNextPageFromLink("")).toBe(null);
+  });
+});

--- a/frontend/src/api/github.ts
+++ b/frontend/src/api/github.ts
@@ -24,7 +24,7 @@ export const retrieveGitHubAppRepositories = async (
   installationIndex: number,
   installations: number[],
   page = 1,
-  per_page = 30,
+  per_page = 100,
 ) => {
   const installationId = installations[installationIndex];
   const response = await openHands.get<GitHubAppRepository>(
@@ -64,7 +64,7 @@ export const retrieveGitHubAppRepositories = async (
  */
 export const retrieveGitHubUserRepositories = async (
   page = 1,
-  per_page = 30,
+  per_page = 100,
 ) => {
   const response = await openHands.get<GitHubRepository[]>(
     "/api/github/repositories",

--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -19,10 +19,13 @@ export function GitHubRepositorySelector({
   // Add option to install app onto more repos
   const { data: paginatedRepos } = useUserRepositories();
   const allRepositories = paginatedRepos?.pages.flatMap((page) => page.data) ?? repositories;
-  
+
   const finalRepositories =
     config?.APP_MODE === "saas"
-      ? [{ id: -1000, full_name: "Add more repositories..." }, ...allRepositories]
+      ? [
+          { id: -1000, full_name: "Add more repositories..." },
+          ...allRepositories,
+        ]
       : allRepositories;
 
   const dispatch = useDispatch();

--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import posthog from "posthog-js";
 import { setSelectedRepository } from "#/state/initial-query-slice";
 import { useConfig } from "#/hooks/query/use-config";
+import { useUserRepositories } from "#/hooks/query/use-user-repositories";
 
 interface GitHubRepositorySelectorProps {
   onSelect: () => void;
@@ -16,10 +17,13 @@ export function GitHubRepositorySelector({
   const { data: config } = useConfig();
 
   // Add option to install app onto more repos
+  const { data: paginatedRepos } = useUserRepositories();
+  const allRepositories = paginatedRepos?.pages.flatMap((page) => page.data) ?? repositories;
+  
   const finalRepositories =
     config?.APP_MODE === "saas"
-      ? [{ id: -1000, full_name: "Add more repositories..." }, ...repositories]
-      : repositories;
+      ? [{ id: -1000, full_name: "Add more repositories..." }, ...allRepositories]
+      : allRepositories;
 
   const dispatch = useDispatch();
 

--- a/openhands/server/routes/github.py
+++ b/openhands/server/routes/github.py
@@ -11,7 +11,7 @@ app = APIRouter(prefix='/api')
 def get_github_repositories(
     request: Request,
     page: int = 1,
-    per_page: int = 10,
+    per_page: int = 100,
     sort: str = 'pushed',
     installation_id: int | None = None,
 ):


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The "Open Github Repo" repo picker does not show all repos in an organization, it seems to only show the first 30 in alphabetical order. This seems to be a problem with pagination.

This PR is attempt to fix this issue.

---
**Link of any specific issues this addresses**

https://github.com/All-Hands-AI/OpenHands/issues/5683

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1ee80aa-nikolaik   --name openhands-app-1ee80aa   docker.all-hands.dev/all-hands-ai/openhands:1ee80aa
```