### PR TITLE
chore(frontend): Migrate from NextUI to HeroUI via codemod

### DIFF
--- a/frontend/__tests__/components/landing-translations.test.tsx
+++ b/frontend/__tests__/components/landing-translations.test.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import translations from "../../src/i18n/translation.json";
 import { UserAvatar } from "../../src/components/features/sidebar/user-avatar";
 
-vi.mock("@nextui-org/react", () => ({
+vi.mock("@heroui/react", () => ({
   Tooltip: ({ content, children }: { content: string; children: React.ReactNode }) => (
     <div>
       {children}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "openhands-frontend",
       "version": "0.23.0",
       "dependencies": {
+        "@heroui/react": "2.6.14",
         "@monaco-editor/react": "^4.7.0-rc.0",
-        "@nextui-org/react": "^2.6.11",
         "@react-router/node": "^7.1.5",
         "@react-router/serve": "^7.1.5",
         "@react-types/shared": "^3.27.0",
@@ -1399,6 +1399,1763 @@
         "tslib": "2"
       }
     },
+    "node_modules/@heroui/accordion": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/accordion/-/accordion-2.2.8.tgz",
+      "integrity": "sha512-azHolskQ1dNUT+A5h0w7n2DO7WFaafGPPPFfNDQZ3N/HigYjCF8E2MPkR40et+jffojji5/PgKjpIezlPlKsPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/divider": "2.2.6",
+        "@heroui/dom-animation": "2.1.2",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-aria-accordion": "2.2.3",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tree": "3.8.6",
+        "@react-types/accordion": "3.0.0-alpha.25",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/accordion/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/alert": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@heroui/alert/-/alert-2.2.10.tgz",
+      "integrity": "sha512-IHr2FiyPq8XL/YYF/QY3KemHdQcqAQaHf8Lz/7fBCz/TYSq2nyNEZdVcj3fAj2Cwutcr3Tjthk8r4KIW+AkxVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.10",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/aria-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/aria-utils/-/aria-utils-2.2.8.tgz",
+      "integrity": "sha512-+1kF96fSbA+PtP/UGxtcpBc8Vuc5KJwO0sndGCu41oijVMZ2RZ4wV6exwoT478U+nH8p8DbpXJHkzOhd6Zlagg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-rsc-utils": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system": "2.4.7",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/collections": "3.12.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/overlays": "3.8.11",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/aria-utils/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/autocomplete": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@heroui/autocomplete/-/autocomplete-2.3.11.tgz",
+      "integrity": "sha512-W49pzRVeNKKCkLnSm5Li9OqNEdzV7lZhvnShGgVdnoxJSpcJpqKuuefRtqiWstTTl5c/uIgsPUk9eIwZAy7ubQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/button": "2.2.10",
+        "@heroui/form": "2.1.9",
+        "@heroui/input": "2.4.10",
+        "@heroui/listbox": "2.3.10",
+        "@heroui/popover": "2.3.10",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/scroll-shadow": "2.3.6",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/spinner": "2.2.7",
+        "@heroui/use-aria-button": "2.2.5",
+        "@heroui/use-safe-layout-effect": "2.1.2",
+        "@react-aria/combobox": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/combobox": "3.10.1",
+        "@react-types/combobox": "3.13.1",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/autocomplete/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/avatar": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/avatar/-/avatar-2.2.7.tgz",
+      "integrity": "sha512-ygQhdpyotejCbGaqBSadEXMulrpWLEl7lgV/0zKr17PVNPcDMt6otcBIrfiirrnGQoBi7rAJg0QS2IlHA/3mVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-image": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/badge": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@heroui/badge/-/badge-2.2.6.tgz",
+      "integrity": "sha512-jF04WHFEnND5ZLl361Di2BDWrWORpCZk2/0Le9U6Wbm11erSO13ChJnD0YdSeQ9+RTHJmxwyDr2o9GsX7Ks15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/breadcrumbs": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/breadcrumbs/-/breadcrumbs-2.2.7.tgz",
+      "integrity": "sha512-IavL3Nl5CO9HexF0foXsOnlYBlHdbMV6eeTxwJ74ww5TVEFJ7i6+4JGKYrra2oze+0sJVFSuU56PLdWhIgy9ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/breadcrumbs": "3.5.19",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/breadcrumbs": "3.7.9",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/breadcrumbs/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/button": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@heroui/button/-/button-2.2.10.tgz",
+      "integrity": "sha512-SsW7t1Ay6SKQtUuwy0RXKmHR43RLHUd0ef9efJrcLAhm7HT6vkwAPQxYV2IMbXJMNDSezjbY+rcUFk3VOE0qqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/ripple": "2.2.8",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/spinner": "2.2.7",
+        "@heroui/use-aria-button": "2.2.5",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/button": "3.10.1",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/button/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/calendar": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@heroui/calendar/-/calendar-2.2.10.tgz",
+      "integrity": "sha512-DaExVGSMYuOZEI7r2R5eb/K4oeuchZIkcaZ3f+Nv2AwI64pUpNfhbS89xDyuuZ+I5dqpGxzW2DVBmWZJ2+G07w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.10",
+        "@heroui/dom-animation": "2.1.2",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-aria-button": "2.2.5",
+        "@internationalized/date": "3.6.0",
+        "@react-aria/calendar": "3.6.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/calendar": "3.6.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/button": "3.10.1",
+        "@react-types/calendar": "3.5.0",
+        "@react-types/shared": "3.26.0",
+        "@types/lodash.debounce": "^4.0.7",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/calendar/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/card": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@heroui/card/-/card-2.2.10.tgz",
+      "integrity": "sha512-VunP298v2FAtBg8U8ZLPIJUz4AIBSqjeaazVxGhN2ld3ipqygLNYCHRkG5UPwN1qYdsOEbx1ebMWgasPklwoLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/ripple": "2.2.8",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-aria-button": "2.2.5",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/card/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/checkbox": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@heroui/checkbox/-/checkbox-2.3.9.tgz",
+      "integrity": "sha512-R5b2L4BKZ1BSTBJVPl4Ipe/4cG7UacnYPb3BUfTJWrkcrbTxJ+VCkcZQ7s8n9FJpJlp6VWky0LY1E1+UXPcWPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.9",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-callback-ref": "2.1.2",
+        "@heroui/use-safe-layout-effect": "2.1.2",
+        "@react-aria/checkbox": "3.15.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/checkbox": "3.6.10",
+        "@react-stately/toggle": "3.8.0",
+        "@react-types/checkbox": "3.9.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.3",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/checkbox/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/chip": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/chip/-/chip-2.2.7.tgz",
+      "integrity": "sha512-PsomfpPUWNAf7OqQEugPYVQsBKkJN/aeNXTp//KoAEVZRxMAHZvPCOvJpvcQR4TaNE1sZ7rQKYjuELrQOjBWbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/checkbox": "3.9.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/code": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/code/-/code-2.2.7.tgz",
+      "integrity": "sha512-klk+i5mLySEXB/aQAntJzY7te0xrvtb1UTTAs0n/U/Qe2HusJDtRwe2JlFp+dtSR7Ge/wBMYZMje7ikx1PvJ6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system-rsc": "2.3.6"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/date-input": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@heroui/date-input/-/date-input-2.3.9.tgz",
+      "integrity": "sha512-aAid8SI6sBARKZKlUzlx5MrHewVY/Aagbb25JkIjAOFH4hjxvE4Lw7bMlWgnLyPouCpENVK13V0Jo6/FmYDP6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.9",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@internationalized/date": "3.6.0",
+        "@react-aria/datepicker": "3.12.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/datepicker": "3.11.0",
+        "@react-types/datepicker": "3.9.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/date-input/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/date-picker": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@heroui/date-picker/-/date-picker-2.3.10.tgz",
+      "integrity": "sha512-6IKxmpORt/PdEI3C8WRhOjLPqQqOgDW6qosgRwJ7azaCHDb6zrTHdlJkAkejnfvoIG6xMB+W+V0CkdCq/hklyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/button": "2.2.10",
+        "@heroui/calendar": "2.2.10",
+        "@heroui/date-input": "2.3.9",
+        "@heroui/form": "2.1.9",
+        "@heroui/popover": "2.3.10",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@internationalized/date": "3.6.0",
+        "@react-aria/datepicker": "3.12.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/datepicker": "3.11.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/datepicker": "3.9.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/date-picker/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/divider": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@heroui/divider/-/divider-2.2.6.tgz",
+      "integrity": "sha512-C9ShXhGstjkFvaympTrqdUg1k+CZ/e3o5IV+x2RaWw3nvEEdnDLeY/j6Uk6r683Bs/R6valzRNlAPocUpRtM5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-rsc-utils": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system-rsc": "2.3.6",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/divider/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/dom-animation": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/dom-animation/-/dom-animation-2.1.2.tgz",
+      "integrity": "sha512-DX5zGe60gjKIk1sYMPGgR4shOsfpL/1xH0EN18o0SyBiJuGtrii2nXW+0sbsapsW6KzqVYMmXzfVhWkAWR190Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+      }
+    },
+    "node_modules/@heroui/drawer": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/drawer/-/drawer-2.2.8.tgz",
+      "integrity": "sha512-ioxD+h6cpD7q/X0vEj1I6abCg5kP1JTsE7dvSOXVkTf9J5glKqw3MfVkQGU/2OTiurIxNA40KS2vpJsLLlN1fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/modal": "2.2.8",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/dropdown": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@heroui/dropdown/-/dropdown-2.3.10.tgz",
+      "integrity": "sha512-T2W5RjInzjU2yiksiYc19Wt0QNU5GUtoiYvT3lrYtRUdOTeWgQ19/Q3zLSxDXaZkf5fYFC0KqaJ52cvJApmNPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/menu": "2.2.10",
+        "@heroui/popover": "2.3.10",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/menu": "3.16.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/menu": "3.9.0",
+        "@react-types/menu": "3.9.13"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/form": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@heroui/form/-/form-2.1.9.tgz",
+      "integrity": "sha512-8qqfWXmVeELDN2JJ45+71tgNil8ird7LkF6chkK/+SLw3OTTE1q7dq9ikc6zzQ12x0Sa7IgVDl4bVn4jHoDCyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system": "2.4.7",
+        "@heroui/theme": "2.4.6",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/form": "3.1.0",
+        "@react-types/form": "3.7.8",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/form/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/framer-utils": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@heroui/framer-utils/-/framer-utils-2.1.7.tgz",
+      "integrity": "sha512-srTMsTO96fnaxbUNhzCpt7zbic+fndWpcSFEl2acxLkUI8bR5zFxqbOSolW53KctJfuvO//KgVz9b0JCjqeUPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system": "2.4.7",
+        "@heroui/use-measure": "2.1.2"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/image": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@heroui/image/-/image-2.2.6.tgz",
+      "integrity": "sha512-x7nEUYGziy7Pr7s9L2hpXwbHnvweyhw4suggwSw0JVQzZh54zyY8NJZYqQyTAnXbWYAtX/LTkn88pRfPQUaDZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-image": "2.1.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/input": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@heroui/input/-/input-2.4.10.tgz",
+      "integrity": "sha512-cHKgDiNq6ppe71epBqpiaHxH8CbIZ9uPTvzSEgSsYaDhI6vos7fNAUkpLwQyp8yAPOQBHO4RHSYDKYTOhyGsIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.9",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-safe-layout-effect": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/textfield": "3.15.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/shared": "3.26.0",
+        "@react-types/textfield": "3.10.0",
+        "react-textarea-autosize": "^8.5.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/input-otp": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@heroui/input-otp/-/input-otp-2.1.9.tgz",
+      "integrity": "sha512-f4RiFxdaWL5k/zSfH/tgVIvcnoDKX28FZs8jTLjSHdLnl/T9iVvPOBuugYCZ/308qy4a83Mg1u+eJPNra0dFjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.9",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/form": "3.0.11",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/form": "3.1.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/textfield": "3.10.0",
+        "input-otp": "1.4.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/input/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/kbd": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/kbd/-/kbd-2.2.7.tgz",
+      "integrity": "sha512-FjSdCvOI/QlQcXVj2MO2CcSnzQ0+x7nAKscuPhxtc8sa9ddBTgb79Q1waaiGlvrlnHO/XpicAYiA2PyvQmn9tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system-rsc": "2.3.6",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/link": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/link/-/link-2.2.8.tgz",
+      "integrity": "sha512-bMvg2IkwFgsjCM5bY6g/DlW818QxQ2kdmeG3QPJAw7XwsPkCKv62s2ibfMnVjgFneoY2opY7o5RsaLfvkFaf2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-aria-link": "2.2.6",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/link": "3.7.7",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/link": "3.5.9"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/listbox": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@heroui/listbox/-/listbox-2.3.10.tgz",
+      "integrity": "sha512-UuGQeGwqOj0v5ibLKd0xvoJ8ZfqvjCQFAAvyy1tERbI7ERGnL8upN+dOdRkwn+rnSYs1CmnFsvK8fNlcGalQQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/divider": "2.2.6",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-is-mobile": "2.2.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/listbox": "3.13.6",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/list": "3.11.1",
+        "@react-types/menu": "3.9.13",
+        "@react-types/shared": "3.26.0",
+        "@tanstack/react-virtual": "3.11.2"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/listbox/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/menu": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@heroui/menu/-/menu-2.2.10.tgz",
+      "integrity": "sha512-gfiD/E56Xxn1UshnuyBcM+MxJcLUDcSGL1sxoMC5IbNVOdKhdoK4d9eBEEfgTgV+qer83KrMG+yFyBiOjA7nXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/divider": "2.2.6",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-is-mobile": "2.2.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/menu": "3.16.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/menu": "3.9.0",
+        "@react-stately/tree": "3.8.6",
+        "@react-types/menu": "3.9.13",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/menu/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/modal": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/modal/-/modal-2.2.8.tgz",
+      "integrity": "sha512-HT2ZYYrkWrrxIR4A/ARppsHVWI1ZhAWfNGU5LQ3BGqvmgTyrbsiRHdDKr9E+sxbCKXFHTxwTKzPAGKoNscVecA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.2",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-aria-button": "2.2.5",
+        "@heroui/use-aria-modal-overlay": "2.2.4",
+        "@heroui/use-disclosure": "2.2.3",
+        "@heroui/use-draggable": "2.1.3",
+        "@react-aria/dialog": "3.5.20",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/overlays": "3.8.11"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/navbar": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@heroui/navbar/-/navbar-2.2.9.tgz",
+      "integrity": "sha512-4wNIzohsGKhw2YiMqI8kXfZ4chnP6OkqHMbmPRxlJ7BQqIQgYtCSVcHkYd3MQydRMWLkyDAbbKeCUjwwjcYvYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.2",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-scroll-position": "2.1.2",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/toggle": "3.8.0",
+        "@react-stately/utils": "3.10.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/pagination": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@heroui/pagination/-/pagination-2.2.9.tgz",
+      "integrity": "sha512-WorO/6AKtTeppEzaAmVtMAKW0DQLAeSYlah+8D0OyY0byO5fX1XtikysjoeV1rHwQImm8S4xn8Xbl6TQoS9oaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-intersection-observer": "2.2.3",
+        "@heroui/use-pagination": "2.2.4",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/popover": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@heroui/popover/-/popover-2.3.10.tgz",
+      "integrity": "sha512-qswvCUxkHGWbXuBQYDl5yCeqyzAgYXTXsPzc95KPVy+QoVFFQaHvvRkgjqK1rfJOZcH6cJpyO45eT3tJi3M/IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/button": "2.2.10",
+        "@heroui/dom-animation": "2.1.2",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-aria-button": "2.2.5",
+        "@heroui/use-safe-layout-effect": "2.1.2",
+        "@react-aria/dialog": "3.5.20",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/button": "3.10.1",
+        "@react-types/overlays": "3.8.11"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/progress": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/progress/-/progress-2.2.7.tgz",
+      "integrity": "sha512-CGCO4rrd1oianr85eFgZtsw15fg5RxDZHfVsbrlQorRJ1DDcGVmW11zkZIWfsC863ozVNXdmAFx7ti+u5iU/Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-is-mounted": "2.1.2",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/progress": "3.4.18",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/progress": "3.5.8"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/radio": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@heroui/radio/-/radio-2.3.9.tgz",
+      "integrity": "sha512-ExmEz4obI485TyNnscFJMADHY8cC9CqALg/3aUXHstyPYFIchLeYMCiJQHs2+o76rk8nNJML+t+5SpdQrQ44WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.9",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/radio": "3.10.10",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/radio": "3.10.9",
+        "@react-types/radio": "3.8.5",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.3",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/radio/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/react": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/@heroui/react/-/react-2.6.14.tgz",
+      "integrity": "sha512-OIJ+4hlbT04zhZASlWU8/kPtjnxKzvQUpf15/WPjUNjsS4Br1mKkwfOcdmJiSw0E+CKkeFAg3EAF9v57KsmVnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/accordion": "2.2.8",
+        "@heroui/alert": "2.2.10",
+        "@heroui/autocomplete": "2.3.11",
+        "@heroui/avatar": "2.2.7",
+        "@heroui/badge": "2.2.6",
+        "@heroui/breadcrumbs": "2.2.7",
+        "@heroui/button": "2.2.10",
+        "@heroui/calendar": "2.2.10",
+        "@heroui/card": "2.2.10",
+        "@heroui/checkbox": "2.3.9",
+        "@heroui/chip": "2.2.7",
+        "@heroui/code": "2.2.7",
+        "@heroui/date-input": "2.3.9",
+        "@heroui/date-picker": "2.3.10",
+        "@heroui/divider": "2.2.6",
+        "@heroui/drawer": "2.2.8",
+        "@heroui/dropdown": "2.3.10",
+        "@heroui/form": "2.1.9",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/image": "2.2.6",
+        "@heroui/input": "2.4.10",
+        "@heroui/input-otp": "2.1.9",
+        "@heroui/kbd": "2.2.7",
+        "@heroui/link": "2.2.8",
+        "@heroui/listbox": "2.3.10",
+        "@heroui/menu": "2.2.10",
+        "@heroui/modal": "2.2.8",
+        "@heroui/navbar": "2.2.9",
+        "@heroui/pagination": "2.2.9",
+        "@heroui/popover": "2.3.10",
+        "@heroui/progress": "2.2.7",
+        "@heroui/radio": "2.3.9",
+        "@heroui/ripple": "2.2.8",
+        "@heroui/scroll-shadow": "2.3.6",
+        "@heroui/select": "2.4.10",
+        "@heroui/skeleton": "2.2.6",
+        "@heroui/slider": "2.4.8",
+        "@heroui/snippet": "2.2.11",
+        "@heroui/spacer": "2.2.7",
+        "@heroui/spinner": "2.2.7",
+        "@heroui/switch": "2.2.9",
+        "@heroui/system": "2.4.7",
+        "@heroui/table": "2.2.9",
+        "@heroui/tabs": "2.2.8",
+        "@heroui/theme": "2.4.6",
+        "@heroui/tooltip": "2.2.8",
+        "@heroui/user": "2.2.7",
+        "@react-aria/visually-hidden": "3.8.18"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react-rsc-utils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/react-rsc-utils/-/react-rsc-utils-2.1.2.tgz",
+      "integrity": "sha512-5qaYUj0eX+y8OFvPsv01RdfHZv8Z/do+3tdaDmq/uNFsyDc+lgea9PyqVZbhv6nf4ido/hUlPDB6KAGqiAeKwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react-utils": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@heroui/react-utils/-/react-utils-2.1.4.tgz",
+      "integrity": "sha512-aXZtrgrGkW3Z892BQ5crP/ttdpTaNtv5N3UYoH2wVyFiGj+ypYfFkZRB/wppBRgf5hsy5liw+fqC/Yg5n3J8qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-rsc-utils": "2.1.2",
+        "@heroui/shared-utils": "2.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/ripple": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/ripple/-/ripple-2.2.8.tgz",
+      "integrity": "sha512-KtOUtetFvKfQn3Lg20LO/Vxzyu7Apj44TcbIOYUhe/EZtZSkqfxQL7A+SwzCiXB9ZVat94UkMgV/wpG3CvetGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.2",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/scroll-shadow": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@heroui/scroll-shadow/-/scroll-shadow-2.3.6.tgz",
+      "integrity": "sha512-n1OxJO8ZrjQHoV5XcAAwmeCGGAw2tHd5BJZXHFb0KH9MbwheFTwudlqlSdLdMV8+kVdaPPZmQTXgebzp1sxaKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-data-scroll-overflow": "2.2.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/select": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@heroui/select/-/select-2.4.10.tgz",
+      "integrity": "sha512-mMxW44Ztkg6oL9DUv327Rm8loG00kjGoTGvlgDxpxGdBJRqEYvLz+r0xBVyyyQdtr9DGJoOSmDHN7IjQpjGwnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/form": "2.1.9",
+        "@heroui/listbox": "2.3.10",
+        "@heroui/popover": "2.3.10",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/scroll-shadow": "2.3.6",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/spinner": "2.2.7",
+        "@heroui/use-aria-button": "2.2.5",
+        "@heroui/use-aria-multiselect": "2.4.4",
+        "@heroui/use-safe-layout-effect": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/form": "3.0.11",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-types/shared": "3.26.0",
+        "@tanstack/react-virtual": "3.11.2"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/select/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/shared-icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/shared-icons/-/shared-icons-2.1.2.tgz",
+      "integrity": "sha512-CUHbRMvXLVXjri+N5AhsTNNL49DXvGLidJ9qSyLQr0uWxt6GVb4/Hd9Lu4CjwrfWxyMwblm9f3BqUUFOC/FyVg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/shared-utils": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@heroui/shared-utils/-/shared-utils-2.1.3.tgz",
+      "integrity": "sha512-MNpo+jcu6xyicSRyxWgL4rNw4xH0XziUR/bhs01GydlGhfFN8n/Y4vKAWfL5xamehiEJX1N0IKAbFadt3wlGAA==",
+      "license": "MIT"
+    },
+    "node_modules/@heroui/skeleton": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@heroui/skeleton/-/skeleton-2.2.6.tgz",
+      "integrity": "sha512-4loGjGqNhYRMiiFjNle+nSDldWduvW2zZ09J5NpZEWM+cD+0Ipw1kAtPdZZrmMjAAR3SOJhISiPs2KGSmeTZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/slider": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@heroui/slider/-/slider-2.4.8.tgz",
+      "integrity": "sha512-u83j9JFmLVXLkct7ZgGDvGZyrkHpy3rUZtEjxzo64ecgfPmyQce64T8pKHfc83uEOC7uCnJSbUMXauMLhxf2lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/tooltip": "2.2.8",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/slider": "3.7.14",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/slider": "3.6.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/snippet": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/@heroui/snippet/-/snippet-2.2.11.tgz",
+      "integrity": "sha512-Yd/D/g0x1Rqzbuya6oY3sEoG2JxcIxNwDGf15M95zyKvoec1MXmjibc6MgV2b2BAOKCUebLuOhISlTyUeJGD3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.10",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/tooltip": "2.2.8",
+        "@heroui/use-clipboard": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/spacer": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/spacer/-/spacer-2.2.7.tgz",
+      "integrity": "sha512-3fOphSWUlklUcxv3YMRzc9AiIhW4tdyhR1HFk6rAcnOeIrg8OohrUApaBbHlki91xnsLxCT//s+sfCSI4otU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system-rsc": "2.3.6"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/spinner": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/spinner/-/spinner-2.2.7.tgz",
+      "integrity": "sha512-mMah9randdSFwyEtte6Ov1rkInGJZNBKfsruhDc0bOmMmFH8RNWJLuOyIMsaaKBXZQDwvRNH+3YTezAWAqKnpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/system-rsc": "2.3.6"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/switch": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@heroui/switch/-/switch-2.2.9.tgz",
+      "integrity": "sha512-qpWnI61xtBqxSPvE6D5/77o9znk81QqxyrjGgzsIVYPms6JdXL6OWJZD0Va9A8t0NIJYr+Plfmu5UbCiDmi+Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-safe-layout-effect": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/switch": "3.6.10",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/toggle": "3.8.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.3",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/switch/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/system": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.7.tgz",
+      "integrity": "sha512-5gWQhHr9ch/amUTkjDb2lHdVHU0PnURqbq2sPasGngi+LJUGqbApOY8n0rp2/RYDhEeR6NmWrSixZTmznBnfxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/system-rsc": "2.3.6",
+        "@internationalized/date": "3.6.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/datepicker": "3.9.0"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/system-rsc": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@heroui/system-rsc/-/system-rsc-2.3.6.tgz",
+      "integrity": "sha512-196LAXv9soGQqkaIyfKI0c+mBJh7QqxEzxEY+QEOYad9Q9LmuhUvu3sQleAw3ImGF20veXQ0U9pfCLjfucDEfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-types/shared": "3.26.0",
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/system-rsc/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/system-rsc/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@heroui/table": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@heroui/table/-/table-2.2.9.tgz",
+      "integrity": "sha512-tke+0bv1kUe4udLQVPXt+hfDKgUDq0YCR3yfx0UtchSgdvTsTQA+MhHBmiIvdR9E9jtGvMi+N7rvUuYZ6mBxaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/checkbox": "2.3.9",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-icons": "2.1.2",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/spacer": "2.2.7",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/table": "3.16.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/table": "3.13.0",
+        "@react-stately/virtualizer": "4.2.0",
+        "@react-types/grid": "3.2.10",
+        "@react-types/table": "3.10.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/tabs": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/tabs/-/tabs-2.2.8.tgz",
+      "integrity": "sha512-3cKwXiUeZNOa4wBalJOBdlOSa0IFFRY4FHR5wOsTiq1UDr2D1sSVEAtqPc5ye3Ly31OUWVe2Pl6opFY+LaEEbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-is-mounted": "2.1.2",
+        "@heroui/use-update-effect": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/tabs": "3.9.8",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tabs": "3.7.0",
+        "@react-types/shared": "3.26.0",
+        "@react-types/tabs": "3.3.11",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/tabs/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/theme": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.6.tgz",
+      "integrity": "sha512-VcmeMRxL3wnKk1o6gzeQehEcXyoKyvqLYr+iRFIrMZZO1kG5bvuX+CWDVovfmLRLK1MuwuhYjm6aJvre9AZAfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.3",
+        "clsx": "^1.2.1",
+        "color": "^4.2.3",
+        "color2k": "^2.0.2",
+        "deepmerge": "4.3.1",
+        "flat": "^5.0.2",
+        "tailwind-merge": "^2.5.2",
+        "tailwind-variants": "^0.1.20"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.4.0"
+      }
+    },
+    "node_modules/@heroui/theme/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@heroui/theme/node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/@heroui/tooltip": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@heroui/tooltip/-/tooltip-2.2.8.tgz",
+      "integrity": "sha512-rvG8KsLfxHjtC6iKYq8TY9zVo+q5TjDDws1/8uaw/reJAK5x1RvjDr5kMhT2e32eZws/IuZ4Jl3ta0PASpsIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.8",
+        "@heroui/dom-animation": "2.1.2",
+        "@heroui/framer-utils": "2.1.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@heroui/use-safe-layout-effect": "2.1.2",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/tooltip": "3.7.10",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tooltip": "3.5.0",
+        "@react-types/overlays": "3.8.11",
+        "@react-types/tooltip": "3.4.13"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-accordion": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-accordion/-/use-aria-accordion-2.2.3.tgz",
+      "integrity": "sha512-xyZjCkpUuN1WIphyCqnjuJ9OecuBUHfYN6pQIt1W1jB7xnPXn9gvBbAjVPXZdfJhNY4BZ5x88RIptBOPPW762Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/selection": "3.21.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tree": "3.8.6",
+        "@react-types/accordion": "3.0.0-alpha.25",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-accordion/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/use-aria-button": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-button/-/use-aria-button-2.2.5.tgz",
+      "integrity": "sha512-3dbtK6Q9QWuRTzry+XQ/awa4PVhmhLNcasermWrJ4PwYOQwJFzB+bslFqrjhxTYu45x5fGe54iCsT3Xx3UY80g==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/button": "3.10.1",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-button/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/use-aria-link": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-link/-/use-aria-link-2.2.6.tgz",
+      "integrity": "sha512-+YxO69qwUgBtqpCYvV8VfOwJp9GR/lEhGB6MR0otWrWWE4+lzgEKb29MHV+GycBOMeKK9247wQ2dyEpUxkoJ+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/link": "3.5.9",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-link/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/use-aria-modal-overlay": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-modal-overlay/-/use-aria-modal-overlay-2.2.4.tgz",
+      "integrity": "sha512-cZnNbdyjo9NSfJZO0Q+NMAe9ZN8PW2gC5Pgm1GfksjbkMHaf6apnIbwU14mFcI0bdKeTw9Bp+9PkWiTfmBRl0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-modal-overlay/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/use-aria-multiselect": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-multiselect/-/use-aria-multiselect-2.4.4.tgz",
+      "integrity": "sha512-ZMRX4bbj9jHMdOi9IQWzaAE9vdLfxr8r9Zew87neDymrCFbvKnBcvag8lMNeTBBvZNAggIMzyTAXbOZWxUkwhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/label": "3.7.13",
+        "@react-aria/listbox": "3.13.6",
+        "@react-aria/menu": "3.16.0",
+        "@react-aria/selection": "3.21.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/form": "3.1.0",
+        "@react-stately/list": "3.11.1",
+        "@react-stately/menu": "3.9.0",
+        "@react-types/button": "3.10.1",
+        "@react-types/overlays": "3.8.11",
+        "@react-types/select": "3.9.8",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-multiselect/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/use-callback-ref": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/use-callback-ref/-/use-callback-ref-2.1.2.tgz",
+      "integrity": "sha512-wPD0L8vK+FHDvsVGZYCJeEm/WwMJvE6qvcZhzo4n2+318FrsfAPI2N1VQKx176/ZHNl8j7Z44o+eZlI5KwSpeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-safe-layout-effect": "2.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-clipboard": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-clipboard/-/use-clipboard-2.1.3.tgz",
+      "integrity": "sha512-VOoXgfuwfsXDjNkrBUYcoLQXPHhIH4R6F4K4lSTSToC6iOam3jHUAMm5NfpZ59uUnXFgBvry8RjossJP3oGB/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-data-scroll-overflow": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-data-scroll-overflow/-/use-data-scroll-overflow-2.2.3.tgz",
+      "integrity": "sha512-G80ZYiKAK6YOlQHbGkjI5iOvm3jBOSAJElpL5/VBto33hRtw0LlvJWiVu0s0nWOaxaAgX0ug/kAihZmq7uRYRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-disclosure": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-disclosure/-/use-disclosure-2.2.3.tgz",
+      "integrity": "sha512-AkoHyEZ+txfeHFtnXCDyC+MY05AjzBLXBF7yVO/bvg7VgGxyVzK+z800OwvgwmN6nQbjVmfQpcVJ44UFfzB1Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-callback-ref": "2.1.2",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-draggable": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-draggable/-/use-draggable-2.1.3.tgz",
+      "integrity": "sha512-2PT8jUGsmbY6CF0QYb06f3T7OCwZe5uXuwpEKx0A0p/TdrzdAzSPtRda9mwU23zSQLByp7bwr7A8Zg0bQqTY/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/interactions": "3.22.5"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-image": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-image/-/use-image-2.1.3.tgz",
+      "integrity": "sha512-d0jqI0Ttz/d68E5O2PHPSQJMftCpkwT+LECJz/7aZIZQqX8KJJA5WymDTDANTtASCO45wm6j8dxhRgRwaRVoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/use-safe-layout-effect": "2.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-intersection-observer": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-intersection-observer/-/use-intersection-observer-2.2.3.tgz",
+      "integrity": "sha512-mz/YdOfOqWQwWht4qmdkGNIJA2sWka0F4HI9THes6USxE02JLM0KDNKzgM3CiFA/8dhDr+rCn9gOhq9QxGw9eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/ssr": "3.9.7",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-intersection-observer/node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@heroui/use-is-mobile": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@heroui/use-is-mobile/-/use-is-mobile-2.2.3.tgz",
+      "integrity": "sha512-O0zV+w2FTjJJP7qCBW5A3qkjvjQwMBkesD3ZOvpn71PR6GDDDFpLt0cr2hkaUd6qpb9rmeEUeJoVSch2QFNPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/ssr": "3.9.7"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-is-mounted": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/use-is-mounted/-/use-is-mounted-2.1.2.tgz",
+      "integrity": "sha512-yS4ZdTiAcW5KxZg1z5Tzd50zJ9lis1xL7G2CsaWu28rgZs4kQylGCBDuFfeD+cG4JmtktDq9GhtG/V2XL2DwSQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-measure": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/use-measure/-/use-measure-2.1.2.tgz",
+      "integrity": "sha512-cHvicTYcgOEeC++GmxogZU1iRVidU09PefQAfQNqCS92XKxebDjDv6eD+ZXN6HHbImJgtTg3utsnZSPFC1ooBg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-pagination": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@heroui/use-pagination/-/use-pagination-2.2.4.tgz",
+      "integrity": "sha512-CXhtm7IT9hquPZYw0Tawq9QvKaMTdszHKzspwXuok3NnuqkVC+oxH0iILl97HzaJf/Z5DJPq3aaXvz1bcVnmOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/i18n": "3.12.4"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-safe-layout-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/use-safe-layout-effect/-/use-safe-layout-effect-2.1.2.tgz",
+      "integrity": "sha512-AVfgvaO2zw30JDKj1LyFPzz+JULMygC/TUK/5g4YA3O/4OwgS8lT8XRNM721zwmYkntFPBx7lYcIRcm8hPWkXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-scroll-position": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/use-scroll-position/-/use-scroll-position-2.1.2.tgz",
+      "integrity": "sha512-ALO/zuGekxWE4+ikd7XPwvLdJMwmPR9XgCsXtenklfPLDVf9Fu1L9E20RW6hSxf96NfwXZIH+hZ5kI4EB2CiYQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-update-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@heroui/use-update-effect/-/use-update-effect-2.1.2.tgz",
+      "integrity": "sha512-83OgHOYfToynF8xP14bbM60zw26iHGkziFOiUIsFA+ZRpLLcIcRZFY9lC+SxIRYEkBe3GIuwwEM6Fez3Xa8u1g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/user": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@heroui/user/-/user-2.2.7.tgz",
+      "integrity": "sha512-ErJmxK3p6kVVYnVkf4nJuj6NtNoa74VbuChxDZIiyDJpfpTUL4e8brNDGR4VMM5TZ2gLus9MGzB6Ma0VlSsx+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/avatar": "2.2.7",
+        "@heroui/react-utils": "2.1.4",
+        "@heroui/shared-utils": "2.1.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.0",
+        "@heroui/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1799,1808 +3556,6 @@
       },
       "peerDependencies": {
         "@mswjs/interceptors": "*"
-      }
-    },
-    "node_modules/@nextui-org/accordion": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/accordion/-/accordion-2.2.7.tgz",
-      "integrity": "sha512-jdobOwUxSi617m+LpxHFzg64UhDuOfDJI2CMk3MP+b2WBJ7SNW4hmN2NW5Scx5JiY+kyBGmlxJ4Y++jZpZgQjQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/accordion instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/divider": "2.2.5",
-        "@nextui-org/dom-animation": "2.1.1",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-aria-accordion": "2.2.2",
-        "@react-aria/button": "3.11.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/tree": "3.8.6",
-        "@react-types/accordion": "3.0.0-alpha.25",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/accordion/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/alert": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/alert/-/alert-2.2.9.tgz",
-      "integrity": "sha512-SjMZewEqknx/jqmMcyQdbeo6RFg40+A3b1lGjnj/fdkiJozQoTesiOslzDsacqiSgvso2F+8u1emC2tFBAU3hw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/alert instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/button": "2.2.9",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/utils": "3.10.5"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/aria-utils": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/aria-utils/-/aria-utils-2.2.7.tgz",
-      "integrity": "sha512-QgMZ8fii6BCI/+ZIkgXgkm/gMNQ92pQJn83q90fBT6DF+6j4hsCpJwLNCF5mIJkX/cQ/4bHDsDaj7w1OzkhQNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-rsc-utils": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system": "2.4.6",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/collections": "3.12.0",
-        "@react-stately/overlays": "3.6.12",
-        "@react-types/overlays": "3.8.11",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/aria-utils/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/autocomplete": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/autocomplete/-/autocomplete-2.3.9.tgz",
-      "integrity": "sha512-1AizOvL8lERoWjm8WiA0NPJWB3h0gqYlbV/qGZeacac5356hb8cNzWUlxGzr9bNkhn9slIoEUyGMgtYeKq7ptg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/autocomplete instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/button": "2.2.9",
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/input": "2.4.8",
-        "@nextui-org/listbox": "2.3.9",
-        "@nextui-org/popover": "2.3.9",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/scroll-shadow": "2.3.5",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/spinner": "2.2.6",
-        "@nextui-org/use-aria-button": "2.2.4",
-        "@nextui-org/use-safe-layout-effect": "2.1.1",
-        "@react-aria/combobox": "3.11.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-stately/combobox": "3.10.1",
-        "@react-types/combobox": "3.13.1",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/autocomplete/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/avatar": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/avatar/-/avatar-2.2.6.tgz",
-      "integrity": "sha512-QRNCAMXnSZrFJYKo78lzRPiAPRq5pn1LIHUVvX/mCRiTvbu1FXrMakAvOWz/n1X1mLndnrfQMRNgmtC8YlHIdg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/avatar instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-image": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/badge": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/badge/-/badge-2.2.5.tgz",
-      "integrity": "sha512-8pLbuY+RVCzI/00CzNudc86BiuXByPFz2yHh00djKvZAXbT0lfjvswClJxSC2FjUXlod+NtE+eHmlhSMo3gmpw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/badge instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/breadcrumbs": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/breadcrumbs/-/breadcrumbs-2.2.6.tgz",
-      "integrity": "sha512-TlAUSiIClmm02tJqOvtwySpKDOENduXCXkKzCbmSaqEFhziHnhyE0eM8IVEprBoK6z1VP+sUrX6C2gZ871KUSw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/breadcrumbs instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/breadcrumbs": "3.5.19",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/breadcrumbs": "3.7.9",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/breadcrumbs/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/button": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.2.9.tgz",
-      "integrity": "sha512-RrfjAZHoc6nmaqoLj40M0Qj3tuDdv2BMGCgggyWklOi6lKwtOaADPvxEorDwY3GnN54Xej+9SWtUwE8Oc3SnOg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/button instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/ripple": "2.2.7",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/spinner": "2.2.6",
-        "@nextui-org/use-aria-button": "2.2.4",
-        "@react-aria/button": "3.11.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/button": "3.10.1",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/button/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/calendar": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/calendar/-/calendar-2.2.9.tgz",
-      "integrity": "sha512-tx1401HLnwadoDHNkmEIZNeAw9uYW6KsgIRRQnXTNVstBXdMmPWjoMBj8fkQqF55+U58k6a+w3N4tTpgRGOpaQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/calendar instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@internationalized/date": "3.6.0",
-        "@nextui-org/button": "2.2.9",
-        "@nextui-org/dom-animation": "2.1.1",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-aria-button": "2.2.4",
-        "@react-aria/calendar": "3.6.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-stately/calendar": "3.6.0",
-        "@react-stately/utils": "3.10.5",
-        "@react-types/button": "3.10.1",
-        "@react-types/calendar": "3.5.0",
-        "@react-types/shared": "3.26.0",
-        "@types/lodash.debounce": "^4.0.7",
-        "scroll-into-view-if-needed": "3.0.10"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/calendar/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/card": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/card/-/card-2.2.9.tgz",
-      "integrity": "sha512-Ltvb5Uy4wwkBJj3QvVQmoB6PwLYUNSoWAFo2xxu7LUHKWcETYI0YbUIuwL2nFU2xfJYeBTGjXGQO1ffBsowrtQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/card instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/ripple": "2.2.7",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-aria-button": "2.2.4",
-        "@react-aria/button": "3.11.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/card/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/checkbox": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/checkbox/-/checkbox-2.3.8.tgz",
-      "integrity": "sha512-T5+AhzQfbg53qZnPn5rgMcJ7T5rnvSGYTx17wHWtdF9Q4QflZOmLGoxqoTWbTVpM4XzUUPyi7KVSKZScWdBDAA==",
-      "deprecated": "This package has been deprecated. Please use @heroui/checkbox instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-callback-ref": "2.1.1",
-        "@nextui-org/use-safe-layout-effect": "2.1.1",
-        "@react-aria/checkbox": "3.15.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-stately/checkbox": "3.6.10",
-        "@react-stately/toggle": "3.8.0",
-        "@react-types/checkbox": "3.9.0",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.3",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/checkbox/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/chip": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/chip/-/chip-2.2.6.tgz",
-      "integrity": "sha512-HrSYagbrD4u4nblsNMIu7WGnDj9A8YnYCt30tasJmNSyydUVHFkxKOc3S8k+VU3BHPxeENxeBT7w0OlYoKbFIQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/chip instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/checkbox": "3.9.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/code": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/code/-/code-2.2.6.tgz",
-      "integrity": "sha512-8qvAywIKAVh1thy/YHNwqH2xjTcwPiOWwNdKqvJMSk0CNtLHYJmDK8i2vmKZTM3zfB08Q/G94H0Wf+YsyrZdDg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/code instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system-rsc": "2.3.5"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/date-input": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/date-input/-/date-input-2.3.8.tgz",
-      "integrity": "sha512-phj0Y8F/GpsKjKSiratFwh7HDzmMsIf6G2L2ljgWqA79PvP+RYf/ogEfaMIq1knF8OlssMo5nsFFJNsNB+xKGg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/date-input instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@internationalized/date": "3.6.0",
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/datepicker": "3.12.0",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/datepicker": "3.11.0",
-        "@react-types/datepicker": "3.9.0",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/date-input/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/date-picker": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/date-picker/-/date-picker-2.3.9.tgz",
-      "integrity": "sha512-RzdVTl/tulTyE5fwGkQfn0is5hsTkPPRJFJZXMqYeci85uhpD+bCreWnTXrGFIXcqUo0ZBJWx3EdtBJZnGp4xQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/date-picker instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@internationalized/date": "3.6.0",
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/button": "2.2.9",
-        "@nextui-org/calendar": "2.2.9",
-        "@nextui-org/date-input": "2.3.8",
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/popover": "2.3.9",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/datepicker": "3.12.0",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/datepicker": "3.11.0",
-        "@react-stately/overlays": "3.6.12",
-        "@react-stately/utils": "3.10.5",
-        "@react-types/datepicker": "3.9.0",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/date-picker/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/divider": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/divider/-/divider-2.2.5.tgz",
-      "integrity": "sha512-OB8b3CU4nQ5ARIGL48izhzrAHR0mnwws+Kd5LqRCZ/1R9uRMqsq7L0gpG9FkuV2jf2FuA7xa/GLOLKbIl4CEww==",
-      "deprecated": "This package has been deprecated. Please use @heroui/divider instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-rsc-utils": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system-rsc": "2.3.5",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/divider/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/dom-animation": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/dom-animation/-/dom-animation-2.1.1.tgz",
-      "integrity": "sha512-xLrVNf1EV9zyyZjk6j3RptOvnga1WUCbMpDgJLQHp+oYwxTfBy0SkXHuN5pRdcR0XpR/IqRBDIobMdZI0iyQyg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
-      }
-    },
-    "node_modules/@nextui-org/drawer": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/drawer/-/drawer-2.2.7.tgz",
-      "integrity": "sha512-a1Sr3sSjOZD0SiXDYSySKkOelTyCYExPvUsIckzjF5A3TNlBw4KFKnJzaXvabC3SNRy6/Ocq7oqz6VRv37wxQg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/drawer instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/modal": "2.2.7",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/dropdown": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/dropdown/-/dropdown-2.3.9.tgz",
-      "integrity": "sha512-ElZxiP+nG0CKC+tm6LMZX42cRWXQ0LLjWBZXymupPsEH3XcQpCF9GWb9efJ2hh+qGROg7i0bnFH7P0GTyCyNBA==",
-      "deprecated": "This package has been deprecated. Please use @heroui/dropdown instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/menu": "2.2.9",
-        "@nextui-org/popover": "2.3.9",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/menu": "3.16.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/menu": "3.9.0",
-        "@react-types/menu": "3.9.13"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/form": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/form/-/form-2.1.8.tgz",
-      "integrity": "sha512-Xn/dUO5zDG7zukbql1MDYh4Xwe1vnIVMRTHgckbkBtXXVNqgoTU09TTfy8WOJ0pMDX4GrZSBAZ86o37O+IHbaA==",
-      "deprecated": "This package has been deprecated. Please use @heroui/form instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system": "2.4.6",
-        "@nextui-org/theme": "2.4.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/form": "3.1.0",
-        "@react-types/form": "3.7.8",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/form/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/framer-utils": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/framer-utils/-/framer-utils-2.1.6.tgz",
-      "integrity": "sha512-b+BxKFox8j9rNAaL+CRe2ZMb1/SKjz9Kl2eLjDSsq3q82K/Hg7lEjlpgE8cu41wIGjH1unQxtP+btiJgl067Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system": "2.4.6",
-        "@nextui-org/use-measure": "2.1.1"
-      },
-      "peerDependencies": {
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/image": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/image/-/image-2.2.5.tgz",
-      "integrity": "sha512-A6DnEqG+/cMrfvqFKKJIdGD7gD88tVkqGxRkfysVMJJR96sDIYCJlP1jsAEtYKh4PfhmtJWclUvY/x9fMw0H1w==",
-      "deprecated": "This package has been deprecated. Please use @heroui/image instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-image": "2.1.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/input": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/input/-/input-2.4.8.tgz",
-      "integrity": "sha512-wfkjyl7vRqT3HDXeybhfZ+IAz+Z02U5EiuWPpc9NbdwhJ/LpDRDa6fYcTDr/6j6MiyrEZsM24CtZZKAKBVBquQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/input instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-safe-layout-effect": "2.1.1",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/textfield": "3.15.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/utils": "3.10.5",
-        "@react-types/shared": "3.26.0",
-        "@react-types/textfield": "3.10.0",
-        "react-textarea-autosize": "^8.5.3"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/input-otp": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/input-otp/-/input-otp-2.1.8.tgz",
-      "integrity": "sha512-J5Pz0aSfWD+2cSgLTKQamCNF/qHILIj8L0lY3t1R/sgK1ApN3kDNcUGnVm6EDh+dOXITKpCfnsCQw834nxZhsg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/input-otp instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/form": "3.0.11",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/form": "3.1.0",
-        "@react-stately/utils": "3.10.5",
-        "@react-types/textfield": "3.10.0",
-        "input-otp": "1.4.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/input/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/kbd": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/kbd/-/kbd-2.2.6.tgz",
-      "integrity": "sha512-IwzvvwYLMbhyqX5PjEZyDBO4iNEHY6Nek4ZrVR+Z2dOSj/oZXHWiabNDrvOcGKgUBE6xc95Fi1jVubE9b5ueuA==",
-      "deprecated": "This package has been deprecated. Please use @heroui/kbd instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system-rsc": "2.3.5",
-        "@react-aria/utils": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/link": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/link/-/link-2.2.7.tgz",
-      "integrity": "sha512-SAeBBCUtdaKtHfZgRD6OH0De/+cKUEuThiErSuFW+sNm/y8m3cUhQH8UqVBPu6HwmqVTEjvZzp/4uhG6lcSZjA==",
-      "deprecated": "This package has been deprecated. Please use @heroui/link instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-aria-link": "2.2.5",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/link": "3.7.7",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/link": "3.5.9"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/listbox": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/listbox/-/listbox-2.3.9.tgz",
-      "integrity": "sha512-iGJ8xwkXf8K7chk1iZgC05KGpHiWJXY1dnV7ytIJ7yu4BbsRIHb0QknK5j8A74YeGpouJQ9+jsmCERmySxlqlg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/listbox instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/divider": "2.2.5",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-is-mobile": "2.2.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/listbox": "3.13.6",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/list": "3.11.1",
-        "@react-types/menu": "3.9.13",
-        "@react-types/shared": "3.26.0",
-        "@tanstack/react-virtual": "3.11.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/listbox/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/menu": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/menu/-/menu-2.2.9.tgz",
-      "integrity": "sha512-Fztvi3GRYl5a5FO/0LRzcAdnw8Yeq6NX8yLQh8XmwkWCrH0S6nTn69CP/j+EMWQR6G2UK5AbNDmX1Sx9aTQdHQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/menu instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/divider": "2.2.5",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-is-mobile": "2.2.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/menu": "3.16.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/menu": "3.9.0",
-        "@react-stately/tree": "3.8.6",
-        "@react-types/menu": "3.9.13",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/menu/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/modal": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/modal/-/modal-2.2.7.tgz",
-      "integrity": "sha512-xxk6B+5s8//qYI4waLjdWoJFwR6Zqym/VHFKkuZAMpNABgTB0FCK022iUdOIP2F2epG69un8zJF0qwMBJF8XAA==",
-      "deprecated": "This package has been deprecated. Please use @heroui/modal instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/dom-animation": "2.1.1",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-aria-button": "2.2.4",
-        "@nextui-org/use-aria-modal-overlay": "2.2.3",
-        "@nextui-org/use-disclosure": "2.2.2",
-        "@nextui-org/use-draggable": "2.1.2",
-        "@react-aria/dialog": "3.5.20",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/overlays": "3.24.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/overlays": "3.6.12",
-        "@react-types/overlays": "3.8.11"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/navbar": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/navbar/-/navbar-2.2.8.tgz",
-      "integrity": "sha512-XutioQ75jonZk6TBtjFdV6N3eLe8y85tetjOdOg6X3mKTPZlQuBb+rtb6pVNOOvcuQ7zKigWIq2ammvF9VNKaQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/navbar instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/dom-animation": "2.1.1",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-scroll-position": "2.1.1",
-        "@react-aria/button": "3.11.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/overlays": "3.24.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/toggle": "3.8.0",
-        "@react-stately/utils": "3.10.5"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/pagination": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/pagination/-/pagination-2.2.8.tgz",
-      "integrity": "sha512-sZcriQq/ssOItX3r54tysnItjcb7dw392BNulJxrMMXi6FA6sUGImpJF1jsbtYJvaq346IoZvMrcrba8PXEk0g==",
-      "deprecated": "This package has been deprecated. Please use @heroui/pagination instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-intersection-observer": "2.2.2",
-        "@nextui-org/use-pagination": "2.2.3",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "scroll-into-view-if-needed": "3.0.10"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/popover": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.3.9.tgz",
-      "integrity": "sha512-glLYKlFJ4EkFrNMBC3ediFPpQwKzaFlzKoaMum2G3HUtmC4d1HLTSOQJOd2scUzZxD3/K9dp1XHYbEcCnCrYpQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/popover instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/button": "2.2.9",
-        "@nextui-org/dom-animation": "2.1.1",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-aria-button": "2.2.4",
-        "@nextui-org/use-safe-layout-effect": "2.1.1",
-        "@react-aria/dialog": "3.5.20",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/overlays": "3.24.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/overlays": "3.6.12",
-        "@react-types/button": "3.10.1",
-        "@react-types/overlays": "3.8.11"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/progress": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/progress/-/progress-2.2.6.tgz",
-      "integrity": "sha512-FTicOncNcXKpt9avxQWWlVATvhABKVMBgsB81SozFXRcn8QsFntjdMp0l3688DJKBY0GxT+yl/S/by0TwY1Z1A==",
-      "deprecated": "This package has been deprecated. Please use @heroui/progress instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-is-mounted": "2.1.1",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/progress": "3.4.18",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/progress": "3.5.8"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/radio": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/radio/-/radio-2.3.8.tgz",
-      "integrity": "sha512-ntwjpQ/WT8zQ3Fw5io65VeH2Q68LOgZ4lII7a6x35NDa7Eda1vlYroMAw/vxK8iyZYlUBSJdsoj2FU/10hBPmg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/radio instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/radio": "3.10.10",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-stately/radio": "3.10.9",
-        "@react-types/radio": "3.8.5",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.3",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/radio/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/react": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@nextui-org/react/-/react-2.6.11.tgz",
-      "integrity": "sha512-MOkBMWI+1nHB6A8YLXakdXrNRFvy5whjFJB1FthwqbP8pVEeksS1e29AbfEFkrzLc5zjN7i24wGNSJ8DKMt9WQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/react instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/accordion": "2.2.7",
-        "@nextui-org/alert": "2.2.9",
-        "@nextui-org/autocomplete": "2.3.9",
-        "@nextui-org/avatar": "2.2.6",
-        "@nextui-org/badge": "2.2.5",
-        "@nextui-org/breadcrumbs": "2.2.6",
-        "@nextui-org/button": "2.2.9",
-        "@nextui-org/calendar": "2.2.9",
-        "@nextui-org/card": "2.2.9",
-        "@nextui-org/checkbox": "2.3.8",
-        "@nextui-org/chip": "2.2.6",
-        "@nextui-org/code": "2.2.6",
-        "@nextui-org/date-input": "2.3.8",
-        "@nextui-org/date-picker": "2.3.9",
-        "@nextui-org/divider": "2.2.5",
-        "@nextui-org/drawer": "2.2.7",
-        "@nextui-org/dropdown": "2.3.9",
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/image": "2.2.5",
-        "@nextui-org/input": "2.4.8",
-        "@nextui-org/input-otp": "2.1.8",
-        "@nextui-org/kbd": "2.2.6",
-        "@nextui-org/link": "2.2.7",
-        "@nextui-org/listbox": "2.3.9",
-        "@nextui-org/menu": "2.2.9",
-        "@nextui-org/modal": "2.2.7",
-        "@nextui-org/navbar": "2.2.8",
-        "@nextui-org/pagination": "2.2.8",
-        "@nextui-org/popover": "2.3.9",
-        "@nextui-org/progress": "2.2.6",
-        "@nextui-org/radio": "2.3.8",
-        "@nextui-org/ripple": "2.2.7",
-        "@nextui-org/scroll-shadow": "2.3.5",
-        "@nextui-org/select": "2.4.9",
-        "@nextui-org/skeleton": "2.2.5",
-        "@nextui-org/slider": "2.4.7",
-        "@nextui-org/snippet": "2.2.10",
-        "@nextui-org/spacer": "2.2.6",
-        "@nextui-org/spinner": "2.2.6",
-        "@nextui-org/switch": "2.2.8",
-        "@nextui-org/system": "2.4.6",
-        "@nextui-org/table": "2.2.8",
-        "@nextui-org/tabs": "2.2.7",
-        "@nextui-org/theme": "2.4.5",
-        "@nextui-org/tooltip": "2.2.7",
-        "@nextui-org/user": "2.2.6",
-        "@react-aria/visually-hidden": "3.8.18"
-      },
-      "peerDependencies": {
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/react-rsc-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.1.1.tgz",
-      "integrity": "sha512-9uKH1XkeomTGaswqlGKt0V0ooUev8mPXtKJolR+6MnpvBUrkqngw1gUGF0bq/EcCCkks2+VOHXZqFT6x9hGkQQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/react-utils": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.1.3.tgz",
-      "integrity": "sha512-o61fOS+S8p3KtgLLN7ub5gR0y7l517l9eZXJabUdnVcZzZjTqEijWjzjIIIyAtYAlL4d+WTXEOROuc32sCmbqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-rsc-utils": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/ripple": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.2.7.tgz",
-      "integrity": "sha512-cphzlvCjdROh1JWQhO/wAsmBdlU9kv/UA2YRQS4viaWcA3zO+qOZVZ9/YZMan6LBlOLENCaE9CtV2qlzFtVpEg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/ripple instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/dom-animation": "2.1.1",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/scroll-shadow": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/scroll-shadow/-/scroll-shadow-2.3.5.tgz",
-      "integrity": "sha512-2H5qro6RHcWo6ZfcG2hHZHsR1LrV3FMZP5Lkc9ZwJdWPg4dXY4erGRE4U+B7me6efj5tBOFmZkIpxVUyMBLtZg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/scroll-shadow instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-data-scroll-overflow": "2.2.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/select": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@nextui-org/select/-/select-2.4.9.tgz",
-      "integrity": "sha512-R8HHKDH7dA4Dv73Pl80X7qfqdyl+Fw4gi/9bmyby0QJG8LN2zu51xyjjKphmWVkAiE3O35BRVw7vMptHnWFUgQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/select instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/form": "2.1.8",
-        "@nextui-org/listbox": "2.3.9",
-        "@nextui-org/popover": "2.3.9",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/scroll-shadow": "2.3.5",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/spinner": "2.2.6",
-        "@nextui-org/use-aria-button": "2.2.4",
-        "@nextui-org/use-aria-multiselect": "2.4.3",
-        "@nextui-org/use-safe-layout-effect": "2.1.1",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/form": "3.0.11",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-types/shared": "3.26.0",
-        "@tanstack/react-virtual": "3.11.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/select/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/shared-icons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/shared-icons/-/shared-icons-2.1.1.tgz",
-      "integrity": "sha512-mkiTpFJnCzB2M8Dl7IwXVzDKKq9ZW2WC0DaQRs1eWgqboRCP8DDde+MJZq331hC7pfH8BC/4rxXsKECrOUUwCg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/shared-utils": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.1.2.tgz",
-      "integrity": "sha512-5n0D+AGB4P9lMD1TxwtdRSuSY0cWgyXKO9mMU11Xl3zoHNiAz/SbCSTc4VBJdQJ7Y3qgNXvZICzf08+bnjjqqA==",
-      "license": "MIT"
-    },
-    "node_modules/@nextui-org/skeleton": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/skeleton/-/skeleton-2.2.5.tgz",
-      "integrity": "sha512-CK1O9dqS0xPW3o1SIekEEOjSosJkXNzU0Zd538Nn1XhY1RjNuIPchpY9Pv5YZr2QSKy0zkwPQt/NalwErke0Jg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/skeleton instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/slider": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/slider/-/slider-2.4.7.tgz",
-      "integrity": "sha512-/RnjnmAPvssebhtElG+ZI8CCot2dEBcEjw7LrHfmVnJOd5jgceMtnXhdJSppQuLvcC4fPpkhd6dY86IezOZwfw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/slider instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/tooltip": "2.2.7",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/slider": "3.7.14",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-stately/slider": "3.6.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/snippet": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@nextui-org/snippet/-/snippet-2.2.10.tgz",
-      "integrity": "sha512-mVjf8muq4TX2PlESN7EeHgFmjuz7PNhrKFP+fb8Lj9J6wvUIUDm5ENv9bs72cRsK+zse6OUNE4JF1er6HllKug==",
-      "deprecated": "This package has been deprecated. Please use @heroui/snippet instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/button": "2.2.9",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/tooltip": "2.2.7",
-        "@nextui-org/use-clipboard": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/utils": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/spacer": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/spacer/-/spacer-2.2.6.tgz",
-      "integrity": "sha512-1qYtZ6xICfSrFV0MMB/nUH1K2X9mHzIikrjC/okzyzWywibsVNbyRfu5vObVClYlVGY0r4M4+7fpV2QV1tKRGw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/spacer instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system-rsc": "2.3.5"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/spinner": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.2.6.tgz",
-      "integrity": "sha512-0V0H8jVpgRolgLnCuKDbrQCSK0VFPAZYiyGOE1+dfyIezpta+Nglh+uEl2sEFNh6B9Z8mARB8YEpRnTcA0ePDw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/spinner instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/system-rsc": "2.3.5"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/switch": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/switch/-/switch-2.2.8.tgz",
-      "integrity": "sha512-wk9qQSOfUEtmdWR1omKjmEYzgMjJhVizvfW6Z0rKOiMUuSud2d4xYnUmZhU22cv2WtoPV//kBjXkYD/E/t6rdg==",
-      "deprecated": "This package has been deprecated. Please use @heroui/switch instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-safe-layout-effect": "2.1.1",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/switch": "3.6.10",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-stately/toggle": "3.8.0",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.3",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/switch/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/system": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.4.6.tgz",
-      "integrity": "sha512-6ujAriBZMfQ16n6M6Ad9g32KJUa1CzqIVaHN/tymadr/3m8hrr7xDw6z50pVjpCRq2PaaA1hT8Hx7EFU3f2z3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@internationalized/date": "3.6.0",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/system-rsc": "2.3.5",
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/overlays": "3.24.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/utils": "3.10.5",
-        "@react-types/datepicker": "3.9.0"
-      },
-      "peerDependencies": {
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/system-rsc": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.3.5.tgz",
-      "integrity": "sha512-DpVLNV9LkeP1yDULFCXm2mxA9m4ygS7XYy3lwgcF9M1A8QAWB+ut+FcP+8a6va50oSHOqwvUwPDUslgXTPMBfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-types/shared": "3.26.0",
-        "clsx": "^1.2.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/system-rsc/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/system-rsc/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@nextui-org/table": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@nextui-org/table/-/table-2.2.8.tgz",
-      "integrity": "sha512-XNM0/Ed7Re3BA1eHL31rzALea9hgsBwD0rMR2qB2SAl2e8KaV2o+4bzgYhpISAzHQtlG8IsXanxiuNDH8OPVyw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/table instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/checkbox": "2.3.8",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-icons": "2.1.1",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/spacer": "2.2.6",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/table": "3.16.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-aria/visually-hidden": "3.8.18",
-        "@react-stately/table": "3.13.0",
-        "@react-stately/virtualizer": "4.2.0",
-        "@react-types/grid": "3.2.10",
-        "@react-types/table": "3.10.3"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/tabs": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/tabs/-/tabs-2.2.7.tgz",
-      "integrity": "sha512-EDPK0MOR4DPTfud9Khr5AikLbyEhHTlkGfazbOxg7wFaHysOnV5Y/E6UfvaN69kgIeT7NQcDFdaCKJ/AX1N7AA==",
-      "deprecated": "This package has been deprecated. Please use @heroui/tabs instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-is-mounted": "2.1.1",
-        "@nextui-org/use-update-effect": "2.1.1",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/tabs": "3.9.8",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/tabs": "3.7.0",
-        "@react-types/shared": "3.26.0",
-        "@react-types/tabs": "3.3.11",
-        "scroll-into-view-if-needed": "3.0.10"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/tabs/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/theme": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/theme/-/theme-2.4.5.tgz",
-      "integrity": "sha512-c7Y17n+hBGiFedxMKfg7Qyv93iY5MteamLXV4Po4c1VF1qZJI6I+IKULFh3FxPWzAoz96r6NdYT7OLFjrAJdWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.1.2",
-        "clsx": "^1.2.1",
-        "color": "^4.2.3",
-        "color2k": "^2.0.2",
-        "deepmerge": "4.3.1",
-        "flat": "^5.0.2",
-        "tailwind-merge": "^2.5.2",
-        "tailwind-variants": "^0.1.20"
-      },
-      "peerDependencies": {
-        "tailwindcss": ">=3.4.0"
-      }
-    },
-    "node_modules/@nextui-org/theme/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@nextui-org/theme/node_modules/tailwind-merge": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
-      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
-    },
-    "node_modules/@nextui-org/tooltip": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@nextui-org/tooltip/-/tooltip-2.2.7.tgz",
-      "integrity": "sha512-NgoaxcNwuCq/jvp77dmGzyS7JxzX4dvD/lAYi/GUhyxEC3TK3teZ3ADRhrC6tb84OpaelPLaTkhRNSaxVAQzjQ==",
-      "deprecated": "This package has been deprecated. Please use @heroui/tooltip instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.2.7",
-        "@nextui-org/dom-animation": "2.1.1",
-        "@nextui-org/framer-utils": "2.1.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@nextui-org/use-safe-layout-effect": "2.1.1",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/overlays": "3.24.0",
-        "@react-aria/tooltip": "3.7.10",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/tooltip": "3.5.0",
-        "@react-types/overlays": "3.8.11",
-        "@react-types/tooltip": "3.4.13"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-accordion": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-accordion/-/use-aria-accordion-2.2.2.tgz",
-      "integrity": "sha512-M8gjX6XmB83cIAZKV2zI1KvmTuuOh+Si50F3SWvYjBXyrDIM5775xCs2PG6AcLjf6OONTl5KwuZ2cbSDHiui6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-aria/button": "3.11.0",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/selection": "3.21.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/tree": "3.8.6",
-        "@react-types/accordion": "3.0.0-alpha.25",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-accordion/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-button": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-button/-/use-aria-button-2.2.4.tgz",
-      "integrity": "sha512-Bz8l4JGzRKh6V58VX8Laq4rKZDppsnVuNCBHpMJuLo2F9ht7UKvZAEJwXcdbUZ87aui/ZC+IPYqgjvT+d8QlQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/button": "3.10.1",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-button/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-link": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-link/-/use-aria-link-2.2.5.tgz",
-      "integrity": "sha512-LBWXLecvuET4ZcpoHyyuS3yxvCzXdkmFcODhYwUmC8PiFSEUHkuFMC+fLwdXCP5GOqrv6wTGYHf41wNy1ugX1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/link": "3.5.9",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-link/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-modal-overlay": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-modal-overlay/-/use-aria-modal-overlay-2.2.3.tgz",
-      "integrity": "sha512-55DIVY0u+Ynxy1/DtzZkMsdVW63wC0mafKXACwCi0xV64D0Ggi9MM7BRePLK0mOboSb3gjCwYqn12gmRiy+kmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-aria/overlays": "3.24.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/overlays": "3.6.12",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-modal-overlay/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-multiselect": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-multiselect/-/use-aria-multiselect-2.4.3.tgz",
-      "integrity": "sha512-PwDA4Y5DOx0SMxc277JeZi8tMtaINTwthPhk8SaDrtOBhP+r9owS3T/W9t37xKnmrTerHwaEq4ADGQtm5/VMXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-aria/i18n": "3.12.4",
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/label": "3.7.13",
-        "@react-aria/listbox": "3.13.6",
-        "@react-aria/menu": "3.16.0",
-        "@react-aria/selection": "3.21.0",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/form": "3.1.0",
-        "@react-stately/list": "3.11.1",
-        "@react-stately/menu": "3.9.0",
-        "@react-types/button": "3.10.1",
-        "@react-types/overlays": "3.8.11",
-        "@react-types/select": "3.9.8",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-multiselect/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/use-callback-ref": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-callback-ref/-/use-callback-ref-2.1.1.tgz",
-      "integrity": "sha512-DzlKJ9p7Tm0x3HGjynZ/CgS1jfoBILXKFXnYPLr/SSETXqVaCguixolT/07BRB1yo9AGwELaCEt91BeI0Rb6hQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/use-safe-layout-effect": "2.1.1"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-clipboard": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-clipboard/-/use-clipboard-2.1.2.tgz",
-      "integrity": "sha512-MUITEPaQAvu9VuMCUQXMc4j3uBgXoD8LVcuuvUVucg/8HK/Xia0dQ4QgK30QlCbZ/BwZ047rgMAgpMZeVKw4MQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-data-scroll-overflow": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-data-scroll-overflow/-/use-data-scroll-overflow-2.2.2.tgz",
-      "integrity": "sha512-TFB6BuaLOsE++K1UEIPR9StkBgj9Cvvc+ccETYpmn62B7pK44DmxjkwhK0ei59wafJPIyytZ3DgdVDblfSyIXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.1.2"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-disclosure": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-disclosure/-/use-disclosure-2.2.2.tgz",
-      "integrity": "sha512-ka+5Fic2MIYtOMHi3zomtkWxCWydmJmcq7+fb6RHspfr0tGYjXWYO/lgtGeHFR1LYksMPLID3c7shT5bqzxJcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/use-callback-ref": "2.1.1",
-        "@react-aria/utils": "3.26.0",
-        "@react-stately/utils": "3.10.5"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-draggable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-draggable/-/use-draggable-2.1.2.tgz",
-      "integrity": "sha512-gN4G42uuRyFlAZ3FgMSeZLBg3LIeGlKTOLRe3JvyaBn1D1mA2+I3XONY1oKd9KKmtYCJNwY/2x6MVsBfy8nsgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-aria/interactions": "3.22.5"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-image": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-image/-/use-image-2.1.2.tgz",
-      "integrity": "sha512-I46M5gCJK4rZ0qYHPx3kVSF2M2uGaWPwzb3w4Cmx8K9QS+LbUQtRMbD8KOGTHZGA3kBDPvFbAi53Ert4eACrZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/use-safe-layout-effect": "2.1.1"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-intersection-observer": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-intersection-observer/-/use-intersection-observer-2.2.2.tgz",
-      "integrity": "sha512-fS/4m8jnXO7GYpnp/Lp+7bfBEAXPzqsXgqGK6qrp7sfFEAbLzuJp0fONkbIB3F6F3FJrbFOlY+Y5qrHptO7U/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-aria/interactions": "3.22.5",
-        "@react-aria/ssr": "3.9.7",
-        "@react-aria/utils": "3.26.0",
-        "@react-types/shared": "3.26.0"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-intersection-observer/node_modules/@react-types/shared": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
-      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@nextui-org/use-is-mobile": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-is-mobile/-/use-is-mobile-2.2.2.tgz",
-      "integrity": "sha512-gcmUL17fhgGdu8JfXF12FZCGATJIATxV4jSql+FNhR+gc+QRRWBRmCJSpMIE2RvGXL777tDvvoh/tjFMB3pW4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-aria/ssr": "3.9.7"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-is-mounted": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-is-mounted/-/use-is-mounted-2.1.1.tgz",
-      "integrity": "sha512-osJB3E/DCu4Le0f+pb21ia9/TaSHwme4r0fHjO5/nUBYk/RCvGlRUUCJClf/wi9WfH8QyjuJ27+zBcUSm6AMMg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-measure": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-measure/-/use-measure-2.1.1.tgz",
-      "integrity": "sha512-2RVn90gXHTgt6fvzBH4fzgv3hMDz+SEJkqaCTbd6WUNWag4AaLb2WU/65CtLcexyu10HrgYf2xG07ZqtJv0zSg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-pagination": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-pagination/-/use-pagination-2.2.3.tgz",
-      "integrity": "sha512-V2WGIq4LLkTpq6EUhJg3MVvHY2ZJ63AYV9N0d52Dc3Qqok0tTRuY51dd1P+F58HyTPW84W2z4q2R8XALtzFxQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/i18n": "3.12.4"
-      },
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-safe-layout-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-safe-layout-effect/-/use-safe-layout-effect-2.1.1.tgz",
-      "integrity": "sha512-p0vezi2eujC3rxlMQmCLQlc8CNbp+GQgk6YcSm7Rk10isWVlUII5T1L3y+rcFYdgTPObCkCngPPciNQhD7Lf7g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-scroll-position": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-scroll-position/-/use-scroll-position-2.1.1.tgz",
-      "integrity": "sha512-RgY1l2POZbSjnEirW51gdb8yNPuQXHqJx3TS8Ut5dk+bhaX9JD3sUdEiJNb3qoHAJInzyjN+27hxnACSlW0gzg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/use-update-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-update-effect/-/use-update-effect-2.1.1.tgz",
-      "integrity": "sha512-fKODihHLWcvDk1Sm8xDua9zjdbstxTOw9shB7k/mPkeR3E7SouSpN0+LW67Bczh1EmbRg1pIrFpEOLnbpgMFzA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@nextui-org/user": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/user/-/user-2.2.6.tgz",
-      "integrity": "sha512-iimFoP3DVK85p78r0ekC7xpVPQiBIbWnyBPdrnBj1UEgQdKoUzGhVbhYUnA8niBz/AS5xLt6aQixsv9/B0/msw==",
-      "deprecated": "This package has been deprecated. Please use @heroui/user instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@nextui-org/avatar": "2.2.6",
-        "@nextui-org/react-utils": "2.1.3",
-        "@nextui-org/shared-utils": "2.1.2",
-        "@react-aria/focus": "3.19.0",
-        "@react-aria/utils": "3.26.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.4.0",
-        "@nextui-org/theme": ">=2.4.0",
-        "react": ">=18 || >=19.0.0-rc.0",
-        "react-dom": ">=18 || >=19.0.0-rc.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0-rc.0",
-    "@nextui-org/react": "^2.6.11",
+    "@heroui/react": "2.6.14",
     "@react-router/node": "^7.1.5",
     "@react-router/serve": "^7.1.5",
     "@react-types/shared": "^3.27.0",

