### PR TITLE
Fix field deprecation in runloop runtime client

### DIFF
--- a/openhands/runtime/impl/runloop/runloop_runtime.py
+++ b/openhands/runtime/impl/runloop/runloop_runtime.py
@@ -115,13 +115,15 @@ class RunloopRuntime(ActionExecutionClient):
 
         devbox = self.runloop_api_client.devboxes.create(
             entrypoint=entrypoint,
-            setup_commands=[f'mkdir -p {self.config.workspace_mount_path_in_sandbox}'],
             name=self.sid,
             environment_variables={'DEBUG': 'true'} if self.config.debug else {},
             prebuilt='openhands',
             launch_parameters=LaunchParameters(
                 available_ports=[self._sandbox_port, self._vscode_port],
                 resource_size_request='LARGE',
+                launch_commands=[
+                    f'mkdir -p {self.config.workspace_mount_path_in_sandbox}'
+                ],
             ),
             metadata={'container-name': self.container_name},
         )


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
Fix field deprecation in runloop runtime client preventing Runloop client from initializing correctly

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Fix field deprecation in runloop runtime client preventing Runloop client from initializing correctly

`setup_commands` was deprecated in favor of the LaunchParameter `launch_command`

---
**Link of any specific issues this addresses**
