### PR TITLE
fix: Don't close runtime on error

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -134,6 +134,10 @@ class Runtime(FileEditRuntimeMixin):
             self.add_env_vars(self.config.sandbox.runtime_startup_env_vars)
 
     def close(self) -> None:
+        """
+        This should only be called by conversation manager or closing the session.
+        If called for instance by error handling, it could prevent recovery.
+        """
         pass
 
     @classmethod
@@ -205,7 +209,6 @@ class Runtime(FileEditRuntimeMixin):
             self.log('error', f'Unexpected error while running action: {error_message}')
             self.log('error', f'Problematic action: {str(event)}')
             self.send_error_message(err_id, error_message)
-            self.close()
             return
 
         observation._cause = event.id  # type: ignore[attr-defined]

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -11,6 +11,7 @@ import requests
 from openhands.core.config import AppConfig
 from openhands.core.exceptions import (
     AgentRuntimeTimeoutError,
+    AgentRuntimeUnavailableError,
 )
 from openhands.events import EventStream
 from openhands.events.action import (
@@ -263,6 +264,10 @@ class ActionExecutionClient(Runtime):
                 raise AgentRuntimeTimeoutError(
                     f'Runtime failed to return execute_action before the requested timeout of {action.timeout}s'
                 )
+            except requests.HTTPError as e:
+                raise AgentRuntimeUnavailableError(
+                    f'Runtime HTTP failure: {str(e)}'
+                ) from e
             return obs
 
     def run(self, action: CmdRunAction) -> Observation:

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -11,7 +11,6 @@ import requests
 from openhands.core.config import AppConfig
 from openhands.core.exceptions import (
     AgentRuntimeTimeoutError,
-    AgentRuntimeUnavailableError,
 )
 from openhands.events import EventStream
 from openhands.events.action import (
@@ -264,10 +263,6 @@ class ActionExecutionClient(Runtime):
                 raise AgentRuntimeTimeoutError(
                     f'Runtime failed to return execute_action before the requested timeout of {action.timeout}s'
                 )
-            except requests.HTTPError as e:
-                raise AgentRuntimeUnavailableError(
-                    f'Runtime HTTP failure: {str(e)}'
-                ) from e
             return obs
 
     def run(self, action: CmdRunAction) -> Observation:

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -341,8 +341,6 @@ class RemoteRuntime(ActionExecutionClient):
                 f'Runtime (ID={self.runtime_id}) is not yet ready. Status: {pod_status}'
             )
         elif pod_status in ('failed', 'unknown', 'crashloopbackoff'):
-            # clean up the runtime
-            self.close()
             if pod_status == 'crashloopbackoff':
                 raise AgentRuntimeUnavailableError(
                     'Runtime crashed and is being restarted, potentially due to memory usage. Please try again.'


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Fix some situations where conversations could not be resumed after an agent error.

- [ x ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

During interactive usage, `Runtime.close()` should only be called by the conversation manager or `Session.close()`. `<--` *That's an important point, please confirm in review*

There were some scenarios where it was called during error handling, preventing remote runtime from being resumable. This change removes those `close()` calls, because we want those errors to be recoverable when the user sends a follow-up message.

Also wrapping HTTP errors from action execution in `AgentRuntimeUnavailableError`, which might not be a behavior change but seems correct.

---
**Link of any specific issues this addresses**
