### PR TITLE
Move GitHub Token export to backend

### DIFF
--- a/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
@@ -1,23 +1,16 @@
 import React from "react";
 import toast from "react-hot-toast";
 import { useDispatch, useSelector } from "react-redux";
-import { useAuth } from "#/context/auth-context";
-import { useWsClient } from "#/context/ws-client-provider";
 import { setImportedProjectZip } from "#/state/initial-query-slice";
 import { RootState } from "#/store";
 import { base64ToBlob } from "#/utils/base64-to-blob";
 import { useUploadFiles } from "../../../hooks/mutation/use-upload-files";
-import { useGitHubUser } from "../../../hooks/query/use-github-user";
 
 import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
 
 export const useHandleRuntimeActive = () => {
-  useAuth();
-  useWsClient();
-
   const dispatch = useDispatch();
 
-  useGitHubUser();
   const { mutate: uploadFiles } = useUploadFiles();
   const { curAgentState } = useSelector((state: RootState) => state.agent);
 

--- a/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
@@ -8,16 +8,16 @@ import { RootState } from "#/store";
 import { base64ToBlob } from "#/utils/base64-to-blob";
 import { useUploadFiles } from "../../../hooks/mutation/use-upload-files";
 import { useGitHubUser } from "../../../hooks/query/use-github-user";
-import { isGitHubErrorReponse } from "#/api/github-axios-instance";
+
 import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
 
 export const useHandleRuntimeActive = () => {
-  const { gitHubToken } = useAuth();
-  const { send } = useWsClient();
+  useAuth();
+  useWsClient();
 
   const dispatch = useDispatch();
 
-  const { data: user } = useGitHubUser();
+  useGitHubUser();
   const { mutate: uploadFiles } = useUploadFiles();
   const { curAgentState } = useSelector((state: RootState) => state.agent);
 
@@ -26,11 +26,6 @@ export const useHandleRuntimeActive = () => {
   const { importedProjectZip } = useSelector(
     (state: RootState) => state.initialQuery,
   );
-
-  const userId = React.useMemo(() => {
-    if (user && !isGitHubErrorReponse(user)) return user.id;
-    return null;
-  }, [user]);
 
   const handleUploadFiles = (zip: string) => {
     const blob = base64ToBlob(zip);

--- a/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
@@ -3,7 +3,6 @@ import toast from "react-hot-toast";
 import { useDispatch, useSelector } from "react-redux";
 import { useAuth } from "#/context/auth-context";
 import { useWsClient } from "#/context/ws-client-provider";
-import { getGitHubTokenCommand } from "#/services/terminal-service";
 import { setImportedProjectZip } from "#/state/initial-query-slice";
 import { RootState } from "#/store";
 import { base64ToBlob } from "#/utils/base64-to-blob";
@@ -48,13 +47,6 @@ export const useHandleRuntimeActive = () => {
     );
     dispatch(setImportedProjectZip(null));
   };
-
-  React.useEffect(() => {
-    if (runtimeActive && userId && gitHubToken) {
-      // Export if the user valid, this could happen mid-session so it is handled here
-      send(getGitHubTokenCommand(gitHubToken));
-    }
-  }, [userId, gitHubToken, runtimeActive]);
 
   React.useEffect(() => {
     if (runtimeActive && importedProjectZip) {

--- a/frontend/src/services/terminal-service.ts
+++ b/frontend/src/services/terminal-service.ts
@@ -4,9 +4,3 @@ export function getTerminalCommand(command: string, hidden: boolean = false) {
   const event = { action: ActionType.RUN, args: { command, hidden } };
   return event;
 }
-
-export function getGitHubTokenCommand(gitHubToken: string) {
-  const command = `export GITHUB_TOKEN=${gitHubToken}`;
-  const event = getTerminalCommand(command, true);
-  return event;
-}

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -210,6 +210,13 @@ class Runtime(FileEditRuntimeMixin):
         source = event.source if event.source else EventSource.AGENT
         self.event_stream.add_event(observation, source)  # type: ignore[arg-type]
 
+    def set_github_token(self, github_token: str):
+        if not github_token:
+            raise ValueError('github_token must be provided to set a github token')
+        action = CmdRunAction(command=f'export GITHUB_TOKEN={github_token}')
+        self.log('info', 'Setting github token')
+        self.run_action(action)
+
     def clone_repo(self, github_token: str, selected_repository: str):
         if not github_token or not selected_repository:
             raise ValueError(

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -213,7 +213,9 @@ class Runtime(FileEditRuntimeMixin):
     def set_github_token(self, github_token: str):
         if not github_token:
             raise ValueError('github_token must be provided to set a github token')
-        action = CmdRunAction(command=f'export GITHUB_TOKEN={github_token}')
+        action = CmdRunAction(
+            command=f'export GITHUB_TOKEN={github_token}', hidden=True
+        )
         self.log('info', 'Setting github token')
         self.run_action(action)
 

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -210,15 +210,6 @@ class Runtime(FileEditRuntimeMixin):
         source = event.source if event.source else EventSource.AGENT
         self.event_stream.add_event(observation, source)  # type: ignore[arg-type]
 
-    def set_github_token(self, github_token: str):
-        if not github_token:
-            raise ValueError('github_token must be provided to set a github token')
-        action = CmdRunAction(
-            command=f'export GITHUB_TOKEN={github_token}', hidden=True
-        )
-        self.log('info', 'Setting github token')
-        self.run_action(action)
-
     def clone_repo(self, github_token: str, selected_repository: str):
         if not github_token or not selected_repository:
             raise ValueError(

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -249,6 +249,8 @@ class RemoteRuntime(ActionExecutionClient):
             timeout=60,
         ):
             pass
+        self._wait_until_alive()
+        self.setup_initial_env()
         self.log('debug', 'Runtime resumed.')
 
     def _parse_runtime_response(self, response: requests.Response):
@@ -388,7 +390,6 @@ class RemoteRuntime(ActionExecutionClient):
             elif e.response.status_code == 503:
                 self.log('warning', 'Runtime appears to be paused. Resuming...')
                 self._resume_runtime()
-                self._wait_until_alive()
                 return super()._send_action_server_request(method, url, **kwargs)
             else:
                 raise e

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -180,6 +180,13 @@ class AgentSession:
 
         logger.debug(f'Initializing runtime `{runtime_name}` now...')
         runtime_cls = get_runtime_cls(runtime_name)
+        env_vars = (
+            {
+                'GITHUB_TOKEN': github_token,
+            }
+            if github_token
+            else None
+        )
         self.runtime = runtime_cls(
             config=config,
             event_stream=self.event_stream,
@@ -187,6 +194,7 @@ class AgentSession:
             plugins=agent.sandbox_plugins,
             status_callback=self._status_callback,
             headless_mode=False,
+            env_vars=env_vars,
         )
 
         # FIXME: this sleep is a terrible hack.
@@ -204,13 +212,10 @@ class AgentSession:
                 )
             return
 
-        if github_token:
-            await call_sync_from_async(self.runtime.set_github_token, github_token)
-
-            if selected_repository:
-                await call_sync_from_async(
-                    self.runtime.clone_repo, github_token, selected_repository
-                )
+        if selected_repository:
+            await call_sync_from_async(
+                self.runtime.clone_repo, github_token, selected_repository
+            )
         if agent.prompt_manager:
             microagents: list[BaseMicroAgent] = await call_sync_from_async(
                 self.runtime.get_microagents_from_selected_repo, selected_repository

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -204,10 +204,13 @@ class AgentSession:
                 )
             return
 
-        if selected_repository:
-            await call_sync_from_async(
-                self.runtime.clone_repo, github_token, selected_repository
-            )
+        if github_token:
+            await call_sync_from_async(self.runtime.set_github_token, github_token)
+
+            if selected_repository:
+                await call_sync_from_async(
+                    self.runtime.clone_repo, github_token, selected_repository
+                )
         if agent.prompt_manager:
             microagents: list[BaseMicroAgent] = await call_sync_from_async(
                 self.runtime.get_microagents_from_selected_repo, selected_repository


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The frontend is currently responsible for setting the GitHub token, which is kind of silly (and also how I originally asked for it to be implemented 🙃). This moves the logic to the backend

---
**Link of any specific issues this addresses**

testing

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a6e95a2-nikolaik   --name openhands-app-a6e95a2   docker.all-hands.dev/all-hands-ai/openhands:a6e95a2
```