### PR TITLE
fix: Restore missing translation keys

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -1259,6 +1259,10 @@
         "no": "Kunne ikke hente modeller og agenter",
         "ja": "モデルとエージェントの取得に失敗しました"
     },
+    "CONFIGURATION$SETTINGS_NOT_FOUND": {
+        "en": "Settings not found. Please check your API key",
+        "es": "Configuraciones no encontradas. Por favor revisa tu API key"
+    },
     "SESSION$SESSION_HANDLING_ERROR_MESSAGE": {
         "en": "Error handling message",
         "zh-CN": "处理会话时出错",

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -1263,6 +1263,24 @@
         "en": "Settings not found. Please check your API key",
         "es": "Configuraciones no encontradas. Por favor revisa tu API key"
     },
+    "CONNECT_TO_GITHUB_BY_TOKEN_MODAL$TERMS_OF_SERVICE": {
+        "en": "terms of service",
+        "es": "términos de servicio"
+    },
+    "SESSION$SERVER_CONNECTED_MESSAGE": {
+        "en": "Connected to server",
+        "zh-CN": "已连接到服务器",
+        "de": "Verbindung zum Server hergestellt",
+        "zh-TW": "已連接到伺服器",
+        "es": "Conectado al servidor",
+        "fr": "Connecté au serveur",
+        "it": "Connesso al server",
+        "pt": "Conectado ao servidor",
+        "ko-KR": "서버에 연결됨",
+        "ar": "تم الاتصال بالخادم",
+        "tr": "Sunucuya bağlandı",
+        "no": "Koblet til server"
+    },
     "SESSION$SESSION_HANDLING_ERROR_MESSAGE": {
         "en": "Error handling message",
         "zh-CN": "处理会话时出错",


### PR DESCRIPTION
### Description
This PR restores several translation keys that were present in commit 92b8d55 but were missing in the current version of the translation file.

### Changes
- Added back `CONFIGURATION$SETTINGS_NOT_FOUND` with English and Spanish translations
- Restored `CONNECT_TO_GITHUB_BY_TOKEN_MODAL$TERMS_OF_SERVICE` (en, es)
- Restored `SESSION$SERVER_CONNECTED_MESSAGE` with all language variants

### Context
These translations were identified as missing when comparing the current translation file against commit 92b8d55. Restoring them ensures we maintain full internationalization support for all features.

### Testing
- Verified all restored keys match exactly with their previous versions from commit 92b8d55
- Maintained JSON structure and formatting

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:096eb59-nikolaik   --name openhands-app-096eb59   docker.all-hands.dev/all-hands-ai/openhands:096eb59
```