### PR TITLE
Headless or endless? Rewrite auto continue response in headless mode

### DIFF
--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -252,9 +252,9 @@ def auto_continue_response(
     Tell the agent to proceed without asking for more input, or finish the interaction.
     """
     message = (
-        'Please continue working on the task on whatever approach you think is suitable.\n'
-        'If you think you have solved the task, please first send your answer to user through message and then finish the interaction.\n'
-        'IMPORTANT: YOU SHOULD NEVER ASK FOR HUMAN HELP.\n'
+        'Please continue on whatever approach you think is suitable.\n'
+        'If you think you have solved the task, please finish the interaction.\n'
+        'IMPORTANT: YOU SHOULD NEVER ASK FOR HUMAN RESPONSE.\n'
     )
     return message
 

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -249,9 +249,14 @@ def auto_continue_response(
     try_parse: Callable[[Action | None], str] | None = None,
 ) -> str:
     """Default function to generate user responses.
-    Returns 'continue' to tell the agent to proceed without asking for more input.
+    Tell the agent to proceed without asking for more input, or finish the interaction.
     """
-    return 'continue'
+    message = (
+        'Please continue working on the task on whatever approach you think is suitable.\n'
+        'If you think you have solved the task, please first send your answer to user through message and then finish the interaction.\n'
+        'IMPORTANT: YOU SHOULD NEVER ASK FOR HUMAN HELP.\n'
+    )
+    return message
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

In headless mode, make OpenHands finish a task if it thinks the task is finished. This sounds stupid, but otherwise OpenHands would never finish or stop.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

#5400 introduced an auto continue response for headless mode, but in practice I found CodeActAgent never stopped, at least for simple tasks. I tried both claude sonnet 3.5 (with function calling) and qwen-2.5 (without function calling). Despite the presence of function `finish`, CodeActAgent never called it. If you give a trivial task `what's 1+1?`, CodeActAgent would start doing random stuff like this:

```
I apologize for the confusion. Since you've asked me to continue without providing a specific question or task, I'll take the initiative to demonstrate some more advanced capabilities of our environment. Let's explore the file system and create a simple Python script that we can run.

First, let's view the contents of the current directory:
Function call: str_replace_editor({"command": "view", "path": "/workspace"})
```

The prompt I used is a bit different from the one used in openhands resolver and evaluation tasks: https://github.com/All-Hands-AI/OpenHands/blob/6a4442e5900817ff834a27e44b420c9834a71812/openhands/resolver/utils.py#L29-L34

, because in headless mode there's no such concept of `send your answer to user through message`.

---
**Link of any specific issues this addresses**
