### PR TITLE
hotfix(frontend): Logout and clear token if retrieving user fails

### DIFF
--- a/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -155,7 +155,9 @@ describe("Sidebar", () => {
       const settingsModal = screen.getByTestId("ai-config-modal");
 
       // Click the advanced options switch to show the API key input
-      const advancedOptionsSwitch = within(settingsModal).getByTestId("advanced-option-switch");
+      const advancedOptionsSwitch = within(settingsModal).getByTestId(
+        "advanced-option-switch",
+      );
       await user.click(advancedOptionsSwitch);
 
       const apiKeyInput = within(settingsModal).getByLabelText(/API\$KEY/i);

--- a/frontend/src/hooks/query/use-github-user.ts
+++ b/frontend/src/hooks/query/use-github-user.ts
@@ -6,7 +6,7 @@ import { useConfig } from "./use-config";
 import OpenHands from "#/api/open-hands";
 
 export const useGitHubUser = () => {
-  const { gitHubToken, setUserId } = useAuth();
+  const { gitHubToken, setUserId, logout } = useAuth();
   const { data: config } = useConfig();
 
   const user = useQuery({
@@ -28,6 +28,12 @@ export const useGitHubUser = () => {
       });
     }
   }, [user.data]);
+
+  React.useEffect(() => {
+    if (user.isError) {
+      logout();
+    }
+  }, [user.isError]);
 
   return user;
 };

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -141,7 +141,7 @@ export const handlers = [
       { id: 2, full_name: "octocat/earth" },
     ]),
   ),
-  http.get("https://api.github.com/user", () => {
+  http.get("/api/github/user", () => {
     const user: GitHubUser = {
       id: 1,
       login: "octocat",


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
IF the GET user fails, it is most likely due to an invalid token. The problem is we no longer have a method of refreshing or removing this token on fail, so the app can get confused

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Logout and clear token if GET user fails


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f62968f-nikolaik   --name openhands-app-f62968f   docker.all-hands.dev/all-hands-ai/openhands:f62968f
```