### PR TITLE
fix: Filter `AgentCondensationObservation` events from agent state

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -77,6 +77,7 @@ class AgentController:
         NullObservation,
         ChangeAgentStateAction,
         AgentStateChangedObservation,
+        AgentCondensationObservation,
     )
 
     def __init__(


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Adds `AgentCondensationObservation` to the agent controller's list of filtered events. These events will still trigger a step, but now the user and LLM will not be made aware because the event is not stored in the agent's state.

---
**Link of any specific issues this addresses**

#6634 - removes chat messages mentioned here