### PR TITLE
Retrieve GitHub IDs more efficiently

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -115,9 +115,6 @@ export function WsClientProvider({
 
     sio = io(baseUrl, {
       transports: ["websocket"],
-      auth: {
-        cookie: document.cookie,
-      },
       query,
     });
     sio.on("connect", handleConnect);

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -43,16 +43,13 @@ const WsClientContext = React.createContext<UseWsClient>({
 
 interface WsClientProviderProps {
   conversationId: string;
-  ghToken: string | null;
 }
 
 export function WsClientProvider({
-  ghToken,
   conversationId,
   children,
 }: React.PropsWithChildren<WsClientProviderProps>) {
   const sioRef = React.useRef<Socket | null>(null);
-  const ghTokenRef = React.useRef<string | null>(ghToken);
   const [status, setStatus] = React.useState(
     WsClientProviderStatus.DISCONNECTED,
   );
@@ -119,7 +116,7 @@ export function WsClientProvider({
     sio = io(baseUrl, {
       transports: ["websocket"],
       auth: {
-        github_token: ghToken || undefined,
+        cookie: document.cookie,
       },
       query,
     });
@@ -130,7 +127,6 @@ export function WsClientProvider({
     sio.on("disconnect", handleDisconnect);
 
     sioRef.current = sio;
-    ghTokenRef.current = ghToken;
 
     return () => {
       sio.off("connect", handleConnect);
@@ -139,7 +135,7 @@ export function WsClientProvider({
       sio.off("connect_failed", handleError);
       sio.off("disconnect", handleDisconnect);
     };
-  }, [ghToken, conversationId]);
+  }, [conversationId]);
 
   React.useEffect(
     () => () => {

--- a/frontend/src/routes/_oh.app/route.tsx
+++ b/frontend/src/routes/_oh.app/route.tsx
@@ -175,7 +175,7 @@ function AppContent() {
   }
 
   return (
-    <WsClientProvider ghToken={gitHubToken} conversationId={conversationId}>
+    <WsClientProvider conversationId={conversationId}>
       <EventHandler>
         <div data-testid="app-route" className="flex flex-col h-full gap-3">
           <div className="flex h-full overflow-auto">{renderMain()}</div>

--- a/openhands/server/auth.py
+++ b/openhands/server/auth.py
@@ -6,9 +6,9 @@ from openhands.core.logger import openhands_logger as logger
 
 
 def get_user_id(request: Request) -> int:
-    if not hasattr(request.state, 'github_user'):
+    if not hasattr(request.state, 'github_user_id'):
         return -1
-    return request.state.github_user.id
+    return request.state.github_user_id
 
 
 def get_sid_from_token(token: str, jwt_secret: str) -> str:

--- a/openhands/server/auth.py
+++ b/openhands/server/auth.py
@@ -6,9 +6,7 @@ from openhands.core.logger import openhands_logger as logger
 
 
 def get_user_id(request: Request) -> int:
-    if not hasattr(request.state, 'github_user_id'):
-        return -1
-    return request.state.github_user_id
+    return getattr(request.state, 'github_user_id', 0)
 
 
 def get_sid_from_token(token: str, jwt_secret: str) -> str:

--- a/openhands/server/auth.py
+++ b/openhands/server/auth.py
@@ -1,7 +1,14 @@
 import jwt
+from fastapi import Request
 from jwt.exceptions import InvalidTokenError
 
 from openhands.core.logger import openhands_logger as logger
+
+
+def get_user_id(request: Request) -> int:
+    if not hasattr(request.state, 'github_user'):
+        return -1
+    return request.state.github_user.id
 
 
 def get_sid_from_token(token: str, jwt_secret: str) -> str:

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -32,8 +32,9 @@ async def connect(connection_id: str, environ, auth):
         raise ConnectionRefusedError('No conversation_id in query params')
 
     github_token = ''
+    user_id = -1
     if openhands_config.app_mode != AppMode.OSS:
-        user_id = ''
+        user_id = -1
         if auth and 'github_token' in auth:
             github_token = auth['github_token']
             with Github(github_token) as g:
@@ -42,9 +43,7 @@ async def connect(connection_id: str, environ, auth):
 
         logger.info(f'User {user_id} is connecting to conversation {conversation_id}')
 
-        conversation_store = await ConversationStoreImpl.get_instance(
-            config, github_token
-        )
+        conversation_store = await ConversationStoreImpl.get_instance(config, user_id)
         metadata = await conversation_store.get_metadata(conversation_id)
         if metadata.github_user_id != user_id:
             logger.error(
@@ -54,7 +53,7 @@ async def connect(connection_id: str, environ, auth):
                 f'User {user_id} is not allowed to join conversation {conversation_id}'
             )
 
-    settings_store = await SettingsStoreImpl.get_instance(config, github_token)
+    settings_store = await SettingsStoreImpl.get_instance(config, user_id)
     settings = await settings_store.load()
 
     if not settings:

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -32,12 +32,8 @@ async def connect(connection_id: str, environ, auth):
 
     user_id = -1
     if openhands_config.app_mode != AppMode.OSS:
-        if 'cookie' not in auth:
-            logger.error('No cookie in auth')
-            raise ConnectionRefusedError('No cookie in auth')
-        cookies = dict(
-            cookie.split('=', 1) for cookie in auth.get('cookie', '').split('; ')
-        )
+        cookies_str = environ.get('HTTP_COOKIE', '')
+        cookies = dict(cookie.split('=', 1) for cookie in cookies_str.split('; '))
         signed_token = cookies.get('github_auth', '')
         if not signed_token:
             logger.error('No github_auth cookie')

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -45,7 +45,7 @@ async def list_files(request: Request, conversation_id: str, path: str | None = 
 
     To list files:
     ```sh
-    curl http://localhost:3000/api/list-files
+    curl http://localhost:3000/api/conversations/{conversation_id}/list-files
     ```
 
     Args:
@@ -110,7 +110,7 @@ async def select_file(file: str, request: Request):
 
     To select a file:
     ```sh
-    curl http://localhost:3000/api/select-file?file=<file_path>
+    curl http://localhost:3000/api/conversations/{conversation_id}select-file?file=<file_path>
     ```
 
     Args:
@@ -154,7 +154,7 @@ async def upload_file(request: Request, conversation_id: str, files: list[Upload
 
     To upload a files:
     ```sh
-    curl -X POST -F "file=@<file_path1>" -F "file=@<file_path2>" http://localhost:3000/api/upload-files
+    curl -X POST -F "file=@<file_path1>" -F "file=@<file_path2>" http://localhost:3000/api/conversations/{conversation_id}/upload-files
     ```
 
     Args:

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -52,9 +52,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     if settings:
         session_init_args = {**settings.__dict__, **session_init_args}
 
-    github_token = (
-        request.state.github_token if hasattr(request.state, 'github_token') else ''
-    )
+    github_token = getattr(request.state, 'github_token', '')
     session_init_args['github_token'] = github_token
     session_init_args['selected_repository'] = data.selected_repository
     conversation_init_data = ConversationInitData(**session_init_args)

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -4,11 +4,11 @@ from typing import Callable
 
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
-from github import Github
 from pydantic import BaseModel
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.stream import EventStreamSubscriber
+from openhands.server.auth import get_user_id
 from openhands.server.routes.settings import ConversationStoreImpl, SettingsStoreImpl
 from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.server.shared import config, session_manager
@@ -21,7 +21,6 @@ from openhands.storage.data_models.conversation_status import ConversationStatus
 from openhands.utils.async_utils import (
     GENERAL_TIMEOUT,
     call_async_from_sync,
-    call_sync_from_async,
     wait_all,
 )
 
@@ -43,10 +42,9 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     using the returned conversation ID
     """
     logger.info('Initializing new conversation')
-    github_token = data.github_token or ''
 
     logger.info('Loading settings')
-    settings_store = await SettingsStoreImpl.get_instance(config, github_token)
+    settings_store = await SettingsStoreImpl.get_instance(config, get_user_id(request))
     settings = await settings_store.load()
     logger.info('Settings loaded')
 
@@ -54,11 +52,16 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     if settings:
         session_init_args = {**settings.__dict__, **session_init_args}
 
+    github_token = (
+        request.state.github_token if hasattr(request.state, 'github_token') else ''
+    )
     session_init_args['github_token'] = github_token
     session_init_args['selected_repository'] = data.selected_repository
     conversation_init_data = ConversationInitData(**session_init_args)
     logger.info('Loading conversation store')
-    conversation_store = await ConversationStoreImpl.get_instance(config, github_token)
+    conversation_store = await ConversationStoreImpl.get_instance(
+        config, get_user_id(request)
+    )
     logger.info('Conversation store loaded')
 
     conversation_id = uuid.uuid4().hex
@@ -67,18 +70,11 @@ async def new_conversation(request: Request, data: InitSessionRequest):
         conversation_id = uuid.uuid4().hex
     logger.info(f'New conversation ID: {conversation_id}')
 
-    user_id = ''
-    if data.github_token:
-        logger.info('Fetching Github user ID')
-        with Github(data.github_token) as g:
-            gh_user = await call_sync_from_async(g.get_user)
-            user_id = gh_user.id
-
     logger.info(f'Saving metadata for conversation {conversation_id}')
     await conversation_store.save_metadata(
         ConversationMetadata(
             conversation_id=conversation_id,
-            github_user_id=user_id,
+            github_user_id=get_user_id(request),
             selected_repository=data.selected_repository,
         )
     )
@@ -90,9 +86,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     try:
         event_stream.subscribe(
             EventStreamSubscriber.SERVER,
-            _create_conversation_update_callback(
-                data.github_token or '', conversation_id
-            ),
+            _create_conversation_update_callback(get_user_id(request), conversation_id),
             UPDATED_AT_CALLBACK_ID,
         )
     except ValueError:
@@ -107,8 +101,9 @@ async def search_conversations(
     page_id: str | None = None,
     limit: int = 20,
 ) -> ConversationInfoResultSet:
-    github_token = getattr(request.state, 'github_token', '') or ''
-    conversation_store = await ConversationStoreImpl.get_instance(config, github_token)
+    conversation_store = await ConversationStoreImpl.get_instance(
+        config, get_user_id(request)
+    )
     conversation_metadata_result_set = await conversation_store.search(page_id, limit)
     conversation_ids = set(
         conversation.conversation_id
@@ -134,8 +129,9 @@ async def search_conversations(
 async def get_conversation(
     conversation_id: str, request: Request
 ) -> ConversationInfo | None:
-    github_token = getattr(request.state, 'github_token', '') or ''
-    conversation_store = await ConversationStoreImpl.get_instance(config, github_token)
+    conversation_store = await ConversationStoreImpl.get_instance(
+        config, get_user_id(request)
+    )
     try:
         metadata = await conversation_store.get_metadata(conversation_id)
         is_running = await session_manager.is_agent_loop_running(conversation_id)
@@ -149,8 +145,9 @@ async def get_conversation(
 async def update_conversation(
     request: Request, conversation_id: str, title: str = Body(embed=True)
 ) -> bool:
-    github_token = getattr(request.state, 'github_token', '') or ''
-    conversation_store = await ConversationStoreImpl.get_instance(config, github_token)
+    conversation_store = await ConversationStoreImpl.get_instance(
+        config, get_user_id(request)
+    )
     metadata = await conversation_store.get_metadata(conversation_id)
     if not metadata:
         return False
@@ -164,8 +161,9 @@ async def delete_conversation(
     conversation_id: str,
     request: Request,
 ) -> bool:
-    github_token = getattr(request.state, 'github_token', '') or ''
-    conversation_store = await ConversationStoreImpl.get_instance(config, github_token)
+    conversation_store = await ConversationStoreImpl.get_instance(
+        config, get_user_id(request)
+    )
     try:
         await conversation_store.get_metadata(conversation_id)
     except FileNotFoundError:
@@ -204,21 +202,21 @@ async def _get_conversation_info(
 
 
 def _create_conversation_update_callback(
-    github_token: str, conversation_id: str
+    user_id: int, conversation_id: str
 ) -> Callable:
     def callback(*args, **kwargs):
         call_async_from_sync(
             _update_timestamp_for_conversation,
             GENERAL_TIMEOUT,
-            github_token,
+            user_id,
             conversation_id,
         )
 
     return callback
 
 
-async def _update_timestamp_for_conversation(github_token: str, conversation_id: str):
-    conversation_store = await ConversationStoreImpl.get_instance(config, github_token)
+async def _update_timestamp_for_conversation(user_id: int, conversation_id: str):
+    conversation_store = await ConversationStoreImpl.get_instance(config, user_id)
     conversation = await conversation_store.get_metadata(conversation_id)
     conversation.last_updated_at = datetime.now()
     await conversation_store.save_metadata(conversation)

--- a/openhands/storage/conversation/conversation_store.py
+++ b/openhands/storage/conversation/conversation_store.py
@@ -40,7 +40,5 @@ class ConversationStore(ABC):
 
     @classmethod
     @abstractmethod
-    async def get_instance(
-        cls, config: AppConfig, token: str | None
-    ) -> ConversationStore:
+    async def get_instance(cls, config: AppConfig, user_id: int) -> ConversationStore:
         """Get a store for the user represented by the token given"""

--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -90,7 +90,9 @@ class FileConversationStore(ConversationStore):
         return get_conversation_metadata_filename(conversation_id)
 
     @classmethod
-    async def get_instance(cls, config: AppConfig, token: str | None):
+    async def get_instance(
+        cls, config: AppConfig, user_id: int
+    ) -> FileConversationStore:
         file_store = get_file_store(config.file_store, config.file_store_path)
         return FileConversationStore(file_store)
 

--- a/openhands/storage/data_models/conversation_metadata.py
+++ b/openhands/storage/data_models/conversation_metadata.py
@@ -5,7 +5,7 @@ from datetime import datetime
 @dataclass
 class ConversationMetadata:
     conversation_id: str
-    github_user_id: int | str
+    github_user_id: int
     selected_repository: str | None
     title: str | None = None
     last_updated_at: datetime | None = None

--- a/openhands/storage/settings/file_settings_store.py
+++ b/openhands/storage/settings/file_settings_store.py
@@ -30,6 +30,6 @@ class FileSettingsStore(SettingsStore):
         await call_sync_from_async(self.file_store.write, self.path, json_str)
 
     @classmethod
-    async def get_instance(cls, config: AppConfig, token: str | None):
+    async def get_instance(cls, config: AppConfig, user_id: int) -> FileSettingsStore:
         file_store = get_file_store(config.file_store, config.file_store_path)
         return FileSettingsStore(file_store)

--- a/openhands/storage/settings/settings_store.py
+++ b/openhands/storage/settings/settings_store.py
@@ -21,5 +21,5 @@ class SettingsStore(ABC):
 
     @classmethod
     @abstractmethod
-    async def get_instance(cls, config: AppConfig, token: str | None) -> SettingsStore:
+    async def get_instance(cls, config: AppConfig, user_id: int) -> SettingsStore:
         """Get a store for the user represented by the token given"""

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -28,7 +28,7 @@ def _patch_store():
                 'title': 'Some Conversation',
                 'selected_repository': 'foobar',
                 'conversation_id': 'some_conversation_id',
-                'github_user_id': 'github_user',
+                'github_user_id': 12345,
                 'last_updated_at': '2025-01-01T00:00:00',
             }
         ),


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This pre-loads GH user IDs in middleware, so we can reuse them instead of repeatedly calling the GitHub API

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:52882a1-nikolaik   --name openhands-app-52882a1   docker.all-hands.dev/all-hands-ai/openhands:52882a1
```