### PR TITLE
Remove free disk space steps from workflows to test if they are necessary

### DIFF
--- a/.github/workflows/dummy-agent-test.yml
+++ b/.github/workflows/dummy-agent-test.yml
@@ -19,20 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: true
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -41,20 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: true
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.3.0
         with:
@@ -104,20 +90,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: true
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.3.0
         with:
@@ -230,20 +202,6 @@ jobs:
         base_image: ['nikolaik']
     steps:
       - uses: actions/checkout@v4
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: true
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -307,20 +265,6 @@ jobs:
         base_image: ['nikolaik']
     steps:
       - uses: actions/checkout@v4
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: true
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This PR removes the "Free Disk Space (Ubuntu)" step from our GitHub Actions workflows to test if they are still necessary. These steps were taking over 5 minutes to complete.

Changes made:
- Removed the `jlumbroso/free-disk-space@main` action from `dummy-agent-test.yml`
- Removed the `jlumbroso/free-disk-space@main` action from multiple jobs in `ghcr-build.yml`:
  - `ghcr_build_app` job
  - `ghcr_build_runtime` job
  - `test_runtime_root` job
  - `test_runtime_oh` job

This is a test to see if our workflows can run successfully without explicitly freeing disk space. If the workflows fail due to disk space issues, we can consider alternative approaches:
1. Use GitHub-hosted runners with more disk space
2. Clean up unnecessary files and caches before running space-intensive tasks
3. Optimize the build process to use less disk space
4. Use a more targeted approach to free disk space by only removing specific tools/packages that we know we do not need

Expected outcomes:
- If the workflows pass: We can keep these changes and benefit from faster CI runs
- If the workflows fail: We will need to explore the alternative approaches listed above

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2e85489-nikolaik   --name openhands-app-2e85489   docker.all-hands.dev/all-hands-ai/openhands:2e85489
```