### PR TITLE
feat: enhance play/pause button visibility

### DIFF
--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -20,7 +20,7 @@ export function ActionButton({
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out"
+        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out bg-gray-800 p-2 rounded-full"
         type="button"
       >
         <span className="relative z-10 group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">


### PR DESCRIPTION
This PR improves the visibility of the play/pause button by:

- Adding a permanent dark background (bg-gray-800)
- Adding padding around the button (p-2)
- Making the button permanently circular (rounded-full)

These changes make the button more visible while maintaining the existing hover effects and functionality.