### PR TITLE
hotfix(frontend): Get bottom right conversation card details even when multi convo is disabled

### DIFF
--- a/frontend/src/hooks/query/use-user-conversation.ts
+++ b/frontend/src/hooks/query/use-user-conversation.ts
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import OpenHands from "#/api/open-hands";
-import { MULTI_CONVERSATION_UI } from "#/utils/feature-flags";
 
 export const useUserConversation = (cid: string | null) =>
   useQuery({
     queryKey: ["user", "conversation", cid],
     queryFn: () => OpenHands.getConversation(cid!),
-    enabled: MULTI_CONVERSATION_UI && !!cid,
+    enabled: !!cid,
     retry: false,
   });


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
![image](https://github.com/user-attachments/assets/d27f2a08-6032-465e-96c2-f607dbc52c1a)



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:daf1e7f-nikolaik   --name openhands-app-daf1e7f   docker.all-hands.dev/all-hands-ai/openhands:daf1e7f
```