### PR TITLE
fix: Settings modal properly tracks if an API key is set

### DIFF
--- a/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -156,7 +156,7 @@ describe("Sidebar", () => {
       await user.click(advancedOptionsSwitch);
 
       const apiKeyInput = within(settingsModal).getByLabelText(/API\$KEY/i);
-      await user.type(apiKeyInput, "SET");
+      await user.type(apiKeyInput, "**********");
 
       const saveButton = within(settingsModal).getByTestId(
         "save-settings-button",

--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -171,7 +171,7 @@ export function SettingsForm({
 
           <APIKeyInput
             isDisabled={!!disabled}
-            isSet={settings.LLM_API_KEY === "SET"}
+            isSet={settings.LLM_API_KEY === "**********"}
           />
 
           {showAdvancedOptions && (

--- a/frontend/src/context/settings-context.tsx
+++ b/frontend/src/context/settings-context.tsx
@@ -34,7 +34,7 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
       ...newSettings,
     };
 
-    if (updatedSettings.LLM_API_KEY === "SET") {
+    if (updatedSettings.LLM_API_KEY === "**********") {
       delete updatedSettings.LLM_API_KEY;
     }
 

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -37,7 +37,11 @@ async def connect(connection_id: str, environ, auth):
         if not signed_token:
             logger.error('No github_auth cookie')
             raise ConnectionRefusedError('No github_auth cookie')
-        decoded = jwt.decode(signed_token, config.jwt_secret, algorithms=['HS256'])
+        if not config.jwt_secret:
+            raise RuntimeError('JWT secret not found')
+        decoded = jwt.decode(
+            signed_token, config.jwt_secret.get_secret_value(), algorithms=['HS256']
+        )
         user_id = decoded['github_user_id']
 
         logger.info(f'User {user_id} is connecting to conversation {conversation_id}')


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The settings modal on the front-end relies on the stored settings -- since the LLM API key is set as a `SecretStr`, it is serialized as a blanked-out value `"**********"`, but the settings form was looking for the value `"SET"`.

---
**Link of any specific issues this addresses**
