### PR TITLE
[Resolver]: Prep env in expectation of release 

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -232,6 +232,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
+          GIT_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
           LLM_MODEL: ${{ secrets.LLM_MODEL || inputs.LLM_MODEL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
@@ -268,6 +269,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
           GITHUB_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
+          GIT_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
           LLM_MODEL: ${{ secrets.LLM_MODEL || inputs.LLM_MODEL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In #6458, we added support for Gitlab to the resolver. This PR also updated the required env `GITHUB_USERNAME` to `GIT_USERNAME` to abstract dealing with both Github/Gitlab in the workflow definition `.github/workflows/openhands-resolver.yml`.

This, however, broke the resolver  as stated in #6718 because the workflow definition was out of sync with released version of the resolver (the released version uses `GITHUB_USERNAME` and has not been updated to use `GIT_USERNAME` yet)

We rolled back the env changes in #6719. 


This PR adds BOTH `GITHUB_USERNAME` and `GIT_USERNAME` in the workflow definition. We're doing this because in the next release, the workflow would be missing `GIT_USERNAME` env and would cause an outage again. 


Note that this PR is so that we don't forget to make these changes. However, we should address #6734 for a long-term fix for such outages

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:43c6a82-nikolaik   --name openhands-app-43c6a82   docker.all-hands.dev/all-hands-ai/openhands:43c6a82
```