### PR TITLE
fn_call_converter: Fix newline in in-context learning prompt

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -224,7 +224,7 @@ IN_CONTEXT_LEARNING_EXAMPLE_SUFFIX = """
 --------------------- END OF NEW TASK DESCRIPTION ---------------------
 
 PLEASE follow the format strictly! PLEASE EMIT ONE AND ONLY ONE FUNCTION CALL PER MESSAGE.
-""".lstrip()
+"""
 
 # Regex patterns for function call parsing
 FN_REGEX_PATTERN = r'<function=([^>]+)>\n(.*?)</function>'


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

This probably doesn't bug LLMs but it bugs me who's been reading the prompt logs :)

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Before this PR:

```
--------------------- NEW TASK DESCRIPTION ---------------------
What's 1+1?--------------------- END OF NEW TASK DESCRIPTION ---------------------
```

After this PR:

```
--------------------- NEW TASK DESCRIPTION ---------------------
What's 1+1?
--------------------- END OF NEW TASK DESCRIPTION ---------------------
```

---
**Link of any specific issues this addresses**
