### PR TITLE
fix(frontend): prevent repository name overflow in project menu card

### DIFF
--- a/frontend/src/components/features/project-menu/project-menu-details.tsx
+++ b/frontend/src/components/features/project-menu/project-menu-details.tsx
@@ -16,16 +16,16 @@ export function ProjectMenuDetails({
 }: ProjectMenuDetailsProps) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col min-w-0">
       <a
         href={`https://github.com/${repoName}`}
         target="_blank"
         rel="noreferrer noopener"
-        className="flex items-center gap-2"
+        className="flex items-center gap-2 min-w-0"
       >
-        {avatar && <img src={avatar} alt="" className="w-4 h-4 rounded-full" />}
-        <span className="text-sm leading-6 font-semibold">{repoName}</span>
-        <ExternalLinkIcon width={16} height={16} />
+        {avatar && <img src={avatar} alt="" className="w-4 h-4 rounded-full flex-shrink-0" />}
+        <span className="text-sm leading-6 font-semibold truncate flex-1">{repoName}</span>
+        <ExternalLinkIcon width={16} height={16} className="flex-shrink-0" />
       </a>
       <a
         href={lastCommit.html_url}


### PR DESCRIPTION
…#6082)

**End-user friendly description of the problem this fixes or functionality that this introduces**

Fixes an issue where long repository names would cause layout issues in the project menu card. Long repository names are now truncated with an ellipsis (...) while maintaining all functionality.

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Long repository names now truncate elegantly in the project menu card instead of causing layout issues.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Adds proper text truncation to repository names in the project menu card
- Uses flexbox with `min-w-0` to ensure proper truncation behavior within the flex container
- Maintains the clickable area and external link icon positioning
- Ensures consistent layout regardless of repository name length
- Avoids hardcoded width constraints for better maintainability and responsiveness
- Preserves all existing functionality (link to GitHub, hover states, etc.)

Design decisions:
- Used flexbox solution instead of fixed width constraints for better maintainability
- Added `min-w-0` to enable proper truncation in flex containers
- Kept external link icon and avatar (when present) at fixed size using `flex-shrink-0`

---
**Link of any specific issues this addresses**

Fixes [#4901](https://github.com/All-Hands-AI/OpenHands/issues/4901)