### PR TITLE
Fix for error when formatting logs

### DIFF
--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -130,6 +130,10 @@ class ColoredFormatter(logging.Formatter):
                 return f'{msg}'
             else:
                 return record.msg
+        if record.exc_info is True and not record.exc_text:
+            # The formatter expects a non boolean value here, and will raise an exception if there is a boolean.
+            # But using sys.exc_info at this point may give the wrong exc_info, so all we can do is drop it.
+            record.exc_info = None
         return super().format(record)
 
 


### PR DESCRIPTION
**Fix for error when formatting logs**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
This one is kind of a big deal because nobody expects an error when writing logs - so having one can cause all sorts of other nasty side effects (Such as cleanup code not getting run). The record unfortunately shares the same name `exc_info` with the log method - but it should include output from sys.exc_info rather than a boolean. I am checking for a boolean and no formatted text and dropping it if present.



---
**Link of any specific issues this addresses**
