### PR TITLE
fix: ensure GitHub repos are sorted by last update time

### DIFF
--- a/openhands/server/routes/github.py
+++ b/openhands/server/routes/github.py
@@ -35,6 +35,7 @@ async def get_github_repositories(
     params: dict[str, str] = {
         'page': str(page),
         'per_page': str(per_page),
+        'sort': sort,
     }
     # Construct the GitHub API URL
     if installation_id:
@@ -43,7 +44,6 @@ async def get_github_repositories(
         )
     else:
         github_api_url = 'https://api.github.com/user/repos'
-        params['sort'] = sort
 
     # Set the authorization header with the GitHub token
     headers = generate_github_headers(github_token)
@@ -93,7 +93,9 @@ async def get_github_installation_ids(
     headers = generate_github_headers(github_token)
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.get('https://api.github.com/user/installations', headers=headers)
+            response = await client.get(
+                'https://api.github.com/user/installations', headers=headers
+            )
             response.raise_for_status()
             data = response.json()
             ids = [installation['id'] for installation in data['installations']]


### PR DESCRIPTION
## Description
Fixed an issue where GitHub repositories were not being sorted by last update time when fetched through an installation. The `sort` parameter is now consistently applied for both installation and non-installation repository requests.

## Changes
- Added `sort` parameter to the base query parameters dictionary
- Removed redundant setting of `sort` parameter in the non-installation case
- Default sort is `pushed` which sorts by last update time

## Testing
The changes have been tested with pre-commit hooks and pass all code quality checks.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:030e08b-nikolaik   --name openhands-app-030e08b   docker.all-hands.dev/all-hands-ai/openhands:030e08b
```