### PR TITLE
fix latest event id

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -79,6 +79,11 @@ export function WsClientProvider({
 
   function handleDisconnect() {
     setStatus(WsClientProviderStatus.DISCONNECTED);
+    let sio = sioRef.current;
+    if (!sio) {
+      return;
+    }
+    sio.io.opts.query.latest_event_id = lastEventRef.current?.id;
   }
 
   function handleError() {

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -83,6 +83,7 @@ export function WsClientProvider({
     if (!sio) {
       return;
     }
+    sio.io.opts.query = sio.io.opts.query || {};
     sio.io.opts.query.latest_event_id = lastEventRef.current?.id;
   }
 

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -79,7 +79,7 @@ export function WsClientProvider({
 
   function handleDisconnect() {
     setStatus(WsClientProviderStatus.DISCONNECTED);
-    let sio = sioRef.current;
+    const sio = sioRef.current;
     if (!sio) {
       return;
     }


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This logic was lost a bit in my latest refactor. If the socket tries to reconnect, it ends up replaying the entire session in the message window, because latest_event_id is still -1. This fixes that issue

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0b04934-nikolaik   --name openhands-app-0b04934   docker.all-hands.dev/all-hands-ai/openhands:0b04934
```