### PR TITLE
Load the event stream fix after it's no longer a dataclass

### DIFF
--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -74,6 +74,9 @@ class EventStream:
         self._lock = threading.Lock()
         self._cur_id = 0
 
+        # load the stream
+        self.__post_init__()
+
     def __post_init__(self) -> None:
         try:
             events = self.file_store.list(get_conversation_events_dir(self.sid))


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix loading the stream from the file store.

---

We just removed the @ dataclass annotation from EventStream. There is actually another detail about dataclass: it was calling `__post_init__` implicitly. Without it, it will never be called and the stream is not restored.

This PR fixes it.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ab5d4c9-nikolaik   --name openhands-app-ab5d4c9   docker.all-hands.dev/all-hands-ai/openhands:ab5d4c9
```