### PR TITLE
Support custom base container image in openhands-app container

### DIFF
--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -79,17 +79,17 @@ class DockerRuntimeBuilder(RuntimeBuilder):
             # since the official openhands app image is built from ubuntu, we use
             # ubuntu way to install docker binary
             commands = [
-                'sudo apt-get update',
-                'sudo apt-get install ca-certificates curl',
-                'sudo install -m 0755 -d /etc/apt/keyrings',
-                'sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc',
-                'sudo chmod a+r /etc/apt/keyrings/docker.asc',
+                'apt-get update',
+                'apt-get install ca-certificates curl',
+                'install -m 0755 -d /etc/apt/keyrings',
+                'curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc',
+                'chmod a+r /etc/apt/keyrings/docker.asc',
                 'echo \
                   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
                   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-                  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null',
-                'sudo apt-get update',
-                'sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin',
+                  tee /etc/apt/sources.list.d/docker.list > /dev/null',
+                'apt-get update',
+                'apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin',
             ]
             for cmd in commands:
                 try:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

WARNING: this PR hasn't been tested yet

Support custom base container image in openhands-app container, e.g.

```
docker run -it --rm --pull=always \
    -e SANDBOX_BASE_CONTAINER_IMAGE=ghcr.io/theagentcompany/pm-ask-for-issue-and-create-in-gitlab-image:1.0.0 \
    -e LOG_ALL_EVENTS=true \
    -e RUN_AS_OPENHANDS=false \
    -v /var/run/docker.sock:/var/run/docker.sock \
    -v ~/.openhands:/home/openhands/.openhands \
    -p 3000:3000 \
    --add-host host.docker.internal:host-gateway \
    --name openhands-app \
    docker.all-hands.dev/all-hands-ai/openhands:0.18
```

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

Fixes #6001 