### PR TITLE
[doc] Fix link in TheAgentCompany benchmark's README.md

### DIFF
--- a/evaluation/benchmarks/the_agent_company/README.md
+++ b/evaluation/benchmarks/the_agent_company/README.md
@@ -5,7 +5,7 @@ This folder contains the evaluation harness that we built on top of the original
 The evaluation consists of three steps:
 
 1. Environment setup: [install python environment](../../README.md#development-environment), [configure LLM config](../../README.md#configure-openhands-and-your-llm), [launch services](https://github.com/TheAgentCompany/TheAgentCompany/blob/main/docs/SETUP.md).
-2. [Run Evaluation](#run-inference-on-the-agent-company-instances): Run all tasks and get the evaluation results.
+2. [Run Evaluation](#run-inference-on-the-agent-company-tasks): Run all tasks and get the evaluation results.
 
 ## Setup Environment and LLM Configuration
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

A link in TheAgentCompany evaluation README is wrong.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ac551b2-nikolaik   --name openhands-app-ac551b2   docker.all-hands.dev/all-hands-ai/openhands:ac551b2
```