### PR TITLE
fix: Update `config.template.toml` to have empty api keys

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -104,7 +104,7 @@ workspace_base = "./workspace"
 #aws_secret_access_key = ""
 
 # API key to use (For Headless / CLI only -  In Web this is overridden by Session Init)
-api_key = "your-api-key"
+api_key = ""
 
 # API base URL (For Headless / CLI only -  In Web this is overridden by Session Init)
 #base_url = ""
@@ -195,7 +195,7 @@ model = "gpt-4o"
 #native_tool_calling = None
 
 [llm.gpt4o-mini]
-api_key = "your-api-key"
+api_key = ""
 model = "gpt-4o"
 
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
The settings API gets the users `config.toml` to set the values if there is an empty settings object. This causes the value `"your-api-key"` to be set as the LLM API key and render that it is set on the frontend.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c7b5127-nikolaik   --name openhands-app-c7b5127   docker.all-hands.dev/all-hands-ai/openhands:c7b5127
```