### PR TITLE
refactor: consolidate runtime startup command into an util function

### DIFF
--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -21,6 +21,7 @@ from openhands.runtime.impl.action_execution.action_execution_client import (
 from openhands.runtime.impl.docker.containers import remove_all_containers
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.utils import find_available_tcp_port
+from openhands.runtime.utils.command import get_action_execution_server_startup_command
 from openhands.runtime.utils.log_streamer import LogStreamer
 from openhands.runtime.utils.runtime_build import build_runtime_image
 from openhands.utils.async_utils import call_sync_from_async
@@ -186,11 +187,7 @@ class DockerRuntime(ActionExecutionClient):
     def _init_container(self):
         self.log('debug', 'Preparing to start container...')
         self.send_status_message('STATUS$PREPARING_CONTAINER')
-        plugin_arg = ''
-        if self.plugins is not None and len(self.plugins) > 0:
-            plugin_arg = (
-                f'--plugins {" ".join([plugin.name for plugin in self.plugins])} '
-            )
+
         self._host_port = self._find_available_port(EXECUTION_SERVER_PORT_RANGE)
         self._container_port = self._host_port
         self._vscode_port = self._find_available_port(VSCODE_PORT_RANGE)
@@ -202,8 +199,6 @@ class DockerRuntime(ActionExecutionClient):
 
         use_host_network = self.config.sandbox.use_host_network
         network_mode: str | None = 'host' if use_host_network else None
-
-        use_host_network = self.config.sandbox.use_host_network
 
         # Initialize port mappings
         port_mapping: dict[str, list[dict[str, str]]] | None = None
@@ -257,26 +252,16 @@ class DockerRuntime(ActionExecutionClient):
             f'Sandbox workspace: {self.config.workspace_mount_path_in_sandbox}',
         )
 
-        if self.config.sandbox.browsergym_eval_env is not None:
-            browsergym_arg = (
-                f'--browsergym-eval-env {self.config.sandbox.browsergym_eval_env}'
-            )
-        else:
-            browsergym_arg = ''
+        command = get_action_execution_server_startup_command(
+            server_port=self._container_port,
+            plugins=self.plugins,
+            app_config=self.config,
+        )
 
         try:
             self.container = self.docker_client.containers.run(
                 self.runtime_container_image,
-                command=(
-                    f'/openhands/micromamba/bin/micromamba run -n openhands '
-                    f'poetry run '
-                    f'python -u -m openhands.runtime.action_execution_server {self._container_port} '
-                    f'--working-dir "{self.config.workspace_mount_path_in_sandbox}" '
-                    f'{plugin_arg}'
-                    f'--username {"openhands" if self.config.run_as_openhands else "root"} '
-                    f'--user-id {self.config.sandbox.user_id} '
-                    f'{browsergym_arg}'
-                ),
+                command=command,
                 network_mode=network_mode,
                 ports=port_mapping,
                 working_dir='/openhands/code/',  # do not change this!

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -256,6 +256,7 @@ class DockerRuntime(ActionExecutionClient):
             server_port=self._container_port,
             plugins=self.plugins,
             app_config=self.config,
+            use_nice_for_root=False,
         )
 
         try:

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -19,7 +19,7 @@ from openhands.runtime.impl.action_execution.action_execution_client import (
     ActionExecutionClient,
 )
 from openhands.runtime.plugins import PluginRequirement
-from openhands.runtime.utils.command import get_remote_startup_command
+from openhands.runtime.utils.command import get_action_execution_server_startup_command
 from openhands.runtime.utils.request import send_request
 from openhands.runtime.utils.runtime_build import build_runtime_image
 from openhands.utils.async_utils import call_sync_from_async
@@ -194,22 +194,10 @@ class RemoteRuntime(ActionExecutionClient):
 
     def _start_runtime(self):
         # Prepare the request body for the /start endpoint
