### PR TITLE
fix(frontend): Prevent message submission during IME composition

### DIFF
--- a/frontend/__tests__/components/chat/chat-input.test.tsx
+++ b/frontend/__tests__/components/chat/chat-input.test.tsx
@@ -218,4 +218,30 @@ describe("ChatInput", () => {
     // Verify image paste was handled
     expect(onImagePaste).toHaveBeenCalledWith([file]);
   });
+
+  it("should not submit when Enter is pressed during IME composition", async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSubmit={onSubmitMock} />);
+    const textarea = screen.getByRole("textbox");
+
+    await user.type(textarea, "こんにちは");
+
+    // Simulate Enter during IME composition
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      isComposing: true,
+      nativeEvent: { isComposing: true },
+    });
+
+    expect(onSubmitMock).not.toHaveBeenCalled();
+
+    // Simulate normal Enter after composition is done
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      isComposing: false,
+      nativeEvent: { isComposing: false },
+    });
+
+    expect(onSubmitMock).toHaveBeenCalledWith("こんにちは");
+  });
 });

--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -94,7 +94,12 @@ export function ChatInput({
   };
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Enter" && !event.shiftKey && !disabled) {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !disabled &&
+      !event.nativeEvent.isComposing
+    ) {
       event.preventDefault();
       handleSubmitMessage();
     }


### PR DESCRIPTION
## Description
This PR fixes an issue where pressing Enter during IME (Input Method Editor) composition would prematurely submit the message. This was particularly problematic for users typing in Japanese and other languages that use IME for text input.

## Changes
- Added a check for \`isComposing\` state in the \`handleKeyPress\` function
- Only submit messages when Enter is pressed and not during IME composition
- Added test case to verify IME composition behavior

## Testing
- Added new test case `should not submit when Enter is pressed during IME composition`
- Verified that existing tests pass
- Manually tested with Japanese IME input
