### PR TITLE
Remove extra optional for github token

### DIFF
--- a/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -128,7 +128,7 @@ describe("Sidebar", () => {
       await user.click(norskOption);
 
       const tokenInput =
-        within(accountSettingsModal).getByLabelText(/GITHUB\$TOKEN_OPTIONAL/i);
+        within(accountSettingsModal).getByLabelText(/GITHUB\$TOKEN_LABEL/i);
       await user.type(tokenInput, "new-token");
 
       const saveButton =

--- a/frontend/src/components/shared/modals/account-settings/account-settings-form.tsx
+++ b/frontend/src/components/shared/modals/account-settings/account-settings-form.tsx
@@ -91,7 +91,7 @@ export function AccountSettingsForm({
             <>
               <CustomInput
                 name="ghToken"
-                label={t(I18nKey.GITHUB$TOKEN_OPTIONAL)}
+                label={t(I18nKey.GITHUB$TOKEN_LABEL)}
                 type="password"
                 defaultValue={gitHubToken ?? ""}
               />


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Remove extra optional for github token

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Small regression from a recent commit

![Screenshot 2025-01-14 at 12 03 11 PM](https://github.com/user-attachments/assets/15e448e8-26e2-41e6-90b5-c3ff67722cad)

to

![Screenshot 2025-01-14 at 12 01 57 PM](https://github.com/user-attachments/assets/822cf449-617d-4ebd-8a21-79068fe172a6)


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6ad40b9-nikolaik   --name openhands-app-6ad40b9   docker.all-hands.dev/all-hands-ai/openhands:6ad40b9
```