### PR TITLE
[Enhancement]: Standardize SecretStr use

### DIFF
--- a/dev_config/python/ruff.toml
+++ b/dev_config/python/ruff.toml
@@ -24,3 +24,6 @@ inline-quotes = "single"
 
 [format]
 quote-style = "single"
+
+[lint.flake8-bugbear]
+extend-immutable-calls = ["Depends", "fastapi.Depends", "fastapi.params.Depends"]

--- a/openhands/server/auth.py
+++ b/openhands/server/auth.py
@@ -1,9 +1,10 @@
 from fastapi import Request
+from pydantic import SecretStr
 
 
 def get_github_token(request: Request) -> str | None:
     return getattr(request.state, 'github_token', None)
 
 
-def get_user_id(request: Request) -> str | None:
+def get_user_id(request: Request) -> SecretStr | None:
     return getattr(request.state, 'github_user_id', None)

--- a/openhands/server/config/server_config.py
+++ b/openhands/server/config/server_config.py
@@ -18,7 +18,7 @@ class ServerConfig(ServerConfigInterface):
     )
     conversation_manager_class: str = 'openhands.server.conversation_manager.standalone_conversation_manager.StandaloneConversationManager'
 
-    github_service_class: str = 'openhands.server.services.github_service.GitHubService'
+    github_service_class: str = 'openhands.services.github.github_service.GitHubService'
 
     def verify_config(self):
         if self.config_cls:

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -196,7 +196,7 @@ class GitHubTokenMiddleware(SessionMiddlewareInterface):
         # TODO: To avoid checks like this we should re-add the abilty to have completely different middleware in SAAS as in OSS
         if getattr(request.state, 'github_token', None) is None:
             if settings and settings.github_token:
-                request.state.github_token = settings.github_token.get_secret_value()
+                request.state.github_token = settings.github_token
             else:
                 request.state.github_token = None
 

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -4,13 +4,13 @@ from typing import Callable
 
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.message import MessageAction
 from openhands.events.stream import EventStreamSubscriber
 from openhands.runtime import get_runtime_cls
-from openhands.server.auth import get_user_id
+from openhands.server.auth import get_github_token, get_user_id
 from openhands.server.routes.github import GithubServiceImpl
 from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.server.shared import (
@@ -44,7 +44,7 @@ class InitSessionRequest(BaseModel):
 
 async def _create_new_conversation(
     user_id: str | None,
-    token: str | None,
+    token: SecretStr | None,
     selected_repository: str | None,
     initial_user_msg: str | None,
     image_urls: list[str] | None,
@@ -72,7 +72,7 @@ async def _create_new_conversation(
         logger.warn('Settings not present, not starting conversation')
         raise MissingSettingsError('Settings not found')
 
-    session_init_args['github_token'] = token or ''
+    session_init_args['github_token'] = token or SecretStr('')
     session_init_args['selected_repository'] = selected_repository
     conversation_init_data = ConversationInitData(**session_init_args)
     logger.info('Loading conversation store')
@@ -131,7 +131,11 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     """
     logger.info('Initializing new conversation')
     user_id = get_user_id(request)
-    github_token = GithubServiceImpl.get_gh_token(request)
+    # github_token = GithubServiceImpl.get_gh_token(request)
+
+    github_service = GithubServiceImpl(user_id=user_id, token=get_github_token(request))
+    github_token = await github_service.get_latest_token()
+
     selected_repository = data.selected_repository
     initial_user_msg = data.initial_user_msg
     image_urls = data.image_urls or []

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
+from pydantic import SecretStr
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.auth import get_user_id
-from openhands.server.services.github_service import GitHubService
 from openhands.server.settings import GETSettingsModel, POSTSettingsModel, Settings
 from openhands.server.shared import SettingsStoreImpl, config
+from openhands.services.github.github_service import GitHubService
 
 app = APIRouter(prefix='/api')
 
@@ -50,7 +51,7 @@ async def store_settings(
         try:
             # We check if the token is valid by getting the user
             # If the token is invalid, this will raise an exception
-            github = GitHubService(None)
+            github = GitHubService(user_id=None, token=SecretStr(settings.github_token))
             await github.validate_user(settings.github_token)
 
         except Exception as e:

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -2,6 +2,8 @@ import asyncio
 import time
 from typing import Callable, Optional
 
+from pydantic import SecretStr
+
 from openhands.controller import AgentController
 from openhands.controller.agent import Agent
 from openhands.controller.state.state import State
@@ -69,7 +71,7 @@ class AgentSession:
         max_budget_per_task: float | None = None,
         agent_to_llm_config: dict[str, LLMConfig] | None = None,
         agent_configs: dict[str, AgentConfig] | None = None,
-        github_token: str | None = None,
+        github_token: SecretStr | None = None,
         selected_repository: str | None = None,
         initial_message: MessageAction | None = None,
     ):
@@ -177,7 +179,7 @@ class AgentSession:
         runtime_name: str,
         config: AppConfig,
         agent: Agent,
-        github_token: str | None = None,
+        github_token: SecretStr | None = None,
         selected_repository: str | None = None,
     ):
         """Creates a runtime instance
@@ -195,7 +197,7 @@ class AgentSession:
         runtime_cls = get_runtime_cls(runtime_name)
         env_vars = (
             {
-                'GITHUB_TOKEN': github_token,
+                'GITHUB_TOKEN': github_token.get_secret_value(),
             }
             if github_token
             else None

--- a/openhands/server/session/conversation_init_data.py
+++ b/openhands/server/session/conversation_init_data.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 from openhands.server.settings import Settings
 
@@ -9,4 +9,4 @@ class ConversationInitData(Settings):
     """
 
     github_token: str | None = Field(default=None)
-    selected_repository: str | None = Field(default=None)
+    selected_repository: SecretStr | None = Field(default=None)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We have instances where the github token is used as either a `SecretStr` or a plain `str`. We should standardize the code to do the following

- Represent all sensitive keys and tokens with `SecretStr`
- Only convert from `SecretStr` to `str` when absolutely needed for its use case

---
**Link of any specific issues this addresses**
