### PR TITLE
Fix download workspace zip file event loop hanging

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -629,8 +629,8 @@ if __name__ == '__main__':
             if not os.path.exists(path):
                 raise HTTPException(status_code=404, detail='File not found')
 
-            with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_file:
-                with ZipFile(temp_file.name, 'w') as zipf:
+            with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+                with ZipFile(temp_zip, 'w') as zipf:
                     for root, _, files in os.walk(path):
                         for file in files:
                             file_path = os.path.join(root, file)
@@ -638,10 +638,10 @@ if __name__ == '__main__':
                                 file_path, arcname=os.path.relpath(file_path, path)
                             )
                 return FileResponse(
-                    path=temp_file.name,
+                    path=temp_zip.name,
                     media_type='application/zip',
                     filename=f'{os.path.basename(path)}.zip',
-                    background=BackgroundTask(lambda: os.unlink(temp_file.name)),
+                    background=BackgroundTask(lambda: os.unlink(temp_zip.name)),
                 )
 
         except Exception as e:

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -8,7 +8,6 @@ NOTE: this will be executed inside the docker sandbox.
 import argparse
 import asyncio
 import base64
-import io
 import mimetypes
 import os
 import shutil
@@ -21,12 +20,13 @@ from zipfile import ZipFile
 
 from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.security import APIKeyHeader
 from openhands_aci.editor.editor import OHEditor
 from openhands_aci.editor.exceptions import ToolError
 from openhands_aci.editor.results import ToolResult
 from pydantic import BaseModel
+from starlette.background import BackgroundTask
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from uvicorn import run
 
@@ -618,7 +618,7 @@ if __name__ == '__main__':
             raise HTTPException(status_code=500, detail=str(e))
 
     @app.get('/download_files')
-    async def download_file(path: str):
+    def download_file(path: str):
         logger.debug('Downloading files')
         try:
             if not os.path.isabs(path):
@@ -629,23 +629,19 @@ if __name__ == '__main__':
             if not os.path.exists(path):
                 raise HTTPException(status_code=404, detail='File not found')
 
-            with tempfile.TemporaryFile() as temp_zip:
-                with ZipFile(temp_zip, 'w') as zipf:
+            with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_file:
+                with ZipFile(temp_file.name, 'w') as zipf:
                     for root, _, files in os.walk(path):
                         for file in files:
                             file_path = os.path.join(root, file)
                             zipf.write(
                                 file_path, arcname=os.path.relpath(file_path, path)
                             )
-                temp_zip.seek(0)  # Rewind the file to the beginning after writing
-                content = temp_zip.read()
-                # Good for small to medium-sized files. For very large files, streaming directly from the
-                # file chunks may be more memory-efficient.
-                zip_stream = io.BytesIO(content)
-                return StreamingResponse(
-                    content=zip_stream,
+                return FileResponse(
+                    path=temp_file.name,
                     media_type='application/zip',
-                    headers={'Content-Disposition': f'attachment; filename={path}.zip'},
+                    filename=f'{os.path.basename(path)}.zip',
+                    background=BackgroundTask(lambda: os.unlink(temp_file.name)),
                 )
 
         except Exception as e:

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -144,7 +144,9 @@ class ActionExecutionClient(Runtime):
                 stream=True,
                 timeout=30,
             ) as response:
-                with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+                with tempfile.NamedTemporaryFile(
+                    suffix='.zip', delete=False
+                ) as temp_file:
                     shutil.copyfileobj(response.raw, temp_file, length=16 * 1024)
                     return Path(temp_file.name)
         except requests.Timeout:

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 import threading
 from abc import abstractmethod
@@ -144,11 +145,7 @@ class ActionExecutionClient(Runtime):
                 timeout=30,
             ) as response:
                 with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-                    total_length = 0
-                    for chunk in response.iter_content(chunk_size=8192):
-                        if chunk:  # filter out keep-alive new chunks
-                            total_length += len(chunk)
-                            temp_file.write(chunk)
+                    shutil.copyfileobj(response.raw, temp_file, length=16 * 1024)
                     return Path(temp_file.name)
         except requests.Timeout:
             raise TimeoutError('Copy operation timed out')

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -325,7 +325,7 @@ def zip_current_workspace(request: Request, conversation_id: str):
         return FileResponse(
             path=zip_file_path,
             filename='workspace.zip',
-            media_type='application/x-zip-compressed',
+            media_type='application/zip',
             background=BackgroundTask(lambda: os.unlink(zip_file_path)),
         )
     except Exception as e:

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -3,7 +3,6 @@ import tempfile
 
 from fastapi import (
     APIRouter,
-    BackgroundTasks,
     HTTPException,
     Request,
     UploadFile,
@@ -12,6 +11,7 @@ from fastapi import (
 from fastapi.responses import FileResponse, JSONResponse
 from pathspec import PathSpec
 from pathspec.patterns import GitWildMatchPattern
+from starlette.background import BackgroundTask
 
 from openhands.core.exceptions import AgentRuntimeUnavailableError
 from openhands.core.logger import openhands_logger as logger
@@ -309,31 +309,25 @@ async def save_file(request: Request):
 
 
 @app.get('/zip-directory')
-async def zip_current_workspace(
-    request: Request, conversation_id: str, background_tasks: BackgroundTasks
-):
+def zip_current_workspace(request: Request, conversation_id: str):
     try:
         logger.debug('Zipping workspace')
         runtime: Runtime = request.state.conversation.runtime
         path = runtime.config.workspace_mount_path_in_sandbox
         try:
-            zip_file = await call_sync_from_async(runtime.copy_from, path)
+            zip_file_path = runtime.copy_from(path)
         except AgentRuntimeUnavailableError as e:
             logger.error(f'Error zipping workspace: {e}')
             return JSONResponse(
                 status_code=500,
                 content={'error': f'Error zipping workspace: {e}'},
             )
-        response = FileResponse(
-            path=zip_file,
+        return FileResponse(
+            path=zip_file_path,
             filename='workspace.zip',
             media_type='application/x-zip-compressed',
+            background=BackgroundTask(lambda: os.unlink(zip_file_path)),
         )
-
-        # This will execute after the response is sent (So the file is not deleted before being sent)
-        background_tasks.add_task(zip_file.unlink)
-
-        return response
     except Exception as e:
         logger.error(f'Error zipping workspace: {e}')
         raise HTTPException(


### PR DESCRIPTION
A bunch of problems with the whole download workspace:
- inside `action_execution_server` the entire zip operation (compute intensive, blocking IO), and the entire zip file was read back in memory, on the `async def ...` route handler, blocking that fastapi event loop, fix this by running that route as a sync handler, and not reading the file back in-mem, let `FileResponse` handle streaming it back out asynchronously
- in `action_execution_client` theres unnecessary looping of the content stream, just let `shutil.copyfileobj` handle streaming that raw socket out to the temp file
- in `zip_current_workspace` even though its an async handler, it immediately throws the real work onto call_sync_from_async, so might as well just run this route handler entirely on the fastAPI blocking threadpool instead, fix the mimetype of the zip file  to the right standard one
- associate the background unlink directly with the `FileResponse` object, so when it finishes streaming, it will delete the temp file 


Verified by adding a 1GB random incompressible file into the workspace and hitting the `/zip-directory` endpoint to retrieve the zip. The only issue remaining is that the entire workspace zip file has to be fully generated before the download stream begins. Ideally, it would be streaming the zip the entire way through incrementally as files are compressed.