### PR TITLE
Add loading spinner to task form during conversation creation

### DIFF
--- a/frontend/src/components/shared/task-form.tsx
+++ b/frontend/src/components/shared/task-form.tsx
@@ -22,6 +22,7 @@ import { cn } from "#/utils/utils";
 import { AttachImageLabel } from "../features/images/attach-image-label";
 import { ImageCarousel } from "../features/images/image-carousel";
 import { UploadImageInput } from "../features/images/upload-image-input";
+import { LoadingSpinner } from "./loading-spinner";
 
 export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
   const dispatch = useDispatch();
@@ -110,32 +111,35 @@ export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
             "hover:border-neutral-500 focus-within:border-neutral-500",
           )}
         >
-          <ChatInput
-            name="q"
-            onSubmit={() => {
-              if (typeof ref !== "function") ref?.current?.requestSubmit();
-            }}
-            onChange={(message) => setText(message)}
-            onFocus={() => setInputIsFocused(true)}
-            onBlur={() => setInputIsFocused(false)}
-            onImagePaste={async (imageFiles) => {
-              const promises = imageFiles.map(convertImageToBase64);
-              const base64Images = await Promise.all(promises);
-              base64Images.forEach((base64) => {
-                dispatch(addFile(base64));
-              });
-            }}
-            placeholder={placeholder}
-            value={text}
-            maxRows={15}
-            showButton={!!text}
-            className="text-[17px] leading-5 py-[17px]"
-            buttonClassName="pb-[17px]"
-            disabled={
-              navigation.state === "submitting" ||
-              newConversationMutation.isPending
-            }
-          />
+          {newConversationMutation.isPending ? (
+            <div className="flex justify-center py-[17px]">
+              <LoadingSpinner size="small" />
+            </div>
+          ) : (
+            <ChatInput
+              name="q"
+              onSubmit={() => {
+                if (typeof ref !== "function") ref?.current?.requestSubmit();
+              }}
+              onChange={(message) => setText(message)}
+              onFocus={() => setInputIsFocused(true)}
+              onBlur={() => setInputIsFocused(false)}
+              onImagePaste={async (imageFiles) => {
+                const promises = imageFiles.map(convertImageToBase64);
+                const base64Images = await Promise.all(promises);
+                base64Images.forEach((base64) => {
+                  dispatch(addFile(base64));
+                });
+              }}
+              placeholder={placeholder}
+              value={text}
+              maxRows={15}
+              showButton={!!text}
+              className="text-[17px] leading-5 py-[17px]"
+              buttonClassName="pb-[17px]"
+              disabled={navigation.state === "submitting"}
+            />
+          )}
         </div>
       </form>
       <UploadImageInput


### PR DESCRIPTION
This PR adds a loading state to the task form when creating a new conversation. When the API request is in progress, the textarea is replaced with a spinner component to provide better visual feedback to users before they are redirected to the conversation page.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b936dda-nikolaik   --name openhands-app-b936dda   docker.all-hands.dev/all-hands-ai/openhands:b936dda
```