### PR TITLE
fix: only register atexit when EventStreamRuntime is initialized

### DIFF
--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -59,7 +59,7 @@ def remove_all_runtime_containers():
     remove_all_containers(CONTAINER_NAME_PREFIX)
 
 
-atexit.register(remove_all_runtime_containers)
+_atexit_registered = False
 
 
 class EventStreamRuntime(Runtime):
@@ -109,6 +109,11 @@ class EventStreamRuntime(Runtime):
         attach_to_existing: bool = False,
         headless_mode: bool = True,
     ):
+        global _atexit_registered
+        if not _atexit_registered:
+            _atexit_registered = True
+            atexit.register(remove_all_runtime_containers)
+
         self.config = config
         self._host_port = 30000  # initial dummy value
         self._container_port = 30001  # initial dummy value


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Otherwise, occasionally we run into docker-related API when docker is not available in the current machine.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ac1969e-nikolaik   --name openhands-app-ac1969e   docker.all-hands.dev/all-hands-ai/openhands:ac1969e
```