### PR TITLE
Add GitHub Actions package ecosystem to Dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,8 @@ updates:
         applies-to: "version-updates"
         patterns:
           - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Extending the Dependabot workflow to update GitHub Actions as well.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Reference https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories
