### PR TITLE
chore: Cleanup runtime exception handling

### DIFF
--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -15,6 +15,7 @@ from evaluation.utils.shared import (
     EvalOutput,
     assert_and_raise,
     codeact_user_response,
+    is_fatal_evaluation_error,
     make_metadata,
     prepare_dataset,
     reset_logger_for_multiprocessing,
@@ -400,11 +401,7 @@ def process_instance(
         )
 
         # if fatal error, throw EvalError to trigger re-run
-        if (
-            state.last_error
-            and 'fatal error during agent execution' in state.last_error
-            and 'stuck in a loop' not in state.last_error
-        ):
+        if is_fatal_evaluation_error(state.last_error):
             raise EvalException('Fatal error detected: ' + state.last_error)
 
         # ======= THIS IS SWE-Bench specific =======

--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -16,6 +16,16 @@ from tqdm import tqdm
 
 from openhands.controller.state.state import State
 from openhands.core.config import LLMConfig
+from openhands.core.exceptions import (
+    AgentRuntimeBuildError,
+    AgentRuntimeDisconnectedError,
+    AgentRuntimeError,
+    AgentRuntimeNotFoundError,
+    AgentRuntimeNotReadyError,
+    AgentRuntimeTimeoutError,
+    AgentRuntimeUnavailableError,
+    AgentStuckInLoopError,
+)
 from openhands.core.logger import get_console_handler
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import Action
@@ -503,3 +513,25 @@ def compatibility_for_eval_history_pairs(
         history_pairs.append((event_to_dict(action), event_to_dict(observation)))
 
     return history_pairs
+
+
+def is_fatal_evaluation_error(error: str | None) -> bool:
+    if not error:
+        return False
+
+    FATAL_EXCEPTIONS = [
+        AgentRuntimeError,
+        AgentRuntimeBuildError,
+        AgentRuntimeTimeoutError,
+        AgentRuntimeUnavailableError,
+        AgentRuntimeNotReadyError,
+        AgentRuntimeDisconnectedError,
+        AgentRuntimeNotFoundError,
+        AgentStuckInLoopError,
+    ]
+
+    if any(exception.__name__ in error for exception in FATAL_EXCEPTIONS):
+        logger.error(f'Fatal evaluation error detected: {error}')
+        return True
+
+    return False

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -12,6 +12,7 @@ from openhands.controller.state.state import State, TrafficControlState
 from openhands.controller.stuck import StuckDetector
 from openhands.core.config import AgentConfig, LLMConfig
 from openhands.core.exceptions import (
+    AgentStuckInLoopError,
     FunctionCallNotExistsError,
     FunctionCallValidationError,
     LLMMalformedActionError,
@@ -196,7 +197,7 @@ class AgentController:
             err_id = ''
             if isinstance(e, litellm.AuthenticationError):
                 err_id = 'STATUS$ERROR_LLM_AUTHENTICATION'
-            self.status_callback('error', err_id, str(e))
+            self.status_callback('error', err_id, type(e).__name__ + ': ' + str(e))
 
     async def start_step_loop(self):
         """The main loop for the agent's step-by-step execution."""
@@ -502,7 +503,9 @@ class AgentController:
             return
 
         if self._is_stuck():
-            await self._react_to_exception(RuntimeError('Agent got stuck in a loop'))
+            await self._react_to_exception(
+                AgentStuckInLoopError('Agent got stuck in a loop')
+            )
             return
 
         self.update_state_before_step()

--- a/openhands/core/exceptions.py
+++ b/openhands/core/exceptions.py
@@ -1,14 +1,25 @@
-class AgentNoInstructionError(Exception):
+# ============================================
+# Agent Exceptions
+# ============================================
+
+
+class AgentError(Exception):
+    """Base class for all agent exceptions."""
+
+    pass
+
+
+class AgentNoInstructionError(AgentError):
     def __init__(self, message='Instruction must be provided'):
         super().__init__(message)
 
 
-class AgentEventTypeError(Exception):
+class AgentEventTypeError(AgentError):
     def __init__(self, message='Event must be a dictionary'):
         super().__init__(message)
 
 
-class AgentAlreadyRegisteredError(Exception):
+class AgentAlreadyRegisteredError(AgentError):
     def __init__(self, name=None):
         if name is not None:
             message = f"Agent class already registered under '{name}'"
@@ -17,13 +28,23 @@ class AgentAlreadyRegisteredError(Exception):
         super().__init__(message)
 
 
-class AgentNotRegisteredError(Exception):
+class AgentNotRegisteredError(AgentError):
     def __init__(self, name=None):
         if name is not None:
             message = f"No agent class registered under '{name}'"
         else:
             message = 'No agent class registered'
         super().__init__(message)
+
+
+class AgentStuckInLoopError(AgentError):
+    def __init__(self, message='Agent got stuck in a loop'):
+        super().__init__(message)
+
+
+# ============================================
+# Agent Controller Exceptions
+# ============================================
 
 
 class TaskInvalidStateError(Exception):
@@ -35,17 +56,9 @@ class TaskInvalidStateError(Exception):
         super().__init__(message)
 
 
-class BrowserInitException(Exception):
-    def __init__(self, message='Failed to initialize browser environment'):
-        super().__init__(message)
-
-
-class BrowserUnavailableException(Exception):
-    def __init__(
-        self,
-        message='Browser environment is not available, please check if has been initialized',
-    ):
-        super().__init__(message)
+# ============================================
+# LLM Exceptions
+# ============================================
 
 
 # This exception gets sent back to the LLM
@@ -96,6 +109,11 @@ class CloudFlareBlockageError(Exception):
     pass
 
 
+# ============================================
+# LLM function calling Exceptions
+# ============================================
+
+
 class FunctionCallConversionError(Exception):
     """Exception raised when FunctionCallingConverter failed to convert a non-function call message to a function call message.
 
@@ -120,4 +138,69 @@ class FunctionCallNotExistsError(Exception):
     """Exception raised when an LLM call a tool that is not registered."""
 
     def __init__(self, message):
+        super().__init__(message)
+
+
+# ============================================
+# Agent Runtime Exceptions
+# ============================================
+
+
+class AgentRuntimeError(Exception):
+    """Base class for all agent runtime exceptions."""
+
+    pass
+
+
+class AgentRuntimeBuildError(AgentRuntimeError):
+    """Exception raised when an agent runtime build operation fails."""
+
+    pass
+
+
+class AgentRuntimeTimeoutError(AgentRuntimeError):
+    """Exception raised when an agent runtime operation times out."""
+
+    pass
+
+
+class AgentRuntimeUnavailableError(AgentRuntimeError):
+    """Exception raised when an agent runtime is unavailable."""
+
+    pass
+
+
+class AgentRuntimeNotReadyError(AgentRuntimeUnavailableError):
+    """Exception raised when an agent runtime is not ready."""
+
+    pass
+
+
+class AgentRuntimeDisconnectedError(AgentRuntimeUnavailableError):
+    """Exception raised when an agent runtime is disconnected."""
+
+    pass
+
+
+class AgentRuntimeNotFoundError(AgentRuntimeUnavailableError):
+    """Exception raised when an agent runtime is not found."""
+
+    pass
+
+
+# ============================================
+# Browser Exceptions
+# ============================================
+
+
+class BrowserInitException(Exception):
+    def __init__(self, message='Failed to initialize browser environment'):
+        super().__init__(message)
+
+
+class BrowserUnavailableException(Exception):
+    def __init__(
+        self,
+        message='Browser environment is not available, please check if has been initialized',
+    ):
         super().__init__(message)

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -9,6 +9,7 @@ from typing import Callable
 from requests.exceptions import ConnectionError
 
 from openhands.core.config import AppConfig, SandboxConfig
+from openhands.core.exceptions import AgentRuntimeDisconnectedError
 from openhands.core.logger import openhands_logger as logger
 from openhands.events import EventSource, EventStream, EventStreamSubscriber
 from openhands.events.action import (
@@ -45,22 +46,6 @@ STATUS_MESSAGES = {
     'STATUS$CONTAINER_STARTED': 'Container started.',
     'STATUS$WAITING_FOR_CLIENT': 'Waiting for client...',
 }
-
-
-class RuntimeUnavailableError(Exception):
-    pass
-
-
-class RuntimeNotReadyError(RuntimeUnavailableError):
-    pass
-
-
-class RuntimeDisconnectedError(RuntimeUnavailableError):
-    pass
-
-
-class RuntimeNotFoundError(RuntimeUnavailableError):
-    pass
 
 
 def _default_env_vars(sandbox_config: SandboxConfig) -> dict[str, str]:
@@ -193,7 +178,7 @@ class Runtime(FileEditRuntimeMixin):
             except Exception as e:
                 err_id = ''
                 if isinstance(e, ConnectionError) or isinstance(
-                    e, RuntimeDisconnectedError
+                    e, AgentRuntimeDisconnectedError
                 ):
                     err_id = 'STATUS$ERROR_RUNTIME_DISCONNECTED'
                 logger.error(

--- a/openhands/runtime/builder/base.py
+++ b/openhands/runtime/builder/base.py
@@ -24,7 +24,7 @@ class RuntimeBuilder(abc.ABC):
                 registry prefix). This should be used for subsequent use (e.g., `docker run`).
 
         Raises:
-            RuntimeError: If the build failed.
+            AgentRuntimeBuildError: If the build failed.
         """
         pass
 

--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -6,6 +6,7 @@ import time
 import docker
 
 from openhands import __version__ as oh_version
+from openhands.core.exceptions import AgentRuntimeBuildError
 from openhands.core.logger import RollingLogger
 from openhands.core.logger import openhands_logger as logger
 from openhands.runtime.builder.base import RuntimeBuilder
@@ -19,7 +20,9 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         version_info = self.docker_client.version()
         server_version = version_info.get('Version', '').replace('-', '.')
         if tuple(map(int, server_version.split('.')[:2])) < (18, 9):
-            raise RuntimeError('Docker server version must be >= 18.09 to use BuildKit')
+            raise AgentRuntimeBuildError(
+                'Docker server version must be >= 18.09 to use BuildKit'
+            )
 
         self.rolling_logger = RollingLogger(max_lines=10)
 
@@ -44,7 +47,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
             str: The name of the built Docker image.
 
         Raises:
-            RuntimeError: If the Docker server version is incompatible or if the build process fails.
+            AgentRuntimeBuildError: If the Docker server version is incompatible or if the build process fails.
 
         Note:
             This method uses Docker BuildKit for improved build performance and caching capabilities.
@@ -55,7 +58,9 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         version_info = self.docker_client.version()
         server_version = version_info.get('Version', '').replace('-', '.')
         if tuple(map(int, server_version.split('.'))) < (18, 9):
-            raise RuntimeError('Docker server version must be >= 18.09 to use BuildKit')
+            raise AgentRuntimeBuildError(
+                'Docker server version must be >= 18.09 to use BuildKit'
+            )
 
         target_image_hash_name = tags[0]
         target_image_repo, target_image_source_tag = target_image_hash_name.split(':')
@@ -154,7 +159,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         # Check if the image is built successfully
         image = self.docker_client.images.get(target_image_hash_name)
         if image is None:
-            raise RuntimeError(
+            raise AgentRuntimeBuildError(
                 f'Build failed: Image {target_image_hash_name} not found'
             )
 

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -10,6 +10,14 @@ import requests
 import tenacity
 
 from openhands.core.config import AppConfig
+from openhands.core.exceptions import (
+    AgentRuntimeDisconnectedError,
+    AgentRuntimeError,
+    AgentRuntimeNotFoundError,
+    AgentRuntimeNotReadyError,
+    AgentRuntimeTimeoutError,
+    AgentRuntimeUnavailableError,
+)
 from openhands.events import EventStream
 from openhands.events.action import (
     BrowseInteractiveAction,
@@ -28,13 +36,7 @@ from openhands.events.observation import (
 )
 from openhands.events.serialization import event_to_dict, observation_from_dict
 from openhands.events.serialization.action import ACTION_TYPE_TO_CLASS
-from openhands.runtime.base import (
-    Runtime,
-    RuntimeDisconnectedError,
-    RuntimeNotFoundError,
-    RuntimeNotReadyError,
-    RuntimeUnavailableError,
-)
+from openhands.runtime.base import Runtime
 from openhands.runtime.builder.remote import RemoteRuntimeBuilder
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.utils.command import get_remote_startup_command
@@ -100,7 +102,7 @@ class RemoteRuntime(Runtime):
     async def connect(self):
         try:
             await call_sync_from_async(self._start_or_attach_to_runtime)
-        except RuntimeNotReadyError:
+        except AgentRuntimeNotReadyError:
             self.log('error', 'Runtime failed to start, timed out before ready')
             raise
         await call_sync_from_async(self.setup_initial_env)
@@ -111,7 +113,7 @@ class RemoteRuntime(Runtime):
         if existing_runtime:
             self.log('debug', f'Using existing runtime with ID: {self.runtime_id}')
         elif self.attach_to_existing:
-            raise RuntimeNotFoundError(
+            raise AgentRuntimeNotFoundError(
                 f'Could not find existing runtime for SID: {self.sid}'
             )
         else:
@@ -215,7 +217,7 @@ class RemoteRuntime(Runtime):
             timeout=60,
         ) as response:
             if not response.json()['exists']:
-                raise RuntimeError(
+                raise AgentRuntimeError(
                     f'Container image {self.container_image} does not exist'
                 )
 
@@ -262,7 +264,7 @@ class RemoteRuntime(Runtime):
             )
         except requests.HTTPError as e:
             self.log('error', f'Unable to start runtime: {e}')
-            raise RuntimeUnavailableError() from e
+            raise AgentRuntimeUnavailableError() from e
 
     def _resume_runtime(self):
         with self._send_request(
@@ -322,7 +324,7 @@ class RemoteRuntime(Runtime):
             )
             | stop_if_should_exit(),
             reraise=True,
-            retry=tenacity.retry_if_exception_type(RuntimeNotReadyError),
+            retry=tenacity.retry_if_exception_type(AgentRuntimeNotReadyError),
             wait=tenacity.wait_fixed(2),
         )
         return retry_decorator(self._wait_until_alive_impl)()
@@ -356,7 +358,7 @@ class RemoteRuntime(Runtime):
                 self.log(
                     'warning', f"Runtime /alive failed, but pod says it's ready: {e}"
                 )
-                raise RuntimeNotReadyError(
+                raise AgentRuntimeNotReadyError(
                     f'Runtime /alive failed to respond with 200: {e}'
                 )
             return
@@ -365,14 +367,14 @@ class RemoteRuntime(Runtime):
             or pod_status == 'pending'
             or pod_status == 'running'
         ):  # nb: Running is not yet Ready
-            raise RuntimeNotReadyError(
+            raise AgentRuntimeNotReadyError(
                 f'Runtime (ID={self.runtime_id}) is not yet ready. Status: {pod_status}'
             )
         elif pod_status in ('failed', 'unknown', 'crashloopbackoff'):
             # clean up the runtime
             self.close()
-            raise RuntimeError(
-                f'Runtime (ID={self.runtime_id}) failed to start. Current status: {pod_status}'
+            raise AgentRuntimeUnavailableError(
+                f'Runtime (ID={self.runtime_id}) failed to start. Current status: {pod_status}. Pod Logs:\n{runtime_data.get("pod_logs", "N/A")}'
             )
         else:
             # Maybe this should be a hard failure, but passing through in case the API changes
@@ -382,7 +384,7 @@ class RemoteRuntime(Runtime):
             'debug',
             f'Waiting for runtime pod to be active. Current status: {pod_status}',
         )
-        raise RuntimeNotReadyError()
+        raise AgentRuntimeNotReadyError()
 
     def close(self, timeout: int = 10):
         if self.config.sandbox.keep_runtime_alive or self.attach_to_existing:
@@ -437,7 +439,7 @@ class RemoteRuntime(Runtime):
                 obs = observation_from_dict(output)
                 obs._cause = action.id  # type: ignore[attr-defined]
             except requests.Timeout:
-                raise RuntimeError(
+                raise AgentRuntimeTimeoutError(
                     f'Runtime failed to return execute_action before the requested timeout of {action.timeout}s'
                 )
             return obs
@@ -451,7 +453,7 @@ class RemoteRuntime(Runtime):
             raise
         except requests.HTTPError as e:
             if is_runtime_request and e.response.status_code == 404:
-                raise RuntimeDisconnectedError(
+                raise AgentRuntimeDisconnectedError(
                     f'404 error while connecting to {self.runtime_url}'
                 )
             elif is_runtime_request and e.response.status_code == 503:

--- a/openhands/runtime/impl/runloop/runloop_runtime.py
+++ b/openhands/runtime/impl/runloop/runloop_runtime.py
@@ -10,6 +10,10 @@ from runloop_api_client.types import DevboxView
 from runloop_api_client.types.shared_params import LaunchParameters
 
 from openhands.core.config import AppConfig
+from openhands.core.exceptions import (
+    AgentRuntimeNotReadyError,
+    AgentRuntimeUnavailableError,
+)
 from openhands.core.logger import openhands_logger as logger
 from openhands.events import EventStream
 from openhands.runtime.impl.eventstream.eventstream_runtime import EventStreamRuntime
@@ -227,7 +231,7 @@ class RunloopRuntime(EventStreamRuntime):
     )
     def _wait_until_alive(self):
         if not self.log_streamer:
-            raise RuntimeError('Runtime client is not ready.')
+            raise AgentRuntimeNotReadyError('Runtime client is not ready.')
         response = send_request(
             self.session,
             'GET',
@@ -239,7 +243,7 @@ class RunloopRuntime(EventStreamRuntime):
         else:
             msg = f'Action execution API is not alive. Response: {response}'
             logger.error(msg)
-            raise RuntimeError(msg)
+            raise AgentRuntimeUnavailableError(msg)
 
     def close(self, rm_all_containers: bool | None = True):
         if self.log_streamer:

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -14,6 +14,7 @@ from jinja2 import Environment, FileSystemLoader
 
 import openhands
 from openhands import __version__ as oh_version
+from openhands.core.exceptions import AgentRuntimeBuildError
 from openhands.core.logger import openhands_logger as logger
 from openhands.runtime.builder import DockerRuntimeBuilder, RuntimeBuilder
 
@@ -364,7 +365,7 @@ def _build_sandbox_image(
         extra_build_args=extra_build_args,
     )
     if not image_name:
-        raise RuntimeError(f'Build failed for image {names}')
+        raise AgentRuntimeBuildError(f'Build failed for image {names}')
 
     return image_name
 

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -5,13 +5,14 @@ from openhands.controller import AgentController
 from openhands.controller.agent import Agent
 from openhands.controller.state.state import State
 from openhands.core.config import AgentConfig, AppConfig, LLMConfig
+from openhands.core.exceptions import AgentRuntimeUnavailableError
 from openhands.core.logger import openhands_logger as logger
 from openhands.core.schema.agent import AgentState
 from openhands.events.action import ChangeAgentStateAction
 from openhands.events.event import EventSource
 from openhands.events.stream import EventStream
 from openhands.runtime import get_runtime_cls
-from openhands.runtime.base import Runtime, RuntimeUnavailableError
+from openhands.runtime.base import Runtime
 from openhands.security import SecurityAnalyzer, options
 from openhands.storage.files import FileStore
 from openhands.utils.async_utils import call_async_from_sync
@@ -222,7 +223,7 @@ class AgentSession:
 
         try:
             await self.runtime.connect()
-        except RuntimeUnavailableError as e:
+        except AgentRuntimeUnavailableError as e:
             logger.error(f'Runtime initialization failed: {e}', exc_info=True)
             if self._status_callback:
                 self._status_callback(

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 import socketio
 
 from openhands.core.config import AppConfig
+from openhands.core.exceptions import AgentRuntimeUnavailableError
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.stream import EventStream, session_exists
-from openhands.runtime.base import RuntimeUnavailableError
 from openhands.server.session.conversation import Conversation
 from openhands.server.session.session import ROOM_KEY, Session
 from openhands.server.session.session_init_data import SessionInitData
@@ -160,7 +160,7 @@ class SessionManager:
             c = Conversation(sid, file_store=self.file_store, config=self.config)
             try:
                 await c.connect()
-            except RuntimeUnavailableError as e:
+            except AgentRuntimeUnavailableError as e:
                 logger.error(f'Error connecting to conversation {c.sid}: {e}')
                 return None
             end_time = time.time()

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -161,7 +161,7 @@ async def test_run_controller_with_fatal_error(mock_agent, mock_event_stream):
     print(f'event_stream: {list(event_stream.get_events())}')
     assert state.iteration == 4
     assert state.agent_state == AgentState.ERROR
-    assert state.last_error == 'Agent got stuck in a loop'
+    assert state.last_error == 'AgentStuckInLoopError: Agent got stuck in a loop'
     assert len(list(event_stream.get_events())) == 11
 
 
@@ -227,7 +227,7 @@ async def test_run_controller_stop_with_stuck():
     assert last_event['observation'] == 'agent_state_changed'
 
     assert state.agent_state == AgentState.ERROR
-    assert state.last_error == 'Agent got stuck in a loop'
+    assert state.last_error == 'AgentStuckInLoopError: Agent got stuck in a loop'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We've been kinda abuse `RuntimeError` a lot in different places of codebase, which makes it really hard to figure out whether this error comes from AgentController or AgentRuntime. This PR:
- Creates AgentRuntimeError class that encapsulate everything AgentRuntime related, and a bunch of child exceptions (eg Timeout, Unavailable)
- Replace all occurrence of RuntimeError in `openhands/runtime` with appropriate exception
- Refactor exception.py a little bit and add comments
- Use this cleaned up exception to revise the `is_fatal_error` condition in SWE-Bench evaluation

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3c9e9f5-nikolaik   --name openhands-app-3c9e9f5   docker.all-hands.dev/all-hands-ai/openhands:3c9e9f5
```