### PR TITLE
hotfix(frontend): Do NOT return DEFAULT_SETTINGS if GET /settings is 404

### DIFF
--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -8,23 +8,18 @@ import { useAuth } from "#/context/auth-context";
 const getSettingsQueryFn = async () => {
   const apiSettings = await OpenHands.getSettings();
 
-  if (apiSettings !== null) {
-    return {
-      LLM_MODEL: apiSettings.llm_model,
-      LLM_BASE_URL: apiSettings.llm_base_url,
-      AGENT: apiSettings.agent,
-      LANGUAGE: apiSettings.language,
-      CONFIRMATION_MODE: apiSettings.confirmation_mode,
-      SECURITY_ANALYZER: apiSettings.security_analyzer,
-      LLM_API_KEY: apiSettings.llm_api_key,
-      REMOTE_RUNTIME_RESOURCE_FACTOR:
-        apiSettings.remote_runtime_resource_factor,
-      GITHUB_TOKEN_IS_SET: apiSettings.github_token_is_set,
-      ENABLE_DEFAULT_CONDENSER: apiSettings.enable_default_condenser,
-    };
-  }
-
-  return DEFAULT_SETTINGS;
+  return {
+    LLM_MODEL: apiSettings.llm_model,
+    LLM_BASE_URL: apiSettings.llm_base_url,
+    AGENT: apiSettings.agent,
+    LANGUAGE: apiSettings.language,
+    CONFIRMATION_MODE: apiSettings.confirmation_mode,
+    SECURITY_ANALYZER: apiSettings.security_analyzer,
+    LLM_API_KEY: apiSettings.llm_api_key,
+    REMOTE_RUNTIME_RESOURCE_FACTOR: apiSettings.remote_runtime_resource_factor,
+    GITHUB_TOKEN_IS_SET: apiSettings.github_token_is_set,
+    ENABLE_DEFAULT_CONDENSER: apiSettings.enable_default_condenser,
+  };
 };
 
 export const useSettings = () => {

--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -1,41 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
 import React from "react";
 import posthog from "posthog-js";
-import { AxiosError } from "axios";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import OpenHands from "#/api/open-hands";
 import { useAuth } from "#/context/auth-context";
 
 const getSettingsQueryFn = async () => {
-  try {
-    const apiSettings = await OpenHands.getSettings();
+  const apiSettings = await OpenHands.getSettings();
 
-    if (apiSettings !== null) {
-      return {
-        LLM_MODEL: apiSettings.llm_model,
-        LLM_BASE_URL: apiSettings.llm_base_url,
-        AGENT: apiSettings.agent,
-        LANGUAGE: apiSettings.language,
-        CONFIRMATION_MODE: apiSettings.confirmation_mode,
-        SECURITY_ANALYZER: apiSettings.security_analyzer,
-        LLM_API_KEY: apiSettings.llm_api_key,
-        REMOTE_RUNTIME_RESOURCE_FACTOR:
-          apiSettings.remote_runtime_resource_factor,
-        GITHUB_TOKEN_IS_SET: apiSettings.github_token_is_set,
-        ENABLE_DEFAULT_CONDENSER: apiSettings.enable_default_condenser,
-      };
-    }
-
-    return DEFAULT_SETTINGS;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      if (error.response?.status === 404) {
-        return DEFAULT_SETTINGS;
-      }
-    }
-
-    throw error;
+  if (apiSettings !== null) {
+    return {
+      LLM_MODEL: apiSettings.llm_model,
+      LLM_BASE_URL: apiSettings.llm_base_url,
+      AGENT: apiSettings.agent,
+      LANGUAGE: apiSettings.language,
+      CONFIRMATION_MODE: apiSettings.confirmation_mode,
+      SECURITY_ANALYZER: apiSettings.security_analyzer,
+      LLM_API_KEY: apiSettings.llm_api_key,
+      REMOTE_RUNTIME_RESOURCE_FACTOR:
+        apiSettings.remote_runtime_resource_factor,
+      GITHUB_TOKEN_IS_SET: apiSettings.github_token_is_set,
+      ENABLE_DEFAULT_CONDENSER: apiSettings.enable_default_condenser,
+    };
   }
+
+  return DEFAULT_SETTINGS;
 };
 
 export const useSettings = () => {

--- a/frontend/src/query-client-config.ts
+++ b/frontend/src/query-client-config.ts
@@ -1,7 +1,7 @@
 import { QueryClientConfig, QueryCache } from "@tanstack/react-query";
 import { renderToastIfError } from "./utils/render-toast-if-error";
 
-const QUERY_KEYS_TO_IGNORE = ["authenticated", "hosts"];
+const QUERY_KEYS_TO_IGNORE = ["authenticated", "hosts", "settings"];
 
 export const queryClientConfig: QueryClientConfig = {
   queryCache: new QueryCache({


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
If settings returned a 404, we would return local defaults. In the saas this is a problem since it prevents the settings modal from showing up

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d667d8d-nikolaik   --name openhands-app-d667d8d   docker.all-hands.dev/all-hands-ai/openhands:d667d8d
```