### PR TITLE
Makefile: Fix poetry version detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ check-poetry:
 	@if command -v poetry > /dev/null; then \
 		POETRY_VERSION=$(shell poetry --version 2>&1 | sed -E 's/Poetry \(version ([0-9]+\.[0-9]+\.[0-9]+)\)/\1/'); \
 		IFS='.' read -r -a POETRY_VERSION_ARRAY <<< "$$POETRY_VERSION"; \
-		if [ $${POETRY_VERSION_ARRAY[0]} -ge 1 ] && [ $${POETRY_VERSION_ARRAY[1]} -ge 8 ]; then \
+		if [ $${POETRY_VERSION_ARRAY[0]} -gt 1 ] || ([ $${POETRY_VERSION_ARRAY[0]} -eq 1 ] && [ $${POETRY_VERSION_ARRAY[1]} -ge 8 ]); then \
 			echo "$(BLUE)$(shell poetry --version) is already installed.$(RESET)"; \
 		else \
 			echo "$(RED)Poetry 1.8 or later is required. You can install poetry by running the following command, then adding Poetry to your PATH:"; \


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Support latest poetry version, 2.0.0

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

If you now install OpenHands source code from scratch, you would see the following error:
```
Checking Poetry installation...
Poetry 1.8 or later is required. You can install poetry by running the following command, then adding Poetry to your PATH:
 curl -sSL https://install.python-poetry.org | python3.12 -
More detail here: https://python-poetry.org/docs/#installing-with-the-official-installer
```

and installing poetry doesn't help, coz it now by default installs 2.0.0 version, which doesn't pass the version check. This PR fixes this problem.

---
**Link of any specific issues this addresses**
