### PR TITLE
[Docs]:Enhanced Installation & Getting Started Docs

### DIFF
--- a/docs/modules/usage/common-use-cases.mdx
+++ b/docs/modules/usage/common-use-cases.mdx
@@ -1,0 +1,38 @@
+# Common Use Cases
+
+This page helps you map common use cases to the more detailed and advanced configuration available to achieve your requirements.
+
+## Changing OpenHands Versions
+
+The `start_openhands.sh` script in [Installation](https://docs.all-hands.dev/modules/usage/installation) pulls the most recent stable release of OpenHands. There may come a time when you want to change this (such as when a new version is released).
+
+Below is a copy og `start_openhands.sh` with the latest version number replaces by `VERSION` (it occurs in 3 places).
+```bash
+#!/bin/bash
+docker pull docker.all-hands.dev/all-hands-ai/runtime:VERSION-nikolaik
+
+docker run -it --rm --pull=always \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:VERSION-nikolaik \
+    -e JWT_SECRET=SECRET_STRING \
+    -e LOG_ALL_EVENTS=true \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v LOCAL_STATE_PATH:/.openhands-state \
+    -p LOCAL_PORT:3000 \
+    --add-host host.docker.internal:host-gateway \
+    --name openhands-app \
+    docker.all-hands.dev/all-hands-ai/openhands:VERSION
+```
+
+You can find the latest releases by checking the [OpenHands Github repository's tags](https://github.com/All-Hands-AI/OpenHands/tags). We use semver, and release major, minor, and patch tags. So `0.9` will automatically point to the latest `0.9.x` release, and `0` will point to the latest `0.x.x` release.
+
+For the most up-to-date development version, you can use `docker.all-hands.dev/all-hands-ai/openhands:main`. This version is unstable and is recommended for testing or development purposes only.
+
+## Setting Up Your Projects Development Environment
+
+Your project likely involves a bunch of dependencies and you may not be using the Python+NodeJS stack that exists in the default sandbox image. You can build your own Docker image containing all of your projects dependencies and have OpenHands use that instead. Checkout the [Custom Sandbox Guide](https://docs.all-hands.dev/modules/usage/how-to/custom-sandbox-guide) for details on this.
+
+## Alternative Usage Modes
+
+You may not want to use the Web UI so OpenHands can also be deployed as an [interactive CLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode) or using the [OpenHands GitHub Action](https://docs.all-hands.dev/modules/usage/how-to/github-action) to address issue directly in Github.
+
+There is also a scriptable [headless mode](https://docs.all-hands.dev/modules/usage/how-to/headless-mode) but this requires a more advanced installation using Development Mode and is not recommended unless you have development experience.

--- a/docs/modules/usage/getting-started.mdx
+++ b/docs/modules/usage/getting-started.mdx
@@ -29,7 +29,7 @@ time setting up its environment!
 
 > Please convert hello.sh to a Ruby script, and run it
 
-## Building From Scratch
+## Building a Project From Scratch
 
 Agents do exceptionally well at "greenfield" tasks (tasks where they don't need
 any context about an existing codebase) and they can just start from scratch.
@@ -51,7 +51,6 @@ This way you can always revert back to an old state if the agent goes off track.
 You can ask the agent to commit and push for you:
 
 > Please commit the changes and push them to a new branch called "feature/due-dates"
-
 
 ## Adding New Code
 

--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -2,33 +2,117 @@
 
 ## System Requirements
 
-* Docker version 26.0.0+ or Docker Desktop 4.31.0+.
-* You must be using Linux or Mac OS.
-  * If you are on Windows, you must use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+* **Docker version 26.0.0+ or Docker Desktop 4.31.0+**. You can check your docker version by running `docker --version` in a terminal. See the [Docker documentation for installing Docker Engine](https://docs.docker.com/engine/install/) if needed.
+* Supported Operation Systems
+    * **Debian/Ubuntu based Linux** - these instructions are written and tested in Debian/Ubuntu Linux systems and should work as expected.
+    * **Mac OS and non-Debian Linux** - these instructions should work as expected but aren't explicitly tested on these OSes.
+    * **Windows** - you must use Windows Subsystem for Linux (WSL). For more information on WSL see the [Microsoft Documentation for WSL](https://learn.microsoft.com/en-us/windows/wsl/install). If someone is able to test and document deploying OpenHands using Docker on native Windows it would be much appreciated.
 
-## Start the app
+## Choosing a Deployment Method
 
-The easiest way to run OpenHands is in Docker.
+There are two ways you can deploy the OpenHands app:
+
+* **Using the official Docker image (recommended)** - this method is the primary method for using OpenHands. It is the simplest and doesn't require any development experience.
+* **Building the OpenHands app from source (for developers only)** - this method is designed for developers working on the OpenHands application. It requires experience building applications from source and working with dependencies. If you only plan to use OpenHands you shouldn't use this method.
+
+## Deploying with Docker
+
+This is the easiest way to run OpenHands and can be easily setup to run in a bash script so you can quickly start and stop the OpenHands app. 
+
+We will run the commands below in a terminal window. First, we make a new directory called `openhands` in your home directory to store Openhands related data. We'll also create a sub-directory called `.openhands-state` that will store session history for Open Hands.
 
 ```bash
+mkdir ~/openhands
+mkdir ~/openhands/.openhands-state
+cd ~/openhands
+```
+
+Next, open a text editor and copy the commands below into a new file. 
+
+```bash
+#!/bin/bash
 docker pull docker.all-hands.dev/all-hands-ai/runtime:0.17-nikolaik
 
 docker run -it --rm --pull=always \
     -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.17-nikolaik \
+    -e JWT_SECRET=SECRET_STRING \
     -e LOG_ALL_EVENTS=true \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -v ~/.openhands-state:/.openhands-state \
+    -v LOCAL_STATE_PATH:/.openhands-state \
+    -p LOCAL_PORT:3000 \
+    --add-host host.docker.internal:host-gateway \
+    --name openhands-app \
+    docker.all-hands.dev/all-hands-ai/openhands:0.17
+```
+
+Most of this can be left as the default but there are three common configuration options we need to set before we can run OpenHands. 
+
+* **SECRET_STRING** - this should be replaced with a string that will be used by OpenHands to create secure access tokens. If you're jsut playing with OpenHnads on your local system it probably doesn't matter too much but it's typically best practice to use a long, random string for this. You can get a rand UUID on your system by running `cat /proc/sys/kernel/random/uuid` in your terminal window or by going to an online UUId generator like [www.uuidgenerator.net](https://www.uuidgenerator.net/version4)
+* **LOCAL_STATE_PATH** - if you followed the setup instructions exactly this will be `~/openhands/.openhands-state`. If you made your own directory names or changes the path just replace it with those instead.
+* **LOCAL_PORT** - this is the local port number you want to access the OpenHands app on. The default is 3000 but this can be anything (make sure it is >1024 to avoid reserved system ports)
+
+Once we've replaced these values with our local configuration our file should look something like below:
+
+```bash
+#!/bin/bash
+docker pull docker.all-hands.dev/all-hands-ai/runtime:0.17-nikolaik
+
+docker run -it --rm --pull=always \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.17-nikolaik \
+    -e JWT_SECRET=07ae43ca-7b66-4d99-857a-a9d7126cce18 \
+    -e LOG_ALL_EVENTS=true \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v ~/openhands/.openhands-state:/.openhands-state \
     -p 3000:3000 \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app \
     docker.all-hands.dev/all-hands-ai/openhands:0.17
 ```
 
-You can also run OpenHands in a scriptable [headless mode](https://docs.all-hands.dev/modules/usage/how-to/headless-mode), as an [interactive CLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode), or using the [OpenHands GitHub Action](https://docs.all-hands.dev/modules/usage/how-to/github-action).
+We're now ready to save this to a file called `start_openhands.sh` in the new `~/openhands` directory. Finally, in the terminal window, we need to add execution permissions to the new script using the `chmod` command and then run it.
+
+```bash
+chmod +x start_openhands.sh
+./start_openhands.sh
+```
+
+After running the command above, you'll find OpenHands running at [http://localhost:3000](http://localhost:3000) (change the port number to your `LOCAL_PORT` value if you customised it).
+
+To close down the OpenHands app simply type `Ctrl+C` in the terminal window or close the terminal window.
+
+**TODO** - this is a bit nasty, is there a cleaner way to close down the app? Does a hard stop risk corrupting things liek session state?
+
+### Common Docker Errors
+
+It's possible you received an error from Docker when you tried to run `./start_openhands.sh`, there are two main reasons for this.
+
+#### Docker Permission Denied Error
+
+> docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.35/containers/create: dial unix /var/run/docker.sock: connect: permission denied. See 'docker run --help'.
+
+This error is because your account was not properly setup to run Docker without `sudo` permissions. You can find the instructions for fixing this in the Docker documentation on [Linux post-installation steps for Docker Engine](https://docs.docker.com/engine/install/linux-postinstall/)
+
+#### Docker Address Already in Use Error
+
+> docker: Error response from daemon: driver failed programming external connectivity on endpoint openhands-app (4861aeaf94495bdc51444d2659579f03f705445393624e414b826c95558e2f46): failed to bind port :::3000/tcp: Error starting userland proxy: listen tcp6 [::]:3000: bind: address already in use.
+
+This error occurs because you have another application or service using the port you configured in `start_openhands.sh` as your `LOCAL_PORT`, change this to another port number >1024 and try again.
+
+#### Docker Client Failed
+
+>Launch docker client failed. Please make sure you have installed docker and started docker desktop/daemon.
+
+Either docker is not installed or it is not being found on your $PATH.
+
+Try the following stpes in order:
+
+* Confirm `docker` is running on your system. You should be able to run `docker ps` in the terminal successfully.
+* If using Docker Desktop
+    * Ensure `Settings > Advanced > Allow the default Docker socket to be used` is enabled.
+    * Depending on your configuration, you may need `Settings > Resources > Network > Enable host networking` enabled.
+* Reinstall Docker Desktop or Docker Engine
 
 ## Setup
-
-After running the command above, you'll find OpenHands running at [http://localhost:3000](http://localhost:3000).
 
 Upon launching OpenHands, you'll see a settings modal. You **must** select an `LLM Provider` and `LLM Model` and enter a corresponding `API Key`.
 These can be changed at any time by selecting the `Settings` button (gear icon) in the UI.
@@ -42,15 +126,16 @@ The `Advanced Options` also allow you to specify a `Base URL` if required.
   <img src="/img/settings-advanced.png" alt="settings-modal" width="335" />
 </div>
 
-## Versions
+**TODO** - I think custom LLM configuration needs more explanation then this (eg what is the syntax for the base URL?) and should be left until Getting Started where it can be addressed in more detail.
 
-The command above pulls the most recent stable release of OpenHands. You have other options as well:
-- For a specific release, use `docker.all-hands.dev/all-hands-ai/openhands:$VERSION`, replacing $VERSION with the version number.
-- We use semver, and release major, minor, and patch tags. So `0.9` will automatically point to the latest `0.9.x` release, and `0` will point to the latest `0.x.x` release.
-- For the most up-to-date development version, you can use `docker.all-hands.dev/all-hands-ai/openhands:main`. This version is unstable and is recommended for testing or development purposes only.
-
-You can choose the tag that best suits your needs based on stability requirements and desired features.
+## Building OpenHands from source
 
 For the development workflow, see [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
 
-Are you having trouble? Check out our [Troubleshooting Guide](https://docs.all-hands.dev/modules/usage/troubleshooting).
+## Still Having Trouble? 
+
+<a href="https://discord.gg/ESHStjSjD4">
+    <img src="https://img.shields.io/badge/Discord-Join%20Us-purple?logo=discord&logoColor=white&style=for-the-badge" alt="Join our Discord community"/>
+</a>
+
+Click the button about to join our Discord Community and post details of your problem to the `#setup-help` channel.

--- a/docs/modules/usage/troubleshooting/troubleshooting.md
+++ b/docs/modules/usage/troubleshooting/troubleshooting.md
@@ -4,30 +4,46 @@
 OpenHands only supports Windows via WSL. Please be sure to run all commands inside your WSL terminal.
 :::
 
-### Launch docker client failed
+## Common Docker Errors
 
-**Description**
+It's possible you received an error from Docker when you tried to run `./start_openhands.sh`, there are two main reasons for this.
 
-When running OpenHands, the following error is seen:
-```
-Launch docker client failed. Please make sure you have installed docker and started docker desktop/daemon.
-```
+### Docker Permission Denied Error
 
-**Resolution**
+> docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.35/containers/create: dial unix /var/run/docker.sock: connect: permission denied. See 'docker run --help'.
 
-Try these in order:
+This error is because your account was not properly setup to run Docker without `sudo` permissions. You can find the instructions for fixing this in the Docker documentation on [Linux post-installation steps for Docker Engine](https://docs.docker.com/engine/install/linux-postinstall/)
+
+### Docker Address Already in Use Error
+
+> docker: Error response from daemon: driver failed programming external connectivity on endpoint openhands-app (4861aeaf94495bdc51444d2659579f03f705445393624e414b826c95558e2f46): failed to bind port :::3000/tcp: Error starting userland proxy: listen tcp6 [::]:3000: bind: address already in use.
+
+This error occurs because you have another application or service using the port you configured in `start_openhands.sh` as your `LOCAL_PORT`, change this to another port number >1024 and try again.
+
+### Docker Client Failed
+
+>Launch docker client failed. Please make sure you have installed docker and started docker desktop/daemon.
+
+Either docker is not installed or it is not being found on your $PATH.
+
+Try the following stpes in order:
+
 * Confirm `docker` is running on your system. You should be able to run `docker ps` in the terminal successfully.
-* If using Docker Desktop, ensure `Settings > Advanced > Allow the default Docker socket to be used` is enabled.
-* Depending on your configuration you may need `Settings > Resources > Network > Enable host networking` enabled in Docker Desktop.
-* Reinstall Docker Desktop.
+* If using Docker Desktop
+    * Ensure `Settings > Advanced > Allow the default Docker socket to be used` is enabled.
+    * Depending on your configuration, you may need `Settings > Resources > Network > Enable host networking` enabled.
+* Reinstall Docker Desktop or Docker Engine
+
 ---
 
-# Development Workflow Specific
+## Development Workflow Specific
+
+This section is specific to local deployment used for Developers and can be ignored if you're using the Docker installation method.
+
 ### Error building runtime docker image
 
-**Description**
+When attempting to start a new session it fails, and errors with terms like the following appearing in the logs:
 
-Attempts to start a new session fail, and errors with terms like the following appear in the logs:
 ```
 debian-security bookworm-security
 InRelease At least one invalid signature was encountered.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -14,6 +14,11 @@ const sidebars: SidebarsConfig = {
       id: 'usage/getting-started',
     },
     {
+      type: 'doc',
+      label: 'Common Use Cases',
+      id: 'usage/common-use-cases',
+    },
+    {
       type: 'category',
       label: 'Prompting',
       items: [


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
This PR provides a more detailed installation and getting started workflow designed to be user friendly for a range of user skill levels and to prevent/deflect requests for setup help for the maintainers. The intended result is a reduction in variability in the deployment state and configuration across users of the OpenHands app (development workflow will be addressed separately).

It's expected that this will require some rounds of feedback so is set to Draft. There are also further changes required to other docs that are part of this effort but I wanted feedback on the general approach ASAP before making too many changes.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- `installation.mdx` - most of the changes are to this page of the docs. The changes here are designed to move the user from zero to getting started as quickly and reliably as possible. There's a huge correlation between time-to-value and product adoption so this stage is critical for growing any project or product.
    - Most steps have been made more verbose to include potential background context that the reader doesn't posses
    - Pre-requisites have links to 3rd party docs
    - It focuses exclusively on deployment by Docker and using the Web UI
    - The installation is now explicitly via a bash script
    - 2 commonly required configuration options are included by default
        - Mounting a local folder as a Docker volume for OpenHands Session State data - this appears to be a common setting that is required for stability.
        - Setting a JWT Secret - this appears to be a setting required for stability,
    - Common Docker errors are addressed inline to prevent the reader having to break out to another troubleshooting page.
    - Readers are encouraged to the Discord #setup-help channel if they fail to complete these steps
- `getting-started.mdx` - minor heading change
- `common-use-cases.mdx` - this is a new page designed to highlight common use cases and requirements and then direct users to the correct advanced documentation sections. This is designed to be more or a routing page that doesn't have any unique content but helps new users find and navigate the technical sections of the documentation at a time when they may not know the OpenHands specific terminology or may need to combine features to complete a use case. At this stage it is pretty sparse but as the feature set and documentation grows I think this will become a very useful page. It is also a good place to catch common but more difficult configuration needs that would distract or complicate users during the installation phase. It also acts as a way to advertise the more advanced capabilities of the app early on.
- `troubleshooting.mdx` - added additional Docker errors for consistency in case users end up here at a later time.
- `sidebars.ts` - added the new Common Use Cases page to the ToC nav tree

---
**Feedback & Open Questions**
- General feedback on approach and style would be very helpful. You can be direct and if you don't like something just say so, you don't need to worry about "hurt feelings" :-) I tend to be direct as well so things are clear, it is not meant to be disrespectful.
- If I'm trying to change or debate something that is non-negotiable to you as the maintainers please just say so and I'll accept it immediately.
- In the Installation section there are two **TODO** markers with questions regarding how to treat some content there. Specifically the case of Custom LLMs during Installation (I think we should skip it and address in the new Common Use Cases page) and another regarding cleanly exiting the Docker deployment when using a bash script. Feedback would be helpful.

---
**Link of any specific issues this addresses**
#5878 
