### PR TITLE
fix: initialize default metadata with all required fields

### DIFF
--- a/evaluation/benchmarks/swe_bench/eval_infer.py
+++ b/evaluation/benchmarks/swe_bench/eval_infer.py
@@ -412,6 +412,17 @@ if __name__ == '__main__':
         with open(metadata_filepath, 'r') as metadata_file:
             data = metadata_file.read()
             metadata = EvalMetadata.model_validate_json(data)
+    else:
+        # Initialize with a dummy metadata when file doesn't exist
+        metadata = EvalMetadata(
+            agent_class="dummy_agent",  # Placeholder agent class
+            llm_config=LLMConfig(model="dummy_model"),  # Minimal LLM config
+            max_iterations=1,  # Minimal iterations
+            eval_output_dir=os.path.dirname(args.input_file),  # Use input file dir as output dir
+            start_time=time.strftime('%Y-%m-%d %H:%M:%S'),  # Current time
+            git_commit=subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip(),  # Current commit
+            dataset=args.dataset  # Dataset name from args
+        )
 
     # The evaluation harness constrains the signature of `process_instance_func` but we need to
     # pass extra information. Build a new function object to avoid issues with multiprocessing.


### PR DESCRIPTION
This PR fixes an issue where the evaluation script would error out if metadata.json doesn't exist. Now it will initialize a default EvalMetadata with all required fields when the file is missing.

Changes:
- Added a fallback to create default metadata when metadata.json doesn't exist
- Initializes EvalMetadata with all required fields:
  - agent_class: "dummy_agent" (placeholder)
  - llm_config: LLMConfig with "dummy_model"
  - max_iterations: 1
  - eval_output_dir: input file directory
  - start_time: current time
  - git_commit: current commit hash
  - dataset: from args.dataset
- Maintains type safety by ensuring metadata is always an EvalMetadata instance

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:543d0ba-nikolaik   --name openhands-app-543d0ba   docker.all-hands.dev/all-hands-ai/openhands:543d0ba
```