### PR TITLE
[Feature] Refactor runtime executor for better extensibility/configurability

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -69,6 +69,9 @@ workspace_base = "./workspace"
 # Runtime environment
 #runtime = "eventstream"
 
+# Runtime executor
+#runtime_executor = "openhands.runtime.executor:ActionExecutor"
+
 # Name of the default agent
 #default_agent = "CodeActAgent"
 

--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -52,6 +52,7 @@ class AppConfig:
     sandbox: SandboxConfig = field(default_factory=SandboxConfig)
     security: SecurityConfig = field(default_factory=SecurityConfig)
     runtime: str = 'docker'
+    runtime_executor: str = 'openhands.runtime.executor:ActionExecutor'
     file_store: str = 'local'
     file_store_path: str = '/tmp/openhands_file_store'
     save_trajectory_path: str | None = None

--- a/openhands/runtime/executor/__init__.py
+++ b/openhands/runtime/executor/__init__.py
@@ -1,0 +1,4 @@
+from .base import RuntimeExecutor
+from .action_executor import ActionExecutor, BaseActionExecutor
+
+__all__ = ['ActionExecutor', 'BaseActionExecutor', 'RuntimeExecutor']

--- a/openhands/runtime/executor/action_executor.py
+++ b/openhands/runtime/executor/action_executor.py
@@ -1,0 +1,267 @@
+import base64
+import json
+import mimetypes
+import os
+from pathlib import Path
+import re
+from openhands_aci.utils.diff import get_diff
+from openhands.core.logger import openhands_logger as logger
+from openhands.events.action.browse import BrowseInteractiveAction, BrowseURLAction
+from openhands.events.action.commands import IPythonRunCellAction
+from openhands.events.action.files import FileReadAction, FileWriteAction
+from openhands.events.event import FileEditSource, FileReadSource
+from openhands.events.observation.commands import (
+    IPythonRunCellObservation,
+)
+from openhands.events.observation.error import ErrorObservation
+from openhands.events.observation.files import (
+    FileEditObservation,
+    FileReadObservation,
+    FileWriteObservation,
+)
+from openhands.events.observation.observation import Observation
+from openhands.runtime.browser import browse
+from openhands.runtime.executor.base import RuntimeExecutor
+from openhands.runtime.plugins.jupyter import JupyterPlugin
+from openhands.runtime.utils.files import insert_lines, read_lines
+
+
+class BaseActionExecutor(RuntimeExecutor):
+    """Runtime executor that dynamically dispatches actions to the appropriate method based on their name."""
+
+    async def run_action(self, action) -> Observation:
+        async with self.lock:
+            action_type = action.action
+            logger.debug(f'Running action:\n{action}')
+            observation = await getattr(self, action_type)(action)
+            logger.debug(f'Action output:\n{observation}')
+            return observation
+
+
+class ActionExecutor(BaseActionExecutor):
+    """ActionExecutor runs inside docker sandbox.
+    It is responsible for executing actions received from OpenHands backend and producing observations.
+    It is a BaseActionExectuor that provides a default implementation for all of the built-in actions.
+    """
+
+    async def run_ipython(self, action: IPythonRunCellAction) -> Observation:
+        assert self.bash_session is not None
+        if 'jupyter' in self.plugins:
+            _jupyter_plugin: JupyterPlugin = self.plugins['jupyter']  # type: ignore
+            # This is used to make AgentSkills in Jupyter aware of the
+            # current working directory in Bash
+            jupyter_cwd = getattr(self, '_jupyter_cwd', None)
+            if self.bash_session.cwd != jupyter_cwd:
+                logger.debug(
+                    f'{self.bash_session.cwd} != {jupyter_cwd} -> reset Jupyter PWD'
+                )
+                reset_jupyter_cwd_code = (
+                    f'import os; os.chdir("{self.bash_session.cwd}")'
+                )
+                _aux_action = IPythonRunCellAction(code=reset_jupyter_cwd_code)
+                _reset_obs: IPythonRunCellObservation = await _jupyter_plugin.run(
+                    _aux_action
+                )
+                logger.debug(
+                    f'Changed working directory in IPython to: {self.bash_session.cwd}. Output: {_reset_obs}'
+                )
+                self._jupyter_cwd = self.bash_session.cwd
+
+            obs: IPythonRunCellObservation = await _jupyter_plugin.run(action)
+            obs.content = obs.content.rstrip()
+            matches = re.findall(
+                r'<oh_aci_output_[0-9a-f]{32}>(.*?)</oh_aci_output_[0-9a-f]{32}>',
+                obs.content,
+                re.DOTALL,
+            )
+            if matches:
+                results: list[str] = []
+                if len(matches) == 1:
+                    # Use specific actions/observations types
+                    match = matches[0]
+                    try:
+                        result_dict = json.loads(match)
+                        if result_dict.get('path'):  # Successful output
+                            if (
+                                result_dict['new_content'] is not None
+                            ):  # File edit commands
+                                diff = get_diff(
+                                    old_contents=result_dict['old_content']
+                                    or '',  # old_content is None when file is created
+                                    new_contents=result_dict['new_content'],
+                                    filepath=result_dict['path'],
+                                )
+                                return FileEditObservation(
+                                    content=diff,
+                                    path=result_dict['path'],
+                                    old_content=result_dict['old_content'],
+                                    new_content=result_dict['new_content'],
+                                    prev_exist=result_dict['prev_exist'],
+                                    impl_source=FileEditSource.OH_ACI,
+                                    formatted_output_and_error=result_dict[
+                                        'formatted_output_and_error'
+                                    ],
+                                )
+                            else:  # File view commands
+                                return FileReadObservation(
+                                    content=result_dict['formatted_output_and_error'],
+                                    path=result_dict['path'],
+                                    impl_source=FileReadSource.OH_ACI,
+                                )
+                        else:  # Error output
+                            results.append(result_dict['formatted_output_and_error'])
+                    except json.JSONDecodeError:
+                        # Handle JSON decoding errors if necessary
+                        results.append(
+                            f"Invalid JSON in 'openhands-aci' output: {match}"
+                        )
+                else:
+                    for match in matches:
+                        try:
+                            result_dict = json.loads(match)
+                            results.append(result_dict['formatted_output_and_error'])
+                        except json.JSONDecodeError:
+                            # Handle JSON decoding errors if necessary
+                            results.append(
+                                f"Invalid JSON in 'openhands-aci' output: {match}"
+                            )
+
+                # Combine the results (e.g., join them) or handle them as required
+                obs.content = '\n'.join(str(result) for result in results)
+
+            if action.include_extra:
+                obs.content += (
+                    f'\n[Jupyter current working directory: {self.bash_session.cwd}]'
+                )
+                obs.content += f'\n[Jupyter Python interpreter: {_jupyter_plugin.python_interpreter_path}]'
+            return obs
+        else:
+            raise RuntimeError(
+                'JupyterRequirement not found. Unable to run IPython action.'
+            )
+
+    def _resolve_path(self, path: str, working_dir: str) -> str:
+        filepath = Path(path)
+        if not filepath.is_absolute():
+            return str(Path(working_dir) / filepath)
+        return str(filepath)
+
+    async def read(self, action: FileReadAction) -> Observation:
+        assert self.bash_session is not None
+        if action.impl_source == FileReadSource.OH_ACI:
+            return await self.run_ipython(
+                IPythonRunCellAction(
+                    code=action.translated_ipython_code,
+                    include_extra=False,
+                )
+            )
+
+        # NOTE: the client code is running inside the sandbox,
+        # so there's no need to check permission
+        working_dir = self.bash_session.cwd
+        filepath = self._resolve_path(action.path, working_dir)
+        try:
+            if filepath.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp', '.gif')):
+                with open(filepath, 'rb') as file:
+                    image_data = file.read()
+                    encoded_image = base64.b64encode(image_data).decode('utf-8')
+                    mime_type, _ = mimetypes.guess_type(filepath)
+                    if mime_type is None:
+                        mime_type = 'image/png'  # default to PNG if mime type cannot be determined
+                    encoded_image = f'data:{mime_type};base64,{encoded_image}'
+
+                return FileReadObservation(path=filepath, content=encoded_image)
+            elif filepath.lower().endswith('.pdf'):
+                with open(filepath, 'rb') as file:
+                    pdf_data = file.read()
+                    encoded_pdf = base64.b64encode(pdf_data).decode('utf-8')
+                    encoded_pdf = f'data:application/pdf;base64,{encoded_pdf}'
+                return FileReadObservation(path=filepath, content=encoded_pdf)
+            elif filepath.lower().endswith(('.mp4', '.webm', '.ogg')):
+                with open(filepath, 'rb') as file:
+                    video_data = file.read()
+                    encoded_video = base64.b64encode(video_data).decode('utf-8')
+                    mime_type, _ = mimetypes.guess_type(filepath)
+                    if mime_type is None:
+                        mime_type = 'video/mp4'  # default to MP4 if MIME type cannot be determined
+                    encoded_video = f'data:{mime_type};base64,{encoded_video}'
+
+                return FileReadObservation(path=filepath, content=encoded_video)
+
+            with open(filepath, 'r', encoding='utf-8') as file:
+                lines = read_lines(file.readlines(), action.start, action.end)
+        except FileNotFoundError:
+            return ErrorObservation(
+                f'File not found: {filepath}. Your current working directory is {working_dir}.'
+            )
+        except UnicodeDecodeError:
+            return ErrorObservation(f'File could not be decoded as utf-8: {filepath}.')
+        except IsADirectoryError:
+            return ErrorObservation(
+                f'Path is a directory: {filepath}. You can only read files'
+            )
+
+        code_view = ''.join(lines)
+        return FileReadObservation(path=filepath, content=code_view)
+
+    async def write(self, action: FileWriteAction) -> Observation:
+        assert self.bash_session is not None
+        working_dir = self.bash_session.cwd
+        filepath = self._resolve_path(action.path, working_dir)
+
+        insert = action.content.split('\n')
+        try:
+            if not os.path.exists(os.path.dirname(filepath)):
+                os.makedirs(os.path.dirname(filepath))
+
+            file_exists = os.path.exists(filepath)
+            if file_exists:
+                file_stat = os.stat(filepath)
+            else:
+                file_stat = None
+
+            mode = 'w' if not file_exists else 'r+'
+            try:
+                with open(filepath, mode, encoding='utf-8') as file:
+                    if mode != 'w':
+                        all_lines = file.readlines()
+                        new_file = insert_lines(
+                            insert, all_lines, action.start, action.end
+                        )
+                    else:
+                        new_file = [i + '\n' for i in insert]
+
+                    file.seek(0)
+                    file.writelines(new_file)
+                    file.truncate()
+
+                # Handle file permissions
+                if file_exists:
+                    assert file_stat is not None
+                    # restore the original file permissions if the file already exists
+                    os.chmod(filepath, file_stat.st_mode)
+                    os.chown(filepath, file_stat.st_uid, file_stat.st_gid)
+                else:
+                    # set the new file permissions if the file is new
+                    os.chmod(filepath, 0o664)
+                    os.chown(filepath, self.user_id, self.user_id)
+
+            except FileNotFoundError:
+                return ErrorObservation(f'File not found: {filepath}')
+            except IsADirectoryError:
+                return ErrorObservation(
+                    f'Path is a directory: {filepath}. You can only write to files'
+                )
+            except UnicodeDecodeError:
+                return ErrorObservation(
+                    f'File could not be decoded as utf-8: {filepath}'
+                )
+        except PermissionError:
+            return ErrorObservation(f'Malformed paths not permitted: {filepath}')
+        return FileWriteObservation(content='', path=filepath)
+
+    async def browse(self, action: BrowseURLAction) -> Observation:
+        return await browse(action, self.browser)
+
+    async def browse_interactive(self, action: BrowseInteractiveAction) -> Observation:
+        return await browse(action, self.browser)

