### PR TITLE
Add conversation age limit configuration

### DIFF
--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -76,6 +76,7 @@ class AppConfig(BaseModel):
     file_uploads_allowed_extensions: list[str] = Field(default_factory=lambda: ['.*'])
     runloop_api_key: SecretStr | None = Field(default=None)
     cli_multiline_input: bool = Field(default=False)
+    conversation_max_age_seconds: int = Field(default=864000)  # 10 days in seconds
 
     defaults_dict: ClassVar[dict] = {}
 

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -194,7 +194,7 @@ async def search_conversations(
     filtered_results = [
         conversation for conversation in conversation_metadata_result_set.results
         if hasattr(conversation, 'created_at') and 
-        (now - conversation.created_at).total_seconds() <= max_age
+        (now - conversation.created_at.replace(tzinfo=timezone.utc)).total_seconds() <= max_age
     ]
     
     conversation_ids = set(

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -129,8 +129,9 @@ async def _create_new_conversation(
 @app.post('/conversations')
 async def new_conversation(request: Request, data: InitSessionRequest):
     """Initialize a new session or join an existing one.
+
     After successful initialization, the client should connect to the WebSocket
-    using the returned conversation ID
+    using the returned conversation ID.
     """
     logger.info('Initializing new conversation')
     user_id = get_user_id(request)

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -1,10 +1,11 @@
 import json
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from openhands.runtime.impl.docker.docker_runtime import DockerRuntime
 from openhands.server.routes.manage_conversations import (
     delete_conversation,
     get_conversation,
@@ -23,24 +24,24 @@ from openhands.storage.memory import InMemoryFileStore
 def _patch_store():
     file_store = InMemoryFileStore()
     file_store.write(
-        'sessions/some_conversation_id/metadata.json',
+        "sessions/some_conversation_id/metadata.json",
         json.dumps(
             {
-                'title': 'Some Conversation',
-                'selected_repository': 'foobar',
-                'conversation_id': 'some_conversation_id',
-                'github_user_id': '12345',
-                'created_at': '2025-01-01T00:00:00',
-                'last_updated_at': '2025-01-01T00:01:00',
+                "title": "Some Conversation",
+                "selected_repository": "foobar",
+                "conversation_id": "some_conversation_id",
+                "github_user_id": "12345",
+                "created_at": "2025-01-01T00:00:00+00:00",
+                "last_updated_at": "2025-01-01T00:01:00+00:00",
             }
         ),
     )
     with patch(
-        'openhands.storage.conversation.file_conversation_store.get_file_store',
+        "openhands.storage.conversation.file_conversation_store.get_file_store",
         MagicMock(return_value=file_store),
     ):
         with patch(
-            'openhands.server.routes.manage_conversations.conversation_manager.file_store',
+            "openhands.server.routes.manage_conversations.conversation_manager.file_store",
             file_store,
         ):
             yield
@@ -49,37 +50,47 @@ def _patch_store():
 @pytest.mark.asyncio
 async def test_search_conversations():
     with _patch_store():
-        result_set = await search_conversations(
-            MagicMock(state=MagicMock(github_token=''))
-        )
-        expected = ConversationInfoResultSet(
-            results=[
-                ConversationInfo(
-                    conversation_id='some_conversation_id',
-                    title='Some Conversation',
-                    created_at=datetime.fromisoformat('2025-01-01T00:00:00'),
-                    last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00'),
-                    status=ConversationStatus.STOPPED,
-                    selected_repository='foobar',
-                )
-            ]
-        )
-        assert result_set == expected
+        with patch('openhands.server.routes.manage_conversations.config') as mock_config:
+            mock_config.conversation_max_age_seconds = 864000  # 10 days
+            with patch('openhands.server.routes.manage_conversations.conversation_manager') as mock_manager:
+                async def mock_get_running_agent_loops(*args, **kwargs):
+                    return set()
+                mock_manager.get_running_agent_loops = mock_get_running_agent_loops
+                with patch('openhands.server.routes.manage_conversations.datetime') as mock_datetime:
+                    mock_datetime.now.return_value = datetime.fromisoformat("2025-01-01T00:00:00+00:00")
+                    mock_datetime.fromisoformat = datetime.fromisoformat
+                    mock_datetime.timezone = timezone
+                    result_set = await search_conversations(
+                        MagicMock(state=MagicMock(github_token=""))
+                    )
+                    expected = ConversationInfoResultSet(
+                        results=[
+                            ConversationInfo(
+                                conversation_id="some_conversation_id",
+                                title="Some Conversation",
+                                created_at=datetime.fromisoformat("2025-01-01T00:00:00+00:00"),
+                                last_updated_at=datetime.fromisoformat("2025-01-01T00:01:00+00:00"),
+                                status=ConversationStatus.STOPPED,
+                                selected_repository="foobar",
+                            )
+                        ]
+                    )
+                    assert result_set == expected
 
 
 @pytest.mark.asyncio
 async def test_get_conversation():
     with _patch_store():
         conversation = await get_conversation(
-            'some_conversation_id', MagicMock(state=MagicMock(github_token=''))
+            "some_conversation_id", MagicMock(state=MagicMock(github_token=""))
         )
         expected = ConversationInfo(
-            conversation_id='some_conversation_id',
-            title='Some Conversation',
-            created_at=datetime.fromisoformat('2025-01-01T00:00:00'),
-            last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00'),
+            conversation_id="some_conversation_id",
+            title="Some Conversation",
+            created_at=datetime.fromisoformat("2025-01-01T00:00:00+00:00"),
+            last_updated_at=datetime.fromisoformat("2025-01-01T00:01:00+00:00"),
             status=ConversationStatus.STOPPED,
-            selected_repository='foobar',
+            selected_repository="foobar",
         )
         assert conversation == expected
 
@@ -89,7 +100,7 @@ async def test_get_missing_conversation():
     with _patch_store():
         assert (
             await get_conversation(
-                'no_such_conversation', MagicMock(state=MagicMock(github_token=''))
+                "no_such_conversation", MagicMock(state=MagicMock(github_token=""))
             )
             is None
         )
@@ -99,20 +110,20 @@ async def test_get_missing_conversation():
 async def test_update_conversation():
     with _patch_store():
         await update_conversation(
-            MagicMock(state=MagicMock(github_token='')),
-            'some_conversation_id',
-            'New Title',
+            MagicMock(state=MagicMock(github_token="")),
+            "some_conversation_id",
+            "New Title",
         )
         conversation = await get_conversation(
-            'some_conversation_id', MagicMock(state=MagicMock(github_token=''))
+            "some_conversation_id", MagicMock(state=MagicMock(github_token=""))
         )
         expected = ConversationInfo(
-            conversation_id='some_conversation_id',
-            title='New Title',
-            created_at=datetime.fromisoformat('2025-01-01T00:00:00'),
-            last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00'),
+            conversation_id="some_conversation_id",
+            title="New Title",
+            created_at=datetime.fromisoformat("2025-01-01T00:00:00+00:00"),
+            last_updated_at=datetime.fromisoformat("2025-01-01T00:01:00+00:00"),
             status=ConversationStatus.STOPPED,
-            selected_repository='foobar',
+            selected_repository="foobar",
         )
         assert conversation == expected
 
@@ -120,11 +131,12 @@ async def test_update_conversation():
 @pytest.mark.asyncio
 async def test_delete_conversation():
     with _patch_store():
-        await delete_conversation(
-            'some_conversation_id',
-            MagicMock(state=MagicMock(github_token='')),
-        )
-        conversation = await get_conversation(
-            'some_conversation_id', MagicMock(state=MagicMock(github_token=''))
-        )
-        assert conversation is None
+        with patch.object(DockerRuntime, "delete", return_value=None):
+            await delete_conversation(
+                "some_conversation_id",
+                MagicMock(state=MagicMock(github_token="")),
+            )
+            conversation = await get_conversation(
+                "some_conversation_id", MagicMock(state=MagicMock(github_token=""))
+            )
+            assert conversation is None

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -24,24 +24,24 @@ from openhands.storage.memory import InMemoryFileStore
 def _patch_store():
     file_store = InMemoryFileStore()
     file_store.write(
-        "sessions/some_conversation_id/metadata.json",
+        'sessions/some_conversation_id/metadata.json',
         json.dumps(
             {
-                "title": "Some Conversation",
-                "selected_repository": "foobar",
-                "conversation_id": "some_conversation_id",
-                "github_user_id": "12345",
-                "created_at": "2025-01-01T00:00:00+00:00",
-                "last_updated_at": "2025-01-01T00:01:00+00:00",
+                'title': 'Some Conversation',
+                'selected_repository': 'foobar',
+                'conversation_id': 'some_conversation_id',
+                'github_user_id': '12345',
+                'created_at': '2025-01-01T00:00:00+00:00',
+                'last_updated_at': '2025-01-01T00:01:00+00:00',
             }
         ),
     )
     with patch(
-        "openhands.storage.conversation.file_conversation_store.get_file_store",
+        'openhands.storage.conversation.file_conversation_store.get_file_store',
         MagicMock(return_value=file_store),
     ):
         with patch(
-            "openhands.server.routes.manage_conversations.conversation_manager.file_store",
+            'openhands.server.routes.manage_conversations.conversation_manager.file_store',
             file_store,
         ):
             yield
@@ -50,28 +50,42 @@ def _patch_store():
 @pytest.mark.asyncio
 async def test_search_conversations():
     with _patch_store():
-        with patch('openhands.server.routes.manage_conversations.config') as mock_config:
+        with patch(
+            'openhands.server.routes.manage_conversations.config'
+        ) as mock_config:
             mock_config.conversation_max_age_seconds = 864000  # 10 days
-            with patch('openhands.server.routes.manage_conversations.conversation_manager') as mock_manager:
+            with patch(
+                'openhands.server.routes.manage_conversations.conversation_manager'
+            ) as mock_manager:
+
                 async def mock_get_running_agent_loops(*args, **kwargs):
                     return set()
+
                 mock_manager.get_running_agent_loops = mock_get_running_agent_loops
-                with patch('openhands.server.routes.manage_conversations.datetime') as mock_datetime:
-                    mock_datetime.now.return_value = datetime.fromisoformat("2025-01-01T00:00:00+00:00")
+                with patch(
+                    'openhands.server.routes.manage_conversations.datetime'
+                ) as mock_datetime:
+                    mock_datetime.now.return_value = datetime.fromisoformat(
+                        '2025-01-01T00:00:00+00:00'
+                    )
                     mock_datetime.fromisoformat = datetime.fromisoformat
                     mock_datetime.timezone = timezone
                     result_set = await search_conversations(
-                        MagicMock(state=MagicMock(github_token=""))
+                        MagicMock(state=MagicMock(github_token=''))
                     )
                     expected = ConversationInfoResultSet(
                         results=[
                             ConversationInfo(
-                                conversation_id="some_conversation_id",
-                                title="Some Conversation",
-                                created_at=datetime.fromisoformat("2025-01-01T00:00:00+00:00"),
-                                last_updated_at=datetime.fromisoformat("2025-01-01T00:01:00+00:00"),
+                                conversation_id='some_conversation_id',
+                                title='Some Conversation',
+                                created_at=datetime.fromisoformat(
+                                    '2025-01-01T00:00:00+00:00'
+                                ),
+                                last_updated_at=datetime.fromisoformat(
+                                    '2025-01-01T00:01:00+00:00'
+                                ),
                                 status=ConversationStatus.STOPPED,
-                                selected_repository="foobar",
+                                selected_repository='foobar',
                             )
                         ]
                     )
@@ -82,15 +96,15 @@ async def test_search_conversations():
 async def test_get_conversation():
     with _patch_store():
         conversation = await get_conversation(
-            "some_conversation_id", MagicMock(state=MagicMock(github_token=""))
+            'some_conversation_id', MagicMock(state=MagicMock(github_token=''))
         )
         expected = ConversationInfo(
-            conversation_id="some_conversation_id",
-            title="Some Conversation",
-            created_at=datetime.fromisoformat("2025-01-01T00:00:00+00:00"),
-            last_updated_at=datetime.fromisoformat("2025-01-01T00:01:00+00:00"),
+            conversation_id='some_conversation_id',
+            title='Some Conversation',
+            created_at=datetime.fromisoformat('2025-01-01T00:00:00+00:00'),
+            last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00+00:00'),
             status=ConversationStatus.STOPPED,
-            selected_repository="foobar",
+            selected_repository='foobar',
         )
         assert conversation == expected
 
@@ -100,7 +114,7 @@ async def test_get_missing_conversation():
     with _patch_store():
         assert (
             await get_conversation(
-                "no_such_conversation", MagicMock(state=MagicMock(github_token=""))
+                'no_such_conversation', MagicMock(state=MagicMock(github_token=''))
             )
             is None
         )
@@ -110,20 +124,20 @@ async def test_get_missing_conversation():
 async def test_update_conversation():
     with _patch_store():
         await update_conversation(
-            MagicMock(state=MagicMock(github_token="")),
-            "some_conversation_id",
-            "New Title",
+            MagicMock(state=MagicMock(github_token='')),
+            'some_conversation_id',
+            'New Title',
         )
         conversation = await get_conversation(
-            "some_conversation_id", MagicMock(state=MagicMock(github_token=""))
+            'some_conversation_id', MagicMock(state=MagicMock(github_token=''))
         )
         expected = ConversationInfo(
-            conversation_id="some_conversation_id",
-            title="New Title",
-            created_at=datetime.fromisoformat("2025-01-01T00:00:00+00:00"),
-            last_updated_at=datetime.fromisoformat("2025-01-01T00:01:00+00:00"),
+            conversation_id='some_conversation_id',
+            title='New Title',
+            created_at=datetime.fromisoformat('2025-01-01T00:00:00+00:00'),
+            last_updated_at=datetime.fromisoformat('2025-01-01T00:01:00+00:00'),
             status=ConversationStatus.STOPPED,
-            selected_repository="foobar",
+            selected_repository='foobar',
         )
         assert conversation == expected
 
@@ -131,12 +145,12 @@ async def test_update_conversation():
 @pytest.mark.asyncio
 async def test_delete_conversation():
     with _patch_store():
-        with patch.object(DockerRuntime, "delete", return_value=None):
+        with patch.object(DockerRuntime, 'delete', return_value=None):
             await delete_conversation(
-                "some_conversation_id",
-                MagicMock(state=MagicMock(github_token="")),
+                'some_conversation_id',
+                MagicMock(state=MagicMock(github_token='')),
             )
             conversation = await get_conversation(
-                "some_conversation_id", MagicMock(state=MagicMock(github_token=""))
+                'some_conversation_id', MagicMock(state=MagicMock(github_token=''))
             )
             assert conversation is None


### PR DESCRIPTION
This PR adds a new configuration parameter `conversation_max_age_seconds` that defaults to 10 days (864000 seconds). The list conversations endpoint will filter out conversations older than this configured age.

Changes:
1. Added `conversation_max_age_seconds` parameter to `AppConfig` with default value of 10 days
2. Updated `/conversations` endpoint to filter out conversations older than the max age
3. Filtering is done in UTC to avoid timezone issues

Confirmed this is working by manually editing the created_at timestamp

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8a6641a-nikolaik   --name openhands-app-8a6641a   docker.all-hands.dev/all-hands-ai/openhands:8a6641a
```