### PR TITLE
Fix share label

### DIFF
--- a/frontend/__tests__/components/feedback-form.test.tsx
+++ b/frontend/__tests__/components/feedback-form.test.tsx
@@ -32,7 +32,7 @@ describe("FeedbackForm", () => {
     screen.getByLabelText(I18nKey.FEEDBACK$PRIVATE_LABEL);
     screen.getByLabelText(I18nKey.FEEDBACK$PUBLIC_LABEL);
 
-    screen.getByRole("button", { name: I18nKey.FEEDBACK$CONTRIBUTE_LABEL });
+    screen.getByRole("button", { name: I18nKey.FEEDBACK$SHARE_LABEL });
     screen.getByRole("button", { name: I18nKey.FEEDBACK$CANCEL_LABEL });
   });
 

--- a/frontend/src/components/features/feedback/feedback-form.tsx
+++ b/frontend/src/components/features/feedback/feedback-form.tsx
@@ -124,7 +124,7 @@ export function FeedbackForm({ onClose, polarity }: FeedbackFormProps) {
         <ModalButton
           disabled={isPending}
           type="submit"
-          text={t(I18nKey.FEEDBACK$CONTRIBUTE_LABEL)}
+          text={t(I18nKey.FEEDBACK$SHARE_LABEL)}
           className="bg-[#4465DB] grow"
         />
         <ModalButton


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Changes the share label back to "share" from "contribute to public dataset" because the latter is not accurate.

---
**Link of any specific issues this addresses**

#6473 

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:06c46eb-nikolaik   --name openhands-app-06c46eb   docker.all-hands.dev/all-hands-ai/openhands:06c46eb
```