### PR TITLE
fix(frontend): fix public github repo cannot be selected

### DIFF
--- a/frontend/src/components/features/github/github-repo-selector.tsx
+++ b/frontend/src/components/features/github/github-repo-selector.tsx
@@ -31,7 +31,7 @@ export function GitHubRepositorySelector({
 
   const allRepositories: GitHubRepository[] = [
     ...publicRepositories.filter(
-      (repo) => !publicRepositories.find((r) => r.id === repo.id),
+      (repo) => !userRepositories.find((r) => r.id === repo.id),
     ),
     ...userRepositories,
   ];


### PR DESCRIPTION
### Current behavior：
Public Github repo cannot be selected.

![image](https://github.com/user-attachments/assets/87d650b9-adc7-409b-a7f9-32eb9c952900)

### Cause analysis:

In file [github-repo-selector.tsx](https://github.com/xyeric/OpenHands/blob/fix-github-repo-merge/frontend/src/components/features/github/github-repo-selector.tsx)，the original intention of this line [L34](https://github.com/xyeric/OpenHands/blob/fix-github-repo-merge/frontend/src/components/features/github/github-repo-selector.tsx#L34) perhaps to deduplicate two lists, but public repo list has filtered with it self, causing the selected repo cannot be matched in the select event hander.

![image](https://github.com/user-attachments/assets/1747efd3-2fa7-486b-b363-d84ce7335b2a)

### Proposed solution

filter public repo list with user repo list.

![image](https://github.com/user-attachments/assets/19be4c23-ea3d-4568-b97e-9b1880b437d2)
