### PR TITLE
FD Leak Tracker

### DIFF
--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -1,3 +1,4 @@
+import openhands.utils.fd_tracker  # noqa F401 (we import this to track FDs in debug mode)
 import warnings
 from contextlib import asynccontextmanager
 

--- a/openhands/utils/fd_tracker.py
+++ b/openhands/utils/fd_tracker.py
@@ -1,0 +1,102 @@
+import builtins
+import logging
+import os
+import socket
+import time
+import traceback
+from dataclasses import dataclass, field
+from threading import Thread
+from typing import Any
+
+from openhands.utils.shutdown_listener import should_continue
+
+
+@dataclass(frozen=True)
+class FD:
+    subject: Any
+    stack: list[str]
+    created_at: float = field(default_factory=time.time)
+
+
+FDS: dict[int, FD] = {}
+UNCLOSED_TIMEOUT = 180
+INTERVAL = 15
+
+
+def get_self(args, kwargs):
+    if len(args) >= 1:
+        return args[0]
+    else:
+        return kwargs['self']
+
+
+original_open = builtins.open
+original_init = socket.socket.__init__
+original_close = socket.socket.close
+original_detach = socket.socket.detach
+logger = logging.getLogger(__name__)
+
+
+def print_error(msg: str, traceback: list[str]):
+    output = [f'\n===== {msg} =====\n']
+    output.extend(traceback[:-1])
+    logger.error(''.join(output))
+
+
+def patched_open(*args, **kwargs):
+    file_obj = original_open(*args, **kwargs)
+    id_ = id(file_obj)
+    original_close = file_obj.close
+
+    def patched_close(*args, **kwargs):
+        FDS.pop(id_, None)
+        result = original_close(*args, **kwargs)
+        return result
+
+    file_obj.close = patched_close
+    FDS[id_] = FD(file_obj, traceback.format_stack())
+    return file_obj
+
+
+def patched_init(*args, **kwargs):
+    result = original_init(*args, **kwargs)
+    self = get_self(args, kwargs)
+    id_ = id(self)
+    FDS[id_] = FD(self, traceback.format_stack())
+    return result
+
+
+def patched_close(*args, **kwargs):
+    self = get_self(args, kwargs)
+    id_ = id(self)
+    FDS.pop(id_, None)
+    result = original_close(*args, **kwargs)
+    return result
+
+
+def patched_detach(*args, **kwargs):
+    self = get_self(args, kwargs)
+    id_ = id(self)
+    FDS.pop(id_, None)
+    result = original_detach(*args, **kwargs)
+    return result
+
+
+def run():
+    while should_continue():
+        time.sleep(INTERVAL)
+        threshold = time.time() - UNCLOSED_TIMEOUT
+        for id_, fd in list(FDS.items()):
+            if fd.created_at < threshold:
+                FDS.pop(id_)
+                print_error('UNCLOSED', fd.stack)
+    for fd in FDS.values():
+        print_error('UNCLOSED', fd.stack)
+
+
+if os.environ.get('DEBUG') == '1':
+    builtins.open = patched_open
+    socket.socket.__init__ = patched_init  # type: ignore
+    socket.socket.close = patched_close  # type: ignore
+    socket.socket.detach = patched_detach  # type: ignore
+    Thread(target=run, daemon=True).start()


### PR DESCRIPTION
**FD Leak Tracker**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
I used this locally to clear up the leaks in the remote runtime, such that as of writing it no longer seems to leak at all. ([In my PR)](https://github.com/All-Hands-AI/OpenHands/pull/6114) I figured it may be useful to others in testing the docker runtime, which currently seems to leak like a sieve.

If the environment variable "DEBUG" is set to "1", This code monkey patches the socket and open methods such that when one of these is initialized a stack trace is recorded. If 5 minutes pass and the resource is not closed, we print the stack trace.

I dunno if this is something we want to permanently include in openhands, but it does make finding leaks easier.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:95dc35d-nikolaik   --name openhands-app-95dc35d   docker.all-hands.dev/all-hands-ai/openhands:95dc35d
```