### PR TITLE
[Bug]: Prevent selection of "add more repo" option in dropdown

### DIFF
--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -1,9 +1,9 @@
+import React from "react";
 import { Autocomplete, AutocompleteItem } from "@nextui-org/react";
 import { useDispatch } from "react-redux";
 import posthog from "posthog-js";
 import { setSelectedRepository } from "#/state/initial-query-slice";
 import { useConfig } from "#/hooks/query/use-config";
-import React from "react";
 
 interface GitHubRepositorySelectorProps {
   onSelect: () => void;

--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -33,7 +33,6 @@ export function GitHubRepositorySelector({
           `https://github.com/apps/${config.APP_SLUG}/installations/new`,
           "_blank",
         );
-      setSelectedKey(null);
     } else if (repo) {
       // set query param
       dispatch(setSelectedRepository(repo.full_name));

--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import posthog from "posthog-js";
 import { setSelectedRepository } from "#/state/initial-query-slice";
 import { useConfig } from "#/hooks/query/use-config";
+import React from "react";
 
 interface GitHubRepositorySelectorProps {
   onSelect: () => void;
@@ -14,6 +15,7 @@ export function GitHubRepositorySelector({
   repositories,
 }: GitHubRepositorySelectorProps) {
   const { data: config } = useConfig();
+  const [selectedKey, setSelectedKey] = React.useState<string | null>(null);
 
   // Add option to install app onto more repos
   const finalRepositories =
@@ -31,11 +33,13 @@ export function GitHubRepositorySelector({
           `https://github.com/apps/${config.APP_SLUG}/installations/new`,
           "_blank",
         );
+      setSelectedKey(null);
     } else if (repo) {
       // set query param
       dispatch(setSelectedRepository(repo.full_name));
       posthog.capture("repository_selected");
       onSelect();
+      setSelectedKey(id);
     }
   };
 
@@ -63,6 +67,7 @@ export function GitHubRepositorySelector({
       name="repo"
       aria-label="GitHub Repository"
       placeholder="Select a GitHub project"
+      selectedKey={selectedKey}
       inputProps={{
         classNames: {
           inputWrapper:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR checks whether the key for "Add more repo" option is being selected; in this event it won't select the "add more repo"option, or clear any existing selection. 

---
**Link of any specific issues this addresses**
Resolves #5686

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f783542-nikolaik   --name openhands-app-f783542   docker.all-hands.dev/all-hands-ai/openhands:f783542
```