### PR TITLE
fix double websocket connection in dev mode

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -88,7 +88,6 @@ export function WsClientProvider({
       throw new Error("No conversation ID provided");
     }
 
-
     let sio = sioRef.current;
 
     const lastEvent = lastEventRef.current;
@@ -125,15 +124,16 @@ export function WsClientProvider({
     };
   }, [ghToken, conversationId]);
 
-  React.useEffect(() => {
-    return () => {
+  React.useEffect(
+    () => () => {
       const sio = sioRef.current;
       if (sio) {
         sio.off("disconnect", handleDisconnect);
         sio.disconnect();
       }
-    };
-  }, []);
+    },
+    [],
+  );
 
   const value = React.useMemo<UseWsClient>(
     () => ({

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -42,9 +42,6 @@ export function WsClientProvider({
 }: React.PropsWithChildren<WsClientProviderProps>) {
   const sioRef = React.useRef<Socket | null>(null);
   const ghTokenRef = React.useRef<string | null>(ghToken);
-  const disconnectRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
   const [status, setStatus] = React.useState(
     WsClientProviderStatus.DISCONNECTED,
   );
@@ -91,6 +88,7 @@ export function WsClientProvider({
       throw new Error("No conversation ID provided");
     }
 
+
     let sio = sioRef.current;
 
     const lastEvent = lastEventRef.current;
@@ -127,22 +125,13 @@ export function WsClientProvider({
     };
   }, [ghToken, conversationId]);
 
-  // Strict mode mounts and unmounts each component twice, so we have to wait in the destructor
-  // before actually disconnecting the socket and cancel the operation if the component gets remounted.
   React.useEffect(() => {
-    const timeout = disconnectRef.current;
-    if (timeout != null) {
-      clearTimeout(timeout);
-    }
-
     return () => {
-      disconnectRef.current = setTimeout(() => {
-        const sio = sioRef.current;
-        if (sio) {
-          sio.off("disconnect", handleDisconnect);
-          sio.disconnect();
-        }
-      }, 100);
+      const sio = sioRef.current;
+      if (sio) {
+        sio.off("disconnect", handleDisconnect);
+        sio.disconnect();
+      }
     };
   }, []);
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In dev mode, the WebSocket connection gets created twice. Seems like this logic broke with the recent refactor--the changes now close the first socket that opens properly

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:45713cc-nikolaik   --name openhands-app-45713cc   docker.all-hands.dev/all-hands-ai/openhands:45713cc
```