### PR TITLE
fix(frontend): Prevent rendering loading spinner in chat interface too frequently

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -5,6 +5,7 @@ import EventLogger from "#/utils/event-logger";
 import { handleAssistantMessage } from "#/services/actions";
 import { useRate } from "#/hooks/use-rate";
 import { OpenHandsParsedEvent } from "#/types/core";
+import { AgentStateChangeObservation } from "#/types/core/observations";
 
 const isOpenHandsMessage = (event: unknown): event is OpenHandsParsedEvent =>
   typeof event === "object" &&
@@ -13,6 +14,11 @@ const isOpenHandsMessage = (event: unknown): event is OpenHandsParsedEvent =>
   "source" in event &&
   "message" in event &&
   "timestamp" in event;
+
+const isAgentStateChangeObservation = (
+  event: OpenHandsParsedEvent,
+): event is AgentStateChangeObservation =>
+  "observation" in event && event.observation === "agent_state_changed";
 
 export enum WsClientProviderStatus {
   CONNECTED,
@@ -68,7 +74,7 @@ export function WsClientProvider({
   }
 
   function handleMessage(event: Record<string, unknown>) {
-    if (isOpenHandsMessage(event)) {
+    if (isOpenHandsMessage(event) && !isAgentStateChangeObservation(event)) {
       messageRateHandler.record(new Date().getTime());
     }
     setEvents((prevEvents) => [...prevEvents, event]);


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
The agent state change was an event that was taking into account when determining whether the app renders a loading spinner or not. Since the state changes almost immediately between actions/observations, it caused the loading spinner to render

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Do not take into account agent state changes


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:144e847-nikolaik   --name openhands-app-144e847   docker.all-hands.dev/all-hands-ai/openhands:144e847
```