### PR TITLE
chore(frontend):  Alternate handling of settings form submissions

### DIFF
--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -102,7 +102,9 @@ function SettingsScreen() {
   const [resetSettingsModalIsOpen, setResetSettingsModalIsOpen] =
     React.useState(false);
 
-  const formAction = async (formData: FormData) => {
+  const formRef = React.useRef<HTMLFormElement>(null);
+
+  const onSubmit = async (formData: FormData) => {
     const languageLabel = formData.get("language-input")?.toString();
     const languageValue = AvailableLanguages.find(
       ({ label }) => label === languageLabel,
@@ -192,21 +194,25 @@ function SettingsScreen() {
   return (
     <main
       data-testid="settings-screen"
-      className="bg-[#24272E] border border-[#454545] h-full rounded-xl"
+      className="bg-[#24272E] border border-[#454545] h-full rounded-xl flex flex-col"
     >
-      <form action={formAction} className="flex flex-col h-full">
-        <header className="px-3 py-1.5 border-b border-b-[#454545] flex items-center gap-2">
-          <SettingsIcon width={16} height={16} />
-          <h1 className="text-sm leading-6">Settings</h1>
-        </header>
+      <header className="px-3 py-1.5 border-b border-b-[#454545] flex items-center gap-2">
+        <SettingsIcon width={16} height={16} />
+        <h1 className="text-sm leading-6">Settings</h1>
+      </header>
 
+      <form
+        ref={formRef}
+        action={onSubmit}
+        className="flex flex-col grow overflow-auto"
+      >
         {isFetching && (
           <div className="flex grow p-4">
             <LoadingSpinner size="large" />
           </div>
         )}
         {!isFetching && settings && (
-          <div className="flex flex-col gap-12 grow overflow-y-auto px-11 py-9">
+          <div className="flex flex-col gap-12 px-11 py-9">
             <section className="flex flex-col gap-6">
               <div className="flex items-center gap-7">
                 <h2 className="text-[28px] leading-8 tracking-[-0.02em] font-bold">
@@ -397,20 +403,26 @@ function SettingsScreen() {
             </section>
           </div>
         )}
-
-        <footer className="flex gap-6 p-6 justify-end border-t border-t-[#454545]">
-          <BrandButton
-            type="button"
-            variant="secondary"
-            onClick={() => setResetSettingsModalIsOpen(true)}
-          >
-            Reset to defaults
-          </BrandButton>
-          <BrandButton type="submit" variant="primary">
-            Save Changes
-          </BrandButton>
-        </footer>
       </form>
+
+      <footer className="flex gap-6 p-6 justify-end border-t border-t-[#454545]">
+        <BrandButton
+          type="button"
+          variant="secondary"
+          onClick={() => setResetSettingsModalIsOpen(true)}
+        >
+          Reset to defaults
+        </BrandButton>
+        <BrandButton
+          type="button"
+          variant="primary"
+          onClick={() => {
+            formRef.current?.requestSubmit();
+          }}
+        >
+          Save Changes
+        </BrandButton>
+      </footer>
 
       {resetSettingsModalIsOpen && (
         <ModalBackdrop>

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -104,7 +104,7 @@ function SettingsScreen() {
 
   const formRef = React.useRef<HTMLFormElement>(null);
 
-  const onSubmit = async (formData: FormData) => {
+  const formAction = async (formData: FormData) => {
     const languageLabel = formData.get("language-input")?.toString();
     const languageValue = AvailableLanguages.find(
       ({ label }) => label === languageLabel,
@@ -203,7 +203,7 @@ function SettingsScreen() {
 
       <form
         ref={formRef}
-        action={onSubmit}
+        action={formAction}
         className="flex flex-col grow overflow-auto"
       >
         {isFetching && (


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
The current way makes it difficult to handle styles since the header and footer are container _within_ the actual form element.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
In order to move them out (for cases when we want to extend styles and add different forms), I have made slight refactors

Unfortunately, the downside is we depend on a litter JavaScript here (for handling the `onClick` for the save button)

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6da1b0f-nikolaik   --name openhands-app-6da1b0f   docker.all-hands.dev/all-hands-ai/openhands:6da1b0f
```