### PR TITLE
Enhance play/pause button styling

### DIFF
--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -20,13 +20,13 @@ export function ActionButton({
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out"
+        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out bg-gray-100 dark:bg-gray-800 p-2 rounded-full"
         type="button"
       >
         <span className="relative z-10 group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">
           {children}
         </span>
-        <span className="absolute -inset-[5px] border-2 border-red-400/40 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out" />
+        <span className="absolute -inset-[5px] border-2 border-red-400/40 rounded-full opacity-100 group-hover:opacity-100 transition-opacity duration-300 ease-in-out" />
       </button>
     </Tooltip>
   );


### PR DESCRIPTION
This PR enhances the play/pause button styling to make it more prominent:

- Added a gray background that adapts to light/dark mode
- Added padding and made the button circular
- Made the circular border always visible

These changes improve the button visibility while maintaining its interactive features and dark mode compatibility.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b6d37f5-nikolaik   --name openhands-app-b6d37f5   docker.all-hands.dev/all-hands-ai/openhands:b6d37f5
```