### PR TITLE
Feat - browser client can now close sessions.

### DIFF
--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -168,7 +168,7 @@ async def delete_conversation(
         return False
     is_running = await session_manager.is_agent_loop_running(conversation_id)
     if is_running:
-        return False
+        await session_manager.close_session(conversation_id)
     await conversation_store.delete_metadata(conversation_id)
     return True
 

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -156,6 +156,10 @@ class SessionManager:
             flag = self._has_remote_connections_flags.get(sid)
             if flag:
                 flag.set()
+        elif message_type == 'close_session':
+            sid = data['sid']
+            if sid in self._local_agent_loops_by_sid:
+                await self._on_close_session(sid)
         elif message_type == 'session_closing':
             # Session closing event - We only get this in the event of graceful shutdown,
             # which can't be guaranteed - nodes can simply vanish unexpectedly!
@@ -419,7 +423,7 @@ class SessionManager:
         if should_continue():
             asyncio.create_task(self._cleanup_session_later(sid))
         else:
-            await self._close_session(sid)
+            await self._on_close_session(sid)
 
     async def _cleanup_session_later(self, sid: str):
         # Once there have been no connections to a session for a reasonable period, we close it
@@ -451,10 +455,22 @@ class SessionManager:
                 json.dumps({'sid': sid, 'message_type': 'session_closing'}),
             )
 
-        await self._close_session(sid)
+        await self._on_close_session(sid)
         return True
 
-    async def _close_session(self, sid: str):
+    async def close_session(self, sid: str):
+        session = self._local_agent_loops_by_sid.get(sid)
+        if session:
+            await self._on_close_session(sid)
+
+        redis_client = self._get_redis_client()
+        if redis_client:
+            await redis_client.publish(
+                'oh_event',
+                json.dumps({'sid': sid, 'message_type': 'close_session'}),
+            )
+
+    async def _on_close_session(self, sid: str):
         logger.info(f'_close_session:{sid}')
 
         # Clear up local variables

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -286,7 +286,7 @@ async def test_cleanup_session_connections():
                 }
             )
 
-            await session_manager._close_session('session1')
+            await session_manager._on_close_session('session1')
 
             remaining_connections = session_manager.local_connection_id_to_session_id
             assert 'conn1' not in remaining_connections


### PR DESCRIPTION
**Client can now instruct server to delete a running session. Added framework for commanding that a session stops. **

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR fixes an issue where conversations could not be deleted while they were running. The changes include:

* Modified `delete_conversation` to properly close the session when attempting to delete a running conversation instead of returning False
* Added `close_session` method to SessionManager to handle session closing across the cluster
* Refactored session closing logic to handle both local and remote session closures
* Added handling for `close_session` message type in the session manager

## Testing

To test:
1. Start a conversation and let it run
2. Try to delete the conversation while it is running
3. Verify that the conversation is properly deleted and the session is closed
4. Verify that this works across multiple nodes in a cluster setup

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:158fee9-nikolaik   --name openhands-app-158fee9   docker.all-hands.dev/all-hands-ai/openhands:158fee9
```