### PR TITLE
Fix: Allow form submission with empty query if repo/files present

### DIFF
--- a/frontend/src/components/shared/task-form.tsx
+++ b/frontend/src/components/shared/task-form.tsx
@@ -44,7 +44,11 @@ export function TaskForm({ ref }: TaskFormProps) {
   const [inputIsFocused, setInputIsFocused] = React.useState(false);
   const newConversationMutation = useMutation({
     mutationFn: (variables: { q?: string }) => {
-      if (variables.q) dispatch(setInitialQuery(variables.q));
+      if (!variables.q?.trim() && !selectedRepository && files.length === 0) {
+        throw new Error("No query provided");
+      }
+
+      if (variables.q?.trim()) dispatch(setInitialQuery(variables.q));
       return OpenHands.newConversation({
         githubToken: gitHubToken || undefined,
         selectedRepository: selectedRepository || undefined,
@@ -90,9 +94,7 @@ export function TaskForm({ ref }: TaskFormProps) {
     const formData = new FormData(event.currentTarget);
 
     const q = formData.get("q")?.toString();
-    if (q?.trim() || selectedRepository || files.length > 0) {
-      newConversationMutation.mutate({ q });
-    }
+    newConversationMutation.mutate({ q });
   };
 
   return (

--- a/frontend/src/components/shared/task-form.tsx
+++ b/frontend/src/components/shared/task-form.tsx
@@ -90,7 +90,7 @@ export function TaskForm({ ref }: TaskFormProps) {
     const formData = new FormData(event.currentTarget);
 
     const q = formData.get("q")?.toString();
-    if (q?.trim()) {
+    if (q?.trim() || selectedRepository || files.length > 0) {
       newConversationMutation.mutate({ q });
     }
   };


### PR DESCRIPTION
This PR fixes a regression where the form would not submit if the query was empty, even when a repository was selected or files were uploaded.

**Changes:**
- Modified the form submit handler to allow submission in three cases:
  1. When there is a non-empty query
  2. When there is a selected repository
  3. When there are uploaded files

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0d14410-nikolaik   --name openhands-app-0d14410   docker.all-hands.dev/all-hands-ai/openhands:0d14410
```