### PR TITLE
Fix French doc

### DIFF
--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -1,5 +1,3 @@
-
-
 # Options de configuration
 
 Ce guide détaille toutes les options de configuration disponibles pour OpenHands, vous aidant à personnaliser son comportement et à l'intégrer avec d'autres services.
@@ -183,6 +181,10 @@ Les options de configuration de base sont définies dans la section `[core]` du 
 Les options de configuration LLM (Large Language Model) sont définies dans la section `[llm]` du fichier `config.toml`.
 
 Pour les utiliser avec la commande docker, passez `-e LLM_<option>`. Exemple : `-e LLM_NUM_RETRIES`.
+
+:::note
+Pour les configurations de développement, vous pouvez également définir des configurations LLM personnalisées. Voir [Configurations LLM personnalisées](https://docs.all-hands.dev/modules/usage/llms/custom-llm-configs) pour plus de détails.
+:::
 
 **Informations d'identification AWS**
 - `aws_access_key_id`
@@ -368,4 +370,26 @@ Les options de configuration de l'agent sont définies dans les sections `[agent
 - `codeact_enable_llm_editor`
   - Type : `bool`
   - Valeur par défaut : `false`
-  - Description : Si l'éditeur LLM est activé dans l'espace d'action (foncti
+  - Description : Si l'éditeur LLM est activé dans l'espace d'action (fonctionne uniquement avec l'appel de fonction)
+
+**Utilisation du micro-agent**
+- `use_microagents`
+  - Type : `bool`
+  - Valeur par défaut : `true`
+  - Description : Indique si l'utilisation des micro-agents est activée ou non
+
+- `disabled_microagents`
+  - Type : `list of str`
+  - Valeur par défaut : `None`
+  - Description : Liste des micro-agents à désactiver
+
+### Exécution
+- `timeout`
+  - Type : `int`
+  - Valeur par défaut : `120`
+  - Description : Délai d'expiration du bac à sable, en secondes
+
+- `user_id`
+  - Type : `int`
+  - Valeur par défaut : `1000`
+  - Description : ID de l'utilisateur du bac à sable

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -183,7 +183,7 @@ Les options de configuration LLM (Large Language Model) sont définies dans la s
 Pour les utiliser avec la commande docker, passez `-e LLM_<option>`. Exemple : `-e LLM_NUM_RETRIES`.
 
 :::note
