### PR TITLE
Feature: User id propagation

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -30,7 +30,7 @@ async def connect(connection_id: str, environ, auth):
         logger.error('No conversation_id in query params')
         raise ConnectionRefusedError('No conversation_id in query params')
 
-    user_id = -1
+    user_id = None
     if openhands_config.app_mode != AppMode.OSS:
         cookies_str = environ.get('HTTP_COOKIE', '')
         cookies = dict(cookie.split('=', 1) for cookie in cookies_str.split('; '))
@@ -63,7 +63,7 @@ async def connect(connection_id: str, environ, auth):
 
     try:
         event_stream = await session_manager.join_conversation(
-            conversation_id, connection_id, settings
+            conversation_id, connection_id, settings, user_id
         )
     except ConversationDoesNotExistError:
         logger.error(f'Conversation {conversation_id} does not exist')

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -37,6 +37,7 @@ class Session:
     loop: asyncio.AbstractEventLoop
     config: AppConfig
     file_store: FileStore
+    user_id: int | None
 
     def __init__(
         self,
@@ -44,6 +45,7 @@ class Session:
         config: AppConfig,
         file_store: FileStore,
         sio: socketio.AsyncServer | None,
+        user_id: int | None = None,
     ):
         self.sid = sid
         self.sio = sio
@@ -58,6 +60,7 @@ class Session:
         # Copying this means that when we update variables they are not applied to the shared global configuration!
         self.config = deepcopy(config)
         self.loop = asyncio.get_event_loop()
+        self.user_id = user_id
 
     def close(self):
         self.is_alive = False

--- a/openhands/storage/conversation/conversation_store.py
+++ b/openhands/storage/conversation/conversation_store.py
@@ -40,5 +40,7 @@ class ConversationStore(ABC):
 
     @classmethod
     @abstractmethod
-    async def get_instance(cls, config: AppConfig, user_id: int) -> ConversationStore:
+    async def get_instance(
+        cls, config: AppConfig, user_id: int | None
+    ) -> ConversationStore:
         """Get a store for the user represented by the token given"""

--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -94,7 +94,7 @@ class FileConversationStore(ConversationStore):
 
     @classmethod
     async def get_instance(
-        cls, config: AppConfig, user_id: int
+        cls, config: AppConfig, user_id: int | None
     ) -> FileConversationStore:
         file_store = get_file_store(config.file_store, config.file_store_path)
         return FileConversationStore(file_store)

--- a/openhands/storage/settings/file_settings_store.py
+++ b/openhands/storage/settings/file_settings_store.py
@@ -30,6 +30,8 @@ class FileSettingsStore(SettingsStore):
         await call_sync_from_async(self.file_store.write, self.path, json_str)
 
     @classmethod
-    async def get_instance(cls, config: AppConfig, user_id: int) -> FileSettingsStore:
+    async def get_instance(
+        cls, config: AppConfig, user_id: int | None
+    ) -> FileSettingsStore:
         file_store = get_file_store(config.file_store, config.file_store_path)
         return FileSettingsStore(file_store)

--- a/openhands/storage/settings/settings_store.py
+++ b/openhands/storage/settings/settings_store.py
@@ -21,5 +21,7 @@ class SettingsStore(ABC):
 
     @classmethod
     @abstractmethod
-    async def get_instance(cls, config: AppConfig, user_id: int) -> SettingsStore:
+    async def get_instance(
+        cls, config: AppConfig, user_id: int | None
+    ) -> SettingsStore:
         """Get a store for the user represented by the token given"""

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -114,10 +114,10 @@ async def test_init_new_local_session():
             sio, AppConfig(), InMemoryFileStore()
         ) as session_manager:
             await session_manager.maybe_start_agent_loop(
-                'new-session-id', ConversationInitData()
+                'new-session-id', ConversationInitData(), 1
             )
             await session_manager.join_conversation(
-                'new-session-id', 'new-session-id', ConversationInitData()
+                'new-session-id', 'new-session-id', ConversationInitData(), 1
             )
     assert session_instance.initialize_agent.call_count == 1
     assert sio.enter_room.await_count == 1
@@ -148,13 +148,13 @@ async def test_join_local_session():
             sio, AppConfig(), InMemoryFileStore()
         ) as session_manager:
             await session_manager.maybe_start_agent_loop(
-                'new-session-id', ConversationInitData()
+                'new-session-id', ConversationInitData(), None
             )
             await session_manager.join_conversation(
-                'new-session-id', 'new-session-id', ConversationInitData()
+                'new-session-id', 'new-session-id', ConversationInitData(), None
             )
             await session_manager.join_conversation(
-                'new-session-id', 'new-session-id', ConversationInitData()
+                'new-session-id', 'new-session-id', ConversationInitData(), None
             )
     assert session_instance.initialize_agent.call_count == 1
     assert sio.enter_room.await_count == 2
@@ -185,7 +185,7 @@ async def test_join_cluster_session():
             sio, AppConfig(), InMemoryFileStore()
         ) as session_manager:
             await session_manager.join_conversation(
-                'new-session-id', 'new-session-id', ConversationInitData()
+                'new-session-id', 'new-session-id', ConversationInitData(), 1
             )
     assert session_instance.initialize_agent.call_count == 0
     assert sio.enter_room.await_count == 1
@@ -216,10 +216,10 @@ async def test_add_to_local_event_stream():
             sio, AppConfig(), InMemoryFileStore()
         ) as session_manager:
             await session_manager.maybe_start_agent_loop(
-                'new-session-id', ConversationInitData()
+                'new-session-id', ConversationInitData(), 1
             )
             await session_manager.join_conversation(
-                'new-session-id', 'connection-id', ConversationInitData()
+                'new-session-id', 'connection-id', ConversationInitData(), 1
             )
             await session_manager.send_to_event_stream(
                 'connection-id', {'event_type': 'some_event'}
@@ -252,7 +252,7 @@ async def test_add_to_cluster_event_stream():
             sio, AppConfig(), InMemoryFileStore()
         ) as session_manager:
             await session_manager.join_conversation(
-                'new-session-id', 'connection-id', ConversationInitData()
+                'new-session-id', 'connection-id', ConversationInitData(), 1
             )
             await session_manager.send_to_event_stream(
                 'connection-id', {'event_type': 'some_event'}


### PR DESCRIPTION
**Propagate the User Id to store initialization**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
* A lot of this was written without user ids in mind - so we need to propagate the user id.
* The user_id is typically `None` in in most environments, and this is explicitly defined now (Rather than 0 or -1)

A lot of this was pulled out of https://github.com/All-Hands-AI/OpenHands/pull/6114

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7d2fcff-nikolaik   --name openhands-app-7d2fcff   docker.all-hands.dev/all-hands-ai/openhands:7d2fcff
```