### PR TITLE
chore(frontend): Handle test warnings

### DIFF
--- a/frontend/__tests__/components/chat-message.test.tsx
+++ b/frontend/__tests__/components/chat-message.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, test } from "vitest";
+import { describe, it, expect } from "vitest";
 import { ChatMessage } from "#/components/features/chat/chat-message";
 
 describe("ChatMessage", () => {
@@ -45,7 +45,9 @@ describe("ChatMessage", () => {
 
     await user.click(copyToClipboardButton);
 
-    expect(navigator.clipboard.readText()).resolves.toBe("Hello, World!");
+    await waitFor(() =>
+      expect(navigator.clipboard.readText()).resolves.toBe("Hello, World!"),
+    );
   });
 
   it("should display an error toast if copying content to clipboard fails", async () => {});

--- a/frontend/__tests__/components/chat/expandable-message.test.tsx
+++ b/frontend/__tests__/components/chat/expandable-message.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "test-utils";
 import { ExpandableMessage } from "#/components/features/chat/expandable-message";
-import { vi } from "vitest";
+import { vi } from "vitest"
 
 vi.mock("react-i18next", async () => {
   const actual = await vi.importActual("react-i18next");

--- a/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -1,5 +1,14 @@
 import { render, screen, within } from "@testing-library/react";
-import { afterEach, describe, expect, it, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  test,
+  vi,
+} from "vitest";
 import userEvent from "@testing-library/user-event";
 import { formatTimeDelta } from "#/utils/format-time-delta";
 import { ConversationCard } from "#/components/features/conversation-panel/conversation-card";
@@ -11,8 +20,16 @@ describe("ConversationCard", () => {
   const onChangeTitle = vi.fn();
   const onDownloadWorkspace = vi.fn();
 
+  beforeAll(() => {
+    vi.stubGlobal("window", { open: vi.fn() });
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
   });
 
   it("should render the conversation card", () => {

--- a/frontend/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/frontend/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -227,7 +227,7 @@ describe("ConversationPanel", () => {
   it("should call onClose after clicking a card", async () => {
     renderConversationPanel();
     const cards = await screen.findAllByTestId("conversation-card");
-    const firstCard = cards[0];
+    const firstCard = cards[1];
 
     await userEvent.click(firstCard);
 

--- a/frontend/__tests__/components/suggestion-item.test.tsx
+++ b/frontend/__tests__/components/suggestion-item.test.tsx
@@ -8,9 +8,10 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => {
       const translations: Record<string, string> = {
-        "SUGGESTIONS$TODO_APP": "ToDoリストアプリを開発する",
-        "LANDING$BUILD_APP_BUTTON": "プルリクエストを表示するアプリを開発する",
-        "SUGGESTIONS$HACKER_NEWS": "Hacker Newsのトップ記事を表示するbashスクリプトを作成する",
+        SUGGESTIONS$TODO_APP: "ToDoリストアプリを開発する",
+        LANDING$BUILD_APP_BUTTON: "プルリクエストを表示するアプリを開発する",
+        SUGGESTIONS$HACKER_NEWS:
+          "Hacker Newsのトップ記事を表示するbashスクリプトを作成する",
       };
       return translations[key] || key;
     },
@@ -38,9 +39,9 @@ describe("SuggestionItem", () => {
       value: "todo app value",
     };
 
-    const { container } = render(<SuggestionItem suggestion={translatedSuggestion} onClick={onClick} />);
-    console.log('Rendered HTML:', container.innerHTML);
-
+    render(
+      <SuggestionItem suggestion={translatedSuggestion} onClick={onClick} />,
+    );
 
     expect(screen.getByText("ToDoリストアプリを開発する")).toBeInTheDocument();
   });

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -143,10 +143,7 @@ export function ConversationCard({
         )}
       >
         {selectedRepository && (
-          <ConversationRepoLink
-            selectedRepository={selectedRepository}
-            onClick={(e) => e.stopPropagation()}
-          />
+          <ConversationRepoLink selectedRepository={selectedRepository} />
         )}
         <p className="text-xs text-neutral-400">
           <time>{formatTimeDelta(new Date(lastUpdatedAt))} ago</time>

--- a/frontend/src/components/features/conversation-panel/conversation-repo-link.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-repo-link.tsx
@@ -1,21 +1,27 @@
 interface ConversationRepoLinkProps {
   selectedRepository: string;
-  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export function ConversationRepoLink({
   selectedRepository,
-  onClick,
 }: ConversationRepoLinkProps) {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    window.open(
+      `https://github.com/${selectedRepository}`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  };
+
   return (
-    <a
+    <button
+      type="button"
       data-testid="conversation-card-selected-repository"
-      href={`https://github.com/${selectedRepository}`}
-      target="_blank noopener noreferrer"
-      onClick={onClick}
+      onClick={handleClick}
       className="text-xs text-neutral-400 hover:text-neutral-200"
     >
       {selectedRepository}
-    </a>
+    </button>
   );
 }

--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -70,7 +70,7 @@ export function GitHubRepositorySelector({
       }}
       onSelectionChange={(id) => handleRepoSelection(id?.toString() ?? null)}
       onInputChange={onInputChange}
-      clearButtonProps={{ onClick: handleClearSelection }}
+      clearButtonProps={{ onPress: handleClearSelection }}
       listboxProps={{
         emptyContent,
       }}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -59,7 +59,6 @@ export default defineConfig(({ mode }) => {
     test: {
       environment: "jsdom",
       setupFiles: ["vitest.setup.ts"],
-      reporters: "basic",
       exclude: [...configDefaults.exclude, "tests"],
       coverage: {
         reporter: ["text", "json", "html", "lcov", "text-summary"],


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Remove use of deprecated reporter
- Fix error for missing conversation path (`/conversation/3`) during testing
- Fix issue of awaiting resolver
- Fix warning of nesting `<a>` in another `<a>`
- Remove logging during tests
- Replaced nextui deprecated `onClick` with `onPress`

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f1a09c8-nikolaik   --name openhands-app-f1a09c8   docker.all-hands.dev/all-hands-ai/openhands:f1a09c8
```