### PR TITLE
Fix: Static assets should not have the same rate limit

### DIFF
--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -11,9 +11,9 @@ from fastapi import (
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands.server.middleware import (
     AttachConversationMiddleware,
+    CacheControlMiddleware,
     InMemoryRateLimiter,
     LocalhostCORSMiddleware,
-    NoCacheMiddleware,
     RateLimitMiddleware,
 )
 from openhands.server.routes.conversation import app as conversation_api_router
@@ -44,7 +44,7 @@ app.add_middleware(
     allow_headers=['*'],
 )
 
-app.add_middleware(NoCacheMiddleware)
+app.add_middleware(CacheControlMiddleware)
 app.add_middleware(
     RateLimitMiddleware, rate_limiter=InMemoryRateLimiter(requests=10, seconds=1)
 )

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -45,7 +45,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         response = await call_next(request)
         if request.url.path.startswith('/assets'):
-            # The content of the assets directory has finger printed file names so we cache agressively
+            # The content of the assets directory has fingerprinted file names so we cache aggressively
             response.headers['Cache-Control'] = 'public, max-age=2592000, immutable'
         else:
             response.headers['Cache-Control'] = (

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -37,14 +37,17 @@ class LocalhostCORSMiddleware(CORSMiddleware):
         return super().is_allowed_origin(origin)
 
 
-class NoCacheMiddleware(BaseHTTPMiddleware):
+class CacheControlMiddleware(BaseHTTPMiddleware):
     """
     Middleware to disable caching for all routes by adding appropriate headers
     """
 
     async def dispatch(self, request, call_next):
         response = await call_next(request)
-        if not request.url.path.startswith('/assets'):
+        if request.url.path.startswith('/assets'):
+            # The content of the assets directory has finger printed file names so we cache agressively
+            response.headers['Cache-Control'] = 'public, max-age=2592000, immutable'
+        else:
             response.headers['Cache-Control'] = (
                 'no-cache, no-store, must-revalidate, max-age=0'
             )


### PR DESCRIPTION
**Fix: Static Assets are not rate limited**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
When loading the application, I sometimes get a 429 when refreshing the page indicating I am being rate limited. We should not rate limit loading static assets.

I am curious if anybody in the OSS community is using this functionality (I'd like to remove it completely. Typically in a K8 cluster this would be controlled at the ingress level.)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5da1ed6-nikolaik   --name openhands-app-5da1ed6   docker.all-hands.dev/all-hands-ai/openhands:5da1ed6
```