### PR TITLE
Add system-preference-based theme support

### DIFF
--- a/frontend/src/context/theme-context.tsx
+++ b/frontend/src/context/theme-context.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextType | undefined>(undefined);
+
+function ThemeProvider({ children }: React.PropsWithChildren) {
+  const [theme, setTheme] = React.useState<Theme>(() => {
+    if (typeof window === "undefined") return "dark";
+    
+    // Check if theme was previously saved
+    const savedTheme = localStorage.getItem("theme") as Theme;
+    if (savedTheme) return savedTheme;
+    
+    // Check system preference
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  });
+
+  React.useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  // Listen for system theme changes
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (e: MediaQueryListEvent) => {
+      const savedTheme = localStorage.getItem("theme");
+      if (!savedTheme) {
+        setTheme(e.matches ? "dark" : "light");
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  const value = React.useMemo(
+    () => ({
+      theme,
+      setTheme,
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+function useTheme() {
+  const context = React.useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+export { ThemeProvider, useTheme };

--- a/frontend/src/root.tsx
+++ b/frontend/src/root.tsx
@@ -10,6 +10,7 @@ import "./tailwind.css";
 import "./index.css";
 import React from "react";
 import { Toaster } from "react-hot-toast";
+import { ThemeProvider } from "./context/theme-context";
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -21,10 +22,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        {children}
-        <ScrollRestoration />
-        <Scripts />
-        <Toaster />
+        <ThemeProvider>
+          {children}
+          <ScrollRestoration />
+          <Scripts />
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -28,9 +28,18 @@ export default {
         },
       },
       themes: {
+        light: {
+          colors: {
+            primary: "#4465DB",
+            background: "#FFFFFF",
+            foreground: "#11181C",
+          },
+        },
         dark: {
           colors: {
             primary: "#4465DB",
+            background: "#171717",
+            foreground: "#ECEDEE",
           },
         }
       }


### PR DESCRIPTION
This PR adds support for automatically switching between light and dark themes based on the user's system preferences.

Changes:
- Updated NextUI configuration to support both light and dark themes with appropriate colors
- Created a new ThemeContext that:
  - Automatically detects system's color scheme preference
  - Persists theme preference in localStorage
  - Listens for system theme changes
  - Provides a way to manually switch themes
- Updated root layout to wrap the application with ThemeProvider

The theme will now:
- Use system's color scheme preference by default
- Remember user's last selected theme
- Update in real-time if system's theme preference changes
- Apply appropriate theme classes to HTML root element

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:96cad63-nikolaik   --name openhands-app-96cad63   docker.all-hands.dev/all-hands-ai/openhands:96cad63
```