### PR TITLE
hotfix(frontend): Only show settings error toast when there is an error

### DIFF
--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -32,6 +32,7 @@ export function Sidebar() {
   const {
     data: settings,
     error: settingsError,
+    isError: settingsIsError,
     isFetching: isFetchingSettings,
   } = useSettings();
   const { mutateAsync: logout } = useLogout();
@@ -54,12 +55,16 @@ export function Sidebar() {
   React.useEffect(() => {
     // We don't show toast errors for settings in the global error handler
     // because we have a special case for 404 errors
-    if (!isFetchingSettings && settingsError?.status !== 404) {
+    if (
+      !isFetchingSettings &&
+      settingsIsError &&
+      settingsError?.status !== 404
+    ) {
       toast.error(
         "Something went wrong while fetching settings. Please reload the page.",
       );
     }
-  }, [settingsError?.status, isFetchingSettings]);
+  }, [settingsError?.status, settingsError, isFetchingSettings]);
 
   const handleEndSession = () => {
     dispatch(setCurrentAgentState(AgentState.LOADING));


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
Whenever `GET /settings` passes, a settings-specific error toast is show.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Only show when it actually errors


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c0b9a74-nikolaik   --name openhands-app-c0b9a74   docker.all-hands.dev/all-hands-ai/openhands:c0b9a74
```