### PR TITLE
Fix for dying sessions/runtimes

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -38,7 +38,7 @@ class SandboxConfig:
 
     remote_runtime_api_url: str = 'http://localhost:8000'
     local_runtime_url: str = 'http://localhost'
-    keep_runtime_alive: bool = False
+    keep_runtime_alive: bool = True
     rm_all_containers: bool = False
     api_key: str | None = None
     base_container_image: str = 'nikolaik/python-nodejs:python3.12-nodejs22'  # default to nikolaik/python-nodejs:python3.12-nodejs22 for eventstream runtime

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -75,7 +75,6 @@ async def connect(connection_id: str, environ, auth):
 
     if agent_state_changed:
         await sio.emit('oh_event', event_to_dict(agent_state_changed), to=connection_id)
-    await session_manager.maybe_start_agent_loop(conversation_id)
 
 
 @sio.event

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -75,6 +75,7 @@ async def connect(connection_id: str, environ, auth):
 
     if agent_state_changed:
         await sio.emit('oh_event', event_to_dict(agent_state_changed), to=connection_id)
+    await session_manager.maybe_start_agent_loop(conversation_id)
 
 
 @sio.event

--- a/openhands/server/routes/new_conversation.py
+++ b/openhands/server/routes/new_conversation.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.routes.settings import SettingsStoreImpl
-from openhands.server.session.session_init_data import SessionInitData
+from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.server.shared import config, session_manager
 from openhands.storage.conversation.conversation_store import (
     ConversationMetadata,
@@ -47,7 +47,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
 
     session_init_args['github_token'] = github_token
     session_init_args['selected_repository'] = data.selected_repository
-    session_init_data = SessionInitData(**session_init_args)
+    conversation_init_data = ConversationInitData(**session_init_args)
 
     conversation_store = await ConversationStore.get_instance(config)
 
@@ -70,5 +70,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
         )
     )
 
-    await session_manager.maybe_start_agent_loop(conversation_id, session_init_data)
+    await session_manager.maybe_start_agent_loop(
+        conversation_id, conversation_init_data
+    )
     return JSONResponse(content={'status': 'ok', 'conversation_id': conversation_id})

--- a/openhands/server/routes/new_conversation.py
+++ b/openhands/server/routes/new_conversation.py
@@ -70,5 +70,5 @@ async def new_conversation(request: Request, data: InitSessionRequest):
         )
     )
 
-    await session_manager.start_agent_loop(conversation_id, session_init_data)
+    await session_manager.maybe_start_agent_loop(conversation_id, session_init_data)
     return JSONResponse(content={'status': 'ok', 'conversation_id': conversation_id})

--- a/openhands/server/session/conversation_init_data.py
+++ b/openhands/server/session/conversation_init_data.py
@@ -4,7 +4,7 @@ from openhands.server.settings import Settings
 
 
 @dataclass
-class SessionInitData(Settings):
+class ConversationInitData(Settings):
     """
     Session initialization data for the web environment - a deep copy of the global config is made and then overridden with this data.
     """

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -285,13 +285,16 @@ class SessionManager:
         finally:
             self._has_remote_connections_flags.pop(sid, None)
 
-    async def start_agent_loop(self, sid: str, session_init_data: SessionInitData):
+    async def maybe_start_agent_loop(
+        self, sid: str, session_init_data: SessionInitData = None
+    ):
         logger.info(f'start_agent_loop:{sid}')
         session = Session(
             sid=sid, file_store=self.file_store, config=self.config, sio=self.sio
         )
         self.local_sessions_by_sid[sid] = session
-        await session.initialize_agent(session_init_data)
+        if not self._is_session_running_in_cluster(sid):
+            await session.initialize_agent(session_init_data)
         return session.agent_session.event_stream
 
     async def send_to_event_stream(self, connection_id: str, data: dict):

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -179,6 +179,7 @@ class SessionManager:
             return c
 
     async def join_conversation(self, sid: str, connection_id: str) -> EventStream:
+        await self.maybe_start_agent_loop(sid)
         await self.sio.enter_room(connection_id, ROOM_KEY.format(sid=sid))
         self.local_connection_id_to_session_id[connection_id] = sid
 

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from copy import deepcopy
 
@@ -21,8 +22,10 @@ from openhands.events.serialization import event_from_dict, event_to_dict
 from openhands.events.stream import EventStreamSubscriber
 from openhands.llm.llm import LLM
 from openhands.server.session.agent_session import AgentSession
-from openhands.server.session.session_init_data import SessionInitData
+from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.storage.files import FileStore
+from openhands.storage.locations import get_conversation_init_data_filename
+from openhands.utils.async_utils import call_sync_from_async
 
 ROOM_KEY = 'room:{sid}'
 
@@ -35,6 +38,7 @@ class Session:
     agent_session: AgentSession
     loop: asyncio.AbstractEventLoop
     config: AppConfig
