### PR TITLE
Add bytes support to FileStore write operations

### DIFF
--- a/openhands/runtime/impl/e2b/filestore.py
+++ b/openhands/runtime/impl/e2b/filestore.py
@@ -5,7 +5,7 @@ class E2BFileStore(FileStore):
     def __init__(self, filesystem):
         self.filesystem = filesystem
 
-    def write(self, path: str, contents: str) -> None:
+    def write(self, path: str, contents: str | bytes) -> None:
         self.filesystem.write(path, contents)
 
     def read(self, path: str) -> str:

--- a/openhands/storage/files.py
+++ b/openhands/storage/files.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 
 class FileStore:
     @abstractmethod
-    def write(self, path: str, contents: str) -> None:
+    def write(self, path: str, contents: str | bytes) -> None:
         pass
 
     @abstractmethod

--- a/openhands/storage/memory.py
+++ b/openhands/storage/memory.py
@@ -12,7 +12,9 @@ class InMemoryFileStore(FileStore):
     def __init__(self, files: dict[str, str] = IN_MEMORY_FILES):
         self.files = files
 
-    def write(self, path: str, contents: str) -> None:
+    def write(self, path: str, contents: str | bytes) -> None:
+        if isinstance(contents, bytes):
+            contents = contents.decode('utf-8')
         self.files[path] = contents
 
     def read(self, path: str) -> str:

--- a/openhands/storage/s3.py
+++ b/openhands/storage/s3.py
@@ -15,8 +15,8 @@ class S3FileStore(FileStore):
         self.bucket = os.getenv('AWS_S3_BUCKET')
         self.client = Minio(endpoint, access_key, secret_key, secure=secure)
 
-    def write(self, path: str, contents: str) -> None:
-        as_bytes = contents.encode('utf-8')
+    def write(self, path: str, contents: str | bytes) -> None:
+        as_bytes = contents.encode('utf-8') if isinstance(contents, str) else contents
         stream = io.BytesIO(as_bytes)
         try:
             self.client.put_object(self.bucket, path, stream, len(as_bytes))


### PR DESCRIPTION
This PR adds support for both string and bytes input in the FileStore write operations.

Changes:
- Updated FileStore base class to accept both str and bytes
- Updated InMemoryFileStore to handle bytes by decoding to UTF-8
- Updated S3FileStore to handle both types
- Updated E2BFileStore to pass through both types
- LocalFileStore and GoogleCloudFileStore already supported both types

All tests are passing.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:56ea983-nikolaik   --name openhands-app-56ea983   docker.all-hands.dev/all-hands-ai/openhands:56ea983
```