### PR TITLE
Fix several async lockups

### DIFF
--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -12,7 +12,7 @@ from openhands.events.serialization.event import event_from_dict, event_to_dict
 from openhands.storage import FileStore
 from openhands.storage.locations import (
     get_conversation_dir,
-    get_conversation_event_file,
+    get_conversation_event_filename,
     get_conversation_events_dir,
 )
 from openhands.utils.async_utils import call_sync_from_async
@@ -77,7 +77,7 @@ class EventStream:
                 self._cur_id = id + 1
 
     def _get_filename_for_id(self, id: int) -> str:
-        return get_conversation_event_file(self.sid, id)
+        return get_conversation_event_filename(self.sid, id)
 
     @staticmethod
     def _get_id_from_filename(filename: str) -> int:

--- a/openhands/server/routes/github.py
+++ b/openhands/server/routes/github.py
@@ -3,12 +3,13 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from openhands.server.shared import openhands_config
+from openhands.utils.async_utils import call_sync_from_async
 
 app = APIRouter(prefix='/api')
 
 
 @app.get('/github/repositories')
-def get_github_repositories(
+async def get_github_repositories(
     request: Request,
     page: int = 1,
     per_page: int = 10,
@@ -44,7 +45,9 @@ def get_github_repositories(
 
     # Fetch repositories from GitHub
     try:
-        response = requests.get(github_api_url, headers=headers, params=params)
+        response = await call_sync_from_async(
+            requests.get, github_api_url, headers=headers, params=params
+        )
         response.raise_for_status()  # Raise an error for HTTP codes >= 400
     except requests.exceptions.RequestException as e:
         raise HTTPException(
@@ -54,6 +57,7 @@ def get_github_repositories(
 
     # Create response with the JSON content
     json_response = JSONResponse(content=response.json())
+    response.close()
 
     # Forward the Link header if it exists
     if 'Link' in response.headers:

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -15,7 +15,7 @@ from openhands.runtime import get_runtime_cls
 from openhands.runtime.base import Runtime
 from openhands.security import SecurityAnalyzer, options
 from openhands.storage.files import FileStore
-from openhands.utils.async_utils import call_async_from_sync
+from openhands.utils.async_utils import call_async_from_sync, call_sync_from_async
 from openhands.utils.shutdown_listener import should_continue
 
 WAIT_TIME_BEFORE_CLOSE = 300
@@ -238,9 +238,10 @@ class AgentSession:
 
         self.runtime.clone_repo(github_token, selected_repository)
         if agent.prompt_manager:
-            agent.prompt_manager.load_microagent_files(
-                self.runtime.get_custom_microagents(selected_repository)
+            microagents = await call_sync_from_async(
+                self.runtime.get_custom_microagents, selected_repository
             )
+            agent.prompt_manager.load_microagent_files(microagents)
 
         logger.debug(
             f'Runtime initialized with plugins: {[plugin.name for plugin in self.runtime.plugins]}'

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -13,6 +13,7 @@ from openhands.server.session.conversation import Conversation
 from openhands.server.session.session import ROOM_KEY, Session
 from openhands.server.session.session_init_data import SessionInitData
 from openhands.storage.files import FileStore
+from openhands.utils.async_utils import call_sync_from_async
 from openhands.utils.shutdown_listener import should_continue
 
 _REDIS_POLL_TIMEOUT = 1.5
@@ -400,4 +401,5 @@ class SessionManager:
                 json.dumps({'sid': session.sid, 'message_type': 'session_closing'}),
             )
 
-        session.close()
+        await call_sync_from_async(session.close)
+        logger.info(f'closed_session:{session.sid}')

--- a/openhands/storage/conversation/conversation_store.py
+++ b/openhands/storage/conversation/conversation_store.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from openhands.core.config.app_config import AppConfig
 from openhands.storage import get_file_store
 from openhands.storage.files import FileStore
-from openhands.storage.locations import get_conversation_metadata_file
+from openhands.storage.locations import get_conversation_metadata_filename
+from openhands.utils.async_utils import call_sync_from_async
 
 
 @dataclass
@@ -20,18 +21,18 @@ class ConversationStore:
 
     async def save_metadata(self, metadata: ConversationMetadata):
         json_str = json.dumps(metadata.__dict__)
-        path = get_conversation_metadata_file(metadata.conversation_id)
-        self.file_store.write(path, json_str)
+        path = get_conversation_metadata_filename(metadata.conversation_id)
+        await call_sync_from_async(self.file_store.write, path, json_str)
 
     async def get_metadata(self, conversation_id: str) -> ConversationMetadata:
-        path = get_conversation_metadata_file(conversation_id)
-        json_str = self.file_store.read(path)
+        path = get_conversation_metadata_filename(conversation_id)
+        json_str = await call_sync_from_async(self.file_store.read, path)
         return ConversationMetadata(**json.loads(json_str))
 
     async def exists(self, conversation_id: str) -> bool:
-        path = get_conversation_metadata_file(conversation_id)
+        path = get_conversation_metadata_filename(conversation_id)
         try:
-            self.file_store.read(path)
+            await call_sync_from_async(self.file_store.read, path)
             return True
         except FileNotFoundError:
             return False

--- a/openhands/storage/file_settings_store.py
+++ b/openhands/storage/file_settings_store.py
@@ -8,6 +8,7 @@ from openhands.server.settings import Settings
 from openhands.storage import get_file_store
 from openhands.storage.files import FileStore
 from openhands.storage.settings_store import SettingsStore
+from openhands.utils.async_utils import call_sync_from_async
 
 
 @dataclass
@@ -17,7 +18,7 @@ class FileSettingsStore(SettingsStore):
 
     async def load(self) -> Settings | None:
         try:
-            json_str = self.file_store.read(self.path)
+            json_str = await call_sync_from_async(self.file_store.read, self.path)
             kwargs = json.loads(json_str)
             settings = Settings(**kwargs)
             return settings
@@ -26,7 +27,7 @@ class FileSettingsStore(SettingsStore):
 
     async def store(self, settings: Settings):
         json_str = json.dumps(settings.__dict__)
-        self.file_store.write(self.path, json_str)
+        await call_sync_from_async(self.file_store.write, self.path, json_str)
 
     @classmethod
     async def get_instance(cls, config: AppConfig, token: str | None):

--- a/openhands/storage/locations.py
+++ b/openhands/storage/locations.py
@@ -9,9 +9,9 @@ def get_conversation_events_dir(sid: str) -> str:
     return f'{get_conversation_dir(sid)}events/'
 
 
-def get_conversation_event_file(sid: str, id: int) -> str:
+def get_conversation_event_filename(sid: str, id: int) -> str:
     return f'{get_conversation_events_dir(sid)}{id}.json'
 
 
-def get_conversation_metadata_file(sid: str) -> str:
+def get_conversation_metadata_filename(sid: str) -> str:
     return f'{get_conversation_dir(sid)}metadata.json'


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We were making some blocking calls here. We should probably make the filestore async :/

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c13c8e5-nikolaik   --name openhands-app-c13c8e5   docker.all-hands.dev/all-hands-ai/openhands:c13c8e5
```