### PR TITLE
fix: prevent race condition in session manager during disconnect

### DIFF
--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -267,10 +267,7 @@ class DockerRuntime(ActionExecutionClient):
                 environment=environment,
                 volumes=volumes,
                 device_requests=(
-                    [docker.types.DeviceRequest(
-                        capabilities=[['gpu']],
-                        count=-1
-                    )]
+                    [docker.types.DeviceRequest(capabilities=[['gpu']], count=-1)]
                     if self.config.sandbox.enable_gpu
                     else None
                 ),

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -162,10 +162,7 @@ class SessionManager:
             sid = data['sid']
             logger.debug(f'session_closing:{sid}')
             # Create a list of items to process to avoid modifying dict during iteration
-            items = [
-                (cid, lsid)
-                for cid, lsid in self.local_connection_id_to_session_id.items()
-            ]
+            items = list(self.local_connection_id_to_session_id.items())
             for connection_id, local_sid in items:
                 if sid == local_sid:
                     logger.warning(

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -161,10 +161,12 @@ class SessionManager:
             # which can't be guaranteed - nodes can simply vanish unexpectedly!
             sid = data['sid']
             logger.debug(f'session_closing:{sid}')
-            for (
-                connection_id,
-                local_sid,
-            ) in self.local_connection_id_to_session_id.items():
+            # Create a list of items to process to avoid modifying dict during iteration
+            items = [
+                (cid, lsid)
+                for cid, lsid in self.local_connection_id_to_session_id.items()
+            ]
+            for connection_id, local_sid in items:
                 if sid == local_sid:
                     logger.warning(
                         'local_connection_to_closing_session:{connection_id}:{sid}'


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Fixes a race condition in the session manager that could cause server errors when disconnecting sessions. This improves the stability of the server by preventing potential crashes during session cleanup.

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Fixed a race condition that could cause server errors when disconnecting sessions, improving server stability.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The session manager was experiencing a race condition where the `local_connection_id_to_session_id` dictionary was being modified during iteration when disconnecting sessions. This could happen because the disconnect operation triggers callbacks that modify the dictionary.

The fix:
1. Create a snapshot list of items before iteration
2. Iterate over the static list instead of the dictionary directly
3. This prevents the "dictionary changed size during iteration" error

The solution uses a common pattern for handling race conditions when you need to iterate over a dictionary that might be modified during the iteration. By creating a snapshot list first, we ensure that any modifications to the original dictionary during the iteration won't affect our processing.

---
**Link of any specific issues this addresses**

N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:48d2a09-nikolaik   --name openhands-app-48d2a09   docker.all-hands.dev/all-hands-ai/openhands:48d2a09
```