### PR TITLE
Better message when trying to reconnect

### DIFF
--- a/frontend/src/components/features/controls/agent-status-bar.tsx
+++ b/frontend/src/components/features/controls/agent-status-bar.tsx
@@ -5,11 +5,16 @@ import toast from "react-hot-toast";
 import { RootState } from "#/store";
 import { AgentState } from "#/types/agent-state";
 import { AGENT_STATUS_MAP } from "../../agent-status-map.constant";
+import {
+  useWsClient,
+  WsClientProviderStatus,
+} from "#/context/ws-client-provider";
 
 export function AgentStatusBar() {
   const { t, i18n } = useTranslation();
   const { curAgentState } = useSelector((state: RootState) => state.agent);
   const { curStatusMessage } = useSelector((state: RootState) => state.status);
+  const { status } = useWsClient();
 
   const [statusMessage, setStatusMessage] = React.useState<string>("");
 
@@ -37,7 +42,11 @@ export function AgentStatusBar() {
   }, [curStatusMessage.id]);
 
   React.useEffect(() => {
-    setStatusMessage(AGENT_STATUS_MAP[curAgentState].message);
+    if (status === WsClientProviderStatus.DISCONNECTED) {
+      setStatusMessage("Trying to reconnect...");
+    } else {
+      setStatusMessage(AGENT_STATUS_MAP[curAgentState].message);
+    }
   }, [curAgentState]);
 
   return (

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -81,6 +81,9 @@ export function updateStatusWhenErrorMessagePresent(data: ErrorArg | unknown) {
     !!val && typeof val === "object";
   const isString = (val: unknown): val is string => typeof val === "string";
   if (isObject(data) && "message" in data && isString(data.message)) {
+    if (data.message === 'websocket error') {
+      return;
+    }
     let msgId: string | undefined;
     if (
       "data" in data &&

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -81,7 +81,7 @@ export function updateStatusWhenErrorMessagePresent(data: ErrorArg | unknown) {
     !!val && typeof val === "object";
   const isString = (val: unknown): val is string => typeof val === "string";
   if (isObject(data) && "message" in data && isString(data.message)) {
-    if (data.message === 'websocket error') {
+    if (data.message === "websocket error") {
       return;
     }
     let msgId: string | undefined;


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Changelog: Better error messages when UI is disconnected from backend

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Currently if the websocket disconnects, we get a stream of chat messages saying `websocket error`. This changes it to show a nicer error message in the status bar

<img width="330" alt="Screenshot 2025-01-16 at 4 37 13 PM" src="https://github.com/user-attachments/assets/b5c60536-d793-44f9-8a81-d981dc3ff817" />



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f899085-nikolaik   --name openhands-app-f899085   docker.all-hands.dev/all-hands-ai/openhands:f899085
```