### PR TITLE
Feat: Using SocketIO ID generator for shorter ids

### DIFF
--- a/openhands/server/routes/new_conversation.py
+++ b/openhands/server/routes/new_conversation.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.routes.settings import SettingsStoreImpl
 from openhands.server.session.conversation_init_data import ConversationInitData
-from openhands.server.shared import config, session_manager
+from openhands.server.shared import config, session_manager, sio
 from openhands.storage.conversation.conversation_store import (
     ConversationMetadata,
     ConversationStore,
@@ -51,7 +51,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
 
     conversation_store = await ConversationStore.get_instance(config)
 
-    conversation_id = uuid.uuid4().hex
+    conversation_id = sio.eio.generate_id()
     while await conversation_store.exists(conversation_id):
         logger.warning(f'Collision on conversation ID: {conversation_id}. Retrying...')
         conversation_id = uuid.uuid4().hex

--- a/openhands/server/routes/new_conversation.py
+++ b/openhands/server/routes/new_conversation.py
@@ -1,5 +1,3 @@
-import uuid
-
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from github import Github
@@ -54,7 +52,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     conversation_id = sio.eio.generate_id()
     while await conversation_store.exists(conversation_id):
         logger.warning(f'Collision on conversation ID: {conversation_id}. Retrying...')
-        conversation_id = uuid.uuid4().hex
+        conversation_id = sio.eio.generate_id()
 
     user_id = ''
     if data.github_token:


### PR DESCRIPTION
**Using socket io id format instead of UUID**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Using SocketIO id generator for ids means ids are 20 digits long instead of 36 - both are still a 128bit number, but the base62 encoded scheme is shorter and more manageable**

Instead of ids like this:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/2a19efd8-ac49-4841-ab1a-392fde0b6268" />

You get ids like this:
<img width="449" alt="image" src="https://github.com/user-attachments/assets/97e913b0-2c40-4aad-b56b-6c56faa5117f" />

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fbd5e8e-nikolaik   --name openhands-app-fbd5e8e   docker.all-hands.dev/all-hands-ai/openhands:fbd5e8e
```