### PR TITLE
Refinements to PostHog error tracking PR

### DIFF
--- a/frontend/__tests__/services/actions.test.ts
+++ b/frontend/__tests__/services/actions.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { handleStatusMessage } from "#/services/actions";
 import store from "#/store";
-import { logError } from "#/utils/error-handler";
+import { trackError } from "#/utils/error-handler";
 
 // Mock dependencies
 vi.mock("#/utils/error-handler", () => ({
-  logError: vi.fn(),
+  trackError: vi.fn(),
 }));
 
 vi.mock("#/store", () => ({
@@ -45,7 +45,7 @@ describe("Actions Service", () => {
 
       handleStatusMessage(message);
 
-      expect(logError).toHaveBeenCalledWith({
+      expect(trackError).toHaveBeenCalledWith({
         message: "Runtime connection failed",
         source: "chat",
         metadata: { msgId: "runtime.connection.failed" },

--- a/frontend/__tests__/utils/error-handler.test.ts
+++ b/frontend/__tests__/utils/error-handler.test.ts
@@ -4,7 +4,6 @@ import posthog from "posthog-js";
 import toast from "react-hot-toast";
 import * as Actions from "#/services/actions";
 
-// Mock dependencies
 vi.mock("posthog-js", () => ({
   default: {
     captureException: vi.fn(),
@@ -13,7 +12,7 @@ vi.mock("posthog-js", () => ({
 
 vi.mock("react-hot-toast", () => ({
   default: {
-    custom: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -79,7 +78,7 @@ describe("Error Handler", () => {
       });
 
       // Verify toast was shown
-      expect(toast.custom).toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
     });
 
     it("should include metadata in PostHog event when showing toast", () => {
@@ -110,19 +109,6 @@ describe("Error Handler", () => {
         id: "error.agent",
       });
 
-      // Test VSCode error
-      showErrorToast({
-        message: "VSCode error",
-        source: "vscode",
-        metadata: { error: "connection failed" },
-      });
-
-      expect(posthog.captureException).toHaveBeenCalledWith(new Error("VSCode error"), {
-        error_source: "vscode",
-        error: "connection failed",
-      });
-
-      // Test server error
       showErrorToast({
         message: "Server error",
         source: "server",
@@ -133,33 +119,6 @@ describe("Error Handler", () => {
         error_source: "server",
         error_code: 500,
         details: "Internal error",
-      });
-    });
-
-    it("should log query and mutation errors with appropriate metadata", () => {
-      // Test query error
-      showErrorToast({
-        message: "Query failed",
-        source: "query",
-        metadata: { queryKey: ["users", "123"] },
-      });
-
-      expect(posthog.captureException).toHaveBeenCalledWith(new Error("Query failed"), {
-        error_source: "query",
-        queryKey: ["users", "123"],
-      });
-
-      // Test mutation error
-      const error = new Error("Mutation failed");
-      showErrorToast({
-        message: error.message,
-        source: "mutation",
-        metadata: { error },
-      });
-
-      expect(posthog.captureException).toHaveBeenCalledWith(new Error("Mutation failed"), {
-        error_source: "mutation",
-        error,
       });
     });
 
@@ -200,26 +159,6 @@ describe("Error Handler", () => {
         message: "Chat error",
         id: "123",
         status_update: true,
-      });
-    });
-
-    it("should include metadata in PostHog event when showing chat error", () => {
-      const error = {
-        message: "Chat error",
-        source: "chat-test",
-        msgId: "123",
-        metadata: {
-          context: "chat testing",
-          severity: "high",
-        },
-      };
-
-      showChatError(error);
-
-      expect(posthog.captureException).toHaveBeenCalledWith(new Error("Chat error"), {
-        error_source: "chat-test",
-        context: "chat testing",
-        severity: "high",
       });
     });
   });

--- a/frontend/__tests__/utils/error-handler.test.ts
+++ b/frontend/__tests__/utils/error-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { logError, showErrorToast, showChatError } from "#/utils/error-handler";
+import { trackError, showErrorToast, showChatError } from "#/utils/error-handler";
 import posthog from "posthog-js";
 import toast from "react-hot-toast";
 import * as Actions from "#/services/actions";
@@ -30,14 +30,14 @@ describe("Error Handler", () => {
     vi.clearAllMocks();
   });
 
-  describe("logError", () => {
-    it("should log error to PostHog with basic info", () => {
+  describe("trackError", () => {
+    it("should send error to PostHog with basic info", () => {
       const error = {
         message: "Test error",
         source: "test",
       };
 
-      logError(error);
+      trackError(error);
 
       expect(posthog.captureException).toHaveBeenCalledWith(new Error("Test error"), {
         error_source: "test",
@@ -54,7 +54,7 @@ describe("Error Handler", () => {
         },
       };
 
-      logError(error);
+      trackError(error);
 
       expect(posthog.captureException).toHaveBeenCalledWith(new Error("Test error"), {
         error_source: "test",

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -4,7 +4,7 @@ import {
   addUserMessage,
   addErrorMessage,
 } from "#/state/chat-slice";
-import { logError } from "#/utils/error-handler";
+import { trackError } from "#/utils/error-handler";
 import { appendSecurityAnalyzerInput } from "#/state/security-analyzer-slice";
 import { setCode, setActiveFilepath } from "#/state/code-slice";
 import { appendJupyterInput } from "#/state/jupyter-slice";
@@ -96,7 +96,7 @@ export function handleStatusMessage(message: StatusMessage) {
       }),
     );
   } else if (message.type === "error") {
-    logError({
+    trackError({
       message: message.message,
       source: "chat",
       metadata: { msgId: message.id },
@@ -118,7 +118,7 @@ export function handleAssistantMessage(message: Record<string, unknown>) {
     handleStatusMessage(message as unknown as StatusMessage);
   } else {
     const errorMsg = "Unknown message type received";
-    logError({
+    trackError({
       message: errorMsg,
       source: "chat",
       metadata: { raw_message: message },

--- a/frontend/src/utils/error-handler.ts
+++ b/frontend/src/utils/error-handler.ts
@@ -1,7 +1,6 @@
 import posthog from "posthog-js";
 import toast from "react-hot-toast";
 import { jsx as _jsx } from "react/jsx-runtime";
-import { ErrorToast } from "#/components/shared/error-toast";
 import { handleStatusMessage } from "#/services/actions";
 
 interface ErrorDetails {
@@ -25,9 +24,7 @@ export function showErrorToast({
   metadata = {},
 }: ErrorDetails) {
   trackError({ message, source, metadata });
-  toast.custom((t: { id: string }) =>
-    _jsx(ErrorToast, { id: t.id, error: message }),
-  );
+  toast.error(message)
 }
 
 export function showChatError({

--- a/frontend/src/utils/error-handler.ts
+++ b/frontend/src/utils/error-handler.ts
@@ -1,6 +1,5 @@
 import posthog from "posthog-js";
 import toast from "react-hot-toast";
-import { jsx as _jsx } from "react/jsx-runtime";
 import { handleStatusMessage } from "#/services/actions";
 
 interface ErrorDetails {
@@ -24,7 +23,7 @@ export function showErrorToast({
   metadata = {},
 }: ErrorDetails) {
   trackError({ message, source, metadata });
-  toast.error(message)
+  toast.error(message);
 }
 
 export function showChatError({

--- a/frontend/src/utils/error-handler.ts
+++ b/frontend/src/utils/error-handler.ts
@@ -11,7 +11,7 @@ interface ErrorDetails {
   msgId?: string;
 }
 
-export function logError({ message, source, metadata = {} }: ErrorDetails) {
+export function trackError({ message, source, metadata = {} }: ErrorDetails) {
   const error = new Error(message);
   posthog.captureException(error, {
     error_source: source || "unknown",
@@ -24,7 +24,7 @@ export function showErrorToast({
   source,
   metadata = {},
 }: ErrorDetails) {
-  logError({ message, source, metadata });
+  trackError({ message, source, metadata });
   toast.custom((t: { id: string }) =>
     _jsx(ErrorToast, { id: t.id, error: message }),
   );
@@ -36,7 +36,7 @@ export function showChatError({
   metadata = {},
   msgId,
 }: ErrorDetails) {
-  logError({ message, source, metadata });
+  trackError({ message, source, metadata });
   handleStatusMessage({
     type: "error",
     message,


### PR DESCRIPTION
Updating @neubig's PR [6346](https://github.com/All-Hands-AI/OpenHands/pull/6346)

* Go back to `toast.error(message)` as in main, instead of our custom element because it isn't displaying properly (the style was missing when I tried it).
* Rename logError to trackError, in hopes that it will be more clear what's happening.
* Removed some tests which appeared redundant.