### PR TITLE
[Fix]: Prevent back tick escape

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -185,12 +185,17 @@ jobs:
 
       - name: Install OpenHands
         uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          REVIEW_BODY: ${{ github.event.review.body || '' }}
+          LABEL_NAME: ${{ github.event.label.name || '' }}
+          EVENT_NAME: ${{ github.event_name }}
         with:
           script: |
-            const commentBody = `${{ github.event.comment.body || '' }}`.trim();
-            const reviewBody = `${{ github.event.review.body || '' }}`.trim();
-            const labelName = `${{ github.event.label.name || '' }}`.trim();
-            const eventName = `${{ github.event_name }}`.trim();
+            const commentBody = process.env.COMMENT_BODY.trim();
+            const reviewBody = process.env.REVIEW_BODY.trim();
+            const labelName = process.env.LABEL_NAME.trim();
+            const eventName = process.env.EVENT_NAME.trim();
 
             // Check conditions
             const isExperimentalLabel = labelName === "fix-me-experimental";


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

There was an issue of the resolver failing with code blocks in the comment body. This occurred because the backtick in the comment body escapes the variable definition in the workflow. This PR makes sure that the escape cannot occur by setting the variable in the ENV.


Here is a sample [workflow log](https://github.com/malhotra5/test-repo/actions/runs/12532725176/job/34951743206)

---
**Link of any specific issues this addresses**
#5892

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b092dd7-nikolaik   --name openhands-app-b092dd7   docker.all-hands.dev/all-hands-ai/openhands:b092dd7
```