### PR TITLE
Enhance play/pause button visibility

### DIFF
--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -20,7 +20,7 @@ export function ActionButton({
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out"
+        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out bg-gray-100 rounded-full p-2"
         type="button"
       >
         <span className="relative z-10 group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">


### PR DESCRIPTION
Added a circle around the play/pause button and a gray background to improve visibility.

Changes:
- Added bg-gray-100 class for a light gray background
- Added rounded-full class to make the button circular
- Added p-2 class for padding around the icon

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:81e0b3b-nikolaik   --name openhands-app-81e0b3b   docker.all-hands.dev/all-hands-ai/openhands:81e0b3b
```