### PR TITLE
Fix #5637: Check for errors in IPython content instead of message

### DIFF
--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -150,7 +150,7 @@ export const chatSlice = createSlice({
         const ipythonObs = observation.payload as IPythonObservation;
         causeMessage.success = !ipythonObs.content
           .toLowerCase()
-          .includes("error");
+          .includes("error:");
       }
 
       if (observationID === "run" || observationID === "run_ipython") {

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -148,7 +148,7 @@ export const chatSlice = createSlice({
       } else if (observationID === "run_ipython") {
         // For IPython, we consider it successful if there's no error message
         const ipythonObs = observation.payload as IPythonObservation;
-        causeMessage.success = !ipythonObs.message
+        causeMessage.success = !ipythonObs.content
           .toLowerCase()
           .includes("error");
       }


### PR DESCRIPTION
This PR fixes #5637 with a simpler approach than PR #5644.

Instead of modifying the backend and adding extensive error detection, we simply check for errors in the content of the IPython output, which is where error messages appear.

The `message` property contains a static string, for an iPython obs; the `content` property should be filled with the actual content.

Changes:
- Modified `chat-slice.ts` to check `ipythonObs.content` instead of `ipythonObs.message` for error detection

This is a minimal change that addresses the core issue while keeping the codebase simpler.