### PR TITLE
chore(frontend): Take into account other error message types

### DIFF
--- a/frontend/src/utils/retrieve-axios-error-message.ts
+++ b/frontend/src/utils/retrieve-axios-error-message.ts
@@ -1,5 +1,8 @@
 import { AxiosError } from "axios";
-import { isAxiosErrorWithResponse } from "./type-guards";
+import {
+  isAxiosErrorWithErrorField,
+  isAxiosErrorWithMessageField,
+} from "./type-guards";
 
 /**
  * Retrieve the error message from an Axios error
@@ -8,8 +11,13 @@ import { isAxiosErrorWithResponse } from "./type-guards";
 export const retrieveAxiosErrorMessage = (error: AxiosError) => {
   let errorMessage: string | null = null;
 
-  if (isAxiosErrorWithResponse(error) && error.response?.data.error) {
+  if (isAxiosErrorWithErrorField(error) && error.response?.data.error) {
     errorMessage = error.response?.data.error;
+  } else if (
+    isAxiosErrorWithMessageField(error) &&
+    error.response?.data.message
+  ) {
+    errorMessage = error.response?.data.message;
   } else {
     errorMessage = error.message;
   }

--- a/frontend/src/utils/type-guards.ts
+++ b/frontend/src/utils/type-guards.ts
@@ -1,9 +1,17 @@
 import { AxiosError } from "axios";
 
-export const isAxiosErrorWithResponse = (
+export const isAxiosErrorWithErrorField = (
   error: AxiosError,
 ): error is AxiosError<{ error: string }> =>
   typeof error.response?.data === "object" &&
   error.response?.data !== null &&
   "error" in error.response.data &&
   typeof error.response?.data?.error === "string";
+
+export const isAxiosErrorWithMessageField = (
+  error: AxiosError,
+): error is AxiosError<{ message: string }> =>
+  typeof error.response?.data === "object" &&
+  error.response?.data !== null &&
+  "message" in error.response.data &&
+  typeof error.response?.data?.message === "string";


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
We have error messages that have details in the `message` field instead of the `error`. Example:

https://github.com/All-Hands-AI/OpenHands/blob/93d2e4a338adcaa8acaa602adad14364abca821f/openhands/server/routes/manage_conversations.py#L152-L170

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
![image](https://github.com/user-attachments/assets/d5079b46-d452-4abb-8957-44cf82bd20ae)



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:84e76a7-nikolaik   --name openhands-app-84e76a7   docker.all-hands.dev/all-hands-ai/openhands:84e76a7
```