### PR TITLE
fix(agent controller): state.metrics is missing on exception

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -191,7 +191,7 @@ class AgentController:
         self,
         e: Exception,
     ):
-        """React to an exception by setting the agent state to error and updating the metrics."""
+        """React to an exception by setting the agent state to error and sending a status message."""
         await self.set_agent_state_to(AgentState.ERROR)
         if self.status_callback is not None:
             err_id = ''

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -127,22 +127,22 @@ class StuckDetector:
 
     def _is_stuck_repeating_action_error(self, last_actions, last_observations):
         # scenario 2: same action, errors
-        # it takes 4 actions and 4 observations to detect a loop
-        # check if the last four actions are the same and result in errors
+        # it takes 3 actions and 3 observations to detect a loop
+        # check if the last three actions are the same and result in errors
 
         if len(last_actions) < 4 or len(last_observations) < 4:
             return False
 
-        # are the last four actions the "same"?
-        if all(self._eq_no_pid(last_actions[0], action) for action in last_actions[:4]):
-            # and the last four observations are all errors?
-            if all(isinstance(obs, ErrorObservation) for obs in last_observations[:4]):
+        # are the last three actions the "same"?
+        if all(self._eq_no_pid(last_actions[0], action) for action in last_actions[:3]):
+            # and the last three observations are all errors?
+            if all(isinstance(obs, ErrorObservation) for obs in last_observations[:3]):
                 logger.warning('Action, ErrorObservation loop detected')
                 return True
-            # or, are the last four observations all IPythonRunCellObservation with SyntaxError?
+            # or, are the last three observations all IPythonRunCellObservation with SyntaxError?
             elif all(
                 isinstance(obs, IPythonRunCellObservation)
-                for obs in last_observations[:4]
+                for obs in last_observations[:3]
             ):
                 warning = 'Action, IPythonRunCellObservation loop detected'
                 for error_message in self.SYNTAX_ERROR_MESSAGES:
@@ -150,7 +150,7 @@ class StuckDetector:
                         'SyntaxError: unterminated string literal (detected at line'
                     ):
                         if self._check_for_consistent_line_error(
-                            last_observations[:4], error_message
+                            last_observations[:3], error_message
                         ):
                             logger.warning(warning)
                             return True
@@ -158,7 +158,7 @@ class StuckDetector:
                         'SyntaxError: invalid syntax. Perhaps you forgot a comma?',
                         'SyntaxError: incomplete input',
                     ) and self._check_for_consistent_invalid_syntax(
-                        last_observations[:4], error_message
+                        last_observations[:3], error_message
                     ):
                         logger.warning(warning)
                         return True
@@ -191,11 +191,11 @@ class StuckDetector:
 
         # Check if:
         # 1. All first lines are identical
