### PR TITLE
switch to use `--rss` to restrict memory use in bash session

### DIFF
--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -192,7 +192,7 @@ class BashSession:
         # otherwise, we are running as the CURRENT USER (e.g., when running LocalRuntime)
         if self.max_memory_mb is not None:
             window_command = (
-                f'prlimit --as={self.max_memory_mb * 1024 * 1024} {_shell_command}'
+                f'prlimit --rss={self.max_memory_mb * 1024 * 1024} {_shell_command}'
             )
         else:
             window_command = _shell_command


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

I start to think maybe we used the wrong arg for the prlimit.

We limit --as address space now instead of --rss  and the difference is:

In a Docker container without swap memory, the distinction between RSS (Resident Set Size) and AS (Address Space) is still important but works a bit differently:

RSS (Resident Set Size):
- Represents the actual physical memory pages being used by the process
- In a no-swap environment, this is the real memory consumption that matters most
- If a process hits its RSS limit in a no-swap environment, it will likely get killed by the OOM (Out Of Memory) killer
- Maps directly to the actual RAM usage you see in `docker stats` or cgroup memory limits

AS (Address Space):
- Represents the virtual memory address space that the process can address
- Even without swap, AS still includes:
  1. Memory-mapped files (like shared libraries)
  2. Anonymous memory (heap allocations)
  3. Shared memory segments
  4. The program's code itself
- A process can have a larger AS than RSS because:
  - Some pages might be shared between processes (like shared libraries)
  - Some pages might be allocated but not yet used (lazy allocation)
  - Some mappings might be to files on disk

Key Practical Difference:
```
In a no-swap environment:
- RSS limit = "How much physical RAM can this process actually use?"
- AS limit = "How much memory can this process potentially address?"
```
When containerizing applications, the RSS limit is typically more important to set and monitor since it directly corresponds to actual resource usage, while AS is more about preventing potential memory mapping abuse or programming errors that could cause excessive virtual memory allocation.

This PR switch to limit RSS as it seems to be more reasonable. We got errors when limiting --as while running "node"


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:643b7f6-nikolaik   --name openhands-app-643b7f6   docker.all-hands.dev/all-hands-ai/openhands:643b7f6
```