### PR TITLE
hotfix(frontend): Show error toast if settings errors

### DIFF
--- a/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/frontend/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "test-utils";
 import { createRoutesStub } from "react-router";
+import { AxiosError } from "axios";
 import { Sidebar } from "#/components/features/sidebar/sidebar";
 import OpenHands from "#/api/open-hands";
 
@@ -153,10 +154,23 @@ describe("Sidebar", () => {
       expect(settingsModal).toBeInTheDocument();
     });
 
-    it("should open the settings modal if GET /settings fails", async () => {
-      vi.spyOn(OpenHands, "getSettings").mockRejectedValue(
-        new Error("Failed to fetch settings"),
+    it("should open the settings modal if GET /settings fails with a 404", async () => {
+      const error = new AxiosError(
+        "Request failed with status code 404",
+        "ERR_BAD_REQUEST",
+        undefined,
+        undefined,
+        {
+          status: 404,
+          statusText: "Not Found",
+          data: { message: "Settings not found" },
+          headers: {},
+          // @ts-expect-error - we only need the response object for this test
+          config: {},
+        },
       );
+
+      vi.spyOn(OpenHands, "getSettings").mockRejectedValue(error);
 
       renderSidebar();
 

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { FaListUl } from "react-icons/fa";
 import { useDispatch } from "react-redux";
 import posthog from "posthog-js";
+import toast from "react-hot-toast";
 import { useGitHubUser } from "#/hooks/query/use-github-user";
 import { UserActions } from "./user-actions";
 import { AllHandsLogoButton } from "#/components/shared/buttons/all-hands-logo-button";
@@ -28,7 +29,11 @@ export function Sidebar() {
   const endSession = useEndSession();
   const user = useGitHubUser();
   const { data: config } = useConfig();
-  const { data: settings, isError: settingsError } = useSettings();
+  const {
+    data: settings,
+    error: settingsError,
+    isFetching: isFetchingSettings,
+  } = useSettings();
   const { mutateAsync: logout } = useLogout();
   const { saveUserSettings } = useCurrentSettings();
 
@@ -45,6 +50,16 @@ export function Sidebar() {
       setAccountSettingsModalOpen(true);
     }
   }, [user.isError]);
+
+  React.useEffect(() => {
+    // We don't show toast errors for settings in the global error handler
+    // because we have a special case for 404 errors
+    if (!isFetchingSettings && settingsError?.status !== 404) {
+      toast.error(
+        "Something went wrong while fetching settings. Please reload the page.",
+      );
+    }
+  }, [settingsError?.status, isFetchingSettings]);
 
   const handleEndSession = () => {
     dispatch(setCurrentAgentState(AgentState.LOADING));
@@ -105,7 +120,7 @@ export function Sidebar() {
       {accountSettingsModalOpen && (
         <AccountSettingsModal onClose={handleAccountSettingsModalClose} />
       )}
-      {(settingsError || settingsModalIsOpen) && (
+      {(settingsError?.status === 404 || settingsModalIsOpen) && (
         <SettingsModal
           settings={settings}
           onClose={() => setSettingsModalIsOpen(false)}


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
We currently prevent a toast being thrown for settings in the global handler, instead we open the modal directly. This is relevant only of the settings 404s, otherwise, we probably want to show the user an error toast that something went wrong.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:07d36d1-nikolaik   --name openhands-app-07d36d1   docker.all-hands.dev/all-hands-ai/openhands:07d36d1
```