### PR TITLE
Clean up global in llm.py (we figured it's not needed)

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -303,7 +303,6 @@ class CodeActAgent(Agent):
                 and len(obs.set_of_marks) > 0
                 and self.config.enable_som_visual_browsing
                 and self.llm.vision_is_active()
-                and self.llm.is_visual_browser_tool_supported()
             ):
                 text += 'Image: Current webpage screenshot (Note that only visible portion of webpage is present in the screenshot. You may need to scroll to view the remaining portion of the web-page.)\n'
                 message = Message(

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -75,16 +75,6 @@ FUNCTION_CALLING_SUPPORTED_MODELS = [
     'o3-mini',
 ]
 
-# visual browsing tool supported models
-# This flag is needed since gpt-4o and gpt-4o-mini do not allow passing image_urls with role='tool'
-VISUAL_BROWSING_TOOL_SUPPORTED_MODELS = [
-    'claude-3-5-sonnet',
-    'claude-3-5-sonnet-20240620',
-    'claude-3-5-sonnet-20241022',
-    'o1-2024-12-17',
-]
-
-
 REASONING_EFFORT_SUPPORTED_MODELS = [
     'o1-2024-12-17',
     'o1',
@@ -494,15 +484,6 @@ class LLM(RetryMixin, DebugMixin):
         The result is cached during initialization for performance.
         """
         return self._function_calling_active
-
-    def is_visual_browser_tool_supported(self) -> bool:
-        return (
-            self.config.model in VISUAL_BROWSING_TOOL_SUPPORTED_MODELS
-            or self.config.model.split('/')[-1] in VISUAL_BROWSING_TOOL_SUPPORTED_MODELS
-            or any(
-                m in self.config.model for m in VISUAL_BROWSING_TOOL_SUPPORTED_MODELS
-            )
-        )
 
     def _post_completion(self, response: ModelResponse) -> float:
         """Post-process the completion response.


### PR DESCRIPTION
The visual browsing is supported when:
- the agent has the option `enable_som_visual_browsing` enabled
- the LLM supports vision and has it enabled.

This is true whether it's a non-native fn calling LLM (like DeepSeek v3 is used by `openhands`) or a native fn calling LLM.

So we figured out the VISUAL_BROWSING_TOOL_SUPPORTED_MODELS isn't necessary, and it actually limits the models for non-fn calling unnecessarily.

Ref: discussion with @adityasoni9998 [here](https://github.com/All-Hands-AI/OpenHands/pull/6464#discussion_r1945918204).

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c5699eb-nikolaik   --name openhands-app-c5699eb   docker.all-hands.dev/all-hands-ai/openhands:c5699eb
```