### PR TITLE
Fix: Exclude node_modules from workspace download (#6640)

### DIFF
--- a/frontend/__tests__/utils/download-files.test.tsx
+++ b/frontend/__tests__/utils/download-files.test.tsx
@@ -1,0 +1,31 @@
+import { downloadFiles } from "../../src/utils/download-files";
+import * as OpenHandsAPI from "../../src/api/open-hands";
+
+jest.mock("../../src/api/open-hands");
+
+describe("downloadFiles", () => {
+  it("should not download node_modules", async () => {
+    const mockGetFiles = OpenHandsAPI.OpenHands.getFiles as jest.Mock;
+    mockGetFiles.mockResolvedValueOnce(["file1.txt", "node_modules/", "file2.txt"]);
+    mockGetFiles.mockResolvedValueOnce(["file_in_node_modules.txt"]); // Should not be called due to exclusion
+    mockGetFiles.mockResolvedValueOnce([]); // For file2.txt directory (not a directory in this test case)
+
+    // Mock showDirectoryPicker and file system API
+    const mockDirHandle = {
+      getFileHandle: jest.fn().mockResolvedValue({
+        createWritable: jest.fn().mockResolvedValue({
+          write: jest.fn().mockResolvedValue(undefined),
+          close: jest.fn().mockResolvedValue(undefined),
+        }),
+      }),
+      getDirectoryHandle: jest.fn().mockResolvedValue({}),
+    };
+    global.window.showDirectoryPicker = jest.fn().mockResolvedValue(mockDirHandle);
+
+    await downloadFiles("test-conversation-id");
+
+    expect(mockGetFiles).toHaveBeenCalledTimes(2); // Should only call getFiles for root and file2.txt, not node_modules
+    expect(mockGetFiles).toHaveBeenCalledWith("test-conversation-id", "");
+    expect(mockGetFiles).not.toHaveBeenCalledWith("test-conversation-id", "node_modules/"); // Verify node_modules is skipped
+  });
+});

--- a/frontend/src/utils/download-files.ts
+++ b/frontend/src/utils/download-files.ts
@@ -60,6 +60,9 @@ async function getAllFiles(
 
     const fullPath = path + entry;
     if (entry.endsWith("/")) {
+      if (entry === "node_modules/") {
+        return [];
+      }
       const subEntries = await OpenHands.getFiles(conversationID, fullPath);
       const subFilesPromises = subEntries.map((subEntry) =>
         processEntry(subEntry),


### PR DESCRIPTION


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0d3a041-nikolaik   --name openhands-app-0d3a041   docker.all-hands.dev/all-hands-ai/openhands:0d3a041
```