### PR TITLE
Fix issue #6134: Document how to use custom sandbox container with Docker

### DIFF
--- a/docs/modules/usage/how-to/custom-sandbox-guide.md
+++ b/docs/modules/usage/how-to/custom-sandbox-guide.md
@@ -58,3 +58,27 @@ sandbox_base_container_image="custom-image"
 ### Run
 
 Run OpenHands by running ```make run``` in the top level directory.
+
+## Using Docker
+
+If you're running OpenHands via Docker, you can specify your custom sandbox image using the `SANDBOX_BASE_CONTAINER_IMAGE` environment variable when running the container:
+
+```bash
+docker run -it --pull=always \
+    -e SANDBOX_BASE_CONTAINER_IMAGE=custom-image \
+    -e LOG_ALL_EVENTS=true \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v ~/.openhands-state:/.openhands-state \
+    -p 3000:3000 \
+    --add-host host.docker.internal:host-gateway \
+    --name openhands-app \
+    docker.all-hands.dev/all-hands-ai/openhands:0.20
+```
+
+Make sure to:
+1. Replace `custom-image` with the name of your custom Docker image
+2. Mount the Docker socket (`/var/run/docker.sock`) to allow OpenHands to create sandbox containers
+3. Mount the state directory (`~/.openhands-state`) to persist OpenHands state between runs
+4. Add the host gateway to allow container-to-host communication
+
+> Note: If you're using macOS, ensure Docker Desktop has the necessary permissions and settings enabled for socket mounting.


### PR DESCRIPTION
This pull request fixes #6134.

The issue has been successfully resolved because:

1. The original issue specifically requested documentation for using custom sandboxes via Docker, which was missing from the docs. The AI agent added this documentation with the exact Docker command syntax that was provided in the issue.

2. The core maintainer (@li-boxuan) clarified that the functionality is already released and working, with the reported issues being related to macOS settings rather than a broken feature.

3. The added documentation includes:
   - The complete Docker command with all necessary parameters
   - Important setup requirements
   - Special notes about macOS configuration requirements, which directly addresses the user-reported issues

4. The changes directly fulfill the original request to "document it accordingly" with the Docker command that was provided in the issue description.

The implementation matches exactly what was requested in the issue - adding documentation for an existing feature that was previously only documented for development workflow. The fact that some users experienced configuration-related issues doesn't invalidate the documentation itself, as those issues were clarified to be platform-specific setup problems rather than feature bugs.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1e263ea-nikolaik   --name openhands-app-1e263ea   docker.all-hands.dev/all-hands-ai/openhands:1e263ea
```