### PR TITLE
Provide a clearer error message when settings are missing midsession

### DIFF
--- a/frontend/__tests__/context/ws-client-provider.test.tsx
+++ b/frontend/__tests__/context/ws-client-provider.test.tsx
@@ -27,4 +27,17 @@ describe("Propagate error message", () => {
       type: 'error'
      });
   });
+
+  it("should display error including translation id when present", () => {
+    const message = "We have a problem!"
+    const addErrorMessageSpy = vi.spyOn(ChatSlice, "addErrorMessage")
+    updateStatusWhenErrorMessagePresent({message, data: {msg_id: '..id..'}})
+
+    expect(addErrorMessageSpy).toHaveBeenCalledWith({
+      message,
+      id: '..id..',
+      status_update: true,
+      type: 'error'
+     });
+  });
 });

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -67,16 +67,36 @@ interface WsClientProviderProps {
   conversationId: string;
 }
 
-export function updateStatusWhenErrorMessagePresent(data: unknown) {
+interface ErrorArg {
+  message?: string;
+  data?: ErrorArgData | unknown;
+}
+
+interface ErrorArgData {
+  msg_id: string;
+}
+
+export function updateStatusWhenErrorMessagePresent(data: ErrorArg | unknown) {
   if (
     data &&
     typeof data === "object" &&
     "message" in data &&
     typeof data.message === "string"
   ) {
+    let msgId: string | undefined;
+    if (
+      "data" in data &&
+      data.data &&
+      typeof data.data === "object" &&
+      "msg_id" in data.data &&
+      typeof data.data.msg_id === "string"
+    ) {
+      msgId = data.data.msg_id;
+    }
     handleStatusMessage({
       type: "error",
       message: data.message,
+      id: msgId,
       status_update: true,
     });
   }

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -77,19 +77,16 @@ interface ErrorArgData {
 }
 
 export function updateStatusWhenErrorMessagePresent(data: ErrorArg | unknown) {
-  if (
-    data &&
-    typeof data === "object" &&
-    "message" in data &&
-    typeof data.message === "string"
-  ) {
+  const isObject = (val: unknown): val is object =>
+    !!val && typeof val === "object";
+  const isString = (val: unknown): val is string => typeof val === "string";
+  if (isObject(data) && "message" in data && isString(data.message)) {
     let msgId: string | undefined;
     if (
       "data" in data &&
-      data.data &&
-      typeof data.data === "object" &&
+      isObject(data.data) &&
       "msg_id" in data.data &&
-      typeof data.data.msg_id === "string"
+      isString(data.data.msg_id)
     ) {
       msgId = data.data.msg_id;
     }

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -454,6 +454,10 @@
     "fr": "Nous avons modifié certains paramètres dans la dernière mise à jour. Prenez un moment pour les examiner.",
     "tr": "Son güncellemede bazı ayarları değiştirdik. Gözden geçirmek için bir dakikanızı ayırın."
   },
+  "CONFIGURATION$SETTINGS_NOT_FOUND": {
+    "en": "Settings not found. Please check your API key",
+    "es": "Configuraciones no encontradas. Por favor revisa tu API key"
+  },
   "CONFIGURATION$AGENT_LOADING": {
     "en": "Please wait while the agent loads. This may take a few minutes...",
     "de": "Bitte warten Sie, während der Agent lädt. Das kann ein paar Minuten dauern...",

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -57,7 +57,9 @@ async def connect(connection_id: str, environ, auth):
     settings = await settings_store.load()
 
     if not settings:
-        raise ConnectionRefusedError('Settings not found')
+        raise ConnectionRefusedError(
+            'Settings not found', {'msg_id': 'CONFIGURATION$SETTINGS_NOT_FOUND'}
+        )
 
     try:
         event_stream = await session_manager.join_conversation(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The changes in #6101 made `ConnectionRefusedError` thrown in `listen_socket.py` display to the client. One of those scenarios is "Settings not found". This change gives those an optional "msg_id" for the translation and adds a user facing message that makes it more clear what action to take.

Another place this could be addressed is in `frontend/src/hooks/query/use-settings.ts`, but I'm not sure how to approach that and making these Websocket errors more first-class seemed like a good direction.


---
**Link of any specific issues this addresses**
ALL-959
