### PR TITLE
fix(frontend): Memoize messages

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -73,6 +73,7 @@
             }
           }
         ],
+        "react/prop-types": "off",
         "react/no-array-index-key": "off",
         "react-hooks/exhaustive-deps": "off",
         "import/no-extraneous-dependencies": "off",

--- a/frontend/src/components/features/chat/messages.tsx
+++ b/frontend/src/components/features/chat/messages.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { ChatMessage } from "#/components/features/chat/chat-message";
 import { ConfirmationButtons } from "#/components/shared/buttons/confirmation-buttons";
 import { ImageCarousel } from "../images/image-carousel";
@@ -8,32 +9,36 @@ interface MessagesProps {
   isAwaitingUserConfirmation: boolean;
 }
 
-export function Messages({
-  messages,
-  isAwaitingUserConfirmation,
-}: MessagesProps) {
-  return messages.map((message, index) => {
-    if (message.type === "error" || message.type === "action") {
-      return (
-        <ExpandableMessage
-          key={index}
-          type={message.type}
-          id={message.translationID}
-          message={message.content}
-          success={message.success}
-        />
-      );
-    }
+export const Messages: React.FC<MessagesProps> = React.memo(
+  ({ messages, isAwaitingUserConfirmation }) =>
+    messages.map((message, index) => {
+      if (message.type === "error" || message.type === "action") {
+        return (
+          <ExpandableMessage
+            key={index}
+            type={message.type}
+            id={message.translationID}
+            message={message.content}
+            success={message.success}
+          />
+        );
+      }
 
-    return (
-      <ChatMessage key={index} type={message.sender} message={message.content}>
-        {message.imageUrls && message.imageUrls.length > 0 && (
-          <ImageCarousel size="small" images={message.imageUrls} />
-        )}
-        {messages.length - 1 === index &&
-          message.sender === "assistant" &&
-          isAwaitingUserConfirmation && <ConfirmationButtons />}
-      </ChatMessage>
-    );
-  });
-}
+      return (
+        <ChatMessage
+          key={index}
+          type={message.sender}
+          message={message.content}
+        >
+          {message.imageUrls && message.imageUrls.length > 0 && (
+            <ImageCarousel size="small" images={message.imageUrls} />
+          )}
+          {messages.length - 1 === index &&
+            message.sender === "assistant" &&
+            isAwaitingUserConfirmation && <ConfirmationButtons />}
+        </ChatMessage>
+      );
+    }),
+);
+
+Messages.displayName = "Messages";


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
All messages re-rendered every time a the chat input changes, resulting in performance issues that are more noticeable the larger the event history.

This is most likely due to the fact that we `setMessageToSend` whenever the input changes.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Memoize `<Messages />`. I have confirmed that messages no longer re-renders on input changes.


---
**Link of any specific issues this addresses**
Resolves #5791

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fcc83a9-nikolaik   --name openhands-app-fcc83a9   docker.all-hands.dev/all-hands-ai/openhands:fcc83a9
```