### PR TITLE
hotfix(frontend): Make conversation  title clickable

### DIFF
--- a/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -46,9 +46,8 @@ describe("ConversationCard", () => {
     const expectedDate = `${formatTimeDelta(new Date("2021-10-01T12:00:00Z"))} ago`;
 
     const card = screen.getByTestId("conversation-card");
-    const title = within(card).getByTestId("conversation-card-title");
 
-    expect(title).toHaveValue("Conversation 1");
+    within(card).getByText("Conversation 1");
     within(card).getByText(expectedDate);
   });
 
@@ -165,10 +164,8 @@ describe("ConversationCard", () => {
       />,
     );
 
-    const title = screen.getByTestId("conversation-card-title");
-    expect(title).toBeDisabled();
-
     await clickOnEditButton(user);
+    const title = screen.getByTestId("conversation-card-title");
 
     expect(title).toBeEnabled();
     expect(screen.queryByTestId("context-menu")).not.toBeInTheDocument();
@@ -181,7 +178,6 @@ describe("ConversationCard", () => {
 
     expect(onChangeTitle).toHaveBeenCalledWith("New Conversation Name");
     expect(title).toHaveValue("New Conversation Name");
-    expect(title).toBeDisabled();
   });
 
   it("should reset title and not call onChangeTitle when the title is empty", async () => {
@@ -208,7 +204,27 @@ describe("ConversationCard", () => {
     expect(title).toHaveValue("Conversation 1");
   });
 
-  test("clicking the title should not trigger the onClick handler", async () => {
+  test("clicking the title should trigger the onClick handler", async () => {
+    const user = userEvent.setup();
+    render(
+      <ConversationCard
+        onClick={onClick}
+        onDelete={onDelete}
+        isActive
+        onChangeTitle={onChangeTitle}
+        title="Conversation 1"
+        selectedRepository={null}
+        lastUpdatedAt="2021-10-01T12:00:00Z"
+      />,
+    );
+
+    const title = screen.getByTestId("conversation-card-title");
+    await user.click(title);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  test("clicking the title should not trigger the onClick handler if edit mode", async () => {
     const user = userEvent.setup();
     render(
       <ConversationCard
@@ -220,6 +236,8 @@ describe("ConversationCard", () => {
         lastUpdatedAt="2021-10-01T12:00:00Z"
       />,
     );
+
+    await clickOnEditButton(user);
 
     const title = screen.getByTestId("conversation-card-title");
     await user.click(title);

--- a/frontend/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/frontend/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -179,9 +179,10 @@ describe("ConversationPanel", () => {
     const user = userEvent.setup();
     renderConversationPanel();
     const cards = await screen.findAllByTestId("conversation-card");
-    const title = within(cards[0]).getByTestId("conversation-card-title");
 
-    await clickOnEditButton(user);
+    const card = cards[0];
+    await clickOnEditButton(user, card);
+    const title = within(card).getByTestId("conversation-card-title");
 
     await user.clear(title);
     await user.type(title, "Conversation 1 Renamed");
@@ -202,7 +203,10 @@ describe("ConversationPanel", () => {
     const user = userEvent.setup();
     renderConversationPanel();
     const cards = await screen.findAllByTestId("conversation-card");
-    const title = within(cards[0]).getByTestId("conversation-card-title");
+
+    const card = cards[0];
+    await clickOnEditButton(user, card);
+    const title = within(card).getByTestId("conversation-card-title");
 
     await user.click(title);
     await user.tab();

--- a/frontend/__tests__/components/features/conversation-panel/utils.ts
+++ b/frontend/__tests__/components/features/conversation-panel/utils.ts
@@ -1,11 +1,16 @@
 import { screen, within } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event";
 
-export const clickOnEditButton = async (user: UserEvent) => {
-  const ellipsisButton = screen.getByTestId("ellipsis-button");
+export const clickOnEditButton = async (
+  user: UserEvent,
+  container?: HTMLElement,
+) => {
+  const wrapper = container ? within(container) : screen;
+
+  const ellipsisButton = wrapper.getByTestId("ellipsis-button");
   await user.click(ellipsisButton);
 
-  const menu = screen.getByTestId("context-menu");
+  const menu = wrapper.getByTestId("context-menu");
   const editButton = within(menu).getByTestId("edit-button");
 
   await user.click(editButton);

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -58,8 +58,10 @@ export function ConversationCard({
   };
 
   const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
+    if (titleMode === "edit") {
+      event.preventDefault();
+      event.stopPropagation();
+    }
   };
 
   const handleDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -101,17 +103,26 @@ export function ConversationCard({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 w-full">
           {isActive && <span className="w-2 h-2 bg-blue-500 rounded-full" />}
-          <input
-            ref={inputRef}
-            disabled={titleMode === "view"}
-            data-testid="conversation-card-title"
-            onClick={handleInputClick}
-            onBlur={handleBlur}
-            onKeyUp={handleKeyUp}
-            type="text"
-            defaultValue={title}
-            className="text-sm leading-6 font-semibold bg-transparent w-full"
-          />
+          {titleMode === "edit" && (
+            <input
+              ref={inputRef}
+              data-testid="conversation-card-title"
+              onClick={handleInputClick}
+              onBlur={handleBlur}
+              onKeyUp={handleKeyUp}
+              type="text"
+              defaultValue={title}
+              className="text-sm leading-6 font-semibold bg-transparent w-full"
+            />
+          )}
+          {titleMode === "view" && (
+            <p
+              data-testid="conversation-card-title"
+              className="text-sm leading-6 font-semibold bg-transparent w-full"
+            >
+              {title}
+            </p>
+          )}
         </div>
 
         <div className="flex items-center gap-2 relative">


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
Clicking the conversation card title did not cause a navigation to the actual conversation. This was due to the fact that we intentionally prevented this behaviour when clicking the input to avoid conflict with clicking to edit title

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Render a `<p`> element when not in edit mode
- Fix tests appropriately


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:865690e-nikolaik   --name openhands-app-865690e   docker.all-hands.dev/all-hands-ai/openhands:865690e
```