### PR TITLE
Add memory limit option for Docker runtime

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -66,6 +66,10 @@ class SandboxConfig(BaseModel):
     close_delay: int = Field(default=15)
     remote_runtime_resource_factor: int = Field(default=1)
     enable_gpu: bool = Field(default=False)
+    memory_limit: str | None = Field(
+        default=None,
+        description="Memory limit for the runtime container (e.g. '2g' for 2GB, '512m' for 512MB). None means no limit."
+    )
     docker_runtime_kwargs: str | None = Field(default=None)
 
     model_config = {'extra': 'forbid'}

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -273,6 +273,7 @@ class DockerRuntime(ActionExecutionClient):
                     if self.config.sandbox.enable_gpu
                     else None
                 ),
+                mem_limit=self.config.sandbox.memory_limit,
                 **(self.config.sandbox.docker_runtime_kwargs or {}),
             )
             self.log('debug', f'Container started. Server url: {self.api_url}')


### PR DESCRIPTION
This PR adds the ability to limit memory usage in the Docker runtime environment.

### Changes
- Added `memory_limit` configuration option to `SandboxConfig`
- Added `mem_limit` parameter to Docker container creation
- Memory limits can be specified in Docker format (e.g. "2g" for 2GB)

### Usage
Users can now limit the memory usage of the runtime by setting the `memory_limit` configuration option:

```python
config = AppConfig(
    sandbox=SandboxConfig(
        memory_limit="2g"  # Limits container to 2GB of memory
    )
)
```

Or in configuration file:
```yaml
sandbox:
  memory_limit: "2g"  # Limits container to 2GB of memory
```

The memory limit follows Docker format:
- Use a positive integer with a suffix of `b`, `k`, `m`, `g` (bytes, kilobytes, megabytes, gigabytes)
- Examples: 
  - `"512m"` for 512MB
  - `"2g"` for 2GB
  - `"1536m"` for 1.5GB

If not set (or set to None), the container will have access to all available system memory.