### PR TITLE
fix: adding support for environment variables type dict

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import platform
 import sys
+from ast import literal_eval
 from types import UnionType
 from typing import Any, MutableMapping, get_args, get_origin
 from uuid import uuid4
@@ -72,6 +73,8 @@ def load_from_env(cfg: AppConfig, env_or_toml_dict: dict | MutableMapping[str, s
                     # Attempt to cast the env var to type hinted in the dataclass
                     if field_type is bool:
                         cast_value = str(value).lower() in ['true', '1']
+                    elif get_origin(field_type) is dict:
+                        cast_value = literal_eval(value)
                     else:
                         cast_value = field_type(value)
                     setattr(sub_config, field_name, cast_value)


### PR DESCRIPTION
When trying to do set env variable SANDBOX_RUNTIME_STARTUP_ENV_VARS:

```
16:53:36 - openhands:ERROR: utils.py:79 - Error setting env var SANDBOX_RUNTIME_STARTUP_ENV_VARS={DATABASE_URL = "postgresql://user:pass@localhost/hello"}: check that the value is of the right type
```

This will happen with any env variable where type `dict` is expected. 

After this change: 

`export SANDBOX_RUNTIME_STARTUP_ENV_VARS="{'key': 'value'}"` will work.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

in `openhands/core/config/utils.py` checking if env variable `field_type` is `dict` use literal_eval. 

---
**Link of any specific issues this addresses**
[Fix issue 6663](https://github.com/All-Hands-AI/OpenHands/issues/6663)
