### PR TITLE
chore(frontend): Replace deprecated nextui component prop onClick with onPress

### DIFF
--- a/frontend/src/components/shared/buttons/icon-button.tsx
+++ b/frontend/src/components/shared/buttons/icon-button.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@nextui-org/react";
-import React, { MouseEventHandler, ReactElement } from "react";
+import React, { ReactElement } from "react";
 
 export interface IconButtonProps {
   icon: ReactElement;
-  onClick: MouseEventHandler<HTMLButtonElement>;
+  onClick: () => void;
   ariaLabel: string;
   testId?: string;
 }
@@ -18,7 +18,7 @@ export function IconButton({
     <Button
       type="button"
       variant="flat"
-      onClick={onClick}
+      onPress={onClick}
       className="cursor-pointer text-[12px] bg-transparent aspect-square px-0 min-w-[20px] h-[20px]"
       aria-label={ariaLabel}
       data-testid={testId}

--- a/frontend/src/components/shared/modals/base-modal/footer-content.tsx
+++ b/frontend/src/components/shared/modals/base-modal/footer-content.tsx
@@ -23,7 +23,7 @@ export function FooterContent({ actions, closeModal }: FooterContentProps) {
             key={label}
             type="button"
             isDisabled={isDisabled}
-            onClick={() => {
+            onPress={() => {
               action();
               if (closeAfterAction) closeModal();
             }}

--- a/frontend/src/components/shared/modals/security/invariant/invariant.tsx
+++ b/frontend/src/components/shared/modals/security/invariant/invariant.tsx
@@ -127,7 +127,7 @@ function SecurityInvariant(): JSX.Element {
       <>
         <div className="flex justify-between items-center border-b border-neutral-600 mb-4 p-4">
           <h2 className="text-2xl">{t(I18nKey.INVARIANT$LOG_LABEL)}</h2>
-          <Button onClick={() => exportTraces()} className="bg-neutral-700">
+          <Button onPress={() => exportTraces()} className="bg-neutral-700">
             {t(I18nKey.INVARIANT$EXPORT_TRACE_LABEL)}
           </Button>
         </div>
@@ -162,7 +162,7 @@ function SecurityInvariant(): JSX.Element {
           <h2 className="text-2xl">{t(I18nKey.INVARIANT$POLICY_LABEL)}</h2>
           <Button
             className="bg-neutral-700"
-            onClick={() => updatePolicy({ policy })}
+            onPress={() => updatePolicy({ policy })}
           >
             {t(I18nKey.INVARIANT$UPDATE_POLICY_LABEL)}
           </Button>
@@ -184,7 +184,7 @@ function SecurityInvariant(): JSX.Element {
           <h2 className="text-2xl">{t(I18nKey.INVARIANT$SETTINGS_LABEL)}</h2>
           <Button
             className="bg-neutral-700"
-            onClick={() => updateRiskSeverity({ riskSeverity: selectedRisk })}
+            onPress={() => updateRiskSeverity({ riskSeverity: selectedRisk })}
           >
             {t(I18nKey.INVARIANT$UPDATE_SETTINGS_LABEL)}
           </Button>


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5318bed-nikolaik   --name openhands-app-5318bed   docker.all-hands.dev/all-hands-ai/openhands:5318bed
```