### PR TITLE
Edit tool prompt tweaking: only plain-text format is supported

### DIFF
--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -75,7 +75,7 @@ IPythonTool = ChatCompletionToolParam(
     ),
 )
 
-_FILE_EDIT_DESCRIPTION = """Edit a file.
+_FILE_EDIT_DESCRIPTION = """Edit a file in plain-text format.
 * The assistant can edit files by specifying the file path and providing a draft of the new file content.
 * The draft content doesn't need to be exactly the same as the existing file; the assistant may skip unchanged lines using comments like `# unchanged` to indicate unchanged sections.
 * IMPORTANT: For large files (e.g., > 300 lines), specify the range of lines to edit using `start` and `end` (1-indexed, inclusive). The range should be smaller than 300 lines.
@@ -211,7 +211,7 @@ LLMBasedFileEditTool = ChatCompletionToolParam(
     ),
 )
 
-_STR_REPLACE_EDITOR_DESCRIPTION = """Custom editing tool for viewing, creating and editing files
+_STR_REPLACE_EDITOR_DESCRIPTION = """Custom editing tool for viewing, creating and editing files in plain-text format
 * State is persistent across command calls and discussions with the user
 * If `path` is a file, `view` displays the result of applying `cat -n`. If `path` is a directory, `view` lists non-hidden files and directories up to 2 levels deep
 * The `create` command cannot be used if the specified `path` already exists as a file


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Tweak edit-related prompts to clarify that edit tools are for plain-text format only.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

### Without this PR:

<img width="1125" alt="Screenshot 2025-01-05 at 8 45 47 PM" src="https://github.com/user-attachments/assets/ec91b286-5d31-4e9c-ab61-0bb2d95fb632" />


<img width="685" alt="Screenshot 2025-01-05 at 8 44 41 PM" src="https://github.com/user-attachments/assets/a5a4c835-126c-44ab-b2e6-07668be53ee1" />

### With this PR:

<img width="452" alt="Screenshot 2025-01-05 at 9 02 50 PM" src="https://github.com/user-attachments/assets/8dc1c333-0380-4187-a8f6-23de3ab3d06a" />

and I verified the result is indeed of MS-doc format.

As a follow-up, we could create some micro-agents to remind LLM of python libraries related to office, such as `python-docx`.

---


**Link of any specific issues this addresses**

This is motivated by a failure I observed when running TheAgentCompany benchmark. Specifically, this one: https://github.com/TheAgentCompany/TheAgentCompany/blob/d456bb0d0c528e3495b6400f156be02695d6731f/workspaces/tasks/ds-answer-numerical-data-question/task.md?plain=1#L9