### PR TITLE
Fix missing closing brace in openhands-resolver.yml

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -347,6 +347,7 @@ jobs:
                     const firstEntry = JSON.parse(jsonLines[0]);
                     resultExplanation = firstEntry.result_explanation || '';
                   }
+                }
               }
             } catch (error){
               console.error('Error reading file:', error);


### PR DESCRIPTION
This PR fixes issue #5728 by adding a missing closing brace in the openhands-resolver.yml file.

The issue was in the JavaScript code block that reads the result_explanation from the output.jsonl file. The if block checking for `fs.existsSync(outputFilePath)` was missing its closing brace, which could cause syntax errors.

Changes made:
- Added the missing closing brace after the `if (jsonLines.length > 0)` block

Fixes #5728

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0467bc6-nikolaik   --name openhands-app-0467bc6   docker.all-hands.dev/all-hands-ai/openhands:0467bc6
```