### PR TITLE
Fix: Keeping runtimes alive again (For now)

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -39,7 +39,7 @@ class SandboxConfig(BaseModel):
 
     remote_runtime_api_url: str = Field(default='http://localhost:8000')
     local_runtime_url: str = Field(default='http://localhost')
-    keep_runtime_alive: bool = Field(default=False)
+    keep_runtime_alive: bool = Field(default=True)
     rm_all_containers: bool = Field(default=False)
     api_key: str | None = Field(default=None)
     base_container_image: str = Field(


### PR DESCRIPTION
**Runtimes will not be actively culled again (For now)**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
We will need to do a follow up fix here before we expose the multi conversation UI to everybody outside the feature flag.

The follow up fix will need to allow pausing / restarting of docker runtimes in a similar manner to the remote runtime.



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:da50d57-nikolaik   --name openhands-app-da50d57   docker.all-hands.dev/all-hands-ai/openhands:da50d57
```