-Pour les configurations de développement, vous pouvez également définir des configurations LLM personnalisées. Voir [Configurations LLM personnalisées](https://docs.all-hands.dev/modules/usage/llms/custom-llm-configs) pour plus de détails.
+Pour les configurations de développement, vous pouvez également définir des configurations LLM personnalisées. Voir [Configurations LLM personnalisées](../llms/custom-llm-configs) pour plus de détails.
 :::
 
 **Informations d'identification AWS**

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -183,7 +183,7 @@ Les options de configuration LLM (Large Language Model) sont définies dans la s
 Pour les utiliser avec la commande docker, passez `-e LLM_<option>`. Exemple : `-e LLM_NUM_RETRIES`.
 
 :::note
-Pour les configurations de développement, vous pouvez également définir des configurations LLM personnalisées. Voir [Configurations LLM personnalisées](../llms/custom-llm-configs) pour plus de détails.
+Pour les configurations de développement, vous pouvez également définir des configurations LLM personnalisées. Voir [Configurations LLM personnalisées](./llms/custom-llm-configs) pour plus de détails.
 :::
 
 **Informations d'identification AWS**

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/llms/custom-llm-configs.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/llms/custom-llm-configs.md
@@ -56,7 +56,7 @@ Chaque configuration LLM nommée prend en charge toutes les mêmes options que l
 - Limites de jetons (`max_input_tokens`, `max_output_tokens`)
 - Et toutes les autres options de configuration LLM
 
-Pour une liste complète des options disponibles, consultez la section Configuration LLM dans la documentation des [Options de configuration](../configuration-options.md).
+Pour une liste complète des options disponibles, consultez la section Configuration LLM dans la documentation des [Options de configuration](../configuration-options).
 
 ## Cas d'utilisation
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/llms/custom-llm-configs.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/llms/custom-llm-configs.md
@@ -1,0 +1,106 @@
+# Configurations LLM personnalisées
+
+OpenHands permet de définir plusieurs configurations LLM nommées dans votre fichier `config.toml`. Cette fonctionnalité vous permet d'utiliser différentes configurations LLM pour différents usages, comme utiliser un modèle moins coûteux pour les tâches qui ne nécessitent pas de réponses de haute qualité, ou utiliser différents modèles avec différents paramètres pour des agents spécifiques.
+
+## Comment ça fonctionne
+
+Les configurations LLM nommées sont définies dans le fichier `config.toml` en utilisant des sections qui commencent par `llm.`. Par exemple :
+
+```toml
+# Configuration LLM par défaut
+[llm]
+model = "gpt-4"
+api_key = "votre-clé-api"
+temperature = 0.0
+
+# Configuration LLM personnalisée pour un modèle moins coûteux
+[llm.gpt3]
+model = "gpt-3.5-turbo"
+api_key = "votre-clé-api"
+temperature = 0.2
+
+# Une autre configuration personnalisée avec des paramètres différents
+[llm.haute-creativite]
+model = "gpt-4"
+api_key = "votre-clé-api"
+temperature = 0.8
+top_p = 0.9
+```
+
+Chaque configuration nommée hérite de tous les paramètres de la section `[llm]` par défaut et peut remplacer n'importe lequel de ces paramètres. Vous pouvez définir autant de configurations personnalisées que nécessaire.
+
+## Utilisation des configurations personnalisées
+
+### Avec les agents
+
+Vous pouvez spécifier quelle configuration LLM un agent doit utiliser en définissant le paramètre `llm_config` dans la section de configuration de l'agent :
+
+```toml
+[agent.RepoExplorerAgent]
+# Utiliser la configuration GPT-3 moins coûteuse pour cet agent
+llm_config = 'gpt3'
+
+[agent.CodeWriterAgent]
+# Utiliser la configuration haute créativité pour cet agent
+llm_config = 'haute-creativite'
+```
+
+### Options de configuration
+
+Chaque configuration LLM nommée prend en charge toutes les mêmes options que la configuration LLM par défaut. Celles-ci incluent :
+
+- Sélection du modèle (`model`)
+- Configuration de l'API (`api_key`, `base_url`, etc.)
+- Paramètres du modèle (`temperature`, `top_p`, etc.)
+- Paramètres de nouvelle tentative (`num_retries`, `retry_multiplier`, etc.)
+- Limites de jetons (`max_input_tokens`, `max_output_tokens`)
+- Et toutes les autres options de configuration LLM
+
+Pour une liste complète des options disponibles, consultez la section Configuration LLM dans la documentation des [Options de configuration](../configuration-options.md).
+
+## Cas d'utilisation
+
+Les configurations LLM personnalisées sont particulièrement utiles dans plusieurs scénarios :
+
+- **Optimisation des coûts** : Utiliser des modèles moins coûteux pour les tâches qui ne nécessitent pas de réponses de haute qualité, comme l'exploration de dépôt ou les opérations simples sur les fichiers.
+- **Réglage spécifique aux tâches** : Configurer différentes valeurs de température et de top_p pour les tâches qui nécessitent différents niveaux de créativité ou de déterminisme.
+- **Différents fournisseurs** : Utiliser différents fournisseurs LLM ou points d'accès API pour différentes tâches.
+- **Tests et développement** : Basculer facilement entre différentes configurations de modèles pendant le développement et les tests.
+
+## Exemple : Optimisation des coûts
+
+Un exemple pratique d'utilisation des configurations LLM personnalisées pour optimiser les coûts :
+
+```toml
+# Configuration par défaut utilisant GPT-4 pour des réponses de haute qualité
+[llm]
+model = "gpt-4"
+api_key = "votre-clé-api"
+temperature = 0.0
+
+# Configuration moins coûteuse pour l'exploration de dépôt
+[llm.repo-explorer]
+model = "gpt-3.5-turbo"
+temperature = 0.2
+
+# Configuration pour la génération de code
+[llm.code-gen]
+model = "gpt-4"
+temperature = 0.0
+max_output_tokens = 2000
+
+[agent.RepoExplorerAgent]
+llm_config = 'repo-explorer'
+
+[agent.CodeWriterAgent]
+llm_config = 'code-gen'
+```
+
+Dans cet exemple :
+- L'exploration de dépôt utilise un modèle moins coûteux car il s'agit principalement de comprendre et de naviguer dans le code
+- La génération de code utilise GPT-4 avec une limite de jetons plus élevée pour générer des blocs de code plus importants
+- La configuration par défaut reste disponible pour les autres tâches
+
+:::note
+Les configurations LLM personnalisées ne sont disponibles que lors de l'utilisation d'OpenHands en mode développement, via `main.py` ou `cli.py`. Lors de l'exécution via `docker run`, veuillez utiliser les options de configuration standard.
+:::

--- a/docs/modules/usage/configuration-options.md
+++ b/docs/modules/usage/configuration-options.md
@@ -141,7 +141,7 @@ The LLM (Large Language Model) configuration options are defined in the `[llm]` 
 To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LLM_NUM_RETRIES`.
 
 :::note
-For development setups, you can also define custom named LLM configurations. See [Custom LLM Configurations](https://docs.all-hands.dev/modules/usage/llms/custom-llm-configs) for details.
+For development setups, you can also define custom named LLM configurations. See [Custom LLM Configurations](../llms/custom-llm-configs) for details.
 :::
 
 **AWS Credentials**

--- a/docs/modules/usage/configuration-options.md
+++ b/docs/modules/usage/configuration-options.md
@@ -141,7 +141,7 @@ The LLM (Large Language Model) configuration options are defined in the `[llm]` 
 To use these with the docker command, pass in `-e LLM_<option>`. Example: `-e LLM_NUM_RETRIES`.
 
 :::note
-For development setups, you can also define custom named LLM configurations. See [Custom LLM Configurations](../llms/custom-llm-configs) for details.
+For development setups, you can also define custom named LLM configurations. See [Custom LLM Configurations](./llms/custom-llm-configs) for details.
 :::
 
 **AWS Credentials**

--- a/docs/modules/usage/llms/custom-llm-configs.md
+++ b/docs/modules/usage/llms/custom-llm-configs.md
@@ -56,7 +56,7 @@ Each named LLM configuration supports all the same options as the default LLM co
 - Token limits (`max_input_tokens`, `max_output_tokens`)
 - And all other LLM configuration options
 
-For a complete list of available options, see the LLM Configuration section in the [Configuration Options](../configuration-options.md) documentation.
+For a complete list of available options, see the LLM Configuration section in the [Configuration Options](../configuration-options) documentation.
 
 ## Use Cases
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Docusaurus reports a broken link for the French version. I thought I fixed it in the previous PR, but the Docusaurus job is not required and it went through with auto-merge without me noticing.

This PR proposes to update the French version to document the custom llm configs in toml, and fix that link.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e2a7041-nikolaik   --name openhands-app-e2a7041   docker.all-hands.dev/all-hands-ai/openhands:e2a7041
```