### PR TITLE
Fix hanging agent loops

### DIFF
--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -359,7 +359,7 @@ class SessionManager:
         if not event_stream:
             logger.error(f'No event stream after starting agent loop: {sid}')
             raise RuntimeError(f'no_event_stream:{sid}')
-        await self._cleanup_session_later(sid)
+        asyncio.create_task(self._cleanup_session_later(sid))
         return event_stream
 
     async def _get_event_stream(self, sid: str) -> EventStream | None:

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -359,6 +359,7 @@ class SessionManager:
         if not event_stream:
             logger.error(f'No event stream after starting agent loop: {sid}')
             raise RuntimeError(f'no_event_stream:{sid}')
+        await self._cleanup_session_later(sid)
         return event_stream
 
     async def _get_event_stream(self, sid: str) -> EventStream | None:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

If you create a new conversation, but the webhook never attaches, the agent loop gets orphaned and never gets cleaned up.

With this change, we call `cleanup` when the loop gets created, so that if no one connects after 15s it gets abandoned

Working on something more robust here as well


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:993b158-nikolaik   --name openhands-app-993b158   docker.all-hands.dev/all-hands-ai/openhands:993b158
```