### PR TITLE
Fix : minor updates to log messages

### DIFF
--- a/openhands/runtime/builder/remote.py
+++ b/openhands/runtime/builder/remote.py
@@ -118,9 +118,7 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
             # Wait before polling again
             sleep_if_should_continue(30)
 
-        raise AgentRuntimeBuildError(
-            'Build interrupted (likely received SIGTERM or SIGINT).'
-        )
+        raise AgentRuntimeBuildError('Build interrupted')
 
     def image_exists(self, image_name: str, pull_from_repo: bool = True) -> bool:
         """Checks if an image exists in the remote registry using the /image_exists endpoint."""

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -113,9 +113,9 @@ class Session:
                 selected_repository=selected_repository,
             )
         except Exception as e:
-            logger.exception(f'Error creating controller: {e}')
+            logger.exception(f'Error creating agent_session: {e}')
             await self.send_error(
-                f'Error creating controller. Please check Docker is running and visit `{TROUBLESHOOTING_URL}` for more debugging information..'
+                f'Error creating agent_session. Please check Docker is running and visit `{TROUBLESHOOTING_URL}` for more debugging information..'
             )
             return
 


### PR DESCRIPTION
**Minor update to log messages**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
These log messages were misleading...
* In sesion.py we are closing creating the agent_session - not the controller
* An interrupted build does not necessarily mean that a SIGTERM was received - it can mean that the browser disconnected while a build was in progress (If keep_runtimes_alive is False)


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c5c9a7e-nikolaik   --name openhands-app-c5c9a7e   docker.all-hands.dev/all-hands-ai/openhands:c5c9a7e
```