### PR TITLE
default to local fs

### DIFF
--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -50,8 +50,8 @@ class AppConfig:
     sandbox: SandboxConfig = field(default_factory=SandboxConfig)
     security: SecurityConfig = field(default_factory=SecurityConfig)
     runtime: str = 'docker'
-    file_store: str = 'memory'
-    file_store_path: str = '/tmp/file_store'
+    file_store: str = 'local'
+    file_store_path: str = '/tmp/openhands_file_store'
     trajectories_path: str | None = None
     workspace_base: str | None = None
     workspace_mount_path: str | None = None


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
CHANGELOG: developer mode now defaults to storing data on the filesystem instead of in-memory, to help LLM settings persist.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c335ca2-nikolaik   --name openhands-app-c335ca2   docker.all-hands.dev/all-hands-ai/openhands:c335ca2
```