### PR TITLE
Add close method to EventStream

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -58,7 +58,7 @@ class SandboxConfig:
     runtime_startup_env_vars: dict[str, str] = field(default_factory=dict)
     browsergym_eval_env: str | None = None
     platform: str | None = None
-    close_delay: int = 900
+    close_delay: int = 5
     remote_runtime_resource_factor: int = 1
     enable_gpu: bool = False
 

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -58,7 +58,7 @@ class SandboxConfig:
     runtime_startup_env_vars: dict[str, str] = field(default_factory=dict)
     browsergym_eval_env: str | None = None
     platform: str | None = None
-    close_delay: int = 5
+    close_delay: int = 900
     remote_runtime_resource_factor: int = 1
     enable_gpu: bool = False
 

--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -116,17 +116,33 @@ class EventStream:
                 self._clean_up_subscriber(subscriber_id, callback_id)
 
     def _clean_up_subscriber(self, subscriber_id: str, callback_id: str):
-        loop = self._thread_loops[subscriber_id][callback_id]
-        try:
-            loop.stop()
-            loop.close()
-        except Exception as e:
-            logger.warning(f'Error closing loop for {subscriber_id}/{callback_id}: {e}')
+        if subscriber_id not in self._subscribers:
+            logger.warning(f'Subscriber not found during cleanup: {subscriber_id}')
+            return
+        if callback_id not in self._subscribers[subscriber_id]:
+            logger.warning(f'Callback not found during cleanup: {callback_id}')
+            return
+        if (
+            subscriber_id in self._thread_loops
+            and callback_id in self._thread_loops[subscriber_id]
+        ):
+            loop = self._thread_loops[subscriber_id][callback_id]
+            try:
+                loop.stop()
+                loop.close()
+            except Exception as e:
+                logger.warning(
+                    f'Error closing loop for {subscriber_id}/{callback_id}: {e}'
+                )
+            del self._thread_loops[subscriber_id][callback_id]
 
-        del self._thread_loops[subscriber_id][callback_id]
-        pool = self._thread_pools[subscriber_id][callback_id]
-        pool.shutdown()
-        del self._thread_pools[subscriber_id][callback_id]
+        if (
+            subscriber_id in self._thread_pools
+            and callback_id in self._thread_pools[subscriber_id]
+        ):
+            pool = self._thread_pools[subscriber_id][callback_id]
+            pool.shutdown()
+            del self._thread_pools[subscriber_id][callback_id]
 
         del self._subscribers[subscriber_id][callback_id]
 

--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -111,8 +111,10 @@ class EventStream:
         if self._queue_thread.is_alive():
             self._queue_thread.join()
 
-        for subscriber_id in self._subscribers:
-            for callback_id in self._subscribers[subscriber_id]:
+        subscriber_ids = list(self._subscribers.keys())
+        for subscriber_id in subscriber_ids:
+            callback_ids = list(self._subscribers[subscriber_id].keys())
+            for callback_id in callback_ids:
                 self._clean_up_subscriber(subscriber_id, callback_id)
 
     def _clean_up_subscriber(self, subscriber_id: str, callback_id: str):

--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -67,7 +67,6 @@ class EventStream:
 
     def __init__(self, sid: str, file_store: FileStore):
         self.sid = sid
-        print('INIT ES', sid)
         self.file_store = file_store
         self._stop_flag = threading.Event()
         self._queue: queue.Queue[Event] = queue.Queue()
@@ -102,15 +101,12 @@ class EventStream:
         asyncio.set_event_loop(loop)
 
     def close(self):
-        print('CLOSE ES', self.sid)
         self._stop_flag.set()
         if self._queue_thread.is_alive():
             self._queue_thread.join()
-        print('JOINED')
         for pool in self._thread_pools.values():
             for p in pool.values():
                 p.shutdown()
-        print('DONE CLOSING ES', self.sid)
 
     def _get_filename_for_id(self, id: int) -> str:
         return get_conversation_event_filename(self.sid, id)

--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -74,7 +74,7 @@ class EventStream:
         self._queue_loop = None
         self._queue_thread = threading.Thread(target=self._run_queue_loop)
         self._queue_thread.daemon = True
-        # self._queue_thread.start()
+        self._queue_thread.start()
         self._subscribers = {}
         self._lock = threading.Lock()
         self._cur_id = 0

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -131,6 +131,8 @@ class AgentSession:
                     f'Waited too long for initialization to finish before closing session {self.sid}'
                 )
                 break
+        if self.event_stream is not None:
+            self.event_stream.close()
         if self.controller is not None:
             end_state = self.controller.get_state()
             end_state.save_to_session(self.sid, self.file_store)

--- a/openhands/server/session/conversation.py
+++ b/openhands/server/session/conversation.py
@@ -43,4 +43,6 @@ class Conversation:
         await self.runtime.connect()
 
     async def disconnect(self):
+        if self.event_stream:
+            self.event_stream.close()
         asyncio.create_task(call_sync_from_async(self.runtime.close))

--- a/openhands/server/session/manager.py
+++ b/openhands/server/session/manager.py
@@ -197,6 +197,7 @@ class SessionManager:
                 await c.connect()
             except AgentRuntimeUnavailableError as e:
                 logger.error(f'Error connecting to conversation {c.sid}: {e}')
+                await c.disconnect()
                 return None
             end_time = time.time()
             logger.info(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Most of this is due to my changes in https://github.com/All-Hands-AI/OpenHands/pull/5868

We were leaving threads hanging around, and more importantly, asyncio loops. Currently each session leaks ~22 file descriptors, this squashes ~~15~~ ALL of them.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:99e6b9a-nikolaik   --name openhands-app-99e6b9a   docker.all-hands.dev/all-hands-ai/openhands:99e6b9a
```