### PR TITLE
fix(frontend(: Create a conversation without a query

### DIFF
--- a/frontend/src/components/shared/task-form.tsx
+++ b/frontend/src/components/shared/task-form.tsx
@@ -40,8 +40,8 @@ export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
   );
   const [inputIsFocused, setInputIsFocused] = React.useState(false);
   const newConversationMutation = useMutation({
-    mutationFn: (variables: { q: string }) => {
-      dispatch(setInitialQuery(variables.q));
+    mutationFn: (variables: { q?: string }) => {
+      if (variables.q) dispatch(setInitialQuery(variables.q));
       return OpenHands.newConversation({
         githubToken: gitHubToken || undefined,
         selectedRepository: selectedRepository || undefined,
@@ -51,7 +51,7 @@ export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
     onSuccess: ({ conversation_id: conversationId }, { q }) => {
       posthog.capture("initial_query_submitted", {
         entry_point: "task_form",
-        query_character_length: q.length,
+        query_character_length: q?.length,
         has_repository: !!selectedRepository,
         has_files: files.length > 0,
       });
@@ -88,8 +88,6 @@ export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
     const formData = new FormData(event.currentTarget);
 
     const q = formData.get("q")?.toString();
-    if (!q) return;
-
     newConversationMutation.mutate({ q });
   };
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- Submitting the initial form only creates and redirects you if a query exists. This means in cases such as project uploads, it will never redirect

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Make request even if query is not present


---
**Link of any specific issues this addresses**
