### PR TITLE
Separate data extraction and convo creation logic

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -44,6 +44,12 @@ async def connect(connection_id: str, environ, auth):
 
         conversation_store = await ConversationStoreImpl.get_instance(config, user_id)
         metadata = await conversation_store.get_metadata(conversation_id)
+
+        logger.info(
+            f'metadata user id {metadata.github_user_id}, {type(metadata.github_user_id)}'
+        )
+        logger.info(f'user id {user_id}, {type(user_id)}')
+
         if metadata.github_user_id != user_id:
             logger.error(
                 f'User {user_id} is not allowed to join conversation {conversation_id}'

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -45,12 +45,7 @@ async def connect(connection_id: str, environ, auth):
         conversation_store = await ConversationStoreImpl.get_instance(config, user_id)
         metadata = await conversation_store.get_metadata(conversation_id)
 
-        logger.info(
-            f'metadata user id {metadata.github_user_id}, {type(metadata.github_user_id)}'
-        )
-        logger.info(f'user id {user_id}, {type(user_id)}')
-
-        if metadata.github_user_id != user_id:
+        if metadata.github_user_id != str(user_id):
             logger.error(
                 f'User {user_id} is not allowed to join conversation {conversation_id}'
             )

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -38,6 +38,7 @@ async def _create_new_conversation(
     token: str | None,
     selected_repository: str | None,
 ):
+    logger.info('Loading settings')
     settings_store = await SettingsStoreImpl.get_instance(config, user_id)
     settings = await settings_store.load()
     logger.info('Settings loaded')
@@ -117,8 +118,6 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     using the returned conversation ID
     """
     logger.info('Initializing new conversation')
-
-    logger.info('Loading settings')
     user_id = get_user_id(request)
     github_token = getattr(request.state, 'github_token', '') or data.github_token
     selected_repository = data.selected_repository

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -18,7 +18,6 @@ from openhands.storage.data_models.conversation_info_result_set import (
 )
 from openhands.storage.data_models.conversation_metadata import ConversationMetadata
 from openhands.storage.data_models.conversation_status import ConversationStatus
-from openhands.storage.settings.settings_store import SettingsStore
 from openhands.utils.async_utils import (
     GENERAL_TIMEOUT,
     call_async_from_sync,
@@ -35,11 +34,11 @@ class InitSessionRequest(BaseModel):
 
 
 async def _create_new_conversation(
-    settings_store: SettingsStore,
     user_id: str | None,
     token: str | None,
     selected_repository: str | None,
 ):
+    settings_store = await SettingsStoreImpl.get_instance(config, user_id)
     settings = await settings_store.load()
     logger.info('Settings loaded')
 
@@ -124,10 +123,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     github_token = getattr(request.state, 'github_token', '') or data.github_token
     selected_repository = data.selected_repository
 
-    settings_store = await SettingsStoreImpl.get_instance(config, user_id)
-    await _create_new_conversation(
-        settings_store, user_id, github_token, selected_repository
-    )
+    await _create_new_conversation(user_id, github_token, selected_repository)
 
 
 @app.get('/conversations')

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -122,7 +122,10 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     github_token = getattr(request.state, 'github_token', '') or data.github_token
     selected_repository = data.selected_repository
 
-    await _create_new_conversation(user_id, github_token, selected_repository)
+    response = await _create_new_conversation(
+        user_id, github_token, selected_repository
+    )
+    return response
 
 
 @app.get('/conversations')

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -108,7 +108,13 @@ async def _create_new_conversation(
     except ValueError:
         pass  # Already subscribed - take no action
     logger.info(f'Finished initializing conversation {conversation_id}')
-    return JSONResponse(content={'status': 'ok', 'conversation_id': conversation_id})
+    return JSONResponse(
+        content={
+            'status': 'ok',
+            'conversation_id': conversation_id,
+            'sid': event_stream.sid,
+        }
+    )
 
 
 @app.post('/conversations')

--- a/openhands/server/types.py
+++ b/openhands/server/types.py
@@ -35,3 +35,15 @@ class OpenhandsConfigInterface(ABC):
     async def get_config(self) -> dict[str, str]:
         """Configure attributes for frontend"""
         raise NotImplementedError
+
+
+class MissingSettingsError(ValueError):
+    """Raised when settings are missing or not found."""
+
+    pass
+
+
+class LLMAuthenticationError(ValueError):
+    """Raised when there is an issue with LLM authentication."""
+
+    pass


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We'd like to extract parameters from the request body, and create a conversation using the parameters in two separate functions; this allows us to reuse `create_convo` elsewhere


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:46482bf-nikolaik   --name openhands-app-46482bf   docker.all-hands.dev/all-hands-ai/openhands:46482bf
```