### PR TITLE
Add support for .openhands/setup.sh script

### DIFF
--- a/openhands/runtime/impl/e2b/filestore.py
+++ b/openhands/runtime/impl/e2b/filestore.py
@@ -5,6 +5,11 @@ class E2BFileStore(FileStore):
     def __init__(self, filesystem):
         self.filesystem = filesystem
 
+    def get_full_path(self, path: str) -> str:
+        if path.startswith('/'):
+            path = path[1:]
+        return path
+
     def write(self, path: str, contents: str) -> None:
         self.filesystem.write(path, contents)
 

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import subprocess
 import time
 from copy import deepcopy
 
@@ -112,6 +114,9 @@ class Session:
                 github_token=github_token,
                 selected_repository=selected_repository,
             )
+
+            # Run setup script if it exists
+            await self._run_setup_script()
         except Exception as e:
             logger.exception(f'Error creating controller: {e}')
             await self.send_error(
@@ -192,6 +197,29 @@ class Session:
     async def send_error(self, message: str):
         """Sends an error message to the client."""
         await self.send({'error': True, 'message': message})
+
+    async def _run_setup_script(self):
+        """Run the .openhands/setup.sh script if it exists."""
+        setup_script = self.file_store.get_full_path('.openhands/setup.sh')
+        if os.path.isfile(setup_script):
+            try:
+                # Make sure the script is executable
+                os.chmod(setup_script, 0o755)
+                process = await asyncio.create_subprocess_exec(
+                    setup_script,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=os.path.dirname(setup_script),
+                )
+                stdout, stderr = await process.communicate()
+
+                if process.returncode != 0:
+                    error_msg = stderr.decode() if stderr else stdout.decode()
+                    logger.error(f'Setup script failed: {error_msg}')
+                    await self.send_error(f'Setup script failed: {error_msg}')
+            except Exception as e:
+                logger.error(f'Failed to run setup script: {e}')
+                await self.send_error(f'Failed to run setup script: {e}')
 
     async def _send_status_message(self, msg_type: str, id: str, message: str):
         """Sends a status message to the client."""

--- a/openhands/storage/files.py
+++ b/openhands/storage/files.py
@@ -3,6 +3,18 @@ from abc import abstractmethod
 
 class FileStore:
     @abstractmethod
+    def get_full_path(self, path: str) -> str:
+        """Get the full path for a given relative path.
+
+        Args:
+            path: The relative path.
+
+        Returns:
+            The full path.
+        """
+        pass
+
+    @abstractmethod
     def write(self, path: str, contents: str) -> None:
         pass
 

--- a/openhands/storage/google_cloud.py
+++ b/openhands/storage/google_cloud.py
@@ -19,6 +19,11 @@ class GoogleCloudFileStore(FileStore):
         self.storage_client = storage.Client()
         self.bucket = self.storage_client.bucket(bucket_name)
 
+    def get_full_path(self, path: str) -> str:
+        if path.startswith('/'):
+            path = path[1:]
+        return path
+
     def write(self, path: str, contents: str | bytes) -> None:
         blob = self.bucket.blob(path)
         with blob.open('w') as f:

--- a/openhands/storage/memory.py
+++ b/openhands/storage/memory.py
@@ -12,6 +12,11 @@ class InMemoryFileStore(FileStore):
     def __init__(self, files: dict[str, str] = IN_MEMORY_FILES):
         self.files = files
 
+    def get_full_path(self, path: str) -> str:
+        if path.startswith('/'):
+            path = path[1:]
+        return path
+
     def write(self, path: str, contents: str) -> None:
         self.files[path] = contents
 

--- a/openhands/storage/s3.py
+++ b/openhands/storage/s3.py
@@ -15,6 +15,11 @@ class S3FileStore(FileStore):
         self.bucket = os.getenv('AWS_S3_BUCKET')
         self.client = Minio(endpoint, access_key, secret_key, secure=secure)
 
+    def get_full_path(self, path: str) -> str:
+        if path.startswith('/'):
+            path = path[1:]
+        return path
+
     def write(self, path: str, contents: str) -> None:
         as_bytes = contents.encode('utf-8')
         stream = io.BytesIO(as_bytes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ reportlab = "*"
 [tool.coverage.run]
 concurrency = ["gevent"]
 
+
 [tool.poetry.group.runtime.dependencies]
 jupyterlab = "*"
 notebook = "*"
@@ -128,6 +129,7 @@ ignore = ["D1"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
 
 [tool.poetry.group.evaluation.dependencies]
 streamlit = "*"


### PR DESCRIPTION
This PR adds support for running `.openhands/setup.sh` after runtime initialization.

- Add _run_setup_script method to Session class to run setup.sh after runtime initialization
- Add get_full_path method to FileStore interface and implementations
- Run setup script with proper permissions and error handling

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8f14520-nikolaik   --name openhands-app-8f14520   docker.all-hands.dev/all-hands-ai/openhands:8f14520
```