### PR TITLE
Fix stack trace in logs

### DIFF
--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -257,7 +257,7 @@ class SessionManager:
             # Nobody replied in time
             return False
         finally:
-            self._session_is_running_flags.pop(sid)
+            self._session_is_running_flags.pop(sid, None)
 
     async def _has_remote_connections(self, sid: str) -> bool:
         """As the rest of the cluster if they still want this session running. Wait a for a short timeout for a reply"""
@@ -283,7 +283,7 @@ class SessionManager:
             # Nobody replied in time
             return False
         finally:
-            self._has_remote_connections_flags.pop(sid)
+            self._has_remote_connections_flags.pop(sid, None)
 
     async def start_agent_loop(self, sid: str, session_init_data: SessionInitData):
         logger.info(f'start_agent_loop:{sid}')


### PR DESCRIPTION
**Fix error in logs due to conversation not existing**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Pop fails if there is no fallback if the item did not exist in the dict, so I added a fallback**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7a36440-nikolaik   --name openhands-app-7a36440   docker.all-hands.dev/all-hands-ai/openhands:7a36440
```