### PR TITLE
Revert "Only show start project button in conversations"

### DIFF
--- a/frontend/src/components/shared/buttons/exit-project-button.tsx
+++ b/frontend/src/components/shared/buttons/exit-project-button.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router";
 import { I18nKey } from "#/i18n/declaration";
 import NewProjectIcon from "#/icons/new-project.svg?react";
 import { TooltipButton } from "./tooltip-button";
@@ -10,12 +9,7 @@ interface ExitProjectButtonProps {
 
 export function ExitProjectButton({ onClick }: ExitProjectButtonProps) {
   const { t } = useTranslation();
-  const location = useLocation();
   const startNewProject = t(I18nKey.PROJECT$START_NEW);
-
-  // Only show the button in the conversations page
-  if (!location.pathname.startsWith("/conversations")) return null;
-
   return (
     <TooltipButton
       tooltip={startNewProject}


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#6626

The sidebar should always remain the same without conditionally rendered parts

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d2c1016-nikolaik   --name openhands-app-d2c1016   docker.all-hands.dev/all-hands-ai/openhands:d2c1016
```