### PR TITLE
[Resolver]: Indicating more informative failures

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -318,6 +318,7 @@ jobs:
 
             let prNumber = '';
             let branchName = '';
+            let successExplanation = '';
 
             try {
               if (success) {
@@ -330,6 +331,24 @@ jobs:
             }
 
 
+            try {
+              if (!success){
+                // Read success_explanation from JSON file for failed resolution
+                const outputFilePath = path.resolve('/tmp/output/output.jsonl');
+                if (fs.existsSync(outputFilePath)) {
+                  const outputContent = fs.readFileSync(outputFilePath, 'utf8');
+                  const jsonLines = outputContent.split('\n').filter(line => line.trim() !== '');
+
+                  if (jsonLines.length > 0) {
+                    // First entry in JSON lines has the key 'success_explanation'
+                    const firstEntry = JSON.parse(jsonLines[0]);
+                    successExplanation = firstEntry.success_explanation || '';
+                  }
+              }
+            } catch (error){
+              console.error('Error reading file:', error);
+            }
+
             // Check "success" log from resolver output
             if (success && prNumber) {
               github.rest.issues.createComment({
@@ -340,11 +359,17 @@ jobs:
               });
               process.env.AGENT_RESPONDED = 'true';
             } else if (!success && branchName) {
+              let commentBody = `An attempt was made to automatically fix this issue, but it was unsuccessful. A branch named '${branchName}' has been created with the attempted changes. You can view the branch [here](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}). Manual intervention may be required.`;
+
+              if (successExplanation) {
+                commentBody += `\n\nAdditional details about the failure:\n${successExplanation}`;
+              }
+
               github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `An attempt was made to automatically fix this issue, but it was unsuccessful. A branch named '${branchName}' has been created with the attempted changes. You can view the branch [here](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}). Manual intervention may be required.`
+                body: commentBody
               });
               process.env.AGENT_RESPONDED = 'true';
             }


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When the resolver is invoked on an issue, it handles the outcome in one of two ways

1. Successful: leave link to a PR in a comment on the issue
2. Unsuccessful: leave link to a branch in a comment on the issue

This PR adds additional failure explanations in the comment body when the resolver is unsuccessful. Note, we don't do this for the successful case, as the success explanation is available in the PR body. 


---
**Link of any specific issues this addresses**
#5137

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:38808b8-nikolaik   --name openhands-app-38808b8   docker.all-hands.dev/all-hands-ai/openhands:38808b8
```