### PR TITLE
Fix issue #5620: [Bug]: Resolver fails when the existing requirements.txt does not end in a newline character

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -84,6 +84,10 @@ jobs:
         run: |
           python -m pip index versions openhands-ai > openhands_versions.txt
           OPENHANDS_VERSION=$(head -n 1 openhands_versions.txt | awk '{print $2}' | tr -d '()')
+          # Ensure requirements.txt ends with newline before appending
+          if [ -f requirements.txt ] && [ -s requirements.txt ]; then
+            sed -i -e '$a\' requirements.txt
+          fi
           echo "openhands-ai==${OPENHANDS_VERSION}" >> requirements.txt
           cat requirements.txt
 


### PR DESCRIPTION
Fixes #5620
Fixes #6387
Fixes #5988

The issue has been successfully resolved based on the changes implemented. The original problem occurred because the new requirement was being appended to requirements.txt without ensuring proper line separation, causing `openai==1.1.0openhands-ai==0.15.2` to be written as a single invalid requirement.

The fix addresses this specific issue by:
1. Adding a check for the existence and non-emptiness of requirements.txt
2. Using sed to ensure the file ends with a newline character before appending the new requirement
3. Maintaining the same append operation but now with guaranteed line separation

This solution will prevent the concatenation problem by ensuring each requirement is on its own line, which will resolve the specific error seen in the original issue where requirements were being merged incorrectly. The error message "Expected end or semicolon (after version specifier)" will no longer occur because each requirement will be properly separated.

The changes directly target and fix the root cause of the problem, making it a complete and effective solution that should work reliably in all cases where requirements need to be appended to an existing requirements.txt file.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ee46b92-nikolaik   --name openhands-app-ee46b92   docker.all-hands.dev/all-hands-ai/openhands:ee46b92
```