### PR TITLE
Agent session no longer stuck in starting on raised exception

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -92,8 +92,9 @@ class RemoteRuntime(ActionExecutionClient):
     async def connect(self):
         try:
             await call_sync_from_async(self._start_or_attach_to_runtime)
-        except AgentRuntimeNotReadyError:
-            self.log('error', 'Runtime failed to start, timed out before ready')
+        except Exception:
+            self.close()
+            self.log('error', 'Runtime failed to start')
             raise
         await call_sync_from_async(self.setup_initial_env)
         self._runtime_initialized = True

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -97,42 +97,43 @@ class AgentSession:
             logger.warning('Session closed before starting')
             return
         self._starting = True
-        self._started_at = time.time()
-        self._create_security_analyzer(config.security.security_analyzer)
-        await self._create_runtime(
-            runtime_name=runtime_name,
-            config=config,
-            agent=agent,
-            github_token=github_token,
-            selected_repository=selected_repository,
-        )
-
-        self.controller = self._create_controller(
-            agent,
-            config.security.confirmation_mode,
-            max_iterations,
-            max_budget_per_task=max_budget_per_task,
-            agent_to_llm_config=agent_to_llm_config,
-            agent_configs=agent_configs,
-        )
-        if github_token:
-            self.event_stream.set_secrets(
-                {
-                    'github_token': github_token.get_secret_value(),
-                }
-            )
-        if initial_message:
-            self.event_stream.add_event(initial_message, EventSource.USER)
-            self.event_stream.add_event(
-                ChangeAgentStateAction(AgentState.RUNNING), EventSource.ENVIRONMENT
-            )
-        else:
-            self.event_stream.add_event(
-                ChangeAgentStateAction(AgentState.AWAITING_USER_INPUT),
-                EventSource.ENVIRONMENT,
+        try:
+            self._started_at = time.time()
+            self._create_security_analyzer(config.security.security_analyzer)
+            await self._create_runtime(
+                runtime_name=runtime_name,
+                config=config,
+                agent=agent,
+                github_token=github_token,
+                selected_repository=selected_repository,
             )
 
-        self._starting = False
+            self.controller = self._create_controller(
+                agent,
+                config.security.confirmation_mode,
+                max_iterations,
+                max_budget_per_task=max_budget_per_task,
+                agent_to_llm_config=agent_to_llm_config,
+                agent_configs=agent_configs,
+            )
+            if github_token:
+                self.event_stream.set_secrets(
+                    {
+                        'github_token': github_token.get_secret_value(),
+                    }
+                )
+            if initial_message:
+                self.event_stream.add_event(initial_message, EventSource.USER)
+                self.event_stream.add_event(
+                    ChangeAgentStateAction(AgentState.RUNNING), EventSource.ENVIRONMENT
+                )
+            else:
+                self.event_stream.add_event(
+                    ChangeAgentStateAction(AgentState.AWAITING_USER_INPUT),
+                    EventSource.ENVIRONMENT,
+                )
+        finally:
+            self._starting = False
 
     async def close(self):
         """Closes the Agent session"""


### PR DESCRIPTION
**Now making sure that the starting flag is no longer left in a True state if an error is thrown while starting**

- [] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
Improves agent session error handling in two ways:

1. Ensures the starting flag is properly reset when an exception occurs during startup, preventing the session from getting stuck in a "starting" state
2. Adds proper error handling for unknown errors from start_or_attach_to_runtime, ensuring HTTP sessions are properly closed in all error cases

These changes prevent unnecessary waits during local shutdown and improve the overall robustness of the session management.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0f34af3-nikolaik   --name openhands-app-0f34af3   docker.all-hands.dev/all-hands-ai/openhands:0f34af3
```
