### PR TITLE
fix: Simplify nested f-string to fix pydoc-markdown parsing

### DIFF
--- a/openhands/resolver/interfaces/gitlab.py
+++ b/openhands/resolver/interfaces/gitlab.py
@@ -46,9 +46,9 @@ class GitlabIssueHandler(IssueHandlerInterface):
         return f'{self.base_url}/issues'
 
     def get_clone_url(self):
-        username_and_token = (
-            f'{self.username}:{self.token}' if self.username else f'{self.token}'
-        )
+        username_and_token = self.token
+        if self.username:
+            username_and_token = f'{self.username}:{self.token}'
         return f'https://{username_and_token}@gitlab.com/{self.owner}/{self.repo}.git'
 
     def get_graphql_url(self):
@@ -361,7 +361,8 @@ class GitlabPRHandler(GitlabIssueHandler):
                 }
             """
 
-        variables = {'projectPath': f'{self.owner}/{self.repo}', 'pr': f'{pull_number}'}
+        project_path = f'{self.owner}/{self.repo}'
+        variables = {'projectPath': project_path, 'pr': str(pull_number)}
 
         response = requests.post(
             self.get_graphql_url(),

--- a/openhands/resolver/interfaces/gitlab.py
+++ b/openhands/resolver/interfaces/gitlab.py
@@ -33,7 +33,8 @@ class GitlabIssueHandler(IssueHandlerInterface):
         }
 
     def get_base_url(self):
-        return f'https://gitlab.com/api/v4/projects/{quote(f'{self.owner}/{self.repo}', safe="")}'
+        project_path = quote(f'{self.owner}/{self.repo}', safe="")
+        return f'https://gitlab.com/api/v4/projects/{project_path}'
 
     def get_authorize_url(self):
         return f'https://{self.username}:{self.token}@gitlab.com/'


### PR DESCRIPTION
This PR fixes the `build docusaurus` GitHub action failure by simplifying a nested f-string that was causing `pydoc-markdown` to fail parsing on `main` (https://github.com/All-Hands-AI/OpenHands/actions/runs/13318999934/job/37199704374).

This issue was introduced in #6458 

### Changes
- Split the complex nested f-string in `gitlab.py` into two separate lines
- Maintains the same functionality while making the code more readable
- Should resolve the documentation build error

### Testing
- The code change is functionally equivalent
- Documentation build should now succeed

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5b9d790-nikolaik   --name openhands-app-5b9d790   docker.all-hands.dev/all-hands-ai/openhands:5b9d790
```