### PR TITLE
refactor: do not add DEBUG env var when it is not set

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -212,11 +212,9 @@ class RemoteRuntime(ActionExecutionClient):
             plugins=self.plugins,
             app_config=self.config,
         )
-        environment = {
-            'DEBUG': 'true'
-            if self.config.debug or os.environ.get('DEBUG', 'false').lower() == 'true'
-            else '',
-        }
+        environment = {}
+        if self.config.debug or os.environ.get('DEBUG', 'false').lower() == 'true':
+            environment['DEBUG'] = 'true'
         environment.update(self.config.sandbox.runtime_startup_env_vars)
         start_request = {
             'image': self.container_image,


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f9b5603-nikolaik   --name openhands-app-f9b5603   docker.all-hands.dev/all-hands-ai/openhands:f9b5603
```