### PR TITLE
Add Ubuntu Desktop fonts including CJK and emoji support

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -21,7 +21,11 @@ RUN apt-get update && \
         {%- else %}
         libgl1-mesa-glx \
         {% endif -%}
-        libasound2-plugins libatomic1 && \
+        libasound2-plugins libatomic1 \
+        fonts-arphic-ukai fonts-arphic-uming fonts-dejavu-core \
+        fonts-droid-fallback fonts-liberation fonts-noto-cjk \
+        fonts-noto-color-emoji fonts-noto-core fonts-noto-mono \
+        fonts-opensymbol fonts-urw-base35 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
This change improves text rendering in the OpenHands container environment by adding standard Ubuntu Desktop fonts. Users will see better quality text display, especially for CJK (Chinese, Japanese, Korean) characters and emoji. This is particularly beneficial for developers working with non-Latin scripts or using emoji in their documentation and communications.

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Added standard Ubuntu Desktop fonts to improve text rendering quality, especially for CJK (Chinese, Japanese, Korean) characters and emoji support. This makes the development environment more user-friendly for international developers.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
This PR adds commonly used Ubuntu Desktop font packages to the base system dependencies in `Dockerfile.j2`. The font selection is based on the Ubuntu 24.04 Desktop manifest, ensuring we include well-maintained and standard fonts that provide comprehensive language support.

Added font packages:
- fonts-arphic-ukai, fonts-arphic-uming (Chinese fonts)
- fonts-noto-cjk (CJK support)
- fonts-noto-color-emoji (Emoji support)
- fonts-noto-core, fonts-noto-mono (Core Noto fonts)
- fonts-dejavu-core, fonts-liberation, fonts-opensymbol, fonts-urw-base35 (Standard Latin fonts)
- fonts-droid-fallback (Fallback fonts)

Design decisions:
1. Used standard Ubuntu packages instead of custom font installation for better maintainability
2. Selected fonts from Ubuntu Desktop manifest to ensure compatibility and long-term support
3. Included both CJK and emoji fonts to provide comprehensive international support

---
**Link of any specific issues this addresses**
Fixes #6363