### PR TITLE
fix: set `tool_choice` to none for non-fncall models

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -232,6 +232,9 @@ class LLM(RetryMixin, DebugMixin):
                     kwargs['stop'] = STOP_WORDS
 
                 mock_fncall_tools = kwargs.pop('tools')
+                kwargs['tool_choice'] = (
+                    'none'  # force no tool calling because we're mocking it - without it, it will cause issue with sglang
+                )
 
             # if we have no messages, something went very wrong
             if not messages:


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

I was testing an open-source model we've trained specifically for OpenHands, and running into issue when deploy that model with SGLang. Basically sglang has a `TOOLS_TAG_LIST` that contains `<function=` which is the format we used for simulate tool calling via prompting

https://github.com/sgl-project/sglang/blob/c1f5f99f607d01900d3974ea779588ebce75693b/python/sglang/srt/function_call_parser.py#L14C1-L14C15

And this will somehow trigger sglang to enable their function calling mode and causing a bunch of issues:
https://github.com/sgl-project/sglang/blob/c1f5f99f607d01900d3974ea779588ebce75693b/python/sglang/srt/openai_api/adapter.py#L1079-L1099

A simple fix would be set `tool_choice` to 'none' when we are mocking function calling


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f4c5a62-nikolaik   --name openhands-app-f4c5a62   docker.all-hands.dev/all-hands-ai/openhands:f4c5a62
```