### PR TITLE
Custom runtime builder: fix NoEmptyContinuation error

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -16,12 +16,12 @@ ENV POETRY_VIRTUALENVS_PATH=/openhands/poetry \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         wget curl sudo apt-utils git jq tmux \
-        {% if 'ubuntu' in base_image and (base_image.endswith(':latest') or base_image.endswith(':24.04')) %}
+        {%- if 'ubuntu' in base_image and (base_image.endswith(':latest') or base_image.endswith(':24.04')) -%}
         libgl1 \
-        {% else %}
+        {%- else %}
         libgl1-mesa-glx \
-        {% endif %}
-        libasound2-plugins libatomic1 curl && \
+        {% endif -%}
+        libasound2-plugins libatomic1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Fix NoEmptyContinuation error in custom runtime builder's template

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When building a custom runtime image, I realize my Docker build log has this error:

> NoEmptyContinuation: Empty continuation line

Not sure if it has any observable impact but why not fix it? Thus this PR. The improper usage of jinja2 syntax led to blank lines between continuation lines, e.g.

```
RUN apt-get update && \
    apt-get install -y --no-install-recommends \
        wget curl sudo apt-utils git jq tmux \

        libgl1-mesa-glx \

        libasound2-plugins libatomic1 curl && \
    apt-get clean ...
```

with this PR, it becomes:

```
# Install base system dependencies
RUN apt-get update && \
    apt-get install -y --no-install-recommends \
        wget curl sudo apt-utils git jq tmux \
        libgl1-mesa-glx \
        libasound2-plugins libatomic1 && \
    apt-get clean ...
```

---
**Link of any specific issues this addresses**
