### PR TITLE
Settings store type is defined in openhands_config rather than main config

### DIFF
--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -66,9 +66,6 @@ class AppConfig:
     modal_api_token_secret: str = ''
     disable_color: bool = False
     jwt_secret: str = ''
-    settings_store_class: str = (
-        'openhands.storage.file_settings_store.FileSettingsStore'
-    )
     debug: bool = False
     file_uploads_max_file_size_mb: int = 0
     file_uploads_restrict_file_types: bool = False

--- a/openhands/server/config/openhands_config.py
+++ b/openhands/server/config/openhands_config.py
@@ -15,6 +15,9 @@ class OpenhandsConfig(OpenhandsConfigInterface):
     attach_session_middleware_path = (
         'openhands.server.middleware.AttachSessionMiddleware'
     )
+    settings_store_class: str = (
+        'openhands.storage.file_settings_store.FileSettingsStore'
+    )
 
     def verify_config(self):
         if self.config_cls:

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -5,13 +5,13 @@ from fastapi.responses import JSONResponse
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.settings import Settings
-from openhands.server.shared import config
+from openhands.server.shared import config, openhands_config
 from openhands.storage.settings_store import SettingsStore
 from openhands.utils.import_utils import get_impl
 
 app = APIRouter(prefix='/api')
 
-SettingsStoreImpl = get_impl(SettingsStore, config.settings_store_class)  # type: ignore
+SettingsStoreImpl = get_impl(SettingsStore, openhands_config.settings_store_class)  # type: ignore
 
 
 @app.get('/settings')
@@ -21,6 +21,9 @@ async def load_settings(
     try:
         settings_store = await SettingsStoreImpl.get_instance(config, github_auth)
         settings = await settings_store.load()
+        if settings:
+            # We don't ever send the api key to the client
+            settings.llm_api_key = None
         return settings
     except Exception as e:
         logger.warning(f'Invalid token: {e}')
@@ -37,8 +40,11 @@ async def store_settings(
 ) -> bool:
     try:
         settings_store = await SettingsStoreImpl.get_instance(config, github_auth)
-        settings = await settings_store.store(settings)
-        return True
+        existing_settings = await settings_store.load()
+        if existing_settings:
+            if not settings.llm_api_key:
+                settings.llm_api_key = existing_settings.llm_api_key
+        return await settings_store.store(settings)
     except Exception as e:
         logger.warning(f'Invalid token: {e}')
         return JSONResponse(

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -22,7 +22,7 @@ async def load_settings(
         settings_store = await SettingsStoreImpl.get_instance(config, github_auth)
         settings = await settings_store.load()
         if settings:
-            # We don't ever send the api key to the client
+            # For security reasons we don't ever send the api key to the client
             settings.llm_api_key = None
         return settings
     except Exception as e:
@@ -42,7 +42,7 @@ async def store_settings(
         settings_store = await SettingsStoreImpl.get_instance(config, github_auth)
         existing_settings = await settings_store.load()
         if existing_settings:
-            if not settings.llm_api_key:
+            if settings.llm_api_key is None:
                 settings.llm_api_key = existing_settings.llm_api_key
         return await settings_store.store(settings)
     except Exception as e:


### PR DESCRIPTION
**Settings store type is defined in openhands_config rather than main config**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
This is to make the code closer to the changes provided by Rohit. Type definitions in the OpenHands config just make more sense.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:65f3260-nikolaik   --name openhands-app-65f3260   docker.all-hands.dev/all-hands-ai/openhands:65f3260
```