### PR TITLE
fix: disable prlimit since limiting --vm breaks nodejs

### DIFF
--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -189,13 +189,15 @@ class BashSession:
         if self.username in ['root', 'openhands']:
             # This starts a non-login (new) shell for the given user
             _shell_command = f'su {self.username} -'
-        # otherwise, we are running as the CURRENT USER (e.g., when running LocalRuntime)
-        if self.max_memory_mb is not None:
-            window_command = (
-                f'prlimit --as={self.max_memory_mb * 1024 * 1024} {_shell_command}'
-            )
-        else:
-            window_command = _shell_command
+
+        # FIXME: we will introduce memory limit using sysbox-runc in coming PR
+        # # otherwise, we are running as the CURRENT USER (e.g., when running LocalRuntime)
+        # if self.max_memory_mb is not None:
+        #     window_command = (
+        #         f'prlimit --as={self.max_memory_mb * 1024 * 1024} {_shell_command}'
+        #     )
+        # else:
+        window_command = _shell_command
 
         logger.debug(f'Initializing bash session with command: {window_command}')
         session_name = f'openhands-{self.username}-{uuid.uuid4()}'

--- a/tests/runtime/test_runtime_resource.py
+++ b/tests/runtime/test_runtime_resource.py
@@ -36,78 +36,78 @@ def test_stress_docker_runtime(temp_dir, runtime_cls, repeat=1):
     _close_test_runtime(runtime)
 
 
-def test_stress_docker_runtime_hit_memory_limits(temp_dir, runtime_cls):
-    """Test runtime behavior under resource constraints."""
-    runtime, config = _load_runtime(
-        temp_dir,
-        runtime_cls,
-        docker_runtime_kwargs={
-            'cpu_period': 100000,  # 100ms
-            'cpu_quota': 100000,  # Can use 100ms out of each 100ms period (1 CPU)
-            'mem_limit': '4G',  # 4 GB of memory
-            'memswap_limit': '0',  # No swap
-            'mem_swappiness': 0,  # Disable swapping
-            'oom_kill_disable': False,  # Enable OOM killer
-        },
-        runtime_startup_env_vars={
-            'RUNTIME_MAX_MEMORY_GB': '3',
-        },
-    )
+# def test_stress_docker_runtime_hit_memory_limits(temp_dir, runtime_cls):
+#     """Test runtime behavior under resource constraints."""
+#     runtime, config = _load_runtime(
+#         temp_dir,
+#         runtime_cls,
+#         docker_runtime_kwargs={
+#             'cpu_period': 100000,  # 100ms
+#             'cpu_quota': 100000,  # Can use 100ms out of each 100ms period (1 CPU)
+#             'mem_limit': '4G',  # 4 GB of memory
+#             'memswap_limit': '0',  # No swap
+#             'mem_swappiness': 0,  # Disable swapping
+#             'oom_kill_disable': False,  # Enable OOM killer
+#         },
+#         runtime_startup_env_vars={
+#             'RUNTIME_MAX_MEMORY_GB': '3',
+#         },
+#     )
 
-    action = CmdRunAction(
-        command='sudo apt-get update && sudo apt-get install -y stress-ng'
-    )
-    logger.info(action, extra={'msg_type': 'ACTION'})
-    obs = runtime.run_action(action)
-    logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert obs.exit_code == 0
+#     action = CmdRunAction(
+#         command='sudo apt-get update && sudo apt-get install -y stress-ng'
+#     )
+#     logger.info(action, extra={'msg_type': 'ACTION'})
+#     obs = runtime.run_action(action)
+#     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
+#     assert obs.exit_code == 0
 
