### PR TITLE
Add max_active_runtimes option to limit and manage active runtimes

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -34,6 +34,7 @@ class SandboxConfig:
         platform: The platform on which the image should be built. Default is None.
         remote_runtime_resource_factor: Factor to scale the resource allocation for remote runtime.
             Must be one of [1, 2, 4, 8]. Will only be used if the runtime is remote.
+        max_active_runtimes: Maximum number of active runtimes to keep. When exceeded, oldest runtimes will be removed.
     """
 
     remote_runtime_api_url: str = 'http://localhost:8000'
@@ -59,6 +60,7 @@ class SandboxConfig:
     platform: str | None = None
     close_delay: int = 15
     remote_runtime_resource_factor: int = 1
+    max_active_runtimes: int = 3
 
     def defaults_to_dict(self) -> dict:
         """Serialize fields to a dict for the frontend, including type hints, defaults, and whether it's optional."""


### PR DESCRIPTION
This PR adds a new `max_active_runtimes` option to SandboxConfig with a default value of 3. When this limit is reached, the EventStreamRuntime will automatically remove the oldest runtimes before creating new ones.

Changes:
- Added `max_active_runtimes` option to SandboxConfig
- Added runtime age tracking in EventStreamRuntime
- Added logic to remove oldest runtimes when limit is reached
- Added cleanup of tracking data when runtimes are closed

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:afeffc3-nikolaik   --name openhands-app-afeffc3   docker.all-hands.dev/all-hands-ai/openhands:afeffc3
```