### PR TITLE
Feature - sort conversations by created at

### DIFF
--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -189,6 +189,7 @@ async def _get_conversation_info(
             conversation_id=conversation.conversation_id,
             title=title,
             last_updated_at=conversation.last_updated_at,
+            created_at=conversation.created_at,
             selected_repository=conversation.selected_repository,
             status=ConversationStatus.RUNNING
             if is_running

--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -96,7 +96,7 @@ class FileConversationStore(ConversationStore):
 
 
 def _sort_key(conversation: ConversationMetadata) -> str:
-    last_updated_at = conversation.last_updated_at
-    if last_updated_at:
-        return last_updated_at.isoformat()  # YYYY-MM-DDTHH:MM:SS for sorting
+    created_at = conversation.created_at
+    if created_at:
+        return created_at.isoformat()  # YYYY-MM-DDTHH:MM:SS for sorting
     return ''

--- a/openhands/storage/data_models/conversation_info.py
+++ b/openhands/storage/data_models/conversation_info.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 from openhands.storage.data_models.conversation_status import ConversationStatus
@@ -13,3 +13,4 @@ class ConversationInfo:
     last_updated_at: datetime | None = None
     status: ConversationStatus = ConversationStatus.STOPPED
     selected_repository: str | None = None
+    created_at: datetime = field(default_factory=datetime.now)

--- a/openhands/storage/data_models/conversation_metadata.py
+++ b/openhands/storage/data_models/conversation_metadata.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 
@@ -9,3 +9,4 @@ class ConversationMetadata:
     selected_repository: str | None
     title: str | None = None
     last_updated_at: datetime | None = None
+    created_at: datetime = field(default_factory=datetime.now)

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -29,7 +29,8 @@ def _patch_store():
                 'selected_repository': 'foobar',
                 'conversation_id': 'some_conversation_id',
                 'github_user_id': 'github_user',
-                'last_updated_at': '2025-01-01T00:00:00',
+                'created_at': '2025-01-01T00:00:00',
+                'last_updated_at': '2025-01-01T00:01:00',
             }
         ),
     )
@@ -55,7 +56,8 @@ async def test_search_conversations():
                 ConversationInfo(
                     conversation_id='some_conversation_id',
                     title='Some Conversation',
-                    last_updated_at=datetime.fromisoformat('2025-01-01T00:00:00'),
+                    created_at=datetime.fromisoformat('2025-01-01T00:00:00'),
+                    last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00'),
                     status=ConversationStatus.STOPPED,
                     selected_repository='foobar',
                 )
@@ -73,7 +75,8 @@ async def test_get_conversation():
         expected = ConversationInfo(
             conversation_id='some_conversation_id',
             title='Some Conversation',
-            last_updated_at=datetime.fromisoformat('2025-01-01T00:00:00'),
+            created_at=datetime.fromisoformat('2025-01-01T00:00:00'),
+            last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00'),
             status=ConversationStatus.STOPPED,
             selected_repository='foobar',
         )
@@ -105,7 +108,8 @@ async def test_update_conversation():
         expected = ConversationInfo(
             conversation_id='some_conversation_id',
             title='New Title',
-            last_updated_at=datetime.fromisoformat('2025-01-01T00:00:00'),
+            created_at=datetime.fromisoformat('2025-01-01T00:00:00'),
+            last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00'),
             status=ConversationStatus.STOPPED,
             selected_repository='foobar',
         )


### PR DESCRIPTION
**Sort Conversations by Created At**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
When sorted by Updated at, they jump around in the UI



---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3a3f2d0-nikolaik   --name openhands-app-3a3f2d0   docker.all-hands.dev/all-hands-ai/openhands:3a3f2d0
```