### PR TITLE
Only show start project button in conversations

### DIFF
--- a/frontend/src/components/shared/buttons/exit-project-button.tsx
+++ b/frontend/src/components/shared/buttons/exit-project-button.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router";
 import { I18nKey } from "#/i18n/declaration";
 import NewProjectIcon from "#/icons/new-project.svg?react";
 import { TooltipButton } from "./tooltip-button";
@@ -9,7 +10,12 @@ interface ExitProjectButtonProps {
 
 export function ExitProjectButton({ onClick }: ExitProjectButtonProps) {
   const { t } = useTranslation();
+  const location = useLocation();
   const startNewProject = t(I18nKey.PROJECT$START_NEW);
+
+  // Only show the button in the conversations page
+  if (!location.pathname.includes("/conversations")) return null;
+
   return (
     <TooltipButton
       tooltip={startNewProject}

--- a/frontend/src/components/shared/buttons/exit-project-button.tsx
+++ b/frontend/src/components/shared/buttons/exit-project-button.tsx
@@ -14,7 +14,7 @@ export function ExitProjectButton({ onClick }: ExitProjectButtonProps) {
   const startNewProject = t(I18nKey.PROJECT$START_NEW);
 
   // Only show the button in the conversations page
-  if (!location.pathname.includes("/conversations")) return null;
+  if (!location.pathname.startsWith("/conversations")) return null;
 
   return (
     <TooltipButton


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Only show start project button in conversations

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Tested that the Start new project button only shows when you are in the conversation page.

---
**Link of any specific issues this addresses**
https://github.com/All-Hands-AI/OpenHands/issues/5857

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fff9cde-nikolaik   --name openhands-app-fff9cde   docker.all-hands.dev/all-hands-ai/openhands:fff9cde
```