### PR TITLE
Fix function calling for Deepseek V3

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -308,9 +308,19 @@ def convert_fncall_messages_to_non_fncall_messages(
     messages: list[dict],
     tools: list[ChatCompletionToolParam],
     add_in_context_learning_example: bool = True,
+    model: str = "",
 ) -> list[dict]:
     """Convert function calling messages to non-function calling messages."""
     messages = copy.deepcopy(messages)
+
+    # Handle Deepseek's message format
+    if 'deepseek' in model.lower():
+        for message in messages:
+            if isinstance(message.get('content'), list):
+                # Convert list of dicts to a single string
+                content = message['content']
+                if all(isinstance(c, dict) and 'type' in c and 'text' in c for c in content):
+                    message['content'] = ' '.join(c['text'] for c in content)
 
     formatted_tools = convert_tools_to_description(tools)
     system_prompt_suffix = SYSTEM_PROMPT_SUFFIX_TEMPLATE.format(

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -71,6 +71,7 @@ FUNCTION_CALLING_SUPPORTED_MODELS = [
     'claude-3-5-haiku-20241022',
     'gpt-4o-mini',
     'gpt-4o',
+    'deepseek',  # Add Deepseek support
 ]
 
 
@@ -183,7 +184,7 @@ class LLM(RetryMixin, DebugMixin):
                     'tools' in kwargs
                 ), "'tools' must be in kwargs when mock_function_calling is True"
                 messages = convert_fncall_messages_to_non_fncall_messages(
-                    messages, kwargs['tools']
+                    messages, kwargs['tools'], model=self.config.model
                 )
                 kwargs['messages'] = messages
                 kwargs['stop'] = STOP_WORDS


### PR DESCRIPTION
This PR fixes function calling support for Deepseek V3 models by:

1. Adding Deepseek to the list of supported function calling models
2. Modifying the message conversion logic to handle Deepseek's format requirements
3. Updating the LLM class to pass model information to the converter

Deepseek's API expects message content to be a string, but we were sending a list of dictionaries with 'type' and 'text' keys. This fix converts the message format appropriately when using Deepseek models.

Fixes #5818