-        # 2. We have exactly 4 valid observations
+        # 2. We have exactly 3 valid observations
         # 3. The error message line is identical in all valid observations
         return (
             len(set(first_lines)) == 1
-            and len(valid_observations) == 4
+            and len(valid_observations) == 3
             and len(
                 set(
                     obs.content.strip().split('\n')[:-2][-1]
@@ -228,9 +228,9 @@ class StuckDetector:
             if error_message in last_lines[-3]:
                 error_lines.append(last_lines[-3])
 
-        # Check if we found the error message in all 4 observations
+        # Check if we found the error message in all 3 observations
         # and the 3rd-to-last line is identical across all occurrences
-        return len(error_lines) == 4 and len(set(error_lines)) == 1
+        return len(error_lines) == 3 and len(set(error_lines)) == 1
 
     def _is_stuck_monologue(self, filtered_history):
         # scenario 3: monologue

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -127,22 +127,22 @@ class StuckDetector:
 
     def _is_stuck_repeating_action_error(self, last_actions, last_observations):
         # scenario 2: same action, errors
-        # it takes 3 actions and 3 observations to detect a loop
-        # check if the last three actions are the same and result in errors
+        # it takes 4 actions and 4 observations to detect a loop
+        # check if the last four actions are the same and result in errors
 
         if len(last_actions) < 4 or len(last_observations) < 4:
             return False
 
-        # are the last three actions the "same"?
-        if all(self._eq_no_pid(last_actions[0], action) for action in last_actions[:3]):
-            # and the last three observations are all errors?
-            if all(isinstance(obs, ErrorObservation) for obs in last_observations[:3]):
+        # are the last four actions the "same"?
+        if all(self._eq_no_pid(last_actions[0], action) for action in last_actions[:4]):
+            # and the last four observations are all errors?
+            if all(isinstance(obs, ErrorObservation) for obs in last_observations[:4]):
                 logger.warning('Action, ErrorObservation loop detected')
                 return True
-            # or, are the last three observations all IPythonRunCellObservation with SyntaxError?
+            # or, are the last four observations all IPythonRunCellObservation with SyntaxError?
             elif all(
                 isinstance(obs, IPythonRunCellObservation)
-                for obs in last_observations[:3]
+                for obs in last_observations[:4]
             ):
                 warning = 'Action, IPythonRunCellObservation loop detected'
                 for error_message in self.SYNTAX_ERROR_MESSAGES:
@@ -150,7 +150,7 @@ class StuckDetector:
                         'SyntaxError: unterminated string literal (detected at line'
                     ):
                         if self._check_for_consistent_line_error(
-                            last_observations[:3], error_message
+                            last_observations[:4], error_message
                         ):
                             logger.warning(warning)
                             return True
@@ -158,7 +158,7 @@ class StuckDetector:
                         'SyntaxError: invalid syntax. Perhaps you forgot a comma?',
                         'SyntaxError: incomplete input',
                     ) and self._check_for_consistent_invalid_syntax(
-                        last_observations[:3], error_message
+                        last_observations[:4], error_message
                     ):
                         logger.warning(warning)
                         return True
@@ -191,11 +191,11 @@ class StuckDetector:
 
         # Check if:
         # 1. All first lines are identical
-        # 2. We have exactly 3 valid observations
+        # 2. We have exactly 4 valid observations
         # 3. The error message line is identical in all valid observations
         return (
             len(set(first_lines)) == 1
-            and len(valid_observations) == 3
+            and len(valid_observations) == 4
             and len(
                 set(
                     obs.content.strip().split('\n')[:-2][-1]
@@ -228,9 +228,9 @@ class StuckDetector:
             if error_message in last_lines[-3]:
                 error_lines.append(last_lines[-3])
 
-        # Check if we found the error message in all 3 observations
+        # Check if we found the error message in all 4 observations
         # and the 3rd-to-last line is identical across all occurrences
-        return len(error_lines) == 3 and len(set(error_lines)) == 1
+        return len(error_lines) == 4 and len(set(error_lines)) == 1
 
     def _is_stuck_monologue(self, filtered_history):
         # scenario 3: monologue

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -296,6 +296,14 @@ async def test_delegate_step_different_states(
 async def test_max_iterations_extension(mock_agent, mock_event_stream):
     # Test with headless_mode=False - should extend max_iterations
     initial_state = State(max_iterations=10)
+
+    # Set up proper metrics mock with required attributes
+    metrics = MagicMock(spec=Metrics)
+    metrics._costs = []
+    metrics._response_latencies = []
+    metrics.accumulated_cost = 0.0
+    mock_agent.llm.metrics = metrics
+
     controller = AgentController(
         agent=mock_agent,
         event_stream=mock_event_stream,

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -39,7 +39,11 @@ def event_loop():
 def mock_agent():
     agent = MagicMock(spec=Agent)
     agent.llm = MagicMock(spec=LLM)
-    agent.llm.metrics = MagicMock(spec=Metrics)
+    metrics = MagicMock(spec=Metrics)
+    metrics.costs = []
+    metrics.accumulated_cost = 0.0
+    metrics.response_latencies = []
+    agent.llm.metrics = metrics
     return agent
 
 

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -141,9 +141,9 @@ def test_llm_reset():
     initial_metrics.add_cost(1.0)
     initial_metrics.add_response_latency(0.5, 'test-id')
     llm.reset()
-    assert llm.metrics._accumulated_cost != initial_metrics._accumulated_cost
-    assert llm.metrics._costs != initial_metrics._costs
-    assert llm.metrics._response_latencies != initial_metrics._response_latencies
+    assert llm.metrics.accumulated_cost != initial_metrics.accumulated_cost
+    assert llm.metrics.costs != initial_metrics.costs
+    assert llm.metrics.response_latencies != initial_metrics.response_latencies
     assert isinstance(llm.metrics, Metrics)
 
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When the agent triggers any type of Exception, the `state.metrics` will not get synced correctly -- hence the evaluation is unable to track LLM costs accurately.

This PR:
- add a test to expose the buggy behavior
- and fix it by sync `.local_metrics` with `state.metrics` right before we reset the agent.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9664121-nikolaik   --name openhands-app-9664121   docker.all-hands.dev/all-hands-ai/openhands:9664121
```