### PR TITLE
hotfix(backend): Remove GH header token middleware

### DIFF
--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -11,7 +11,6 @@ from fastapi import (
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands.server.middleware import (
     AttachConversationMiddleware,
-    GitHubTokenMiddleware,
     InMemoryRateLimiter,
     LocalhostCORSMiddleware,
     NoCacheMiddleware,
@@ -45,7 +44,6 @@ app.add_middleware(
     allow_headers=['*'],
 )
 
-app.add_middleware(GitHubTokenMiddleware)
 app.add_middleware(NoCacheMiddleware)
 app.add_middleware(
     RateLimitMiddleware, rate_limiter=InMemoryRateLimiter(requests=10, seconds=1)

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -166,16 +166,3 @@ class AttachConversationMiddleware(SessionMiddlewareInterface):
             await self._detach_session(request)
 
         return response
-
-
-class GitHubTokenMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path.startswith('/api/github'):
-            github_token = request.headers.get('X-GitHub-Token')
-            if not github_token:
-                return JSONResponse(
-                    status_code=400,
-                    content={'error': 'Missing X-GitHub-Token header'},
-                )
-            request.state.github_token = github_token
-        return await call_next(request)

--- a/openhands/server/routes/github.py
+++ b/openhands/server/routes/github.py
@@ -15,7 +15,6 @@ def require_github_token(request: Request):
             status_code=400,
             detail='Missing X-GitHub-Token header',
         )
-    # You can return the token if needed
     return github_token
 
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- The middleware messed with the saas `/api/github/callback` endpoint since it also starts with `/api/github`. This was only meant to apply to requests under `github.py`

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Use route specific dependencies instead of app-wide middleware (see https://fastapi.tiangolo.com/tutorial/dependencies/#create-a-dependency-or-dependable)


---
**Link of any specific issues this addresses**