--- a/openhands/runtime/executor/base.py
+++ b/openhands/runtime/executor/base.py
@@ -1,0 +1,126 @@
+import asyncio
+import time
+from openhands.core.logger import openhands_logger as logger
+from openhands.events.action.commands import CmdRunAction, IPythonRunCellAction
+from openhands.events.observation.commands import CmdOutputObservation
+from openhands.events.observation.error import ErrorObservation
+from openhands.runtime.browser.browser_env import BrowserEnv
+from openhands.runtime.plugins.jupyter import JupyterPlugin
+from openhands.runtime.plugins.requirement import Plugin
+from openhands.runtime.utils.bash import BashSession
+from openhands.runtime.utils.runtime_init import init_user_and_working_directory
+from openhands.utils.async_utils import call_sync_from_async, wait_all
+
+
+ROOT_GID = 0
+INIT_COMMANDS = [
+    'git config --global user.name "openhands" && git config --global user.email "openhands@all-hands.dev" && alias git="git --no-pager"',
+]
+
+
+class RuntimeExecutor:
+    """RuntimeExecutor for running inside docker sandbox.
+    It provides a minimal base class that handles initialization of the executor, and provides a run method to execute bash commands.
+    """
+
+    def __init__(
+        self,
+        plugins_to_load: list[Plugin],
+        work_dir: str,
+        username: str,
+        user_id: int,
+        browsergym_eval_env: str | None,
+    ) -> None:
+        self.plugins_to_load = plugins_to_load
+        self._initial_cwd = work_dir
+        self.username = username
+        self.user_id = user_id
+        _updated_user_id = init_user_and_working_directory(
+            username=username, user_id=self.user_id, initial_cwd=work_dir
+        )
+        if _updated_user_id is not None:
+            self.user_id = _updated_user_id
+
+        self.bash_session: BashSession | None = None
+        self.lock = asyncio.Lock()
+        self.plugins: dict[str, Plugin] = {}
+        self.browser = BrowserEnv(browsergym_eval_env)
+        self.start_time = time.time()
+        self.last_execution_time = self.start_time
+        self._initialized = False
+
+    @property
+    def initial_cwd(self):
+        return self._initial_cwd
+
+    async def ainit(self):
+        # bash needs to be initialized first
+        self.bash_session = BashSession(
+            work_dir=self._initial_cwd,
+            username=self.username,
+        )
+        self.bash_session.initialize()
+        await wait_all(
+            (self._init_plugin(plugin) for plugin in self.plugins_to_load),
+            timeout=30,
+        )
+
+        # This is a temporary workaround
+        # TODO: refactor AgentSkills to be part of JupyterPlugin
+        # AFTER ServerRuntime is deprecated
+        if 'agent_skills' in self.plugins and 'jupyter' in self.plugins:
+            obs = await self.run_ipython(
+                IPythonRunCellAction(
+                    code='from openhands.runtime.plugins.agent_skills.agentskills import *\n'
+                )
+            )
+            logger.debug(f'AgentSkills initialized: {obs}')
+
+        await self._init_bash_commands()
+        logger.debug('Runtime client initialized.')
+
+        self._initialized = True
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    async def _init_plugin(self, plugin: Plugin):
+        assert self.bash_session is not None
+        await plugin.initialize(self.username)
+        self.plugins[plugin.name] = plugin
+        logger.debug(f'Initializing plugin: {plugin.name}')
+
+        if isinstance(plugin, JupyterPlugin):
+            await self.run_ipython(
+                IPythonRunCellAction(
+                    code=f'import os; os.chdir("{self.bash_session.cwd}")'
+                )
+            )
+
+    async def _init_bash_commands(self):
+        logger.debug(f'Initializing by running {len(INIT_COMMANDS)} bash commands...')
+        for command in INIT_COMMANDS:
+            action = CmdRunAction(command=command)
+            action.timeout = 300
+            logger.debug(f'Executing init command: {command}')
+            obs = await self.run(action)
+            assert isinstance(obs, CmdOutputObservation)
+            logger.debug(
+                f'Init command outputs (exit code: {obs.exit_code}): {obs.content}'
+            )
+            assert obs.exit_code == 0
+
+        logger.debug('Bash init commands completed')
+
+    async def run(
+        self, action: CmdRunAction
+    ) -> CmdOutputObservation | ErrorObservation:
+        assert self.bash_session is not None
+        obs = await call_sync_from_async(self.bash_session.execute, action)
+        return obs
+
+    def close(self):
+        if self.bash_session is not None:
+            self.bash_session.close()
+        self.browser.close()

