### PR TITLE
Fix Docker runtimes not stopping

### DIFF
--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -1,6 +1,7 @@
 import atexit
 from functools import lru_cache
 from typing import Callable
+from uuid import UUID
 
 import docker
 import requests
@@ -26,6 +27,7 @@ from openhands.runtime.utils.command import get_action_execution_server_startup_
 from openhands.runtime.utils.log_streamer import LogStreamer
 from openhands.runtime.utils.runtime_build import build_runtime_image
 from openhands.utils.async_utils import call_sync_from_async
+from openhands.utils.shutdown_listener import add_shutdown_listener
 from openhands.utils.tenacity_stop import stop_if_should_exit
 
 CONTAINER_NAME_PREFIX = 'openhands-runtime-'
@@ -34,13 +36,6 @@ EXECUTION_SERVER_PORT_RANGE = (30000, 39999)
 VSCODE_PORT_RANGE = (40000, 49999)
 APP_PORT_RANGE_1 = (50000, 54999)
 APP_PORT_RANGE_2 = (55000, 59999)
-
-
-def stop_all_runtime_containers():
-    stop_all_containers(CONTAINER_NAME_PREFIX)
-
-
-_atexit_registered = False
 
 
 class DockerRuntime(ActionExecutionClient):
@@ -54,6 +49,7 @@ class DockerRuntime(ActionExecutionClient):
         plugins (list[PluginRequirement] | None, optional): List of plugin requirements. Defaults to None.
         env_vars (dict[str, str] | None, optional): Environment variables to set. Defaults to None.
     """
+    _shutdown_listener_id: UUID | None = None
 
     def __init__(
         self,
@@ -66,10 +62,8 @@ class DockerRuntime(ActionExecutionClient):
         attach_to_existing: bool = False,
         headless_mode: bool = True,
     ):
-        global _atexit_registered
-        if not _atexit_registered:
-            _atexit_registered = True
-            atexit.register(stop_all_runtime_containers)
+        if not self._shutdown_listener_id:
+            self.__class__._shutdown_listener_id = add_shutdown_listener(lambda: stop_all_containers(CONTAINER_NAME_PREFIX))
 
         self.config = config
         self._runtime_initialized: bool = False

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -1,4 +1,3 @@
-import atexit
 from functools import lru_cache
 from typing import Callable
 from uuid import UUID
@@ -49,6 +48,7 @@ class DockerRuntime(ActionExecutionClient):
         plugins (list[PluginRequirement] | None, optional): List of plugin requirements. Defaults to None.
         env_vars (dict[str, str] | None, optional): Environment variables to set. Defaults to None.
     """
+
     _shutdown_listener_id: UUID | None = None
 
     def __init__(
@@ -62,8 +62,10 @@ class DockerRuntime(ActionExecutionClient):
         attach_to_existing: bool = False,
         headless_mode: bool = True,
     ):
-        if not self._shutdown_listener_id:
-            self.__class__._shutdown_listener_id = add_shutdown_listener(lambda: stop_all_containers(CONTAINER_NAME_PREFIX))
+        if not DockerRuntime._shutdown_listener_id:
+            DockerRuntime._shutdown_listener_id = add_shutdown_listener(
+                lambda: stop_all_containers(CONTAINER_NAME_PREFIX)
+            )
 
         self.config = config
         self._runtime_initialized: bool = False

--- a/tests/unit/test_shutdown_listener.py
+++ b/tests/unit/test_shutdown_listener.py
@@ -1,13 +1,14 @@
 import signal
-from types import FrameType
-from unittest.mock import MagicMock
+from dataclasses import dataclass, field
+from signal import Signals
+from typing import Callable
+from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
 
