### PR TITLE
fix: handle SAAS mode properly in useSettings hook

### DIFF
--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -25,7 +25,7 @@ const getSettingsQueryFn = async () => {
 };
 
 export const useSettings = () => {
-  const { setGitHubTokenIsSet, isAuthenticated } = useAuth();
+  const { setGitHubTokenIsSet, githubTokenIsSet } = useAuth();
   const { data: config } = useConfig();
 
   const query = useQuery({
@@ -34,7 +34,7 @@ export const useSettings = () => {
     initialData: DEFAULT_SETTINGS,
     staleTime: 0,
     retry: false,
-    enabled: config?.APP_MODE !== "saas" || isAuthenticated,
+    enabled: config?.APP_MODE !== "saas" || githubTokenIsSet,
     meta: {
       disableToast: true,
     },
@@ -51,7 +51,7 @@ export const useSettings = () => {
   }, [query.data?.GITHUB_TOKEN_IS_SET, query.isFetched]);
 
   // Return default settings if in SAAS mode and not authenticated
-  if (config?.APP_MODE === "saas" && !isAuthenticated) {
+  if (config?.APP_MODE === "saas" && !githubTokenIsSet) {
     return {
       ...query,
       data: DEFAULT_SETTINGS,

--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -4,6 +4,7 @@ import posthog from "posthog-js";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import OpenHands from "#/api/open-hands";
 import { useAuth } from "#/context/auth-context";
+import { useConfig } from "#/hooks/query/use-config";
 
 const getSettingsQueryFn = async () => {
   const apiSettings = await OpenHands.getSettings();
@@ -24,7 +25,8 @@ const getSettingsQueryFn = async () => {
 };
 
 export const useSettings = () => {
-  const { setGitHubTokenIsSet } = useAuth();
+  const { setGitHubTokenIsSet, isAuthenticated } = useAuth();
+  const { data: config } = useConfig();
 
   const query = useQuery({
     queryKey: ["settings"],
@@ -32,6 +34,7 @@ export const useSettings = () => {
     initialData: DEFAULT_SETTINGS,
     staleTime: 0,
     retry: false,
+    enabled: config?.APP_MODE !== "saas" || isAuthenticated,
     meta: {
       disableToast: true,
     },
@@ -46,6 +49,14 @@ export const useSettings = () => {
   React.useEffect(() => {
     setGitHubTokenIsSet(!!query.data?.GITHUB_TOKEN_IS_SET);
   }, [query.data?.GITHUB_TOKEN_IS_SET, query.isFetched]);
+
+  // Return default settings if in SAAS mode and not authenticated
+  if (config?.APP_MODE === "saas" && !isAuthenticated) {
+    return {
+      ...query,
+      data: DEFAULT_SETTINGS,
+    };
+  }
 
   return query;
 };


### PR DESCRIPTION
The useSettings hook was not properly handling SAAS mode when users were not logged in. This PR fixes the issue by:

1. Adding useConfig hook to check application mode
2. Only fetching settings when:
   - App is NOT in SAAS mode OR
   - User is authenticated
3. Returning default settings when:
   - App is in SAAS mode AND
   - User is not authenticated

This ensures proper behavior in both SAAS and non-SAAS modes.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a2f028f-nikolaik   --name openhands-app-a2f028f   docker.all-hands.dev/all-hands-ai/openhands:a2f028f
```