### PR TITLE
Fix issue #6236: Browser notification when the agent has finished

### DIFF
--- a/frontend/__tests__/components/notification-settings.test.tsx
+++ b/frontend/__tests__/components/notification-settings.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NotificationSettings } from '../../src/components/features/notifications/notification-settings';
 
 describe('NotificationSettings', () => {

--- a/frontend/__tests__/components/notification-settings.test.tsx
+++ b/frontend/__tests__/components/notification-settings.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NotificationSettings } from '../../src/components/features/notifications/notification-settings';
+
+describe('NotificationSettings', () => {
+  beforeEach(() => {
+    // Mock localStorage
+    Storage.prototype.getItem = vi.fn();
+    Storage.prototype.setItem = vi.fn();
+
+    // Mock Notification API
+    Object.defineProperty(window, 'Notification', {
+      value: {
+        requestPermission: vi.fn(),
+        permission: 'default',
+      },
+      writable: true,
+    });
+  });
+
+  it('renders notification settings', () => {
+    render(<NotificationSettings />);
+    expect(screen.getByText('Browser Notifications')).toBeInTheDocument();
+    expect(screen.getByText('Get notified when the agent completes its task')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('requests notification permission when enabling notifications', async () => {
+    (window.Notification.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue('granted');
+
+    render(<NotificationSettings />);
+    const checkbox = screen.getByRole('checkbox');
+
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(window.Notification.requestPermission).toHaveBeenCalled();
+      expect(localStorage.setItem).toHaveBeenCalledWith('notifications-enabled', 'true');
+    });
+  });
+
+  it('disables notifications when toggling off', async () => {
+    render(<NotificationSettings />);
+    const checkbox = screen.getByRole('checkbox');
+
+    // First enable notifications
+    (window.Notification.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue('granted');
+    fireEvent.click(checkbox);
+    await waitFor(() => {
+      expect(localStorage.setItem).toHaveBeenCalledWith('notifications-enabled', 'true');
+    });
+
+    // Then disable them
+    fireEvent.click(checkbox);
+    expect(localStorage.setItem).toHaveBeenCalledWith('notifications-enabled', 'false');
+  });
+
+  it('does not enable notifications if permission is denied', async () => {
+    (window.Notification.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue('denied');
+
+    render(<NotificationSettings />);
+    const checkbox = screen.getByRole('checkbox');
+
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(window.Notification.requestPermission).toHaveBeenCalled();
+      expect(localStorage.setItem).not.toHaveBeenCalledWith('notifications-enabled', 'true');
+    });
+  });
+});

--- a/frontend/__tests__/hooks/use-agent-status-notification.test.tsx
+++ b/frontend/__tests__/hooks/use-agent-status-notification.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useAgentStatusNotification } from '../../src/hooks/use-agent-status-notification';
 import { sendNotification } from '../../src/services/notification';
+import { ProjectStatus } from '../../src/components/features/conversation-panel/conversation-state-indicator';
 
 import { vi } from 'vitest';
 
@@ -18,8 +19,8 @@ describe('useAgentStatusNotification', () => {
   it('sends notification when agent status changes from RUNNING to STOPPED', () => {
     // First render with RUNNING status
     const { rerender } = renderHook(
-      ({ status }) => useAgentStatusNotification(status),
-      { initialProps: { status: 'RUNNING' } }
+      ({ status }) => useAgentStatusNotification(status as ProjectStatus),
+      { initialProps: { status: 'RUNNING' as ProjectStatus } }
     );
 
     // Change status to STOPPED
@@ -34,8 +35,8 @@ describe('useAgentStatusNotification', () => {
   it('does not send notification when agent status changes from STOPPED to RUNNING', () => {
     // First render with STOPPED status
     const { rerender } = renderHook(
-      ({ status }) => useAgentStatusNotification(status),
-      { initialProps: { status: 'STOPPED' } }
+      ({ status }) => useAgentStatusNotification(status as ProjectStatus),
+      { initialProps: { status: 'STOPPED' as ProjectStatus } }
     );
 
     // Change status to RUNNING
@@ -45,14 +46,14 @@ describe('useAgentStatusNotification', () => {
   });
 
   it('does not send notification on initial render with STOPPED status', () => {
-    renderHook(() => useAgentStatusNotification('STOPPED'));
+    renderHook(() => useAgentStatusNotification('STOPPED' as ProjectStatus));
     expect(sendNotification).not.toHaveBeenCalled();
   });
 
   it('does not send notification when status remains the same', () => {
     const { rerender } = renderHook(
-      ({ status }) => useAgentStatusNotification(status),
-      { initialProps: { status: 'RUNNING' } }
+      ({ status }) => useAgentStatusNotification(status as ProjectStatus),
+      { initialProps: { status: 'RUNNING' as ProjectStatus } }
     );
 
     // Re-render with same status

--- a/frontend/__tests__/hooks/use-agent-status-notification.test.tsx
+++ b/frontend/__tests__/hooks/use-agent-status-notification.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAgentStatusNotification } from '../../src/hooks/use-agent-status-notification';
+import { sendNotification } from '../../src/services/notification';
+
+import { vi } from 'vitest';
+
+vi.mock('../../src/services/notification', () => ({
+  sendNotification: vi.fn(),
+}));
+
+describe('useAgentStatusNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('sends notification when agent status changes from RUNNING to STOPPED', () => {
+    // First render with RUNNING status
+    const { rerender } = renderHook(
+      ({ status }) => useAgentStatusNotification(status),
+      { initialProps: { status: 'RUNNING' } }
+    );
+
+    // Change status to STOPPED
+    rerender({ status: 'STOPPED' });
+
+    expect(sendNotification).toHaveBeenCalledWith('OpenHands Agent', {
+      body: 'The agent has finished its task',
+      icon: '/android-chrome-192x192.png'
+    });
+  });
+
+  it('does not send notification when agent status changes from STOPPED to RUNNING', () => {
+    // First render with STOPPED status
+    const { rerender } = renderHook(
+      ({ status }) => useAgentStatusNotification(status),
+      { initialProps: { status: 'STOPPED' } }
+    );
+
+    // Change status to RUNNING
+    rerender({ status: 'RUNNING' });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not send notification on initial render with STOPPED status', () => {
+    renderHook(() => useAgentStatusNotification('STOPPED'));
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not send notification when status remains the same', () => {
+    const { rerender } = renderHook(
+      ({ status }) => useAgentStatusNotification(status),
+      { initialProps: { status: 'RUNNING' } }
+    );
+
+    // Re-render with same status
+    rerender({ status: 'RUNNING' });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/setup.ts
+++ b/frontend/__tests__/setup.ts
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+// Mock localStorage
+Storage.prototype.getItem = vi.fn();
+Storage.prototype.setItem = vi.fn();
+
+// Mock Notification API
+Object.defineProperty(window, 'Notification', {
+  value: {
+    requestPermission: vi.fn(),
+    permission: 'default',
+  },
+  writable: true,
+});

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -8,6 +8,7 @@ import {
 import { EllipsisButton } from "./ellipsis-button";
 import { ConversationCardContextMenu } from "./conversation-card-context-menu";
 import { cn } from "#/utils/utils";
+import { useAgentStatusNotification } from "#/hooks/use-agent-status-notification";
 
 interface ConversationCardProps {
   onClick?: () => void;
@@ -37,6 +38,8 @@ export function ConversationCard({
   const [contextMenuVisible, setContextMenuVisible] = React.useState(false);
   const [titleMode, setTitleMode] = React.useState<"view" | "edit">("view");
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  useAgentStatusNotification(status);
 
   const handleBlur = () => {
     if (inputRef.current?.value) {

--- a/frontend/src/components/features/notifications/notification-settings.tsx
+++ b/frontend/src/components/features/notifications/notification-settings.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useLocalStorage } from '#/hooks/use-local-storage';
+
+export const NotificationSettings: React.FC = () => {
+  const [notificationsEnabled, setNotificationsEnabled] = useLocalStorage('notifications-enabled', false);
+
+  const handleToggleNotifications = async () => {
+    if (!notificationsEnabled) {
+      try {
+        const permission = await Notification.requestPermission();
+        if (permission === 'granted') {
+          setNotificationsEnabled(true);
+        }
+      } catch (error) {
+        console.error('Error requesting notification permission:', error);
+      }
+    } else {
+      setNotificationsEnabled(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between p-4 border-b">
+      <div>
+        <h3 className="text-lg font-medium">Browser Notifications</h3>
+        <p className="text-sm text-gray-500">Get notified when the agent completes its task</p>
+      </div>
+      <label className="relative inline-flex items-center cursor-pointer">
+        <input
+          type="checkbox"
+          className="sr-only peer"
+          checked={notificationsEnabled}
+          onChange={handleToggleNotifications}
+        />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+      </label>
+    </div>
+  );
+};

--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -15,6 +15,7 @@ import { AgentInput } from "../../inputs/agent-input";
 import { APIKeyInput } from "../../inputs/api-key-input";
 import { BaseUrlInput } from "../../inputs/base-url-input";
 import { ConfirmationModeSwitch } from "../../inputs/confirmation-mode-switch";
+import { NotificationSettings } from "#/components/features/notifications/notification-settings";
 import { CustomModelInput } from "../../inputs/custom-model-input";
 import { SecurityAnalyzerInput } from "../../inputs/security-analyzers-input";
 import { ModalBackdrop } from "../modal-backdrop";
@@ -199,6 +200,8 @@ export function SettingsForm({
                 isDisabled={!!disabled}
                 defaultSelected={settings.CONFIRMATION_MODE}
               />
+
+              <NotificationSettings />
             </>
           )}
         </div>

--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -20,6 +20,7 @@ const getSettingsQueryFn = async () => {
         LLM_API_KEY: apiSettings.llm_api_key,
         REMOTE_RUNTIME_RESOURCE_FACTOR:
           apiSettings.remote_runtime_resource_factor,
+        NOTIFICATIONS_ENABLED: apiSettings.notifications_enabled,
       };
     }
 

--- a/frontend/src/hooks/use-agent-status-notification.ts
+++ b/frontend/src/hooks/use-agent-status-notification.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+import { ProjectStatus } from '../components/features/conversation-panel/conversation-state-indicator';
+import { sendNotification } from '../services/notification';
+
+export const useAgentStatusNotification = (status: ProjectStatus) => {
+  const previousStatus = useRef<ProjectStatus>(status);
+
+  useEffect(() => {
+    if (previousStatus.current === 'RUNNING' && status === 'STOPPED') {
+      sendNotification('OpenHands Agent', {
+        body: 'The agent has finished its task',
+        icon: '/android-chrome-192x192.png'
+      });
+    }
+    previousStatus.current = status;
+  }, [status]);
+};

--- a/frontend/src/hooks/use-local-storage.ts
+++ b/frontend/src/hooks/use-local-storage.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+
+export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
+  // Get from local storage then
+  // parse stored json or return initialValue
+  const readValue = () => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
+    }
+  };
+
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(readValue);
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      console.warn(`Error setting localStorage key "${key}":`, error);
+    }
+  };
+
+  useEffect(() => {
+    setStoredValue(readValue());
+  }, []);
+
+  return [storedValue, setValue];
+}

--- a/frontend/src/services/notification.ts
+++ b/frontend/src/services/notification.ts
@@ -1,0 +1,15 @@
+export const sendNotification = (title: string, options?: NotificationOptions) => {
+  if (!('Notification' in window)) {
+    console.warn('This browser does not support desktop notifications');
+    return;
+  }
+
+  const notificationsEnabled = localStorage.getItem('notifications-enabled') === 'true';
+  if (!notificationsEnabled) {
+    return;
+  }
+
+  if (Notification.permission === 'granted') {
+    new Notification(title, options);
+  }
+};

--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -9,6 +9,7 @@ export type Settings = {
   CONFIRMATION_MODE: boolean;
   SECURITY_ANALYZER: string;
   REMOTE_RUNTIME_RESOURCE_FACTOR: number;
+  NOTIFICATIONS_ENABLED: boolean;
 };
 
 export type ApiSettings = {
@@ -20,6 +21,7 @@ export type ApiSettings = {
   confirmation_mode: boolean;
   security_analyzer: string;
   remote_runtime_resource_factor: number;
+  notifications_enabled: boolean;
 };
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -31,6 +33,7 @@ export const DEFAULT_SETTINGS: Settings = {
   CONFIRMATION_MODE: false,
   SECURITY_ANALYZER: "",
   REMOTE_RUNTIME_RESOURCE_FACTOR: 1,
+  NOTIFICATIONS_ENABLED: false,
 };
 
 export const getCurrentSettingsVersion = () => {
@@ -60,6 +63,7 @@ export const getLocalStorageSettings = (): Settings => {
   const llmApiKey = localStorage.getItem("LLM_API_KEY");
   const confirmationMode = localStorage.getItem("CONFIRMATION_MODE") === "true";
   const securityAnalyzer = localStorage.getItem("SECURITY_ANALYZER");
+  const notificationsEnabled = localStorage.getItem("NOTIFICATIONS_ENABLED") === "true";
 
   return {
     LLM_MODEL: llmModel || DEFAULT_SETTINGS.LLM_MODEL,
@@ -71,6 +75,7 @@ export const getLocalStorageSettings = (): Settings => {
     SECURITY_ANALYZER: securityAnalyzer || DEFAULT_SETTINGS.SECURITY_ANALYZER,
     REMOTE_RUNTIME_RESOURCE_FACTOR:
       DEFAULT_SETTINGS.REMOTE_RUNTIME_RESOURCE_FACTOR,
+    NOTIFICATIONS_ENABLED: notificationsEnabled || DEFAULT_SETTINGS.NOTIFICATIONS_ENABLED,
   };
 };
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR implement a browser notification when the agent finishes work.

WIP - still needs my review.

---
**Link of any specific issues this addresses**

Fixes issue #6236 

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a963f7e-nikolaik   --name openhands-app-a963f7e   docker.all-hands.dev/all-hands-ai/openhands:a963f7e
```