### PR TITLE
Add resizable panels and account settings translations

### DIFF
--- a/frontend/src/components/layout/resizable-panel.tsx
+++ b/frontend/src/components/layout/resizable-panel.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { cn } from "#/utils/cn";
+
+interface ResizablePanelProps {
+  leftPanel: React.ReactNode;
+  rightPanel: React.ReactNode;
+  defaultLeftWidth?: number;
+  minLeftWidth?: number;
+  maxLeftWidth?: number;
+}
+
+export function ResizablePanel({
+  leftPanel,
+  rightPanel,
+  defaultLeftWidth = 390,
+  minLeftWidth = 300,
+  maxLeftWidth = 600,
+}: ResizablePanelProps) {
+  const [leftWidth, setLeftWidth] = useState(defaultLeftWidth);
+  const [isResizing, setIsResizing] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const startResizing = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsResizing(true);
+  }, []);
+
+  const stopResizing = useCallback(() => {
+    setIsResizing(false);
+  }, []);
+
+  const resize = useCallback(
+    (e: MouseEvent) => {
+      if (isResizing) {
+        const newWidth = e.clientX;
+        if (newWidth >= minLeftWidth && newWidth <= maxLeftWidth) {
+          setLeftWidth(newWidth);
+        }
+      }
+    },
+    [isResizing, minLeftWidth, maxLeftWidth],
+  );
+
+  useEffect(() => {
+    if (isResizing) {
+      window.addEventListener("mousemove", resize);
+      window.addEventListener("mouseup", stopResizing);
+    }
+
+    return () => {
+      window.removeEventListener("mousemove", resize);
+      window.removeEventListener("mouseup", stopResizing);
+    };
+  }, [isResizing, resize, stopResizing]);
+
+  const toggleCollapse = () => {
+    setIsCollapsed(!isCollapsed);
+  };
+
+  return (
+    <div className="flex h-full overflow-auto gap-3">
+      <div
+        style={{ width: isCollapsed ? "0px" : `${leftWidth}px` }}
+        className={cn(
+          "transition-[width] duration-200",
+          isCollapsed && "w-0 overflow-hidden",
+        )}
+      >
+        {leftPanel}
+      </div>
+
+      <div
+        className="relative flex items-center cursor-col-resize select-none"
+        onMouseDown={startResizing}
+        onClick={toggleCollapse}
+      >
+        <div className="w-3 h-16 hover:bg-default-100 rounded-full flex items-center justify-center">
+          <div className="w-0.5 h-6 bg-default-200" />
+        </div>
+      </div>
+
+      <div className="flex-1 min-w-0">{rightPanel}</div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -2024,10 +2024,32 @@
     "en": "Browser Screenshot"
   },
   "ACCOUNT_SETTINGS$SETTINGS": {
-    "en": "Account Settings"
+    "en": "Account Settings",
+    "zh-CN": "账户设置",
+    "de": "Kontoeinstellungen",
+    "ko-KR": "계정 설정",
+    "no": "Kontoinnstillinger",
+    "zh-TW": "帳戶設定",
+    "it": "Impostazioni account",
+    "pt": "Configurações da conta",
+    "es": "Configuración de la cuenta",
+    "ar": "إعدادات الحساب",
+    "fr": "Paramètres du compte",
+    "tr": "Hesap Ayarları"
   },
   "ACCOUNT_SETTINGS$LOGOUT": {
-    "en": "Logout"
+    "en": "Logout",
+    "zh-CN": "退出登录",
+    "de": "Abmelden",
+    "ko-KR": "로그아웃",
+    "no": "Logg ut",
+    "zh-TW": "登出",
+    "it": "Esci",
+    "pt": "Sair",
+    "es": "Cerrar sesión",
+    "ar": "تسجيل الخروج",
+    "fr": "Déconnexion",
+    "tr": "Çıkış"
   },
   "ERROR_TOAST$CLOSE_BUTTON_LABEL": {
     "en": "Close"

--- a/frontend/src/routes/_oh.app/route.tsx
+++ b/frontend/src/routes/_oh.app/route.tsx
@@ -24,6 +24,7 @@ import { useAuth } from "#/context/auth-context";
 import { useSettings } from "#/context/settings-context";
 import { useConversationConfig } from "#/hooks/query/use-conversation-config";
 import { Container } from "#/components/layout/container";
+import { ResizablePanel } from "#/components/layout/resizable-panel";
 import Security from "#/components/shared/modals/security/security";
 import { CountBadge } from "#/components/layout/count-badge";
 import { TerminalStatusLabel } from "#/components/features/terminal/terminal-status-label";
@@ -72,45 +73,50 @@ function AppContent() {
     <WsClientProvider ghToken={gitHubToken} conversationId={conversationId}>
       <EventHandler>
         <div className="flex flex-col h-full gap-3">
-          <div className="flex h-full overflow-auto gap-3">
-            <Container className="w-full md:w-[390px] max-h-full relative">
-              <ChatInterface />
-            </Container>
-
-            <div className="hidden md:flex flex-col grow gap-3">
-              <Container
-                className="h-2/3"
-                labels={[
-                  { label: "Workspace", to: "", icon: <CodeIcon /> },
-                  { label: "Jupyter", to: "jupyter", icon: <ListIcon /> },
-                  {
-                    label: (
-                      <div className="flex items-center gap-1">
-                        Browser
-                        {updateCount > 0 && <CountBadge count={updateCount} />}
-                      </div>
-                    ),
-                    to: "browser",
-                    icon: <GlobeIcon />,
-                  },
-                ]}
-              >
-                <FilesProvider>
-                  <Outlet />
-                </FilesProvider>
+          <ResizablePanel
+            leftPanel={
+              <Container className="w-full h-full relative">
+                <ChatInterface />
               </Container>
-              {/* Terminal uses some API that is not compatible in a server-environment. For this reason, we lazy load it to ensure
-               * that it loads only in the client-side. */}
-              <Container
-                className="h-1/3 overflow-scroll"
-                label={<TerminalStatusLabel />}
-              >
-                <React.Suspense fallback={<div className="h-full" />}>
-                  <Terminal secrets={secrets} />
-                </React.Suspense>
-              </Container>
-            </div>
-          </div>
+            }
+            rightPanel={
+              <div className="hidden md:flex flex-col grow gap-3">
+                <Container
+                  className="h-2/3"
+                  labels={[
+                    { label: "Workspace", to: "", icon: <CodeIcon /> },
+                    { label: "Jupyter", to: "jupyter", icon: <ListIcon /> },
+                    {
+                      label: (
+                        <div className="flex items-center gap-1">
+                          Browser
+                          {updateCount > 0 && (
+                            <CountBadge count={updateCount} />
+                          )}
+                        </div>
+                      ),
+                      to: "browser",
+                      icon: <GlobeIcon />,
+                    },
+                  ]}
+                >
+                  <FilesProvider>
+                    <Outlet />
+                  </FilesProvider>
+                </Container>
+                {/* Terminal uses some API that is not compatible in a server-environment. For this reason, we lazy load it to ensure
+                 * that it loads only in the client-side. */}
+                <Container
+                  className="h-1/3 overflow-scroll"
+                  label={<TerminalStatusLabel />}
+                >
+                  <React.Suspense fallback={<div className="h-full" />}>
+                    <Terminal secrets={secrets} />
+                  </React.Suspense>
+                </Container>
+              </div>
+            }
+          />
 
           <div className="h-[60px]">
             <Controls


### PR DESCRIPTION
This PR adds:

- A new ResizablePanel component that allows users to adjust the width of panels in the layout
- Translations for account settings menu items in all supported languages

The changes improve the user experience by:
- Making the layout more flexible and customizable
- Ensuring consistent translations across all languages

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:10a7f87-nikolaik   --name openhands-app-10a7f87   docker.all-hands.dev/all-hands-ai/openhands:10a7f87
```