### PR TITLE
Fix issue #6134: Document how to use custom sandbox container with Docker

### DIFF
--- a/docs/modules/usage/how-to/custom-sandbox-guide.md
+++ b/docs/modules/usage/how-to/custom-sandbox-guide.md
@@ -58,3 +58,27 @@ sandbox_base_container_image="custom-image"
 ### Run
 
 Run OpenHands by running ```make run``` in the top level directory.
+
+## Using Docker
+
+If you're running OpenHands via Docker, you can specify a custom sandbox container by setting the `SANDBOX_BASE_CONTAINER_IMAGE` environment variable when running the Docker container.
+
+Here's an example of how to run OpenHands with a custom sandbox container:
+
+```bash
+docker run -it --pull=always \
+    -e SANDBOX_BASE_CONTAINER_IMAGE=custom-image \
+    -e LOG_ALL_EVENTS=true \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v ~/.openhands-state:/.openhands-state \
+    -p 3000:3000 \
+    --add-host host.docker.internal:host-gateway \
+    --name openhands-app \
+    docker.all-hands.dev/all-hands-ai/openhands:0.20
+```
+
+Replace `custom-image` with the name of your custom Docker image. This could be either:
+- An image you built locally (as described in the "Create Your Docker Image" section)
+- An existing image from Docker Hub or another registry
+
+> Note: On macOS, you might need to configure Docker Desktop to allow access to the host network. This can be done through Docker Desktop's settings.


### PR DESCRIPTION
This pull request fixes #6134.

The issue has been successfully resolved because:

1. The original issue specifically requested documentation for using custom sandbox containers via Docker, which was missing from the guide
2. The AI agent added a new "Using Docker" section that includes:
   - The complete Docker command with all required parameters exactly as specified in the issue
   - Explanations for how to specify custom images
   - Additional context about image compatibility
   - Important notes about macOS configuration requirements based on the thread context

The changes directly address the documentation gap identified in the issue by providing the missing Docker-specific instructions that were previously only available for the Development Workflow. The inclusion of the exact command syntax and supporting details ensures users have all necessary information to implement custom sandbox containers via Docker.

The solution is complete since this was purely a documentation issue and the requested content has been added in full, including the specific Docker command that was provided in the issue description.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:25817ee-nikolaik   --name openhands-app-25817ee   docker.all-hands.dev/all-hands-ai/openhands:25817ee
```