### PR TITLE
chore(frontend): Better error toast handling mechanism

### DIFF
--- a/frontend/src/hooks/query/use-active-host.ts
+++ b/frontend/src/hooks/query/use-active-host.ts
@@ -23,6 +23,9 @@ export const useActiveHost = () => {
     },
     enabled: !RUNTIME_INACTIVE_STATES.includes(curAgentState),
     initialData: { hosts: [] },
+    meta: {
+      disableToast: true,
+    },
   });
 
   const apps = useQueries({
@@ -37,6 +40,9 @@ export const useActiveHost = () => {
         }
       },
       refetchInterval: 3000,
+      meta: {
+        disableToast: true,
+      },
     })),
   });
 

--- a/frontend/src/hooks/query/use-is-authed.ts
+++ b/frontend/src/hooks/query/use-is-authed.ts
@@ -16,5 +16,8 @@ export const useIsAuthed = () => {
     enabled: !!appMode,
     staleTime: 1000 * 60 * 5, // 5 minutes
     retry: false,
+    meta: {
+      disableToast: true,
+    },
   });
 };

--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -32,6 +32,9 @@ export const useSettings = () => {
     initialData: DEFAULT_SETTINGS,
     staleTime: 0,
     retry: false,
+    meta: {
+      disableToast: true,
+    },
   });
 
   React.useEffect(() => {

--- a/frontend/src/query-client-config.ts
+++ b/frontend/src/query-client-config.ts
@@ -1,13 +1,22 @@
 import { QueryClientConfig, QueryCache } from "@tanstack/react-query";
-import { renderToastIfError } from "./utils/render-toast-if-error";
+import toast from "react-hot-toast";
+import { retrieveAxiosErrorMessage } from "./utils/retrieve-axios-error-message";
 
-const QUERY_KEYS_TO_IGNORE = ["authenticated", "hosts", "settings"];
-
+const shownErrors = new Set<string>();
 export const queryClientConfig: QueryClientConfig = {
   queryCache: new QueryCache({
     onError: (error, query) => {
-      if (!QUERY_KEYS_TO_IGNORE.some((key) => query.queryKey.includes(key))) {
-        renderToastIfError(error);
+      if (!query.meta?.disableToast) {
+        const errorMessage = retrieveAxiosErrorMessage(error);
+
+        if (!shownErrors.has(errorMessage)) {
+          toast.error(errorMessage || "An error occurred");
+          shownErrors.add(errorMessage);
+
+          setTimeout(() => {
+            shownErrors.delete(errorMessage);
+          }, 3000);
+        }
       }
     },
   }),
@@ -18,7 +27,8 @@ export const queryClientConfig: QueryClientConfig = {
     },
     mutations: {
       onError: (error) => {
-        renderToastIfError(error);
+        const message = retrieveAxiosErrorMessage(error);
+        toast.error(message);
       },
     },
   },

--- a/frontend/src/utils/retrieve-axios-error-message.ts
+++ b/frontend/src/utils/retrieve-axios-error-message.ts
@@ -1,12 +1,11 @@
 import { AxiosError } from "axios";
-import toast from "react-hot-toast";
 import { isAxiosErrorWithResponse } from "./type-guards";
 
 /**
- * Renders a toast with the error message from an Axios error
+ * Retrieve the error message from an Axios error
  * @param error The error to render a toast for
  */
-export const renderToastIfError = (error: AxiosError) => {
+export const retrieveAxiosErrorMessage = (error: AxiosError) => {
   let errorMessage: string | null = null;
 
   if (isAxiosErrorWithResponse(error) && error.response?.data.error) {
@@ -15,5 +14,5 @@ export const renderToastIfError = (error: AxiosError) => {
     errorMessage = error.message;
   }
 
-  toast.error(errorMessage || "An error occurred");
+  return errorMessage || "An error occurred";
 };


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
![image](https://github.com/user-attachments/assets/c69f65c1-7ec9-4b77-a54b-b505afaa3788)
Since we may use one of our custom query handlers (e.g., `useSettings`, `useGitHubUser`) in multiple parts of the app, if the `queryFn` errors, then we will handle the `onError` for all instances. In the case of `useGitHubUser`, this could be 3+ times.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Store messages in a `Set` after they are toasted that reset after 3 seconds (changes only applied to queries)
- Use `meta` key to determine whether we want the global error handler to ignore certain queries instead of watching a list of query key


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5be310f-nikolaik   --name openhands-app-5be310f   docker.all-hands.dev/all-hands-ai/openhands:5be310f
```