### PR TITLE
Fix for delete conversation

### DIFF
--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from pydantic import TypeAdapter
 
@@ -39,7 +40,9 @@ class FileConversationStore(ConversationStore):
         return result
 
     async def delete_metadata(self, conversation_id: str) -> None:
-        path = self.get_conversation_metadata_filename(conversation_id)
+        path = str(
+            Path(self.get_conversation_metadata_filename(conversation_id)).parent
+        )
         await call_sync_from_async(self.file_store.delete, path)
 
     async def exists(self, conversation_id: str) -> bool:

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from openhands.server.routes.manage_conversations import (
+    delete_conversation,
     get_conversation,
     search_conversations,
     update_conversation,
@@ -114,3 +115,16 @@ async def test_update_conversation():
             selected_repository='foobar',
         )
         assert conversation == expected
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation():
+    with _patch_store():
+        await delete_conversation(
+            'some_conversation_id',
+            MagicMock(state=MagicMock(github_token='')),
+        )
+        conversation = await get_conversation(
+            'some_conversation_id', MagicMock(state=MagicMock(github_token=''))
+        )
+        assert conversation is None


### PR DESCRIPTION
**Fix: for delete conversation (Which was not working)**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Deleting the directory rather than just the metadata.json**

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:12e86c3-nikolaik   --name openhands-app-12e86c3   docker.all-hands.dev/all-hands-ai/openhands:12e86c3
```