### PR TITLE
Feat: Ability to filter events by multiple types

### DIFF
--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -328,11 +328,11 @@ class EventStream:
 
         Args:
             event: The event to check
-            query (str, optional): Text to search for in event content
-            event_type (tuple[type[Event], ...], optional): Filter by event type classes (e.g., (FileReadAction, ) ).
-            source (str, optional): Filter by event source
-            start_date (str, optional): Filter events after this date (ISO format)
-            end_date (str, optional): Filter events before this date (ISO format)
+            query: Text to search for in event content
+            event_type: Filter by event type classes (e.g., (FileReadAction, ) ).
+            source: Filter by event source
+            start_date: Filter events after this date (ISO format)
+            end_date: Filter events before this date (ISO format)
 
         Returns:
             bool: True if the event should be filtered out, False if it matches all criteria
@@ -371,13 +371,13 @@ class EventStream:
         """Get matching events from the event stream based on filters.
 
         Args:
-            query (str, optional): Text to search for in event content
-            event_types (tuple[type[Event], ...], optional): Filter by event type classes (e.g., (FileReadAction, ) ).
-            source (str, optional): Filter by event source
-            start_date (str, optional): Filter events after this date (ISO format)
-            end_date (str, optional): Filter events before this date (ISO format)
-            start_id (int): Starting ID in the event stream. Defaults to 0
-            limit (int): Maximum number of events to return. Must be between 1 and 100. Defaults to 100
+            query: Text to search for in event content
+            event_types: Filter by event type classes (e.g., (FileReadAction, ) ).
+            source: Filter by event source
+            start_date: Filter events after this date (ISO format)
+            end_date: Filter events before this date (ISO format)
+            start_id: Starting ID in the event stream. Defaults to 0
+            limit: Maximum number of events to return. Must be between 1 and 100. Defaults to 100
 
         Returns:
             list: List of matching events (as dicts)

--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -319,7 +319,7 @@ class EventStream:
         self,
         event,
         query: str | None = None,
-        event_type: type[Event] | None = None,
+        event_types: tuple[type[Event], ...] | None = None,
         source: str | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
@@ -329,7 +329,7 @@ class EventStream:
         Args:
             event: The event to check
             query (str, optional): Text to search for in event content
-            event_type (type[Event], optional): Filter by event type class (e.g., FileReadAction)
+            event_type (tuple[type[Event], ...], optional): Filter by event type classes (e.g., (FileReadAction, ) ).
             source (str, optional): Filter by event source
             start_date (str, optional): Filter events after this date (ISO format)
             end_date (str, optional): Filter events before this date (ISO format)
@@ -337,7 +337,7 @@ class EventStream:
         Returns:
             bool: True if the event should be filtered out, False if it matches all criteria
         """
-        if event_type and not isinstance(event, event_type):
+        if event_types and not isinstance(event, event_types):
             return True
 
         if source and not event.source.value == source:
