### PR TITLE
hotfix(Secrets): Add event stream filter for refreshed secret

### DIFF
--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -280,6 +280,9 @@ class EventStream:
         self._queue.put(event)
 
     def set_secrets(self, secrets: dict[str, str]):
+        self.secrets = secrets.copy()
+
+    def update_secrets(self, secrets: dict[str, str]):
         self.secrets.update(secrets)
 
     def _replace_secrets(self, data: dict) -> dict:

--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -280,7 +280,7 @@ class EventStream:
         self._queue.put(event)
 
     def set_secrets(self, secrets: dict[str, str]):
-        self.secrets = secrets.copy()
+        self.secrets.update(secrets)
 
     def _replace_secrets(self, data: dict) -> dict:
         for key in data:

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -225,6 +225,13 @@ class Runtime(FileEditRuntimeMixin):
                         export_cmd = CmdRunAction(
                             f"export GITHUB_TOKEN='{token.get_secret_value()}'"
                         )
+
+                        self.event_stream.set_secrets(
+                            {
+                                'github_token': token.get_secret_value(),
+                            }
+                        )
+
                         await call_sync_from_async(self.run, export_cmd)
 
             observation: Observation = await call_sync_from_async(

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -226,7 +226,7 @@ class Runtime(FileEditRuntimeMixin):
                             f"export GITHUB_TOKEN='{token.get_secret_value()}'"
                         )
 
-                        self.event_stream.set_secrets(
+                        self.event_stream.update_secrets(
                             {
                                 'github_token': token.get_secret_value(),
                             }


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

When the GH token is refreshed, it is possible for it to be leaked in in the event stream. This happens because after we refresh the token we don't add a filter against the new value in the event stream.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f185f73-nikolaik   --name openhands-app-f185f73   docker.all-hands.dev/all-hands-ai/openhands:f185f73
```