### PR TITLE
Fix broken anchor links in documentation

### DIFF
--- a/docs/modules/python/openhands/core/config/sandbox_config.md
+++ b/docs/modules/python/openhands/core/config/sandbox_config.md
@@ -1,0 +1,126 @@
+# Sandbox Configuration
+
+The `SandboxConfig` class defines the configuration options for the OpenHands sandbox environment.
+
+## Configuration Options
+
+### Remote Runtime Settings
+
+- `remote_runtime_api_url` (str)
+  - Default: `'http://localhost:8000'`
+  - The hostname for the Remote Runtime API
+
+- `local_runtime_url` (str)
+  - Default: `'http://localhost'`
+  - The default hostname for the local runtime
+  - You may want to change to `http://host.docker.internal` for DIND environments
+
+- `keep_runtime_alive` (bool)
+  - Default: `True`
+  - Whether to keep the runtime alive after execution
+
+- `rm_all_containers` (bool)
+  - Default: `False`
+  - Whether to remove all containers after execution
+
+### Container Settings
+
+- `base_container_image` (str)
+  - Default: `'nikolaik/python-nodejs:python3.12-nodejs22'`
+  - The base container image from which to build the runtime image
+
+- `runtime_container_image` (str | None)
+  - Default: `None`
+  - The runtime container image to use
+
+- `user_id` (int)
+  - Default: System's UID or 1000
+  - The user ID for the sandbox
+
+### Execution Settings
+
+- `timeout` (int)
+  - Default: `120`
+  - The timeout for the default sandbox action execution (in seconds)
+
+- `remote_runtime_init_timeout` (int)
+  - Default: `180`
+  - The timeout for the remote runtime to start (in seconds)
+
+- `close_delay` (int)
+  - Default: `900`
+  - Delay before closing the runtime (in seconds)
+
+### Runtime Configuration
+
+- `enable_auto_lint` (bool)
+  - Default: `False`
+  - Whether to enable auto-lint after editing files
+
+- `use_host_network` (bool)
+  - Default: `False`
+  - Whether to use the host network
+
+- `initialize_plugins` (bool)
+  - Default: `True`
+  - Whether to initialize plugins
+
+- `force_rebuild_runtime` (bool)
+  - Default: `False`
+  - Whether to force rebuild the runtime image
+
+### Dependencies and Environment
+
+- `runtime_extra_deps` (str | None)
+  - Default: `None`
+  - Extra dependencies to install in the runtime image (typically used for evaluation)
+  - Will be rendered into the end of the Dockerfile that builds the runtime image
+  - Can contain any valid shell commands (e.g., `pip install numpy`)
+  - The path to the interpreter is available as `$OH_INTERPRETER_PATH`
+
+- `runtime_startup_env_vars` (dict[str, str])
+  - Default: `{}`
+  - Environment variables to set at runtime launch
+  - Useful for setting environment variables needed by the runtime
+  - Example: specifying base URL for browsergym evaluation
+
+### Resource Management
+
+- `remote_runtime_resource_factor` (int)
+  - Default: `1`
+  - Factor to scale resource allocation for remote runtime
+  - Must be one of [1, 2, 4, 8]
+  - Only used if the runtime is remote
+
+- `enable_gpu` (bool)
+  - Default: `False`
+  - Whether to enable GPU support
+
+### Docker Runtime Configuration
+
+- `docker_runtime_kwargs` (str | None)
+  - Default: `None`
+  - Additional keyword arguments to pass to the Docker runtime
+  - Should be a JSON string that will be parsed into a dictionary
+  - Example in config.toml:
+    ```toml
+    docker_runtime_kwargs = '{"mem_limit": "4g", "cpu_quota": 100000}'
+    ```
+
+### Evaluation
+
+- `browsergym_eval_env` (str | None)
+  - Default: `None`
+  - The BrowserGym environment to use for evaluation
+  - Default is None for general purpose browsing
+  - Check evaluation/miniwob and evaluation/webarena for examples
+
+### Build Configuration
+
+- `platform` (str | None)
+  - Default: `None`
+  - The platform on which the image should be built
+
+- `runtime_extra_build_args` (list[str] | None)
+  - Default: `None`
+  - Additional build arguments for the runtime

