### PR TITLE
More effective remote runtime identification

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -308,7 +308,7 @@ class RemoteRuntime(ActionExecutionClient):
         self.log('debug', f'Waiting for runtime to be alive at url: {self.runtime_url}')
         with self._send_runtime_api_request(
             'GET',
-            f'{self.config.sandbox.remote_runtime_api_url}/sessions/{self.sid}',
+            f'{self.config.sandbox.remote_runtime_api_url}/runtime/{self.runtime_id}',
         ) as runtime_info_response:
             runtime_data = runtime_info_response.json()
         assert 'runtime_id' in runtime_data


### PR DESCRIPTION
**Fix issues where remote runtime is confused by multiple runtimes using the same session id**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**We should identify the runtime by runtime_id where possible.**
We can have multiple remote runtimes with the same conversation id (Where some of them are stopped) if...

* Keep runtimes alive is set to false
* A user tries to start more than 3 conversations at the same time
* A conversation is more than 24 hours old and we try to restart it

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4941c17-nikolaik   --name openhands-app-4941c17   docker.all-hands.dev/all-hands-ai/openhands:4941c17
```