### PR TITLE
Fix circular import by moving AttachConversationMiddleware to separate module

### DIFF
--- a/openhands/server/config/openhands_config.py
+++ b/openhands/server/config/openhands_config.py
@@ -3,8 +3,8 @@ import os
 from fastapi import FastAPI, HTTPException
 
 from openhands.core.logger import openhands_logger as logger
+from openhands.server.conversation_middleware import AttachConversationMiddleware
 from openhands.server.middleware import (
-    AttachConversationMiddleware,
     CacheControlMiddleware,
     InMemoryRateLimiter,
     LocalhostCORSMiddleware,

--- a/openhands/server/conversation_middleware.py
+++ b/openhands/server/conversation_middleware.py
@@ -1,0 +1,70 @@
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+from typing import Callable
+
+from openhands.server import shared
+from openhands.server.types import SessionMiddlewareInterface
+
+
+class AttachConversationMiddleware(SessionMiddlewareInterface):
+    def __init__(self, app):
+        self.app = app
+
+    def _should_attach(self, request) -> bool:
+        """
+        Determine if the middleware should attach a session for the given request.
+        """
+        if request.method == 'OPTIONS':
+            return False
+
+        conversation_id = ''
+        if request.url.path.startswith('/api/conversation'):
+            # FIXME: we should be able to use path_params
+            path_parts = request.url.path.split('/')
+            if len(path_parts) > 4:
+                conversation_id = request.url.path.split('/')[3]
+        if not conversation_id:
+            return False
+
+        request.state.sid = conversation_id
+
+        return True
+
+    async def _attach_conversation(self, request: Request) -> JSONResponse | None:
+        """
+        Attach the user's session based on the provided authentication token.
+        """
+        request.state.conversation = (
+            await shared.conversation_manager.attach_to_conversation(request.state.sid)
+        )
+        if not request.state.conversation:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content={'error': 'Session not found'},
+            )
+        return None
+
+    async def _detach_session(self, request: Request) -> None:
+        """
+        Detach the user's session.
+        """
+        await shared.conversation_manager.detach_from_conversation(
+            request.state.conversation
+        )
+
+    async def __call__(self, request: Request, call_next: Callable):
+        if not self._should_attach(request):
+            return await call_next(request)
+
+        response = await self._attach_conversation(request)
+        if response:
+            return response
+
+        try:
+            # Continue processing the request
+            response = await call_next(request)
+        finally:
+            # Ensure the session is detached
+            await self._detach_session(request)
+
+        return response

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -1,18 +1,13 @@
 import asyncio
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Callable
 from urllib.parse import urlparse
 
-from fastapi import Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
 from starlette.types import ASGIApp
-
-from openhands.server import shared
-from openhands.server.types import SessionMiddlewareInterface
 
 
 class LocalhostCORSMiddleware(CORSMiddleware):
@@ -118,65 +113,4 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return True
 
 
-class AttachConversationMiddleware(SessionMiddlewareInterface):
-    def __init__(self, app):
-        self.app = app
 
-    def _should_attach(self, request) -> bool:
-        """
-        Determine if the middleware should attach a session for the given request.
-        """
-        if request.method == 'OPTIONS':
-            return False
-
-        conversation_id = ''
-        if request.url.path.startswith('/api/conversation'):
-            # FIXME: we should be able to use path_params
-            path_parts = request.url.path.split('/')
-            if len(path_parts) > 4:
-                conversation_id = request.url.path.split('/')[3]
-        if not conversation_id:
-            return False
-
-        request.state.sid = conversation_id
-
-        return True
-
-    async def _attach_conversation(self, request: Request) -> JSONResponse | None:
-        """
-        Attach the user's session based on the provided authentication token.
-        """
-        request.state.conversation = (
-            await shared.conversation_manager.attach_to_conversation(request.state.sid)
-        )
-        if not request.state.conversation:
-            return JSONResponse(
-                status_code=status.HTTP_404_NOT_FOUND,
-                content={'error': 'Session not found'},
-            )
-        return None
-
-    async def _detach_session(self, request: Request) -> None:
-        """
-        Detach the user's session.
-        """
-        await shared.conversation_manager.detach_from_conversation(
-            request.state.conversation
-        )
-
-    async def __call__(self, request: Request, call_next: Callable):
-        if not self._should_attach(request):
-            return await call_next(request)
-
-        response = await self._attach_conversation(request)
-        if response:
-            return response
-
-        try:
-            # Continue processing the request
-            response = await call_next(request)
-        finally:
-            # Ensure the session is detached
-            await self._detach_session(request)
-
-        return response


### PR DESCRIPTION
This PR fixes a circular import issue between middleware.py, shared.py, and openhands_config.py by:

1. Creating a new file `conversation_middleware.py` containing the `AttachConversationMiddleware` class
2. Removing the `AttachConversationMiddleware` class and its imports from `middleware.py`
3. Updating `openhands_config.py` to import `AttachConversationMiddleware` from the new location

This breaks the circular dependency by establishing a clear dependency direction without cycles.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b41d27a-nikolaik   --name openhands-app-b41d27a   docker.all-hands.dev/all-hands-ai/openhands:b41d27a
```