### PR TITLE
Fix issue #6063: [Bug]: Build error on `opencv-python`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5423,24 +5423,6 @@ datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
 realtime = ["websockets (>=13,<15)"]
 
 [[package]]
-name = "opencv-python"
-version = "4.10.0.84"
-description = "Wrapper package for OpenCV python bindings."
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "opencv-python-4.10.0.84.tar.gz", hash = "sha256:72d234e4582e9658ffea8e9cae5b63d488ad06994ef12d81dc303b17472f3526"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-macosx_12_0_x86_64.whl", hash = "sha256:71e575744f1d23f79741450254660442785f45a0797212852ee5199ef12eed98"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09a332b50488e2dda866a6c5573ee192fe3583239fb26ff2f7f9ceb0bc119ea6"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ace140fc6d647fbe1c692bcb2abce768973491222c067c131d80957c595b71f"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-win32.whl", hash = "sha256:2db02bb7e50b703f0a2d50c50ced72e95c574e1e5a0bb35a8a86d0b35c98c236"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-win_amd64.whl", hash = "sha256:32dbbd94c26f611dc5cc6979e6b7aa1f55a64d6b463cc1dcd3c95505a63e48fe"},
-]
-
-[package.dependencies]
-numpy = {version = ">=1.26.0", markers = "python_version >= \"3.12\""}
-
-[[package]]
 name = "openhands-aci"
 version = "0.1.6"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
@@ -10083,4 +10065,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "6f8fd9ffcc411aed1c8f50aff98e36bf06932c27b82485e4f9fd05bbe7b195c4"
+content-hash = "3c4cae19fcbd9183bde1bd88cea55454921281e26447d9a2c64404a5defffb3e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ pytest-forked = "*"
 pytest-xdist = "*"
 flake8 = "*"
 openai = "*"
-opencv-python = "*"
 pandas = "*"
 reportlab = "*"
 
@@ -108,7 +107,6 @@ jupyterlab = "*"
 notebook = "*"
 jupyter_kernel_gateway = "*"
 flake8 = "*"
-opencv-python = "*"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This pull request fixes #6063.

The issue has been successfully resolved by removing the `opencv-python` dependency from the project. Here's a summary for the PR review:

This PR fixes the build error on macOS by:
1. Removing `opencv-python` from both test and runtime dependencies in pyproject.toml
2. Updating the poetry lock file to reflect these changes
3. Verifying that the project builds and functions correctly without this dependency

The changes were validated by:
- Successfully building the project with `INSTALL_DOCKER=0 make build`
- Running the full test suite with `make test`, which passed
- Confirming that no core functionality was impacted by the removal

This fix is appropriate because:
- The `opencv-python` dependency was causing build failures on macOS
- The package wasn't actually being used in the codebase
- All tests pass without the dependency, indicating it wasn't necessary

The solution is clean and minimalistic, removing an unnecessary dependency rather than trying to work around version compatibility issues.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:467fe2d-nikolaik   --name openhands-app-467fe2d   docker.all-hands.dev/all-hands-ai/openhands:467fe2d
```