### PR TITLE
Fix file descriptor leak in S3FileStore

### DIFF
--- a/openhands/storage/s3.py
+++ b/openhands/storage/s3.py
@@ -45,7 +45,8 @@ class S3FileStore(FileStore):
     def read(self, path: str) -> str:
         try:
             response = self.client.get_object(Bucket=self.bucket, Key=path)
-            return response['Body'].read().decode('utf-8')
+            with response['Body'] as stream:
+                return stream.read().decode('utf-8')
         except botocore.exceptions.ClientError as e:
             # Catch all S3-related errors
             if e.response['Error']['Code'] == 'NoSuchBucket':


### PR DESCRIPTION
This PR fixes a potential file descriptor leak in the S3FileStore implementation. The issue was in the `read()` method where the StreamingBody object from boto3 was not being properly closed after use.

### Changes
- Modified `read()` method to use a context manager (`with` statement) to ensure proper cleanup of the StreamingBody object

### Why
- The StreamingBody object from boto3 maintains an open HTTP connection to S3
- Without proper closing, these connections can accumulate over time
- This can lead to resource exhaustion, particularly in long-running applications or those that read many files

The fix ensures that the stream is properly closed even if an error occurs during reading, preventing file descriptor leaks.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:30b5056-nikolaik   --name openhands-app-30b5056   docker.all-hands.dev/all-hands-ai/openhands:30b5056
```