### PR TITLE
Revert changes to config defaults

### DIFF
--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -27,6 +27,6 @@ class AgentConfig(BaseModel):
     memory_enabled: bool = Field(default=False)
     memory_max_threads: int = Field(default=3)
     llm_config: str | None = Field(default=None)
-    enable_prompt_extensions: bool = Field(default=False)
+    enable_prompt_extensions: bool = Field(default=True)
     disabled_microagents: list[str] | None = Field(default=None)
     condenser: CondenserConfig = Field(default_factory=NoOpCondenserConfig)

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -60,7 +60,7 @@ class SandboxConfig(BaseModel):
     runtime_startup_env_vars: dict[str, str] = Field(default_factory=dict)
     browsergym_eval_env: str | None = Field(default=None)
     platform: str | None = Field(default=None)
-    close_delay: int = Field(default=900)
+    close_delay: int = Field(default=15)
     remote_runtime_resource_factor: int = Field(default=1)
     enable_gpu: bool = Field(default=False)
     docker_runtime_kwargs: str | None = Field(default=None)

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -48,7 +48,8 @@ each of which has a corresponding port:
 * {{ host }} (port {{ port }})
 {% endfor %}
 When starting a web server, use the corresponding ports. You should also
-set any options to allow iframes and CORS requests.
+set any options to allow iframes and CORS requests, and allow the server to
+be accessed from any host (e.g. 0.0.0.0).
 </RUNTIME_INFORMATION>
 {% endif %}
 """


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog
---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The default seems to have changed in https://github.com/All-Hands-AI/OpenHands/commit/a12087243a9d5ba8651af5ff6dd9ac88aa758157

@csmith49 any reason it changed? Are there any other defaults that changed in your PR?

Edit: found `close_delay` as well--probably a merge conflict

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e546b2b-nikolaik   --name openhands-app-e546b2b   docker.all-hands.dev/all-hands-ai/openhands:e546b2b
```