### PR TITLE
allow http session reuse

### DIFF
--- a/openhands/utils/http_session.py
+++ b/openhands/utils/http_session.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 
 import requests
 
+from openhands.core.logger import openhands_logger as logger
+
 
 @dataclass
 class HttpSession:
@@ -15,10 +17,11 @@ class HttpSession:
 
     def __getattr__(self, name):
         if self.session is None:
-            raise ValueError('session_was_closed')
+            logger.error(
+                'Session is being used after close!', stack_info=True, exc_info=True
+            )
         return object.__getattribute__(self.session, name)
 
     def close(self):
         if self.session is not None:
             self.session.close()
-        self.session = None


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix for continuing sessions, which would originally result in a `session_was_closed` error

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We should fix the underlying issue here, but this is a quick fix to make the app more usable.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:88a4d89-nikolaik   --name openhands-app-88a4d89   docker.all-hands.dev/all-hands-ai/openhands:88a4d89
```