+    file_store: FileStore
 
     def __init__(
         self,
@@ -46,6 +50,7 @@ class Session:
         self.sid = sid
         self.sio = sio
         self.last_active_ts = int(time.time())
+        self.file_store = file_store
         self.agent_session = AgentSession(
             sid, file_store, status_callback=self.queue_status_message
         )
@@ -60,35 +65,63 @@ class Session:
         self.is_alive = False
         self.agent_session.close()
 
-    async def initialize_agent(self, session_init_data: SessionInitData = None):
+    async def _restore_init_data(self, sid: str) -> ConversationInitData:
+        print('restore init data')
+        json_str = await call_sync_from_async(
+            self.file_store.read, get_conversation_init_data_filename(sid)
+        )
+        data = json.loads(json_str)
+        return ConversationInitData(**data)
+
+    async def _save_init_data(self, sid: str, init_data: ConversationInitData):
+        print('save init data')
+        json_str = json.dumps(init_data.__dict__)
+        await call_sync_from_async(
+            self.file_store.write, get_conversation_init_data_filename(sid), json_str
+        )
+        print('save done')
+
+    async def initialize_agent(
+        self, conversation_init_data: ConversationInitData | None = None
+    ):
+        print('init agent')
         self.agent_session.event_stream.add_event(
             AgentStateChangedObservation('', AgentState.LOADING),
             EventSource.ENVIRONMENT,
         )
-        # Extract the agent-relevant arguments from the request
-        agent_cls = session_init_data.agent or self.config.default_agent
+        if conversation_init_data is None:
+            try:
+                conversation_init_data = await self._restore_init_data(self.sid)
+            except FileNotFoundError:
+                logger.error(f'User settings not found for session {self.sid}')
+                raise RuntimeError('User settings not found')
+
+        agent_cls = conversation_init_data.agent or self.config.default_agent
         self.config.security.confirmation_mode = (
             self.config.security.confirmation_mode
-            if session_init_data.confirmation_mode is None
-            else session_init_data.confirmation_mode
+            if conversation_init_data.confirmation_mode is None
+            else conversation_init_data.confirmation_mode
         )
         self.config.security.security_analyzer = (
-            session_init_data.security_analyzer
+            conversation_init_data.security_analyzer
             or self.config.security.security_analyzer
         )
-        max_iterations = session_init_data.max_iterations or self.config.max_iterations
+        max_iterations = (
+            conversation_init_data.max_iterations or self.config.max_iterations
+        )
         # override default LLM config
 
         default_llm_config = self.config.get_llm_config()
         default_llm_config.model = (
-            session_init_data.llm_model or default_llm_config.model
+            conversation_init_data.llm_model or default_llm_config.model
         )
         default_llm_config.api_key = (
-            session_init_data.llm_api_key or default_llm_config.api_key
+            conversation_init_data.llm_api_key or default_llm_config.api_key
         )
         default_llm_config.base_url = (
-            session_init_data.llm_base_url or default_llm_config.base_url
+            conversation_init_data.llm_base_url or default_llm_config.base_url
         )
+        await self._save_init_data(self.sid, conversation_init_data)
 
         # TODO: override other LLM config & agent config groups (#2075)
 
@@ -105,8 +138,8 @@ class Session:
                 max_budget_per_task=self.config.max_budget_per_task,
                 agent_to_llm_config=self.config.get_agent_to_llm_config_map(),
                 agent_configs=self.config.get_agent_configs(),
-                github_token=session_init_data.github_token,
-                selected_repository=session_init_data.selected_repository,
+                github_token=conversation_init_data.github_token,
+                selected_repository=conversation_init_data.selected_repository,
             )
         except Exception as e:
             logger.exception(f'Error creating controller: {e}')

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -60,7 +60,7 @@ class Session:
         self.is_alive = False
         self.agent_session.close()
 
-    async def initialize_agent(self, session_init_data: SessionInitData):
+    async def initialize_agent(self, session_init_data: SessionInitData = None):
         self.agent_session.event_stream.add_event(
             AgentStateChangedObservation('', AgentState.LOADING),
             EventSource.ENVIRONMENT,

--- a/openhands/storage/locations.py
+++ b/openhands/storage/locations.py
@@ -15,3 +15,7 @@ def get_conversation_event_filename(sid: str, id: int) -> str:
 
 def get_conversation_metadata_filename(sid: str) -> str:
     return f'{get_conversation_dir(sid)}metadata.json'
+
+
+def get_conversation_init_data_filename(sid: str) -> str:
+    return f'{get_conversation_dir(sid)}init.json'

--- a/openhands/storage/settings_store.py
+++ b/openhands/storage/settings_store.py
@@ -8,7 +8,7 @@ from openhands.server.settings import Settings
 
 class SettingsStore(ABC):
     """
-    Storage for SessionInitData. May or may not support multiple users depending on the environment
+    Storage for ConversationInitData. May or may not support multiple users depending on the environment
     """
 
     @abstractmethod


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog--don't think this bug made it into release

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When you close your tab, the websocket disconnects, causing two things to happen after ~15s
* the agent loop stops
* and the runtime is deleted

This PR prevents the runtime from getting deleted, and successfully restarts the agent loop

---
**Link of any specific issues this addresses**
