### PR TITLE
remove useless axtree str

### DIFF
--- a/openhands/events/observation/browse.py
+++ b/openhands/events/observation/browse.py
@@ -100,5 +100,4 @@ class BrowserOutputObservation(Observation):
             skip_generic=False,
             filter_visible_only=filter_visible_only,
         )
-        self._axtree_str = cur_axtree_txt
         return cur_axtree_txt


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- This PR removes an unnecessary variable (`_axtree_str`) in the `BrowserOutputObservation` class, which was not being used.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Removed the unused `_axtree_str` assignment to clean up the code and improve maintainability. This change does not affect any external functionality.

---
**Link of any specific issues this addresses**
