### PR TITLE
chore: improve error logging for RuntimeError

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -209,10 +209,15 @@ class AgentController:
         try:
             await self._step()
         except Exception as e:
-            traceback.print_exc()
-            self.log('error', f'Error while running the agent: {e}')
+            self.log(
+                'error',
+                f'Error while running the agent (session ID: {self.id}): {e}. '
+                f'Traceback: {traceback.format_exc()}',
+            )
             reported = RuntimeError(
-                'There was an unexpected error while running the agent.'
+                'There was an unexpected error while running the agent. Please '
+                f'report this error to the developers. Your session ID is {self.id}. '
+                f'Exception: {e}.'
             )
             if isinstance(e, litellm.AuthenticationError) or isinstance(
                 e, litellm.BadRequestError


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We typically see these opaque error in the UI without knowing what caused them. This PR adds a little bit more information (eg the exception type), and also print out the session ID for easier debug.

![image](https://github.com/user-attachments/assets/9810cd5c-e04e-46b3-b672-f888ea4c7f6f)


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4f171b5-nikolaik   --name openhands-app-4f171b5   docker.all-hands.dev/all-hands-ai/openhands:4f171b5
```