-    action = CmdRunAction(
-        command='stress-ng --vm 1 --vm-bytes 6G --timeout 30s --metrics'
-    )
-    action.set_hard_timeout(120)
-    logger.info(action, extra={'msg_type': 'ACTION'})
-    obs = runtime.run_action(action)
-    logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert 'aborted early, out of system resources' in obs.content
-    assert obs.exit_code == 3  # OOM killed!
+#     action = CmdRunAction(
+#         command='stress-ng --vm 1 --vm-bytes 6G --timeout 30s --metrics'
+#     )
+#     action.set_hard_timeout(120)
+#     logger.info(action, extra={'msg_type': 'ACTION'})
+#     obs = runtime.run_action(action)
+#     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
+#     assert 'aborted early, out of system resources' in obs.content
+#     assert obs.exit_code == 3  # OOM killed!
 
-    _close_test_runtime(runtime)
+#     _close_test_runtime(runtime)
 
 
-def test_stress_docker_runtime_within_memory_limits(temp_dir, runtime_cls):
-    """Test runtime behavior under resource constraints."""
-    runtime, config = _load_runtime(
-        temp_dir,
-        runtime_cls,
-        docker_runtime_kwargs={
-            'cpu_period': 100000,  # 100ms
-            'cpu_quota': 100000,  # Can use 100ms out of each 100ms period (1 CPU)
-            'mem_limit': '4G',  # 4 GB of memory
-            'memswap_limit': '0',  # No swap
-            'mem_swappiness': 0,  # Disable swapping
-            'oom_kill_disable': False,  # Enable OOM killer
-        },
-        runtime_startup_env_vars={
-            'RUNTIME_MAX_MEMORY_GB': '7',
-        },
-    )
+# def test_stress_docker_runtime_within_memory_limits(temp_dir, runtime_cls):
+#     """Test runtime behavior under resource constraints."""
+#     runtime, config = _load_runtime(
+#         temp_dir,
+#         runtime_cls,
+#         docker_runtime_kwargs={
+#             'cpu_period': 100000,  # 100ms
+#             'cpu_quota': 100000,  # Can use 100ms out of each 100ms period (1 CPU)
+#             'mem_limit': '4G',  # 4 GB of memory
+#             'memswap_limit': '0',  # No swap
+#             'mem_swappiness': 0,  # Disable swapping
+#             'oom_kill_disable': False,  # Enable OOM killer
+#         },
+#         runtime_startup_env_vars={
+#             'RUNTIME_MAX_MEMORY_GB': '7',
+#         },
+#     )
 
-    action = CmdRunAction(
-        command='sudo apt-get update && sudo apt-get install -y stress-ng'
-    )
-    logger.info(action, extra={'msg_type': 'ACTION'})
-    obs = runtime.run_action(action)
-    logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert obs.exit_code == 0
+#     action = CmdRunAction(
+#         command='sudo apt-get update && sudo apt-get install -y stress-ng'
+#     )
+#     logger.info(action, extra={'msg_type': 'ACTION'})
+#     obs = runtime.run_action(action)
+#     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
+#     assert obs.exit_code == 0
 
-    action = CmdRunAction(
-        command='stress-ng --vm 1 --vm-bytes 6G --timeout 30s --metrics'
-    )
-    action.set_hard_timeout(120)
-    logger.info(action, extra={'msg_type': 'ACTION'})
-    obs = runtime.run_action(action)
-    logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-    assert obs.exit_code == 0
+#     action = CmdRunAction(
+#         command='stress-ng --vm 1 --vm-bytes 6G --timeout 30s --metrics'
+#     )
+#     action.set_hard_timeout(120)
+#     logger.info(action, extra={'msg_type': 'ACTION'})
+#     obs = runtime.run_action(action)
+#     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
+#     assert obs.exit_code == 0
 
-    _close_test_runtime(runtime)
+#     _close_test_runtime(runtime)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

As discussed here: 
https://github.com/All-Hands-AI/OpenHands/pull/6730

Limiting --vm using prlimit could be a little bit too strict, so we will need to revert this first for the next release.

And we will find better ways to handle these memory limits: https://github.com/All-Hands-AI/OpenHands/pull/6730#issuecomment-2663704217

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7a504d3-nikolaik   --name openhands-app-7a504d3   docker.all-hands.dev/all-hands-ai/openhands:7a504d3
```