-        plugin_args = []
-        if self.plugins is not None and len(self.plugins) > 0:
-            plugin_args = ['--plugins'] + [plugin.name for plugin in self.plugins]
-        browsergym_args = []
-        if self.config.sandbox.browsergym_eval_env is not None:
-            browsergym_args = [
-                '--browsergym-eval-env'
-            ] + self.config.sandbox.browsergym_eval_env.split(' ')
-        command = get_remote_startup_command(
-            self.port,
-            self.config.workspace_mount_path_in_sandbox,
-            'openhands' if self.config.run_as_openhands else 'root',
-            self.config.sandbox.user_id,
-            plugin_args,
-            browsergym_args,
-            is_root=not self.config.run_as_openhands,  # is_root=True when running as root
+        command = get_action_execution_server_startup_command(
+            server_port=self.port,
+            plugins=self.plugins,
+            app_config=self.config,
         )
         start_request = {
             'image': self.container_image,

--- a/openhands/runtime/impl/runloop/runloop_runtime.py
+++ b/openhands/runtime/impl/runloop/runloop_runtime.py
@@ -13,7 +13,7 @@ from openhands.runtime.impl.action_execution.action_execution_client import (
     ActionExecutionClient,
 )
 from openhands.runtime.plugins import PluginRequirement
-from openhands.runtime.utils.command import get_remote_startup_command
+from openhands.runtime.utils.command import get_action_execution_server_startup_command
 from openhands.utils.tenacity_stop import stop_if_should_exit
 
 CONTAINER_NAME_PREFIX = 'openhands-runtime-'
@@ -78,28 +78,10 @@ class RunloopRuntime(ActionExecutionClient):
 
     def _create_new_devbox(self) -> DevboxView:
         # Note: Runloop connect
-        sandbox_workspace_dir = self.config.workspace_mount_path_in_sandbox
-        plugin_args = []
-        if self.plugins is not None and len(self.plugins) > 0:
-            plugin_args.append('--plugins')
-            plugin_args.extend([plugin.name for plugin in self.plugins])
-
-        browsergym_args = []
-        if self.config.sandbox.browsergym_eval_env is not None:
-            browsergym_args = [
-                '-browsergym-eval-env',
-                self.config.sandbox.browsergym_eval_env,
-            ]
-
-        # Copied from EventstreamRuntime
-        start_command = get_remote_startup_command(
-            self._sandbox_port,
-            sandbox_workspace_dir,
-            'openhands' if self.config.run_as_openhands else 'root',
-            self.config.sandbox.user_id,
-            plugin_args,
-            browsergym_args,
-            is_root=not self.config.run_as_openhands,  # is_root=True when running as root
+        start_command = get_action_execution_server_startup_command(
+            server_port=self._sandbox_port,
+            plugins=self.plugins,
+            app_config=self.config,
         )
 
         # Add some additional commands based on our image

--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -1,31 +1,52 @@
-def get_remote_startup_command(
-    port: int,
-    sandbox_workspace_dir: str,
-    username: str,
-    user_id: int,
-    plugin_args: list[str],
-    browsergym_args: list[str],
-    is_root: bool = False,
+from openhands.core.config import AppConfig
+from openhands.runtime.plugins import PluginRequirement
+
+DEFAULT_PYTHON_PREFIX = [
+    '/openhands/micromamba/bin/micromamba',
+    'run',
+    '-n',
+    'openhands',
+    'poetry',
+    'run',
+]
+
+
+def get_action_execution_server_startup_command(
+    server_port: int,
+    plugins: list[PluginRequirement],
+    app_config: AppConfig,
+    python_prefix: list[str] = DEFAULT_PYTHON_PREFIX,
 ):
+    sandbox_config = app_config.sandbox
+
+    # Plugin args
+    plugin_args = []
+    if plugins is not None and len(plugins) > 0:
+        plugin_args = ['--plugins'] + [plugin.name for plugin in plugins]
+
+    # Browsergym stuffs
+    browsergym_args = []
+    if sandbox_config.browsergym_eval_env is not None:
+        browsergym_args = [
+            '--browsergym-eval-env'
+        ] + sandbox_config.browsergym_eval_env.split(' ')
+
+    is_root = not app_config.run_as_openhands
+
     base_cmd = [
-        '/openhands/micromamba/bin/micromamba',
-        'run',
-        '-n',
-        'openhands',
-        'poetry',
-        'run',
+        *python_prefix,
         'python',
         '-u',
         '-m',
         'openhands.runtime.action_execution_server',
-        str(port),
+        str(server_port),
         '--working-dir',
-        sandbox_workspace_dir,
+        app_config.workspace_mount_path_in_sandbox,
         *plugin_args,
         '--username',
-        username,
+        'openhands' if app_config.run_as_openhands else 'root',
         '--user-id',
-        str(user_id),
+        str(sandbox_config.user_id),
         *browsergym_args,
     ]
 

--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -16,6 +16,7 @@ def get_action_execution_server_startup_command(
     plugins: list[PluginRequirement],
     app_config: AppConfig,
     python_prefix: list[str] = DEFAULT_PYTHON_PREFIX,
+    use_nice_for_root: bool = True,
 ):
     sandbox_config = app_config.sandbox
 
@@ -50,7 +51,7 @@ def get_action_execution_server_startup_command(
         *browsergym_args,
     ]
 
-    if is_root:
+    if is_root and use_nice_for_root:
         # If running as root, set highest priority and lowest OOM score
         cmd_str = ' '.join(base_cmd)
         return [
@@ -62,5 +63,5 @@ def get_action_execution_server_startup_command(
             f'echo -1000 > /proc/self/oom_score_adj && exec {cmd_str}',
         ]
     else:
-        # If not root, run with normal priority
+        # If not root OR not using nice for root, run with normal priority
         return base_cmd


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We have a lot of code duplications!

This PR simplifies existing runtime implementations by consolidating all runtime startup commands into one single util function. Helpful for https://github.com/All-Hands-AI/OpenHands/pull/5284

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:50ee58e-nikolaik   --name openhands-app-50ee58e   docker.all-hands.dev/all-hands-ai/openhands:50ee58e
```