### PR TITLE
Fix for issue where S3FileStore does not delete directory objects

### DIFF
--- a/openhands/storage/s3.py
+++ b/openhands/storage/s3.py
@@ -41,6 +41,10 @@ class S3FileStore(FileStore):
 
     def delete(self, path: str) -> None:
         try:
-            self.client.remove_object(self.bucket, path)
+            client = self.client
+            bucket = self.bucket
+            objects_to_delete = client.list_objects(bucket, prefix=path, recursive=True)
+            for obj in objects_to_delete:
+                client.remove_object(bucket, obj.object_name)
         except Exception as e:
             raise FileNotFoundError(f'Failed to delete S3 object at path {path}: {e}')


### PR DESCRIPTION
**Fix for issue where S3FileStore does not delete directory objects**

- [] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
The other file store implementations delete directories, but the S3 store did not - resulting in failure to delete conversations in the UI:
* https://github.com/All-Hands-AI/OpenHands/blob/99eda0e571bd4d1b000a0d4891278c1a6961a5c3/openhands/storage/local.py#L47
* https://github.com/All-Hands-AI/OpenHands/blob/99eda0e571bd4d1b000a0d4891278c1a6961a5c3/openhands/storage/memory.py#L46


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e7900d4-nikolaik   --name openhands-app-e7900d4   docker.all-hands.dev/all-hands-ai/openhands:e7900d4
```