### PR TITLE
chore: remove repo info from initial query for #6057

### DIFF
--- a/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
@@ -14,17 +14,12 @@ import { AgentState } from "#/types/agent-state";
 
 export const useWSStatusChange = () => {
   const { send, status } = useWsClient();
-  const { gitHubToken } = useAuth();
   const { curAgentState } = useSelector((state: RootState) => state.agent);
   const dispatch = useDispatch();
 
   const statusRef = React.useRef<WsClientProviderStatus | null>(null);
 
-  const { selectedRepository } = useSelector(
-    (state: RootState) => state.initialQuery,
-  );
-
-  const { files, importedProjectZip, initialQuery } = useSelector(
+  const { files, initialQuery } = useSelector(
     (state: RootState) => state.initialQuery,
   );
 

--- a/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
@@ -33,30 +33,15 @@ export const useWSStatusChange = () => {
     send(createChatMessage(query, base64Files, timestamp));
   };
 
-  const dispatchInitialQuery = (query: string, additionalInfo: string) => {
-    if (additionalInfo) {
-      sendInitialQuery(`${query}\n\n[${additionalInfo}]`, files);
-    } else {
-      sendInitialQuery(query, files);
-    }
-
+  const dispatchInitialQuery = (query: string) => {
+    sendInitialQuery(query, files);
     dispatch(clearFiles()); // reset selected files
     dispatch(clearInitialQuery()); // reset initial query
   };
 
   const handleAgentInit = () => {
-    let additionalInfo = "";
-
-    if (gitHubToken && selectedRepository) {
-      additionalInfo = `Repository ${selectedRepository} has been cloned to /workspace. Please check the /workspace for files.`;
-    } else if (importedProjectZip) {
-      // if there's an uploaded project zip, add it to the chat
-      additionalInfo =
-        "Files have been uploaded. Please check the /workspace for files.";
-    }
-
     if (initialQuery) {
-      dispatchInitialQuery(initialQuery, additionalInfo);
+      dispatchInitialQuery(initialQuery);
     }
   };
   React.useEffect(() => {

--- a/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
@@ -1,6 +1,5 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useAuth } from "#/context/auth-context";
 import {
   useWsClient,
   WsClientProviderStatus,


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In https://github.com/All-Hands-AI/OpenHands/pull/6057, we inject information about repo from backend, therefore we can remove these addition info from FE.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9e03384-nikolaik   --name openhands-app-9e03384   docker.all-hands.dev/all-hands-ai/openhands:9e03384
```