--- a/docs/modules/usage/configuration-options.md
+++ b/docs/modules/usage/configuration-options.md
@@ -15,7 +15,6 @@ take precedence.
    - [API Keys](#api-keys)
    - [Workspace](#workspace)
    - [Debugging and Logging](#debugging-and-logging)
-   - [Session Management](#session-management)
    - [Trajectories](#trajectories)
    - [File Store](#file-store)
    - [Task Management](#task-management)
@@ -33,7 +32,7 @@ take precedence.
 - [Agent Configuration](#agent-configuration)
    - [Microagent Configuration](#microagent-configuration)
    - [Memory Configuration](#memory-configuration)
-   - [LLM Configuration](#llm-configuration-2)
+   - [LLM Configuration](#llm-configuration)
    - [ActionSpace Configuration](#actionspace-configuration)
    - [Microagent Usage](#microagent-usage)
 - [Sandbox Configuration](#sandbox-configuration)
@@ -53,7 +52,7 @@ take precedence.
 
 The core configuration options are defined in the `[core]` section of the `config.toml` file.
 
-**API Keys**
+### API Keys {#api-keys}
 - `e2b_api_key`
   - Type: `str`
   - Default: `""`
@@ -69,7 +68,7 @@ The core configuration options are defined in the `[core]` section of the `confi
   - Default: `""`
   - Description: API token secret for Modal
 
-**Workspace**
+### Workspace {#workspace}
 - `workspace_base`
   - Type: `str`
   - Default: `"./workspace"`
@@ -80,7 +79,7 @@ The core configuration options are defined in the `[core]` section of the `confi
   - Default: `"/tmp/cache"`
   - Description: Cache directory path
 
-**Debugging and Logging**
+### Debugging and Logging {#debugging-and-logging}
 - `debug`
   - Type: `bool`
   - Default: `false`
@@ -91,13 +90,13 @@ The core configuration options are defined in the `[core]` section of the `confi
   - Default: `false`
   - Description: Disable color in terminal output
 
-**Trajectories**
+### Trajectories {#trajectories}
 - `trajectories_path`
   - Type: `str`
   - Default: `"./trajectories"`
   - Description: Path to store trajectories (can be a folder or a file). If it's a folder, the trajectories will be saved in a file named with the session id name and .json extension, in that folder.
 
-**File Store**
+### File Store {#file-store}
 - `file_store_path`
   - Type: `str`
   - Default: `"/tmp/file_store"`
@@ -128,7 +127,7 @@ The core configuration options are defined in the `[core]` section of the `confi
   - Default: `[".*"]`
   - Description: List of allowed file extensions for uploads
 
-**Task Management**
+### Task Management {#task-management}
 - `max_budget_per_task`
   - Type: `float`
   - Default: `0.0`
@@ -139,7 +138,7 @@ The core configuration options are defined in the `[core]` section of the `confi
   - Default: `100`
   - Description: Maximum number of iterations
 
-**Sandbox Configuration**
+### Sandbox Configuration {#sandbox-configuration}
 - `workspace_mount_path_in_sandbox`
   - Type: `str`
   - Default: `"/workspace"`
@@ -155,7 +154,7 @@ The core configuration options are defined in the `[core]` section of the `confi
   - Default: `""`
   - Description: Path to rewrite the workspace mount path to. You can usually ignore this, it refers to special cases of running inside another container.
 
-**Miscellaneous**
+### Miscellaneous {#miscellaneous}
 - `run_as_openhands`
   - Type: `bool`
   - Default: `true`
@@ -182,7 +181,7 @@ The LLM (Large Language Model) configuration options are defined in the `[llm]` 
 
 To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LLM_NUM_RETRIES`.
 
-**AWS Credentials**
+### AWS Credentials {#aws-credentials}
 - `aws_access_key_id`
   - Type: `str`
   - Default: `""`
@@ -198,7 +197,7 @@ To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LL
   - Default: `""`
   - Description: AWS secret access key
 
-**API Configuration**
+### API Configuration {#api-configuration}
 - `api_key`
   - Type: `str`
   - Default: `None`
@@ -224,13 +223,13 @@ To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LL
   - Default: `0.0`
   - Description: Cost per output token
 
-**Custom LLM Provider**
+### Custom LLM Provider {#custom-llm-provider}
 - `custom_llm_provider`
   - Type: `str`
   - Default: `""`
   - Description: Custom LLM provider
 
-**Embeddings**
+### Embeddings {#embeddings}
 - `embedding_base_url`
   - Type: `str`
   - Default: `""`
@@ -246,7 +245,7 @@ To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LL
   - Default: `"local"`
   - Description: Embedding model to use
 
-**Message Handling**
+### Message Handling {#message-handling}
 - `max_message_chars`
   - Type: `int`
   - Default: `30000`
@@ -262,13 +261,13 @@ To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LL
   - Default: `0`
   - Description: Maximum number of output tokens
 
-**Model Selection**
+### Model Selection {#model-selection}
 - `model`
   - Type: `str`
   - Default: `"claude-3-5-sonnet-20241022"`
   - Description: Model to use
 
-**Retrying**
+### Retrying {#retrying}
 - `num_retries`
   - Type: `int`
   - Default: `8`
@@ -289,7 +288,7 @@ To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LL
   - Default: `2.0`
   - Description: Multiplier for exponential backoff calculation
 
-**Advanced Options**
+### Advanced Options {#advanced-options}
 - `drop_params`
   - Type: `bool`
   - Default: `false`
@@ -329,13 +328,13 @@ To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LL
 
 The agent configuration options are defined in the `[agent]` and `[agent.<agent_name>]` sections of the `config.toml` file.
 
-**Microagent Configuration**
+### Microagent Configuration {#microagent-configuration}
 - `micro_agent_name`
   - Type: `str`
   - Default: `""`
   - Description: Name of the micro agent to use for this agent
 
-**Memory Configuration**
+### Memory Configuration {#memory-configuration}
 - `memory_enabled`
   - Type: `bool`
   - Default: `false`
@@ -346,13 +345,13 @@ The agent configuration options are defined in the `[agent]` and `[agent.<agent_
   - Default: `3`
   - Description: The maximum number of threads indexing at the same time for embeddings
 
-**LLM Configuration**
+### LLM Configuration {#llm-configuration}
 - `llm_config`
   - Type: `str`
   - Default: `'your-llm-config-group'`
   - Description: The name of the LLM config to use
 
-**ActionSpace Configuration**
+### ActionSpace Configuration {#actionspace-configuration}
 - `function_calling`
   - Type: `bool`
   - Default: `true`
@@ -373,7 +372,7 @@ The agent configuration options are defined in the `[agent]` and `[agent.<agent_
   - Default: `false`
   - Description: Whether Jupyter is enabled in the action space
 
-**Microagent Usage**
+### Microagent Usage {#microagent-usage}
 - `use_microagents`
   - Type: `bool`
   - Default: `true`
@@ -390,7 +389,7 @@ The sandbox configuration options are defined in the `[sandbox]` section of the 
 
 To use these with the docker command, pass in `-e SANDBOX_<option>`. Example: `-e SANDBOX_TIMEOUT`.
 
-**Execution**
+### Execution {#execution}
 - `timeout`
   - Type: `int`
   - Default: `120`
@@ -401,19 +400,19 @@ To use these with the docker command, pass in `-e SANDBOX_<option>`. Example: `-
   - Default: `1000`
   - Description: Sandbox user ID
 
-**Container Image**
+### Container Image {#container-image}
 - `base_container_image`
   - Type: `str`
   - Default: `"nikolaik/python-nodejs:python3.12-nodejs22"`
   - Description: Container image to use for the sandbox
 
-**Networking**
+### Networking {#networking}
 - `use_host_network`
   - Type: `bool`
   - Default: `false`
   - Description: Use host network
 
-**Linting and Plugins**
+### Linting and Plugins {#linting-and-plugins}
 - `enable_auto_lint`
   - Type: `bool`
   - Default: `false`
@@ -424,7 +423,7 @@ To use these with the docker command, pass in `-e SANDBOX_<option>`. Example: `-
   - Default: `true`
   - Description: Whether to initialize plugins
 
-**Dependencies and Environment**
+### Dependencies and Environment {#dependencies-and-environment}
 - `runtime_extra_deps`
   - Type: `str`
   - Default: `""`
@@ -435,7 +434,7 @@ To use these with the docker command, pass in `-e SANDBOX_<option>`. Example: `-
   - Default: `{}`
   - Description: Environment variables to set at the launch of the runtime
 
-**Evaluation**
+### Evaluation {#evaluation}
 - `browsergym_eval_env`
   - Type: `str`
   - Default: `""`
@@ -447,13 +446,13 @@ The security configuration options are defined in the `[security]` section of th
 
 To use these with the docker command, pass in `-e SECURITY_<option>`. Example: `-e SECURITY_CONFIRMATION_MODE`.
 
-**Confirmation Mode**
+### Confirmation Mode {#confirmation-mode}
 - `confirmation_mode`
   - Type: `bool`
   - Default: `false`
   - Description: Enable confirmation mode
 
-**Security Analyzer**
+### Security Analyzer {#security-analyzer}
 - `security_analyzer`
   - Type: `str`
   - Default: `""`


### PR DESCRIPTION
This PR fixes broken anchor links in the configuration-options.md documentation file by adding proper heading IDs to all sections. This resolves the build warnings for the English version of the documentation.

Remaining warnings are for French and Chinese translations which would need to be updated separately.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:def7b90-nikolaik   --name openhands-app-def7b90   docker.all-hands.dev/all-hands-ai/openhands:def7b90
```