### PR TITLE
fix(runtime): replace send_request with _send_action_server_request

### DIFF
--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -114,8 +114,7 @@ class ActionExecutionClient(Runtime):
             if path is not None:
                 data['path'] = path
 
-            with send_request(
-                self.session,
+            with self._send_action_server_request(
                 'POST',
                 f'{self._get_action_execution_server_host()}/list_files',
                 json=data,
@@ -132,8 +131,7 @@ class ActionExecutionClient(Runtime):
 
         try:
             params = {'path': path}
-            with send_request(
-                self.session,
+            with self._send_action_server_request(
                 'GET',
                 f'{self._get_action_execution_server_host()}/download_files',
                 params=params,
@@ -198,8 +196,7 @@ class ActionExecutionClient(Runtime):
         if self.vscode_enabled and self._runtime_initialized:
             if self._vscode_token is not None:  # cached value
                 return self._vscode_token
-            with send_request(
-                self.session,
+            with self._send_action_server_request(
                 'GET',
                 f'{self._get_action_execution_server_host()}/vscode/connection_token',
                 timeout=10,
@@ -249,8 +246,7 @@ class ActionExecutionClient(Runtime):
             assert action.timeout is not None
 
             try:
-                with send_request(
-                    self.session,
+                with self._send_action_server_request(
                     'POST',
                     f'{self._get_action_execution_server_host()}/execute_action',
                     json={'action': event_to_dict(action)},

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -20,9 +20,7 @@ from openhands.runtime.impl.action_execution.action_execution_client import (
 )
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.utils.command import get_remote_startup_command
-from openhands.runtime.utils.request import (
-    send_request,
-)
+from openhands.runtime.utils.request import send_request
 from openhands.runtime.utils.runtime_build import build_runtime_image
 from openhands.utils.async_utils import call_sync_from_async
 from openhands.utils.tenacity_stop import stop_if_should_exit


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Try to use `_send_action_server_request` as much as possible, otherwise the error handling we did in this PR https://github.com/All-Hands-AI/OpenHands/pull/5975 won't work.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:dd8bd49-nikolaik   --name openhands-app-dd8bd49   docker.all-hands.dev/all-hands-ai/openhands:dd8bd49
```