### PR TITLE
Add note to Windows that docker command must be run in WSL terminal

### DIFF
--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -43,6 +43,10 @@
   - General: `Use the WSL 2 based engine` is enabled.
   - Resources > WSL Integration: `Enable integration with my default WSL distro` is enabled.
 
+  :::note
+  The docker command below to start the app must be run inside the WSL terminal.
+  :::
+
 </details>
 
 ## Start the App


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Add note to Windows that docker command must be run in WSL terminal

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Some users are still running this command in powershell or the docker desktop terminal so this should help.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c54c567-nikolaik   --name openhands-app-c54c567   docker.all-hands.dev/all-hands-ai/openhands:c54c567
```