### PR TITLE
Optimize Docker cleanup to preserve caching

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -39,6 +39,17 @@ jobs:
     outputs:
       hash_from_app_image: ${{ steps.get_hash_in_app_image.outputs.hash_from_app_image }}
     steps:
+      - name: Check initial disk space
+        run: |
+          echo "=== Initial Disk Space Overview ==="
+          df -h
+          echo
+          echo "=== Initial Docker Space Usage ==="
+          docker system df
+          echo
+          echo "=== Largest Files/Directories ==="
+          sudo du -h / 2>/dev/null | sort -rh | head -n 20
+
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up QEMU
@@ -62,6 +73,27 @@ jobs:
         if: "github.event.pull_request.head.repo.fork"
         run: |
           ./containers/build.sh -i openhands -o ${{ github.repository_owner }} --load
+
+      - name: Check disk space after build
+        run: |
+          echo "=== Disk Space After Build ==="
+          df -h
+          echo
+          echo "=== Docker Space Usage After Build ==="
+          docker system df
+          echo
+          echo "=== Largest Files/Directories ==="
+          sudo du -h / 2>/dev/null | sort -rh | head -n 20
+
+      - name: Clean up Docker resources
+        run: |
+          echo "=== Cleaning up Docker resources ==="
+          docker system prune -af --volumes
+          docker builder prune -af
+          echo
+          echo "=== Docker Space Usage After Cleanup ==="
+          docker system df
+
       - name: Get hash in App Image
         id: get_hash_in_app_image
         run: |
@@ -74,6 +106,26 @@ jobs:
           hash_from_app_image=$(cat docker-outputs.txt | grep "Hash for docker build directory" | awk -F "): " '{print $2}' | uniq | head -n1)
           echo "hash_from_app_image=$hash_from_app_image" >> $GITHUB_OUTPUT
           echo "Hash from app image: $hash_from_app_image"
+
+      - name: Check disk space after hash verification
+        run: |
+          echo "=== Disk Space After Hash Verification ==="
+          df -h
+          echo
+          echo "=== Docker Space Usage After Hash Verification ==="
+          docker system df
+          echo
+          echo "=== Largest Files/Directories ==="
+          sudo du -h / 2>/dev/null | sort -rh | head -n 20
+
+      - name: Clean up Docker resources after hash verification
+        run: |
+          echo "=== Cleaning up Docker resources ==="
+          docker system prune -af --volumes
+          docker builder prune -af
+          echo
+          echo "=== Docker Space Usage After Cleanup ==="
+          docker system df
 
   # Builds the runtime Docker images
   ghcr_build_runtime:

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -85,11 +85,15 @@ jobs:
           echo "=== Largest Files/Directories ==="
           sudo du -h / 2>/dev/null | sort -rh | head -n 20
 
-      - name: Clean up Docker resources
+      - name: Clean up unused Docker resources
         run: |
-          echo "=== Cleaning up Docker resources ==="
-          docker system prune -af --volumes
-          docker builder prune -af
+          echo "=== Cleaning up unused Docker resources ==="
+          # Remove only dangling images (untagged)
+          docker image prune -f
+          # Remove containers that have exited more than 1 hour ago
+          docker container prune -f --filter "until=1h"
+          # Remove only unused volumes
+          docker volume prune -f
           echo
           echo "=== Docker Space Usage After Cleanup ==="
           docker system df
@@ -118,11 +122,15 @@ jobs:
           echo "=== Largest Files/Directories ==="
           sudo du -h / 2>/dev/null | sort -rh | head -n 20
 
-      - name: Clean up Docker resources after hash verification
+      - name: Clean up unused Docker resources after hash verification
         run: |
-          echo "=== Cleaning up Docker resources ==="
-          docker system prune -af --volumes
-          docker builder prune -af
+          echo "=== Cleaning up unused Docker resources ==="
+          # Remove only dangling images (untagged)
+          docker image prune -f
+          # Remove containers that have exited more than 1 hour ago
+          docker container prune -f --filter "until=1h"
+          # Remove only unused volumes
+          docker volume prune -f
           echo
           echo "=== Docker Space Usage After Cleanup ==="
           docker system df


### PR DESCRIPTION
This PR optimizes the Docker cleanup strategy to better preserve caching while still managing disk space effectively.

Changes:
- Replace aggressive `docker system prune` with targeted cleanup:
  - Only remove dangling (untagged) images
  - Only remove containers stopped for >1h
  - Only remove unused volumes
- Keep build cache for frequently used base images

This should help maintain better build performance (previous approach was taking ~12 minutes vs the usual 3-6 minutes) while still preventing disk space issues like the one seen in #6346.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2218e72-nikolaik   --name openhands-app-2218e72   docker.all-hands.dev/all-hands-ai/openhands:2218e72
```