### PR TITLE
Fix for when settings are unset

### DIFF
--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -21,10 +21,11 @@ export function Sidebar() {
   const { data: isAuthed } = useIsAuthed();
 
   const { logout } = useAuth();
-  const { settingsAreUpToDate } = useSettings();
+  const { settingsAreUpToDate, settings } = useSettings();
 
   const [accountSettingsModalOpen, setAccountSettingsModalOpen] =
     React.useState(false);
+
   const [settingsModalIsOpen, setSettingsModalIsOpen] = React.useState(false);
   const [startNewProjectModalIsOpen, setStartNewProjectModalIsOpen] =
     React.useState(false);
@@ -35,6 +36,12 @@ export function Sidebar() {
       setAccountSettingsModalOpen(true);
     }
   }, [user.isError]);
+
+  React.useEffect(() => {
+    if (!settings || !settingsAreUpToDate) {
+      setSettingsModalIsOpen(true);
+    }
+  }, [settings, settingsAreUpToDate]);
 
   const handleAccountSettingsModalClose = () => {
     // If the user closes the modal without connecting to GitHub,
@@ -48,9 +55,6 @@ export function Sidebar() {
     if (location.pathname.startsWith("/conversations/"))
       setStartNewProjectModalIsOpen(true);
   };
-
-  const showSettingsModal =
-    isAuthed && (!settingsAreUpToDate || settingsModalIsOpen);
 
   return (
     <>
@@ -79,7 +83,7 @@ export function Sidebar() {
       {accountSettingsModalOpen && (
         <AccountSettingsModal onClose={handleAccountSettingsModalClose} />
       )}
-      {showSettingsModal && (
+      {settingsModalIsOpen && (
         <SettingsModal onClose={() => setSettingsModalIsOpen(false)} />
       )}
       {startNewProjectModalIsOpen && (

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -80,7 +80,7 @@ export function Sidebar() {
       {accountSettingsModalOpen && (
         <AccountSettingsModal onClose={handleAccountSettingsModalClose} />
       )}
-      {settingsModalIsOpen && (
+      {(!accountSettingsModalOpen && settingsModalIsOpen) && (
         <SettingsModal onClose={() => setSettingsModalIsOpen(false)} />
       )}
       {startNewProjectModalIsOpen && (

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router";
 import { useAuth } from "#/context/auth-context";
 import { useSettings } from "#/context/settings-context";
 import { useGitHubUser } from "#/hooks/query/use-github-user";
-import { useIsAuthed } from "#/hooks/query/use-is-authed";
 import { UserActions } from "./user-actions";
 import { AllHandsLogoButton } from "#/components/shared/buttons/all-hands-logo-button";
 import { DocsButton } from "#/components/shared/buttons/docs-button";
@@ -18,8 +17,6 @@ export function Sidebar() {
   const location = useLocation();
 
   const user = useGitHubUser();
-  const { data: isAuthed } = useIsAuthed();
-
   const { logout } = useAuth();
   const { settingsAreUpToDate, settings } = useSettings();
 

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -80,7 +80,7 @@ export function Sidebar() {
       {accountSettingsModalOpen && (
         <AccountSettingsModal onClose={handleAccountSettingsModalClose} />
       )}
-      {(!accountSettingsModalOpen && settingsModalIsOpen) && (
+      {!accountSettingsModalOpen && settingsModalIsOpen && (
         <SettingsModal onClose={() => setSettingsModalIsOpen(false)} />
       )}
       {startNewProjectModalIsOpen && (

--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -144,7 +144,7 @@ export const getSettings = async (): Promise<Settings> => {
       LLM_API_KEY: "",
     };
   } catch (error) {
-    // @ts-expect-error
+    // @ts-expect-error we don't have a type annotation for the response
     if (error.response?.status !== 404) {
       throw error;
     }

--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -131,18 +131,27 @@ export const getDefaultSettings = (): Settings => DEFAULT_SETTINGS;
  * Get the settings from the server or use the default settings if not found
  */
 export const getSettings = async (): Promise<Settings> => {
-  const { data: apiSettings } =
-    await openHands.get<ApiSettings>("/api/settings");
-  if (apiSettings != null) {
-    return {
-      LLM_MODEL: apiSettings.llm_model,
-      LLM_BASE_URL: apiSettings.llm_base_url,
-      AGENT: apiSettings.agent,
-      LANGUAGE: apiSettings.language,
-      CONFIRMATION_MODE: apiSettings.confirmation_mode,
-      SECURITY_ANALYZER: apiSettings.security_analyzer,
-      LLM_API_KEY: "",
-    };
+  try {
+    const { data: apiSettings } =
+      await openHands.get<ApiSettings>("/api/settings");
+    if (apiSettings != null) {
+      return {
+        LLM_MODEL: apiSettings.llm_model,
+        LLM_BASE_URL: apiSettings.llm_base_url,
+        AGENT: apiSettings.agent,
+        LANGUAGE: apiSettings.language,
+        CONFIRMATION_MODE: apiSettings.confirmation_mode,
+        SECURITY_ANALYZER: apiSettings.security_analyzer,
+        LLM_API_KEY: "",
+      };
+    }
+  } catch (error) {
+    if (error.response.status !== 404) {
+      throw error;
+    }
   }
-  return getLocalStorageSettings();
+  // FIXME: remove local storage settings after 1/31/2025
+  const localSettings = getLocalStorageSettings();
+  await saveSettings(localSettings);
+  return localSettings;
 };

--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -144,7 +144,8 @@ export const getSettings = async (): Promise<Settings> => {
       LLM_API_KEY: "",
     };
   } catch (error) {
-    if (error.response.status !== 404) {
+    // @ts-expect-error
+    if (error.response?.status !== 404) {
       throw error;
     }
   }

--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -134,17 +134,15 @@ export const getSettings = async (): Promise<Settings> => {
   try {
     const { data: apiSettings } =
       await openHands.get<ApiSettings>("/api/settings");
-    if (apiSettings != null) {
-      return {
-        LLM_MODEL: apiSettings.llm_model,
-        LLM_BASE_URL: apiSettings.llm_base_url,
-        AGENT: apiSettings.agent,
-        LANGUAGE: apiSettings.language,
-        CONFIRMATION_MODE: apiSettings.confirmation_mode,
-        SECURITY_ANALYZER: apiSettings.security_analyzer,
-        LLM_API_KEY: "",
-      };
-    }
+    return {
+      LLM_MODEL: apiSettings.llm_model,
+      LLM_BASE_URL: apiSettings.llm_base_url,
+      AGENT: apiSettings.agent,
+      LANGUAGE: apiSettings.language,
+      CONFIRMATION_MODE: apiSettings.confirmation_mode,
+      SECURITY_ANALYZER: apiSettings.security_analyzer,
+      LLM_API_KEY: "",
+    };
   } catch (error) {
     if (error.response.status !== 404) {
       throw error;


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Currently if the settings endpoint returns a 404, the user doesn't properly get prompted to fill out their settings

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e0e5792-nikolaik   --name openhands-app-e0e5792   docker.all-hands.dev/all-hands-ai/openhands:e0e5792
```