### PR TITLE
fix: better handle bashlex error

### DIFF
--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -1,6 +1,7 @@
 import os
 import re
 import time
+import traceback
 import uuid
 from enum import Enum
 
@@ -23,11 +24,11 @@ def split_bash_commands(commands):
         return ['']
     try:
         parsed = bashlex.parse(commands)
-    except bashlex.errors.ParsingError as e:
+    except (bashlex.errors.ParsingError, NotImplementedError):
         logger.debug(
             f'Failed to parse bash commands\n'
             f'[input]: {commands}\n'
-            f'[warning]: {e}\n'
+            f'[warning]: {traceback.format_exc()}\n'
             f'The original command will be returned as is.'
         )
         # If parsing fails, return the original commands
@@ -143,9 +144,13 @@ def escape_bash_special_chars(command: str) -> str:
         remaining = command[last_pos:]
         parts.append(remaining)
         return ''.join(parts)
-    except bashlex.errors.ParsingError:
-        # Fallback if parsing fails
-        logger.warning(f'Failed to parse command: {command}')
+    except (bashlex.errors.ParsingError, NotImplementedError):
+        logger.debug(
+            f'Failed to parse bash commands for special characters escape\n'
+            f'[input]: {command}\n'
+            f'[warning]: {traceback.format_exc()}\n'
+            f'The original command will be returned as is.'
+        )
         return command
 
 

--- a/tests/runtime/test_bash.py
+++ b/tests/runtime/test_bash.py
@@ -153,6 +153,20 @@ def test_multiple_multiline_commands(temp_dir, runtime_cls, run_as_openhands):
         _close_test_runtime(runtime)
 
 
+def test_complex_commands(temp_dir, runtime_cls):
+    cmd = """count=0; tries=0; while [ $count -lt 3 ]; do result=$(echo "Heads"); tries=$((tries+1)); echo "Flip $tries: $result"; if [ "$result" = "Heads" ]; then count=$((count+1)); else count=0; fi; done; echo "Got 3 heads in a row after $tries flips!";"""
+
+    runtime = _load_runtime(temp_dir, runtime_cls)
+    try:
+        obs = _run_cmd_action(runtime, cmd)
+        logger.info(obs, extra={'msg_type': 'OBSERVATION'})
+        assert obs.exit_code == 0, 'The exit code should be 0.'
+        assert 'Got 3 heads in a row after 3 flips!' in obs.content
+
+    finally:
+        _close_test_runtime(runtime)
+
+
 def test_no_ps2_in_output(temp_dir, runtime_cls, run_as_openhands):
     """Test that the PS2 sign is not added to the output of a multiline command."""
     runtime = _load_runtime(temp_dir, runtime_cls, run_as_openhands)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Fix for this error due to bashlex parsing implementation:
```
500 Server Error: Internal Server Error for url: https://hfgypcmwswlqnczo.staging-runtime.all-hands.dev/execute_action Details: Traceback (most recent call last): File "/openhands/code/openhands/runtime/action_execution_server.py", line 525, in execute_action observation = await client.run_action(action) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/code/openhands/runtime/action_execution_server.py", line 182, in run_action observation = await getattr(self, action_type)(action) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/code/openhands/runtime/action_execution_server.py", line 190, in run obs = await call_sync_from_async(self.bash_session.execute, action) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/code/openhands/utils/async_utils.py", line 18, in call_sync_from_async result = await coro ^^^^^^^^^^ File "/openhands/micromamba/envs/openhands/lib/python3.12/concurrent/futures/thread.py", line 59, in run result = self.fn(*self.args, **self.kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/code/openhands/utils/async_utils.py", line 17, in <lambda> coro = loop.run_in_executor(None, lambda: fn(*args, **kwargs)) ^^^^^^^^^^^^^^^^^^^ File "/openhands/code/openhands/runtime/utils/bash.py", line 470, in execute splited_commands = split_bash_commands(command) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/code/openhands/runtime/utils/bash.py", line 25, in split_bash_commands parsed = bashlex.parse(commands) ^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/parser.py", line 610, in parse parts = [p.parse()] ^^^^^^^^^ File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/parser.py", line 691, in parse tree = theparser.parse(lexer=self.tok, context=self) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/yacc.py", line 439, in parse p.callable(pslice) File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/parser.py", line 167, in p_simple_command_element p[0] = [_expandword(parserobj, p.slice[1])] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/parser.py", line 145, in _expandword parts, expandedword = subst._expandwordinternal(parser, ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/subst.py", line 271, in _expandwordinternal node, sindex[0] = _paramexpand(parserobj, string, sindex[0]) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/subst.py", line 165, in _paramexpand return _extractcommandsubst(parserobj, string, zindex + 1) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/bashlex/subst.py", line 52, in _extractcommandsubst raise NotImplementedError('arithmetic expansion') NotImplementedError: arithmetic expansion
```


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:42e14c0-nikolaik   --name openhands-app-42e14c0   docker.all-hands.dev/all-hands-ai/openhands:42e14c0
```