### PR TITLE
One more SecretStr fix

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 import toml
 from dotenv import load_dotenv
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, SecretStr, ValidationError
 
 from openhands.core import logger
 from openhands.core.config.agent_config import AgentConfig
@@ -192,7 +192,7 @@ def load_from_toml(cfg: AppConfig, toml_file: str = 'config.toml'):
                                     custom_fields[k] = v
                             merged_llm_dict = generic_llm_fields.copy()
                             merged_llm_dict.update(custom_fields)
-                            
+
                             custom_llm_config = LLMConfig(**merged_llm_dict)
                             cfg.set_llm_config(custom_llm_config, nested_key)
 
@@ -287,8 +287,10 @@ def finalize_config(cfg: AppConfig):
         pathlib.Path(cfg.cache_dir).mkdir(parents=True, exist_ok=True)
 
     if not cfg.jwt_secret:
-        cfg.jwt_secret = get_or_create_jwt_secret(
-            get_file_store(cfg.file_store, cfg.file_store_path)
+        cfg.jwt_secret = SecretStr(
+            get_or_create_jwt_secret(
+                get_file_store(cfg.file_store, cfg.file_store_path)
+            )
         )
 
 


### PR DESCRIPTION
**JWT Secret Type Fix**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Improved security by properly handling JWT secrets using Pydantic SecretStr type.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR fixes the handling of JWT secrets by properly wrapping them in Pydantic's SecretStr type. The changes include:

1. Added SecretStr import from pydantic
2. Modified the jwt_secret assignment in finalize_config to wrap the secret in SecretStr

This change ensures that sensitive JWT secrets are properly handled and not accidentally exposed in logs or string representations.

---
**Link of any specific issues this addresses**

N/A - Security improvement

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:227e292-nikolaik   --name openhands-app-227e292   docker.all-hands.dev/all-hands-ai/openhands:227e292
```