### PR TITLE
Fix log formatting error

### DIFF
--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -90,6 +90,12 @@ class NoColorFormatter(logging.Formatter):
         # Strip ANSI color codes from the message
         new_record.msg = strip_ansi(new_record.msg)
 
+        if new_record.exc_info is True and not new_record.exc_text:  # type: ignore
+            # The formatter expects a non boolean value here, and will raise an exception if there is a boolean.
+            # But using sys.exc_info at this point may give the wrong exc_info, so all we can do is drop it.
+            record.exc_info = None  # type: ignore
+            record.stack_info = None  # type: ignore
+
         return super().format(new_record)
 
 
@@ -134,6 +140,7 @@ class ColoredFormatter(logging.Formatter):
             # The formatter expects a non boolean value here, and will raise an exception if there is a boolean.
             # But using sys.exc_info at this point may give the wrong exc_info, so all we can do is drop it.
             record.exc_info = None
+            record.stack_info = None
         return super().format(record)
 
 

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -130,6 +130,10 @@ class ColoredFormatter(logging.Formatter):
                 return f'{msg}'
             else:
                 return record.msg
+        if record.exc_info is True and not record.exc_text:
+            # The formatter expects a non boolean value here, and will raise an exception if there is a boolean.
+            # But using sys.exc_info at this point may give the wrong exc_info, so all we can do is drop it.
+            record.exc_info = None
         return super().format(record)
 
 

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -86,15 +86,10 @@ class NoColorFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         # Create a deep copy of the record to avoid modifying the original
-        new_record: logging.LogRecord = copy.deepcopy(record)
+        new_record = _fix_record(record)
+
         # Strip ANSI color codes from the message
         new_record.msg = strip_ansi(new_record.msg)
-
-        if new_record.exc_info is True and not new_record.exc_text:  # type: ignore
-            # The formatter expects a non boolean value here, and will raise an exception if there is a boolean.
-            # But using sys.exc_info at this point may give the wrong exc_info, so all we can do is drop it.
-            record.exc_info = None  # type: ignore
-            record.stack_info = None  # type: ignore
 
         return super().format(new_record)
 
@@ -136,12 +131,18 @@ class ColoredFormatter(logging.Formatter):
                 return f'{msg}'
             else:
                 return record.msg
-        if record.exc_info is True and not record.exc_text:
-            # The formatter expects a non boolean value here, and will raise an exception if there is a boolean.
-            # But using sys.exc_info at this point may give the wrong exc_info, so all we can do is drop it.
-            record.exc_info = None
-            record.stack_info = None
-        return super().format(record)
+
+        new_record = _fix_record(record)
+        return super().format(new_record)
+
+
+def _fix_record(record: logging.LogRecord):
+    new_record = copy.copy(record)
+    # The formatter expects non boolean values, and will raise an exception if there is a boolean - so we fix these
+    if new_record.exc_info is True and not new_record.exc_text:  # type: ignore
+        new_record.exc_info = sys.exc_info()  # type: ignore
+        new_record.stack_info = None  # type: ignore
+    return new_record
 
 
 file_formatter = NoColorFormatter(


### PR DESCRIPTION
**Fix for error when formatting logs**

- [X] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
This one is kind of a big deal because nobody expects an error when writing logs - so having one can cause all sorts of other nasty side effects (Such as cleanup code not getting run). The record unfortunately shares the same name `exc_info` with the log method - but it should include output from sys.exc_info rather than a boolean. I am dropping the exc_info if there is no formatted text, and fixing this issue.

**Instead of log messages like this which have nothing to do with the raised exception...**
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/tofarr/dev/all-hands/deploy/.venv/lib/python3.12/site-packages/openhands/core/logger.py", line 93, in format
    return super().format(new_record)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 711, in format
    record.exc_text = self.formatException(record.exc_info)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 657, in formatException
    tb = ei[2]
         ~~^^^
TypeError: 'bool' object is not subscriptable
```

You get log messages actually related to the exception.


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:20b76f6-nikolaik   --name openhands-app-20b76f6   docker.all-hands.dev/all-hands-ai/openhands:20b76f6
```