### PR TITLE
Feat: Filter matching events in reverse order

### DIFF
--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -367,6 +367,7 @@ class EventStream:
         end_date: str | None = None,
         start_id: int = 0,
         limit: int = 100,
+        reverse: bool = False,
     ) -> list:
         """Get matching events from the event stream based on filters.
 
@@ -378,6 +379,7 @@ class EventStream:
             end_date: Filter events before this date (ISO format)
             start_id: Starting ID in the event stream. Defaults to 0
             limit: Maximum number of events to return. Must be between 1 and 100. Defaults to 100
+            reverse: Whether to retrieve events in reverse order. Defaults to False.
 
         Returns:
             list: List of matching events (as dicts)
@@ -390,7 +392,7 @@ class EventStream:
 
         matching_events: list = []
 
-        for event in self.get_events(start_id=start_id):
+        for event in self.get_events(start_id=start_id, reverse=reverse):
             if self._should_filter_event(
                 event, query, event_types, source, start_date, end_date
             ):

--- a/tests/unit/test_event_stream.py
+++ b/tests/unit/test_event_stream.py
@@ -89,6 +89,10 @@ def test_get_matching_events_type_filter(temp_dir: str):
     events = event_stream.get_matching_events(event_types=(NullAction, MessageAction))
     assert len(events) == 3
 
+    # Filter in reverse
+    events = event_stream.get_matching_events(reverse=True, limit=1)
+    assert events[0]['message'] == 'test'
+
 
 def test_get_matching_events_query_search(temp_dir: str):
     file_store = get_file_store('local', temp_dir)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Adds option to traverse events in reverse when filtering matching criteria

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:dceaca4-nikolaik   --name openhands-app-dceaca4   docker.all-hands.dev/all-hands-ai/openhands:dceaca4
```