### PR TITLE
Changed Dockerfile template so using ubuntu:22.04 as runtime base image does not have docker build error

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -16,8 +16,13 @@ ENV POETRY_VIRTUALENVS_PATH=/openhands/poetry \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         wget curl sudo apt-utils git jq tmux \
-        {%- if 'ubuntu' in base_image and (base_image.endswith(':latest') or base_image.endswith(':24.04')) -%}
-        libgl1 \
+        {%- if 'ubuntu' in base_image %}
+            build-essential g++-10 python3-dev ca-certificates \
+            {%- if base_image.endswith(':latest') or base_image.endswith(':24.04') %}
+            libgl1 \
+            {%- else %}
+            libgl1-mesa-glx \
+            {% endif -%}
         {%- else %}
         libgl1-mesa-glx \
         {% endif -%}


### PR DESCRIPTION
I have problem building docker image using ubuntu as base image. It turned out it was missing a few dependencies. 

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below



