### PR TITLE
Fix: Added fallback when download files fails

### DIFF
--- a/frontend/src/utils/download-files.ts
+++ b/frontend/src/utils/download-files.ts
@@ -1,4 +1,5 @@
 import OpenHands from "#/api/open-hands";
+import { downloadWorkspace } from "./download-workspace";
 
 interface DownloadProgress {
   filesTotal: number;
@@ -296,14 +297,16 @@ export async function downloadFiles(
     if (error instanceof Error && error.message === "Download cancelled") {
       throw error;
     }
-    // Re-throw the error as is if it's already a user-friendly message
+    // Fallback to old style download
     if (
       error instanceof Error &&
       (error.message.includes("browser doesn't support") ||
         error.message.includes("Failed to select") ||
-        error.message === "Download cancelled")
+        error.message.includes("Permission denied")
+      )
     ) {
-      throw error;
+      await downloadWorkspace(conversationID);
+      return
     }
 
     // Otherwise, wrap it with a generic message

--- a/frontend/src/utils/download-files.ts
+++ b/frontend/src/utils/download-files.ts
@@ -302,11 +302,10 @@ export async function downloadFiles(
       error instanceof Error &&
       (error.message.includes("browser doesn't support") ||
         error.message.includes("Failed to select") ||
-        error.message.includes("Permission denied")
-      )
+        error.message.includes("Permission denied"))
     ) {
       await downloadWorkspace(conversationID);
-      return
+      return;
     }
 
     // Otherwise, wrap it with a generic message


### PR DESCRIPTION
**Allow downloading workspace on phones / browsers where the DirectoryAPI is not available.**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
The Directory API is not available in all environments - I have intermittently even got errors when running it in chrome on desktop. We try it first, but then fall back to the traditional method of download.


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:908aa9b-nikolaik   --name openhands-app-908aa9b   docker.all-hands.dev/all-hands-ai/openhands:908aa9b
```