@@ -361,7 +361,7 @@ class EventStream:
     def get_matching_events(
         self,
         query: str | None = None,
-        event_type: type[Event] | None = None,
+        event_types: tuple[type[Event], ...] | None = None,
         source: str | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
@@ -372,7 +372,7 @@ class EventStream:
 
         Args:
             query (str, optional): Text to search for in event content
-            event_type (type[Event], optional): Filter by event type class (e.g., FileReadAction)
+            event_types (tuple[type[Event], ...], optional): Filter by event type classes (e.g., (FileReadAction, ) ).
             source (str, optional): Filter by event source
             start_date (str, optional): Filter events after this date (ISO format)
             end_date (str, optional): Filter events before this date (ISO format)
@@ -392,7 +392,7 @@ class EventStream:
 
         for event in self.get_events(start_id=start_id):
             if self._should_filter_event(
-                event, query, event_type, source, start_date, end_date
+                event, query, event_types, source, start_date, end_date
             ):
                 continue
 

--- a/openhands/server/routes/conversation.py
+++ b/openhands/server/routes/conversation.py
@@ -119,14 +119,14 @@ async def search_events(
 ):
     """Search through the event stream with filtering and pagination.
     Args:
-        request (Request): The incoming request object
-        query (str, optional): Text to search for in event content
-        start_id (int): Starting ID in the event stream. Defaults to 0
-        limit (int): Maximum number of events to return. Must be between 1 and 100. Defaults to 20
-        event_type (str, optional): Filter by event type (e.g., "FileReadAction")
-        source (str, optional): Filter by event source
-        start_date (str, optional): Filter events after this date (ISO format)
-        end_date (str, optional): Filter events before this date (ISO format)
+        request: The incoming request object
+        query: Text to search for in event content
+        start_id: Starting ID in the event stream. Defaults to 0
+        limit: Maximum number of events to return. Must be between 1 and 100. Defaults to 20
+        event_type: Filter by event type (e.g., "FileReadAction")
+        source: Filter by event source
+        start_date: Filter events after this date (ISO format)
+        end_date: Filter events before this date (ISO format)
     Returns:
         dict: Dictionary containing:
             - events: List of matching events

--- a/openhands/server/routes/conversation.py
+++ b/openhands/server/routes/conversation.py
@@ -145,7 +145,7 @@ async def search_events(
     cast_event_type = str_to_event_type(event_type)
     matching_events = event_stream.get_matching_events(
         query=query,
-        event_type=cast_event_type,
+        event_types=(cast_event_type),
         source=source,
         start_date=start_date,
         end_date=end_date,

--- a/tests/unit/test_event_stream.py
+++ b/tests/unit/test_event_stream.py
@@ -74,12 +74,12 @@ def test_get_matching_events_type_filter(temp_dir: str):
     event_stream.add_event(NullAction(), EventSource.AGENT)
 
     # Filter by NullAction
-    events = event_stream.get_matching_events(event_type=NullAction)
+    events = event_stream.get_matching_events(event_types=(NullAction,))
     assert len(events) == 2
     assert all(e['action'] == 'null' for e in events)
 
     # Filter by NullObservation
-    events = event_stream.get_matching_events(event_type=NullObservation)
+    events = event_stream.get_matching_events(event_types=(NullObservation,))
     assert len(events) == 1
     assert events[0]['observation'] == 'null'
 

--- a/tests/unit/test_event_stream.py
+++ b/tests/unit/test_event_stream.py
@@ -7,6 +7,7 @@ from openhands.events import EventSource, EventStream
 from openhands.events.action import (
     NullAction,
 )
+from openhands.events.action.message import MessageAction
 from openhands.events.observation import NullObservation
 from openhands.storage import get_file_store
 
@@ -72,6 +73,7 @@ def test_get_matching_events_type_filter(temp_dir: str):
     event_stream.add_event(NullAction(), EventSource.AGENT)
     event_stream.add_event(NullObservation('test'), EventSource.AGENT)
     event_stream.add_event(NullAction(), EventSource.AGENT)
+    event_stream.add_event(MessageAction(content='test'), EventSource.AGENT)
 
     # Filter by NullAction
     events = event_stream.get_matching_events(event_types=(NullAction,))
@@ -82,6 +84,10 @@ def test_get_matching_events_type_filter(temp_dir: str):
     events = event_stream.get_matching_events(event_types=(NullObservation,))
     assert len(events) == 1
     assert events[0]['observation'] == 'null'
+
+    # Filter by NullAction and MessageAction
+    events = event_stream.get_matching_events(event_types=(NullAction, MessageAction))
+    assert len(events) == 3
 
 
 def test_get_matching_events_query_search(temp_dir: str):


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR adds the ability to filter events from the `EventStream` based on multiple event types (as in if the event matches ANY ONE of the event type criteria provided) 


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1f0f180-nikolaik   --name openhands-app-1f0f180   docker.all-hands.dev/all-hands-ai/openhands:1f0f180
```