### PR TITLE
fix: handle binary data in GoogleCloudFileStore.write

### DIFF
--- a/openhands/storage/google_cloud.py
+++ b/openhands/storage/google_cloud.py
@@ -21,7 +21,8 @@ class GoogleCloudFileStore(FileStore):
 
     def write(self, path: str, contents: str | bytes) -> None:
         blob = self.bucket.blob(path)
-        with blob.open('w') as f:
+        mode = 'wb' if isinstance(contents, bytes) else 'w'
+        with blob.open(mode) as f:
             f.write(contents)
 
     def read(self, path: str) -> str:


### PR DESCRIPTION
The `write` operation in `GoogleCloudFileStore` accepts bytes or string input, but currently fails when given bytes. This PR fixes the issue by using the appropriate mode (`wb` for bytes, `w` for strings) when opening the blob for writing.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ccddd6c-nikolaik   --name openhands-app-ccddd6c   docker.all-hands.dev/all-hands-ai/openhands:ccddd6c
```