### PR TITLE
Fix: RM debug print

### DIFF
--- a/openhands/server/routes/github.py
+++ b/openhands/server/routes/github.py
@@ -32,7 +32,6 @@ async def get_github_repositories(
     github_token: str = Depends(require_github_token),
     github_user_id: str | None = Depends(get_user_id),
 ):
-    print('got user id ', github_user_id)
     client = GithubServiceImpl(github_token, github_user_id)
     return await client.fetch_response(
         'get_repositories', page, per_page, sort, installation_id


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

#6558 introduced a debug print that wasn't cleaned up cc @enyst 

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:989cbbe-nikolaik   --name openhands-app-989cbbe   docker.all-hands.dev/all-hands-ai/openhands:989cbbe
```