### PR TITLE
Update llm.py

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -89,6 +89,7 @@ REASONING_EFFORT_SUPPORTED_MODELS = [
 
 MODELS_WITHOUT_STOP_WORDS = [
     'o1-mini',
+    'o1-preview',
 ]
 
 


### PR DESCRIPTION
o1-preview does not support STOP either

**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

It's a very simple fix. The o1-preview model doesn't work because it does not support the STOP command and this PR fixes that.

---
**Link of any specific issues this addresses**
