### PR TITLE
Enable strict type checking with mypy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,8 +51,20 @@ jobs:
           cache: 'pip'
       - name: Install pre-commit
         run: pip install pre-commit==3.7.0
+      - name: Install project in editable mode
+        run: pip install -e .
       - name: Run pre-commit hooks
         run: pre-commit run --files openhands/**/* evaluation/**/* tests/**/* --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+      - name: Run mypy directly (for better error reporting)
+        if: always()  # Run even if pre-commit fails
+        run: |
+          pip install mypy==1.9.0 \
+            types-requests types-setuptools types-pyyaml types-toml \
+            types-redis types-protobuf types-python-dateutil types-pyjwt \
+            types-docutils types-Pillow types-boto3 types-cryptography \
+            types-Jinja2 types-MarkupSafe types-click types-filelock \
+            types-decorator types-docopt types-emoji types-enum34 types-paramiko
+          PYTHONPATH=$PWD mypy --config-file dev_config/python/mypy.ini --scripts-are-modules openhands/
 
   # Check version consistency across documentation
   check-version-consistency:

--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -36,8 +36,30 @@ repos:
     rev: v1.9.0
     hooks:
       - id: mypy
+        name: mypy (with strict type checking)
         additional_dependencies:
-          [types-requests, types-setuptools, types-pyyaml, types-toml]
-        entry: mypy --config-file dev_config/python/mypy.ini openhands/
+          - types-requests
+          - types-setuptools
+          - types-pyyaml
+          - types-toml
+          - types-redis
+          - types-protobuf
+          - types-python-dateutil
+          - types-pyjwt
+          - types-docutils
+          - types-Pillow
+          - types-boto3
+          - types-cryptography
+          - types-Jinja2
+          - types-MarkupSafe
+          - types-click
+          - types-filelock
+          - types-decorator
+          - types-docopt
+          - types-emoji
+          - types-enum34
+          - types-paramiko
+        entry: mypy --config-file dev_config/python/mypy.ini --scripts-are-modules openhands/
         always_run: true
         pass_filenames: false
+        verbose: true

--- a/dev_config/python/mypy.ini
+++ b/dev_config/python/mypy.ini
@@ -1,9 +1,29 @@
 [mypy]
-warn_unused_configs = True
+# Error output
+show_error_codes = True
+pretty = True
+show_column_numbers = True
+
+# Import discovery
 ignore_missing_imports = True
+follow_imports = normal
+
+# Untyped definitions and calls
+disallow_untyped_defs = True
 check_untyped_defs = True
-explicit_package_bases = True
-warn_unreachable = True
-warn_redundant_casts = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+
+# None and Optional handling
 no_implicit_optional = True
 strict_optional = True
+
+# Warnings
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+
+# Misc
+explicit_package_bases = True


### PR DESCRIPTION
This PR enables stricter type checking with mypy by:

1. Updating mypy configuration with stricter type checking rules:
   - Enable more error checks
   - Show error codes and column numbers
   - Disallow untyped definitions and decorators
   - Enable more warnings

2. Adding more type stubs to pre-commit configuration:
   - Add types for redis, protobuf, dateutil, jwt, etc.
   - Add types for common dependencies like Jinja2, click, etc.

3. Improving CI configuration:
   - Run mypy both through pre-commit and directly
   - Install project in editable mode for better type checking
   - Set correct PYTHONPATH in CI environment

This will help catch type errors earlier and improve code quality. The PR is marked as draft because it will likely fail CI due to the stricter type checking - we will need to fix the type errors in follow-up PRs.