### PR TITLE
Don't enforce user IDs in oss mode

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -14,7 +14,8 @@ from openhands.events.observation.agent import AgentStateChangedObservation
 from openhands.events.serialization import event_to_dict
 from openhands.events.stream import AsyncEventStreamWrapper
 from openhands.server.session.manager import ConversationDoesNotExistError
-from openhands.server.shared import config, session_manager, sio
+from openhands.server.shared import config, openhands_config, session_manager, sio
+from openhands.server.types import AppMode
 from openhands.storage.conversation.conversation_store import (
     ConversationStore,
 )
@@ -31,23 +32,24 @@ async def connect(connection_id: str, environ, auth):
         logger.error('No conversation_id in query params')
         raise ConnectionRefusedError('No conversation_id in query params')
 
-    user_id = ''
-    if auth and 'github_token' in auth:
-        with Github(auth['github_token']) as g:
-            gh_user = await call_sync_from_async(g.get_user)
-            user_id = gh_user.id
+    if openhands_config.app_mode != AppMode.OSS:
+        user_id = ''
+        if auth and 'github_token' in auth:
+            with Github(auth['github_token']) as g:
+                gh_user = await call_sync_from_async(g.get_user)
+                user_id = gh_user.id
 
-    logger.info(f'User {user_id} is connecting to conversation {conversation_id}')
+        logger.info(f'User {user_id} is connecting to conversation {conversation_id}')
 
-    conversation_store = await ConversationStore.get_instance(config)
-    metadata = await conversation_store.get_metadata(conversation_id)
-    if metadata.github_user_id != user_id:
-        logger.error(
-            f'User {user_id} is not allowed to join conversation {conversation_id}'
-        )
-        raise ConnectionRefusedError(
-            f'User {user_id} is not allowed to join conversation {conversation_id}'
-        )
+        conversation_store = await ConversationStore.get_instance(config)
+        metadata = await conversation_store.get_metadata(conversation_id)
+        if metadata.github_user_id != user_id:
+            logger.error(
+                f'User {user_id} is not allowed to join conversation {conversation_id}'
+            )
+            raise ConnectionRefusedError(
+                f'User {user_id} is not allowed to join conversation {conversation_id}'
+            )
 
     try:
         event_stream = await session_manager.join_conversation(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Logging out/in with GitHub mid-session causes issues due to the auth piece here, so I'm disabling it for now. Would be better to refactor this a bit so this code doesn't live here

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ed2494e-nikolaik   --name openhands-app-ed2494e   docker.all-hands.dev/all-hands-ai/openhands:ed2494e
```