--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -49,6 +49,8 @@ def get_action_execution_server_startup_command(
         '--user-id',
         str(sandbox_config.user_id),
         *browsergym_args,
+        '--executor-class',
+        app_config.runtime_executor,
     ]
 
     if is_root and use_nice_for_root:


### PR DESCRIPTION
### Overview

This PR refactors the action_execution_server and ActionExecutor, to facilitate extensibility and customization of the executor within the runtime. In particular:

* Definition of the executor class is moved out of the `action_executor_server.py` script, leaving it to focus on the API server implementation.
* The `ActionExecutor` class has been refactored into a hierarchy:
  * `RuntimeExecutor` in `runtime/executor/base.py` handles the setup/teardown of the common resources: bash session, browser, plugins, etc.
  * `BaseActionExecutor` in `runtime/executor/action_executor.py` adds the dynamic `run_action` dispatcher.
  * `ActionExecutor` in the same file, adds the detailed implementation for all of the standard runners (`run_ipython`, `read`, `browse`, etc).

Importantly, the executor class to be used as been added to the AppConfig and can be used to specify an arbitrary class (even from an external module) to provide the executor implementation, as long as it implements the base interface. For example, you can set `runtime_executor = "my_package.some_module:MyCustomExecutor"`.

Note that I have not changed any code/functionality of the existing `ActionExecutor`, just distributed its code around into the three-class hierarchy. There are minor changes elsewhere in the code to accommodate the new configuration setting.

### Rationale

This change makes it possible to easily extend/override/customize the builtin executor implementation, without having to operate on core classes in the OpenHands repo (or even make change to the repo at all).

### Caveats

In the exiting `ActionExecutor`, there is a block of code labeled "TODO" in the `ainit` method, which evidently is meant to be removed pending an unrelated refactoring operation. This temporary block of code depends on the `run_ipython` method, which is not implemented in the base class. Rather that introducing additional abstractions to accommodate this temporary code, I have elected to leave it in place in the base implementation. However **this means executor classes will fail to initialize unless they provide the `run_ipython` method** (as the default ActionExecutor does).

A more general fix would be to add an overridable hook method that can be called in the ainit function, which I'm happy to add if deemed necessary.


In the the base `RuntimeExecutor` in `runtime/executor/base.py`, there 



**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Runtime executor can now be subclassed to provide custom or extended functionality.
The executor class used in the runtime can be configured with:

```
[core]
runtime_executor = "your_package.your_module:YourCustomExecutorClass"
```

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**


---
**Link of any specific issues this addresses**