### PR TITLE
Refactor to make FileConversationStore more extendable

### DIFF
--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -18,21 +18,24 @@ class FileConversationStore(ConversationStore):
 
     async def save_metadata(self, metadata: ConversationMetadata):
         json_str = json.dumps(metadata.__dict__)
-        path = get_conversation_metadata_filename(metadata.conversation_id)
+        path = self.get_conversation_metadata_filename(metadata.conversation_id)
         await call_sync_from_async(self.file_store.write, path, json_str)
 
     async def get_metadata(self, conversation_id: str) -> ConversationMetadata:
-        path = get_conversation_metadata_filename(conversation_id)
+        path = self.get_conversation_metadata_filename(conversation_id)
         json_str = await call_sync_from_async(self.file_store.read, path)
         return ConversationMetadata(**json.loads(json_str))
 
     async def exists(self, conversation_id: str) -> bool:
-        path = get_conversation_metadata_filename(conversation_id)
+        path = self.get_conversation_metadata_filename(conversation_id)
         try:
             await call_sync_from_async(self.file_store.read, path)
             return True
         except FileNotFoundError:
             return False
+
+    def get_conversation_metadata_filename(self, conversation_id: str) -> str:
+        return get_conversation_metadata_filename(conversation_id)
 
     @classmethod
     async def get_instance(cls, config: AppConfig, token: str | None):


### PR DESCRIPTION
**Attaching get_conversation_metadata_filename to self means it is overridable**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Attaching get_conversation_metadata_filename to self means it is overridable - a subclass can override this single method to customize behavior


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ce353a7-nikolaik   --name openhands-app-ce353a7   docker.all-hands.dev/all-hands-ai/openhands:ce353a7
```