### PR TITLE
feat: runtime improvements for rate-limit and 502/503/404 error

### DIFF
--- a/evaluation/utils/shared.py
+++ b/evaluation/utils/shared.py
@@ -376,7 +376,12 @@ def _process_instance_wrapper(
                 + '\n'
             )
             if isinstance(
-                e, (AgentRuntimeDisconnectedError, AgentRuntimeUnavailableError)
+                e,
+                (
+                    AgentRuntimeDisconnectedError,
+                    AgentRuntimeUnavailableError,
+                    AgentRuntimeNotFoundError,
+                ),
             ):
                 runtime_failure_count += 1
                 msg += f'Runtime disconnected error detected for instance {instance.instance_id}, runtime failure count: {runtime_failure_count}'

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -10,6 +10,7 @@ import requests
 
 from openhands.core.config import AppConfig
 from openhands.core.exceptions import (
+    AgentRuntimeNotFoundError,
     AgentRuntimeTimeoutError,
 )
 from openhands.events import EventStream
@@ -264,6 +265,12 @@ class ActionExecutionClient(Runtime):
                 raise AgentRuntimeTimeoutError(
                     f'Runtime failed to return execute_action before the requested timeout of {action.timeout}s'
                 )
+            except requests.HTTPError as e:
+                if e.response.status_code in (404, 502, 503):
+                    raise AgentRuntimeNotFoundError(
+                        'Runtime unavailable: System resources may be exhausted due to running commands. This may be fixed by retrying.'
+                    ) from e
+                raise e
 
             return obs
 

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -10,7 +10,6 @@ import requests
 
 from openhands.core.config import AppConfig
 from openhands.core.exceptions import (
-    AgentRuntimeNotFoundError,
     AgentRuntimeTimeoutError,
 )
 from openhands.events import EventStream
@@ -265,12 +264,6 @@ class ActionExecutionClient(Runtime):
                 raise AgentRuntimeTimeoutError(
                     f'Runtime failed to return execute_action before the requested timeout of {action.timeout}s'
                 )
-            except requests.HTTPError as e:
-                if e.response.status_code in (404, 502, 503):
-                    raise AgentRuntimeNotFoundError(
-                        'Runtime unavailable: System resources may be exhausted due to running commands. This may be fixed by retrying.'
-                    ) from e
-                raise e
 
             return obs
 

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -7,7 +7,6 @@ import tenacity
 
 from openhands.core.config import AppConfig
 from openhands.core.exceptions import (
-    AgentRuntimeDisconnectedError,
     AgentRuntimeError,
     AgentRuntimeNotFoundError,
     AgentRuntimeNotReadyError,
@@ -21,7 +20,6 @@ from openhands.runtime.impl.action_execution.action_execution_client import (
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.utils.command import get_remote_startup_command
 from openhands.runtime.utils.request import (
-    RequestHTTPError,
     send_request,
 )
 from openhands.runtime.utils.runtime_build import build_runtime_image
@@ -367,10 +365,10 @@ class RemoteRuntime(ActionExecutionClient):
         except requests.Timeout:
             self.log('error', 'No response received within the timeout period.')
             raise
-        except RequestHTTPError as e:
+        except requests.HTTPError as e:
             if e.response.status_code in (404, 502):
-                raise AgentRuntimeDisconnectedError(
-                    f'{e.response.status_code} error while connecting to {self.runtime_url}'
+                raise AgentRuntimeNotFoundError(
+                    'Runtime unavailable: System resources may be exhausted due to running commands. This may be fixed by retrying.'
                 ) from e
             elif e.response.status_code == 503:
                 self.log('warning', 'Runtime appears to be paused. Resuming...')

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -2,6 +2,9 @@ import json
 from typing import Any
 
 import requests
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from openhands.utils.tenacity_stop import stop_if_should_exit
 
 
 class RequestHTTPError(requests.HTTPError):
@@ -18,6 +21,18 @@ class RequestHTTPError(requests.HTTPError):
         return s
 
 
+def is_rate_limit_error(exception):
+    return (
+        isinstance(exception, requests.HTTPError)
+        and exception.response.status_code == 429
+    )
+
+
+@retry(
+    retry=retry_if_exception(is_rate_limit_error),
+    stop=stop_after_attempt(3) | stop_if_should_exit(),
+    wait=wait_exponential(multiplier=1, min=4, max=60),
+)
 def send_request(
     session: requests.Session,
     method: str,


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Convert HTTP 502/503/404 error into `AgentRuntimeNotFoundError,` so it can be systematically handled by evaluation harness (e.g., when it happens, automatically increase runtime resource and retry).
- Handle rate limit 429 error from remote runtime to retry: this is a new feature for RemoteRuntime, we need to adjust client code for it

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:611dea7-nikolaik   --name openhands-app-611dea7   docker.all-hands.dev/all-hands-ai/openhands:611dea7
```