### PR TITLE
remove timeouts on remote runtime

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -156,7 +156,6 @@ class RemoteRuntime(ActionExecutionClient):
         with self._send_runtime_api_request(
             'GET',
             f'{self.config.sandbox.remote_runtime_api_url}/registry_prefix',
-            timeout=60,
         ) as response:
             response_json = response.json()
         registry_prefix = response_json['registry_prefix']

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -127,7 +127,6 @@ class RemoteRuntime(ActionExecutionClient):
             with self._send_runtime_api_request(
                 'GET',
                 f'{self.config.sandbox.remote_runtime_api_url}/sessions/{self.sid}',
-                timeout=60,
             ) as response:
                 data = response.json()
                 status = data.get('status')

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -187,7 +187,6 @@ class RemoteRuntime(ActionExecutionClient):
             'GET',
             f'{self.config.sandbox.remote_runtime_api_url}/image_exists',
             params={'image': self.container_image},
-            timeout=60,
         ) as response:
             if not response.json()['exists']:
                 raise AgentRuntimeError(
@@ -230,7 +229,6 @@ class RemoteRuntime(ActionExecutionClient):
                 'POST',
                 f'{self.config.sandbox.remote_runtime_api_url}/start',
                 json=start_request,
-                timeout=60,
             ) as response:
                 self._parse_runtime_response(response)
             self.log(
@@ -246,7 +244,6 @@ class RemoteRuntime(ActionExecutionClient):
             'POST',
             f'{self.config.sandbox.remote_runtime_api_url}/resume',
             json={'runtime_id': self.runtime_id},
-            timeout=60,
         ):
             pass
         self._wait_until_alive()
@@ -301,7 +298,6 @@ class RemoteRuntime(ActionExecutionClient):
         with self._send_runtime_api_request(
             'GET',
             f'{self.config.sandbox.remote_runtime_api_url}/sessions/{self.sid}',
-            timeout=60,
         ) as runtime_info_response:
             runtime_data = runtime_info_response.json()
         assert 'runtime_id' in runtime_data
@@ -353,7 +349,7 @@ class RemoteRuntime(ActionExecutionClient):
         )
         raise AgentRuntimeNotReadyError()
 
-    def close(self, timeout: int = 10):
+    def close(self):
         if self.config.sandbox.keep_runtime_alive or self.attach_to_existing:
             super().close()
             return
@@ -362,7 +358,6 @@ class RemoteRuntime(ActionExecutionClient):
                 'POST',
                 f'{self.config.sandbox.remote_runtime_api_url}/stop',
                 json={'runtime_id': self.runtime_id},
-                timeout=timeout,
             ):
                 self.log('debug', 'Runtime stopped.')
         except Exception as e:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This timeout should be very unnecessary, and was making it hard for me to debug a separate issue

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7d2e1a0-nikolaik   --name openhands-app-7d2e1a0   docker.all-hands.dev/all-hands-ai/openhands:7d2e1a0
```