--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -55,7 +55,7 @@ export function GitHubRepositorySelector({
   const emptyContent = t(I18nKey.GITHUB$NO_RESULTS);
 
   return (
-    (<Autocomplete
+    <Autocomplete
       data-testid="github-repo-selector"
       name="repo"
       aria-label="GitHub Repository"
@@ -82,7 +82,7 @@ export function GitHubRepositorySelector({
       {config?.APP_MODE === "saas" &&
         config?.APP_SLUG &&
         ((
-          (<AutocompleteItem key="install">
+          <AutocompleteItem key="install">
             <a
               href={`https://github.com/apps/${config.APP_SLUG}/installations/new`}
               target="_blank"
@@ -91,7 +91,7 @@ export function GitHubRepositorySelector({
             >
               {t(I18nKey.GITHUB$ADD_MORE_REPOS)}
             </a>
-          </AutocompleteItem>) // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          </AutocompleteItem> // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ) as any)}
       {userRepositories.length > 0 && (
         <AutocompleteSection showDivider title={t(I18nKey.GITHUB$YOUR_REPOS)}>
@@ -126,6 +126,6 @@ export function GitHubRepositorySelector({
           ))}
         </AutocompleteSection>
       )}
-    </Autocomplete>)
+    </Autocomplete>
   );
 }

--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -4,7 +4,7 @@ import {
   Autocomplete,
   AutocompleteItem,
   AutocompleteSection,
-} from "@nextui-org/react";
+} from "@heroui/react";
 import { useDispatch } from "react-redux";
 import posthog from "posthog-js";
 import { I18nKey } from "#/i18n/declaration";
@@ -55,7 +55,7 @@ export function GitHubRepositorySelector({
   const emptyContent = t(I18nKey.GITHUB$NO_RESULTS);
 
   return (
-    <Autocomplete
+    (<Autocomplete
       data-testid="github-repo-selector"
       name="repo"
       aria-label="GitHub Repository"
@@ -82,7 +82,7 @@ export function GitHubRepositorySelector({
       {config?.APP_MODE === "saas" &&
         config?.APP_SLUG &&
         ((
-          <AutocompleteItem key="install">
+          (<AutocompleteItem key="install">
             <a
               href={`https://github.com/apps/${config.APP_SLUG}/installations/new`}
               target="_blank"
@@ -91,7 +91,7 @@ export function GitHubRepositorySelector({
             >
               {t(I18nKey.GITHUB$ADD_MORE_REPOS)}
             </a>
-          </AutocompleteItem> // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          </AutocompleteItem>) // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ) as any)}
       {userRepositories.length > 0 && (
         <AutocompleteSection showDivider title={t(I18nKey.GITHUB$YOUR_REPOS)}>
@@ -126,6 +126,6 @@ export function GitHubRepositorySelector({
           ))}
         </AutocompleteSection>
       )}
-    </Autocomplete>
+    </Autocomplete>)
   );
 }

--- a/frontend/src/components/shared/action-tooltip.tsx
+++ b/frontend/src/components/shared/action-tooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@nextui-org/react";
+import { Tooltip } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import ConfirmIcon from "#/assets/confirm";
 import RejectIcon from "#/assets/reject";

--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@nextui-org/react";
+import { Tooltip } from "@heroui/react";
 import { AgentState } from "#/types/agent-state";
 
 interface ActionButtonProps {

--- a/frontend/src/components/shared/buttons/icon-button.tsx
+++ b/frontend/src/components/shared/buttons/icon-button.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@nextui-org/react";
+import { Button } from "@heroui/react";
 import React, { ReactElement } from "react";
 
 export interface IconButtonProps {

--- a/frontend/src/components/shared/buttons/tooltip-button.tsx
+++ b/frontend/src/components/shared/buttons/tooltip-button.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@nextui-org/react";
+import { Tooltip } from "@heroui/react";
 import React, { ReactNode } from "react";
 import { cn } from "#/utils/utils";
 

--- a/frontend/src/components/shared/form-fieldset.tsx
+++ b/frontend/src/components/shared/form-fieldset.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, AutocompleteItem } from "@nextui-org/react";
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
 
 interface FormFieldsetProps {
   id: string;

--- a/frontend/src/components/shared/inputs/advanced-option-switch.tsx
+++ b/frontend/src/components/shared/inputs/advanced-option-switch.tsx
@@ -1,4 +1,4 @@
-import { Switch } from "@nextui-org/react";
+import { Switch } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";

--- a/frontend/src/components/shared/inputs/agent-input.tsx
+++ b/frontend/src/components/shared/inputs/agent-input.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, AutocompleteItem } from "@nextui-org/react";
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 

--- a/frontend/src/components/shared/inputs/api-key-input.tsx
+++ b/frontend/src/components/shared/inputs/api-key-input.tsx
@@ -1,4 +1,4 @@
-import { Input, Tooltip } from "@nextui-org/react";
+import { Input, Tooltip } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { FaCheckCircle, FaExclamationCircle } from "react-icons/fa";
 import { I18nKey } from "#/i18n/declaration";

--- a/frontend/src/components/shared/inputs/base-url-input.tsx
+++ b/frontend/src/components/shared/inputs/base-url-input.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@nextui-org/react";
+import { Input } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 

--- a/frontend/src/components/shared/inputs/confirmation-mode-switch.tsx
+++ b/frontend/src/components/shared/inputs/confirmation-mode-switch.tsx
@@ -1,4 +1,4 @@
-import { Switch } from "@nextui-org/react";
+import { Switch } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";

--- a/frontend/src/components/shared/inputs/custom-model-input.tsx
+++ b/frontend/src/components/shared/inputs/custom-model-input.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@nextui-org/react";
+import { Input } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 

--- a/frontend/src/components/shared/inputs/security-analyzers-input.tsx
+++ b/frontend/src/components/shared/inputs/security-analyzers-input.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, AutocompleteItem } from "@nextui-org/react";
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 

--- a/frontend/src/components/shared/modals/base-modal/base-modal.tsx
+++ b/frontend/src/components/shared/modals/base-modal/base-modal.tsx
@@ -4,7 +4,7 @@ import {
   ModalContent,
   ModalFooter,
   ModalHeader,
-} from "@nextui-org/react";
+} from "@heroui/react";
 import React from "react";
 import { Action, FooterContent } from "./footer-content";
 import { HeaderContent } from "./header-content";

--- a/frontend/src/components/shared/modals/base-modal/footer-content.tsx
+++ b/frontend/src/components/shared/modals/base-modal/footer-content.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@nextui-org/react";
+import { Button } from "@heroui/react";
 import React from "react";
 
 export interface Action {

--- a/frontend/src/components/shared/modals/security/invariant/invariant.tsx
+++ b/frontend/src/components/shared/modals/security/invariant/invariant.tsx
@@ -4,7 +4,7 @@ import { IoAlertCircle } from "react-icons/io5";
 import { useTranslation } from "react-i18next";
 import { Editor, Monaco } from "@monaco-editor/react";
 import { editor } from "monaco-editor";
-import { Button, Select, SelectItem } from "@nextui-org/react";
+import { Button, Select, SelectItem } from "@heroui/react";
 import { useMutation } from "@tanstack/react-query";
 import { RootState } from "#/store";
 import {

--- a/frontend/src/components/shared/modals/settings/model-selector.tsx
+++ b/frontend/src/components/shared/modals/settings/model-selector.tsx
@@ -2,7 +2,7 @@ import {
   Autocomplete,
   AutocompleteItem,
   AutocompleteSection,
-} from "@nextui-org/react";
+} from "@heroui/react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";

--- a/frontend/src/components/shared/modals/settings/runtime-size-selector.tsx
+++ b/frontend/src/components/shared/modals/settings/runtime-size-selector.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Select, SelectItem } from "@nextui-org/react";
+import { Select, SelectItem } from "@heroui/react";
 import { I18nKey } from "#/i18n/declaration";
 
 interface RuntimeSizeSelectorProps {

--- a/frontend/src/routes/_oh.app/route.tsx
+++ b/frontend/src/routes/_oh.app/route.tsx
@@ -1,4 +1,4 @@
-import { useDisclosure } from "@nextui-org/react";
+import { useDisclosure } from "@heroui/react";
 import React from "react";
 import { Outlet } from "react-router";
 import { useDispatch, useSelector } from "react-redux";

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,10 +1,10 @@
 /** @type {import('tailwindcss').Config} */
-import { nextui } from "@nextui-org/react";
+import { heroui } from "@heroui/react";
 import typography from '@tailwindcss/typography';
 export default {
   content: [
     "./src/**/*.{js,ts,jsx,tsx}",
-    "./node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}",
+    "./node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {
@@ -19,7 +19,7 @@ export default {
   },
   darkMode: "class",
   plugins: [
-    nextui({
+    heroui({
       defaultTheme: "dark",
       layout: {
         radius: {


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
NextUI has been rebranded to HeroUI. Update was carried out following: https://www.heroui.com/docs/guide/nextui-to-heroui#verification

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9e1e914-nikolaik   --name openhands-app-9e1e914   docker.all-hands.dev/all-hands-ai/openhands:9e1e914
```