### PR TITLE
Add a sanity test for load_app_config and get_agent_config_arg

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,6 +11,7 @@ from openhands.core.config import (
     finalize_config,
     get_agent_config_arg,
     get_llm_config_arg,
+    load_app_config,
     load_from_env,
     load_from_toml,
 )
@@ -811,3 +812,29 @@ memory_max_threads = 10
     assert not agent_config2.memory_enabled
     assert agent_config2.enable_prompt_extensions
     assert agent_config2.memory_max_threads == 10
+
+
+def test_agent_config_custom_group_name(temp_toml_file):
+    temp_toml = """
+[core]
+max_iterations = 99
+
+[agent.group1]
+memory_enabled = true
+
+[agent.group2]
+memory_enabled = false
+"""
+    with open(temp_toml_file, 'w') as f:
+        f.write(temp_toml)
+
+    # just a sanity check that load app config wouldn't fail
+    app_config = load_app_config(config_file=temp_toml_file)
+    assert app_config.max_iterations == 99
+
+    # run_infer in evaluation can use `get_agent_config_arg` to load custom
+    # agent configs with any group name (not just agent name)
+    agent_config1 = get_agent_config_arg('group1', temp_toml_file)
+    assert agent_config1.memory_enabled
+    agent_config2 = get_agent_config_arg('group2', temp_toml_file)
+    assert not agent_config2.memory_enabled


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Follow-up of https://github.com/All-Hands-AI/OpenHands/pull/6662#discussion_r1949722936

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:04eba26-nikolaik   --name openhands-app-04eba26   docker.all-hands.dev/all-hands-ai/openhands:04eba26
```