+from openhands.utils import shutdown_listener
 from openhands.utils.shutdown_listener import (
-    _register_signal_handler,
-    _shutdown_listeners,
     add_shutdown_listener,
     remove_shutdown_listener,
     should_continue,
@@ -16,41 +17,23 @@ from openhands.utils.shutdown_listener import (
 
 @pytest.fixture(autouse=True)
 def cleanup_listeners():
-    _shutdown_listeners.clear()
-    global _should_exit
-    _should_exit = False
-    yield
-    _shutdown_listeners.clear()
-    _should_exit = False
+    shutdown_listener._shutdown_listeners.clear()
+    shutdown_listener._should_exit = False
 
 
-@pytest.fixture(autouse=True)
-def mock_register_handlers(monkeypatch):
-    def mock_register_all():
-        pass
+@dataclass
+class MockSignal:
+    handlers: dict[Signals, Callable] = field(default_factory=dict)
 
-    monkeypatch.setattr(
-        'openhands.utils.shutdown_listener._register_signal_handlers', mock_register_all
-    )
+    def signal(self, signalnum: Signals, handler: Callable):
+        result = self.handlers.get(signalnum)
+        self.handlers[signalnum] = handler
+        return result
 
-
-@pytest.fixture(autouse=True)
-def mock_should_continue(monkeypatch):
-    def mock_continue():
-        return not _should_exit
-
-    monkeypatch.setattr(
-        'openhands.utils.shutdown_listener.should_continue', mock_continue
-    )
-
-
-@pytest.fixture(autouse=True)
-def mock_signal(monkeypatch):
-    def mock_signal_handler(sig, handler):
-        handler(sig, None)  # Call the handler immediately
-        return None
-
-    monkeypatch.setattr('signal.signal', mock_signal_handler)
+    def trigger(self, signalnum: Signals):
+        handler = self.handlers.get(signalnum)
+        if handler:
+            handler(signalnum.value, None)
 
 
 def test_add_shutdown_listener():
@@ -58,8 +41,8 @@ def test_add_shutdown_listener():
     listener_id = add_shutdown_listener(mock_callable)
 
     assert isinstance(listener_id, UUID)
-    assert listener_id in _shutdown_listeners
-    assert _shutdown_listeners[listener_id] == mock_callable
+    assert listener_id in shutdown_listener._shutdown_listeners
+    assert shutdown_listener._shutdown_listeners[listener_id] == mock_callable
 
 
 def test_remove_shutdown_listener():
@@ -68,63 +51,66 @@ def test_remove_shutdown_listener():
 
     # Test successful removal
     assert remove_shutdown_listener(listener_id) is True
-    assert listener_id not in _shutdown_listeners
+    assert listener_id not in shutdown_listener._shutdown_listeners
 
     # Test removing non-existent listener
     assert remove_shutdown_listener(listener_id) is False
 
 
 def test_signal_handler_calls_listeners():
-    mock_callable1 = MagicMock()
-    mock_callable2 = MagicMock()
-    add_shutdown_listener(mock_callable1)
-    add_shutdown_listener(mock_callable2)
+    mock_signal = MockSignal()
+    with patch('openhands.utils.shutdown_listener.signal', mock_signal):
+        mock_callable1 = MagicMock()
+        mock_callable2 = MagicMock()
+        add_shutdown_listener(mock_callable1)
+        add_shutdown_listener(mock_callable2)
 
-    # Register and trigger signal handler
-    handler = _register_signal_handler(signal.SIGTERM)
-    mock_frame = MagicMock(spec=FrameType)
-    handler(signal.SIGTERM, mock_frame)
+        # Register and trigger signal handler
+        shutdown_listener._register_signal_handler(signal.SIGTERM)
+        mock_signal.trigger(signal.SIGTERM)
 
-    # Verify both listeners were called
-    mock_callable1.assert_called_once()
-    mock_callable2.assert_called_once()
+        # Verify both listeners were called
+        mock_callable1.assert_called_once()
+        mock_callable2.assert_called_once()
 
-    # Verify should_continue returns False after shutdown
-    assert should_continue() is False
+        # Verify should_continue returns False after shutdown
+        assert should_continue() is False
 
 
 def test_listeners_called_only_once():
-    mock_callable = MagicMock()
-    add_shutdown_listener(mock_callable)
+    mock_signal = MockSignal()
+    with patch('openhands.utils.shutdown_listener.signal', mock_signal):
+        mock_callable = MagicMock()
+        add_shutdown_listener(mock_callable)
 
-    # Register and trigger signal handler multiple times
-    handler = _register_signal_handler(signal.SIGTERM)
-    mock_frame = MagicMock(spec=FrameType)
-    handler(signal.SIGTERM, mock_frame)
-    handler(signal.SIGTERM, mock_frame)
+        # Register and trigger signal handler multiple times
+        shutdown_listener._register_signal_handler(signal.SIGTERM)
+        mock_signal.trigger(signal.SIGTERM)
+        mock_signal.trigger(signal.SIGTERM)
 
-    # Verify listener was called only once
-    assert mock_callable.call_count == 1
+        # Verify listener was called only once
+        assert mock_callable.call_count == 1
 
 
 def test_remove_listener_during_shutdown():
-    mock_callable1 = MagicMock()
-    mock_callable2 = MagicMock()
+    mock_signal = MockSignal()
+    with patch('openhands.utils.shutdown_listener.signal', mock_signal):
+        mock_callable1 = MagicMock()
+        mock_callable2 = MagicMock()
 
-    # Second listener removes the first listener when called
-    listener1_id = add_shutdown_listener(mock_callable1)
+        # Second listener removes the first listener when called
+        listener1_id = add_shutdown_listener(mock_callable1)
 
-    def remove_other_listener():
-        remove_shutdown_listener(listener1_id)
-        mock_callable2()
+        def remove_other_listener():
+            remove_shutdown_listener(listener1_id)
+            mock_callable2()
 
-    add_shutdown_listener(remove_other_listener)
+        add_shutdown_listener(remove_other_listener)
 
-    # Register and trigger signal handler
-    handler = _register_signal_handler(signal.SIGTERM)
-    mock_frame = MagicMock(spec=FrameType)
-    handler(signal.SIGTERM, mock_frame)
+        # Register and trigger signal handler
+        shutdown_listener._register_signal_handler(signal.SIGTERM)
+        mock_signal.trigger(signal.SIGTERM)
 
-    # Both listeners should still be called
-    assert mock_callable1.call_count == 1
-    assert mock_callable2.call_count == 1
+        # Both listeners should still be called
+        assert mock_callable1.call_count == 1
+        assert mock_callable2.call_count == 1

--- a/tests/unit/test_shutdown_listener.py
+++ b/tests/unit/test_shutdown_listener.py
@@ -1,0 +1,120 @@
+import signal
+from types import FrameType
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from openhands.utils.shutdown_listener import (
+    _register_signal_handler,
+    _register_signal_handlers,
+    _shutdown_listeners,
+    add_shutdown_listener,
+    remove_shutdown_listener,
+    should_continue,
+)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_listeners():
+    _shutdown_listeners.clear()
+    global _should_exit
+    _should_exit = False
+    yield
+    _shutdown_listeners.clear()
+    _should_exit = False
+
+@pytest.fixture(autouse=True)
+def mock_register_handlers(monkeypatch):
+    def mock_register_all():
+        pass
+    monkeypatch.setattr('openhands.utils.shutdown_listener._register_signal_handlers', mock_register_all)
+
+@pytest.fixture(autouse=True)
+def mock_should_continue(monkeypatch):
+    def mock_continue():
+        return not _should_exit
+    monkeypatch.setattr('openhands.utils.shutdown_listener.should_continue', mock_continue)
+
+@pytest.fixture(autouse=True)
+def mock_signal(monkeypatch):
+    def mock_signal_handler(sig, handler):
+        handler(sig, None)  # Call the handler immediately
+        return None
+    monkeypatch.setattr('signal.signal', mock_signal_handler)
+
+
+def test_add_shutdown_listener():
+    mock_callable = MagicMock()
+    listener_id = add_shutdown_listener(mock_callable)
+
+    assert isinstance(listener_id, UUID)
+    assert listener_id in _shutdown_listeners
+    assert _shutdown_listeners[listener_id] == mock_callable
+
+
+def test_remove_shutdown_listener():
+    mock_callable = MagicMock()
+    listener_id = add_shutdown_listener(mock_callable)
+
+    # Test successful removal
+    assert remove_shutdown_listener(listener_id) is True
+    assert listener_id not in _shutdown_listeners
+
+    # Test removing non-existent listener
+    assert remove_shutdown_listener(listener_id) is False
+
+
+def test_signal_handler_calls_listeners():
+    mock_callable1 = MagicMock()
+    mock_callable2 = MagicMock()
+    add_shutdown_listener(mock_callable1)
+    add_shutdown_listener(mock_callable2)
+
+    # Register and trigger signal handler
+    handler = _register_signal_handler(signal.SIGTERM)
+    mock_frame = MagicMock(spec=FrameType)
+    handler(signal.SIGTERM, mock_frame)
+
+    # Verify both listeners were called
+    mock_callable1.assert_called_once()
+    mock_callable2.assert_called_once()
+
+    # Verify should_continue returns False after shutdown
+    assert should_continue() is False
+
+
+def test_listeners_called_only_once():
+    mock_callable = MagicMock()
+    add_shutdown_listener(mock_callable)
+
+    # Register and trigger signal handler multiple times
+    handler = _register_signal_handler(signal.SIGTERM)
+    mock_frame = MagicMock(spec=FrameType)
+    handler(signal.SIGTERM, mock_frame)
+    handler(signal.SIGTERM, mock_frame)
+
+    # Verify listener was called only once
+    assert mock_callable.call_count == 1
+
+
+def test_remove_listener_during_shutdown():
+    mock_callable1 = MagicMock()
+    mock_callable2 = MagicMock()
+    
+    # Second listener removes the first listener when called
+    listener1_id = add_shutdown_listener(mock_callable1)
+    def remove_other_listener():
+        remove_shutdown_listener(listener1_id)
+        mock_callable2()
+    
+    add_shutdown_listener(remove_other_listener)
+
+    # Register and trigger signal handler
+    handler = _register_signal_handler(signal.SIGTERM)
+    mock_frame = MagicMock(spec=FrameType)
+    handler(signal.SIGTERM, mock_frame)
+
+    # Both listeners should still be called
+    assert mock_callable1.call_count == 1
+    assert mock_callable2.call_count == 1

--- a/tests/unit/test_shutdown_listener.py
+++ b/tests/unit/test_shutdown_listener.py
@@ -1,13 +1,12 @@
 import signal
 from types import FrameType
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
 
 from openhands.utils.shutdown_listener import (
     _register_signal_handler,
-    _register_signal_handlers,
     _shutdown_listeners,
     add_shutdown_listener,
     remove_shutdown_listener,
@@ -24,23 +23,33 @@ def cleanup_listeners():
     _shutdown_listeners.clear()
     _should_exit = False
 
+
 @pytest.fixture(autouse=True)
 def mock_register_handlers(monkeypatch):
     def mock_register_all():
         pass
-    monkeypatch.setattr('openhands.utils.shutdown_listener._register_signal_handlers', mock_register_all)
+
+    monkeypatch.setattr(
+        'openhands.utils.shutdown_listener._register_signal_handlers', mock_register_all
+    )
+
 
 @pytest.fixture(autouse=True)
 def mock_should_continue(monkeypatch):
     def mock_continue():
         return not _should_exit
-    monkeypatch.setattr('openhands.utils.shutdown_listener.should_continue', mock_continue)
+
+    monkeypatch.setattr(
+        'openhands.utils.shutdown_listener.should_continue', mock_continue
+    )
+
 
 @pytest.fixture(autouse=True)
 def mock_signal(monkeypatch):
     def mock_signal_handler(sig, handler):
         handler(sig, None)  # Call the handler immediately
         return None
+
     monkeypatch.setattr('signal.signal', mock_signal_handler)
 
 
@@ -101,13 +110,14 @@ def test_listeners_called_only_once():
 def test_remove_listener_during_shutdown():
     mock_callable1 = MagicMock()
     mock_callable2 = MagicMock()
-    
+
     # Second listener removes the first listener when called
     listener1_id = add_shutdown_listener(mock_callable1)
+
     def remove_other_listener():
         remove_shutdown_listener(listener1_id)
         mock_callable2()
-    
+
     add_shutdown_listener(remove_other_listener)
 
     # Register and trigger signal handler


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR fixes an issue where Docker runtime containers were not being properly stopped when the application shuts down. The changes include:

### Changes

1. Enhanced Shutdown Listener System:
   - Added a new shutdown listener mechanism in `shutdown_listener.py` that works better with Starlette/Uvicorn shutdown signals
   - Replaced the `atexit` handler with the new shutdown listener system
   - Added UUID-based listener registration and removal functionality

2. Docker Runtime Improvements:
   - Removed global `_atexit_registered` flag and `stop_all_runtime_containers` function
   - Added class-level `_shutdown_listener_id` to track the shutdown listener
   - Containers are now properly stopped when the application shuts down

3. Added Comprehensive Tests:
   - New test file `test_shutdown_listener.py` with thorough test coverage
   - Tests for listener registration, removal, and shutdown behavior
   - Tests for edge cases like removing listeners during shutdown

### Technical Details
- The new shutdown listener system uses a dictionary to track listeners by UUID
- Signal handlers are properly chained to preserve existing handlers
- Listeners are called exactly once during shutdown
- Added safeguards against recursive shutdown calls

This change ensures that Docker containers are properly cleaned up when the application exits, preventing orphaned containers from consuming system resources.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:26f53e2-nikolaik   --name openhands-app-26f53e2   docker.all-hands.dev/all-hands-ai/openhands:26f53e2
```