### PR TITLE
Fix for issue with user id

### DIFF
--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -36,7 +37,13 @@ class FileConversationStore(ConversationStore):
     async def get_metadata(self, conversation_id: str) -> ConversationMetadata:
         path = self.get_conversation_metadata_filename(conversation_id)
         json_str = await call_sync_from_async(self.file_store.read, path)
-        result = conversation_metadata_type_adapter.validate_json(json_str)
+
+        # Temp: force int to str to stop pydandic being, well... pedantic
+        json_obj = json.loads(json_str)
+        if isinstance(json_obj.get('github_user_id'), int):
+            json_obj['github_user_id'] = str(json_obj.get('github_user_id'))
+
+        result = conversation_metadata_type_adapter.validate_python(json_obj)
         return result
 
     async def delete_metadata(self, conversation_id: str) -> None:

--- a/tests/unit/test_file_conversation_store.py
+++ b/tests/unit/test_file_conversation_store.py
@@ -1,0 +1,42 @@
+import json
+
+import pytest
+
+from openhands.storage.conversation.file_conversation_store import FileConversationStore
+from openhands.storage.data_models.conversation_metadata import ConversationMetadata
+from openhands.storage.memory import InMemoryFileStore
+
+
+@pytest.mark.asyncio
+async def test_load_store():
+    store = FileConversationStore(InMemoryFileStore({}))
+    expected = ConversationMetadata(
+        conversation_id='some-conversation-id',
+        github_user_id='some-user-id',
+        selected_repository='some-repo',
+        title="Let's talk about trains",
+    )
+    await store.save_metadata(expected)
+    found = await store.get_metadata('some-conversation-id')
+    assert expected == found
+
+
+@pytest.mark.asyncio
+async def test_load_int_user_id():
+    store = FileConversationStore(
+        InMemoryFileStore(
+            {
+                'sessions/some-conversation-id/metadata.json': json.dumps(
+                    {
+                        'conversation_id': 'some-conversation-id',
+                        'github_user_id': 12345,
+                        'selected_repository': 'some-repo',
+                        'title': "Let's talk about trains",
+                        'created_at': '2025-01-16T19:51:04.886331Z',
+                    }
+                )
+            }
+        )
+    )
+    found = await store.get_metadata('some-conversation-id')
+    assert found.github_user_id == '12345'


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Fixes an issue where conversations could fail to load if the GitHub user ID was stored as a number instead of a string.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Fixed an issue that could prevent loading previous conversations for some users.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR fixes a type mismatch issue in the conversation metadata handling:

1. The `ConversationMetadata` model expects `github_user_id` to be a string
2. However, some metadata files have this stored as an integer (likely from direct GitHub API responses)
3. Added a temporary conversion step in `get_metadata()` to convert integer user IDs to strings
4. Added unit tests to verify the conversion works correctly

This is a temporary fix to handle existing data. A more permanent solution would be to:
1. Ensure all new data is stored with string IDs
2. Add a migration script to update existing data

---
**Link of any specific issues this addresses**

N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:61fbddb-nikolaik   --name openhands-app-61fbddb   docker.all-hands.dev/all-hands-ai/openhands:61fbddb
```