### PR TITLE
fix(frontend): Prevent from send a SET API key

### DIFF
--- a/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -141,5 +141,30 @@ describe("Sidebar", () => {
         llm_api_key: undefined, // null or undefined
       });
     });
+
+    it("should not send the api key if its SET", async () => {
+      const user = userEvent.setup();
+      renderSidebar();
+
+      const settingsButton = screen.getByTestId("settings-button");
+      await user.click(settingsButton);
+
+      const settingsModal = screen.getByTestId("ai-config-modal");
+
+      const apiKeyInput = within(settingsModal).getByLabelText(/api key/i);
+      await user.type(apiKeyInput, "SET");
+
+      const saveButton = within(settingsModal).getByTestId(
+        "save-settings-button",
+      );
+      await user.click(saveButton);
+
+      expect(saveSettingsSpy).toHaveBeenCalledWith({
+        ...MOCK_USER_PREFERENCES.settings,
+        llm_api_key: undefined,
+        llm_base_url: undefined,
+        security_analyzer: undefined,
+      });
+    });
   });
 });

--- a/frontend/src/context/settings-context.tsx
+++ b/frontend/src/context/settings-context.tsx
@@ -33,6 +33,11 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
       ...userSettings,
       ...newSettings,
     };
+
+    if (updatedSettings.LLM_API_KEY === "SET") {
+      delete updatedSettings.LLM_API_KEY;
+    }
+
     await saveSettings(updatedSettings, {
       onSuccess: () => {
         if (!isUpToDate) {


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- If an API key is set and then user changes account settings, the settings are saved with the LLM key set to `"SET"`

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- If API key is already set, do not send the key so the backend uses the already set and existing key


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:aca39f5-nikolaik   --name openhands-app-aca39f5   docker.all-hands.dev/all-hands-ai/openhands:aca39f5
```