### PR TITLE
CSS Fixes

### DIFF
--- a/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
+++ b/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
@@ -22,7 +22,7 @@ export function AccountSettingsContextMenu({
     <ContextMenu
       testId="account-settings-context-menu"
       ref={ref}
-      className="absolute left-full -top-1 z-10"
+      className="absolute right-full md:left-full -top-1 z-10"
     >
       <ContextMenuListItem onClick={onLogout} isDisabled={!isLoggedIn}>
         {t(I18nKey.ACCOUNT_SETTINGS$LOGOUT)}

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -92,7 +92,7 @@ export function Sidebar() {
             <NavLink
               to="/settings"
               className={({ isActive }) =>
-                (isActive ? "text-white" : "text-[#9099AC]") + " mt-0.5 md:mt-0"
+                `${isActive ? "text-white" : "text-[#9099AC]"} mt-0.5 md:mt-0`
               }
             >
               <SettingsButton />

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -71,8 +71,8 @@ export function Sidebar() {
   return (
     <>
       <aside className="h-[40px] md:h-auto px-1 flex flex-row md:flex-col gap-1">
-        <nav className="flex flex-row md:flex-col items-center justify-between h-full">
-          <div className="flex flex-col items-center gap-[26px]">
+        <nav className="flex flex-row md:flex-col items-center justify-between w-full h-auto md:w-auto md:h-full">
+          <div className="flex flex-row md:flex-col items-center gap-[26px]">
             <div className="flex items-center justify-center">
               <AllHandsLogoButton onClick={handleEndSession} />
             </div>
@@ -88,11 +88,11 @@ export function Sidebar() {
             <DocsButton />
           </div>
 
-          <div className="flex flex-col items-center gap-[26px] mb-4">
+          <div className="flex flex-row md:flex-col md:items-center gap-[26px] md:mb-4">
             <NavLink
               to="/settings"
               className={({ isActive }) =>
-                isActive ? "text-white" : "text-[#9099AC]"
+                (isActive ? "text-white" : "text-[#9099AC]") + " mt-0.5 md:mt-0"
               }
             >
               <SettingsButton />

--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -23,7 +23,7 @@ export function ActionButton({
         className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out"
         type="button"
       >
-        <span className="relative z-10 group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">
+        <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">
           {children}
         </span>
         <span className="absolute -inset-[5px] border-2 border-red-400/40 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out" />


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

**Removed the z index on action button icons**
Before:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/88a74da9-e055-473a-b10f-1ce8fdbec32f" />

After:
<img width="344" alt="image" src="https://github.com/user-attachments/assets/77ac058e-8fbc-4638-b573-83e5f2b99c03" />

**Specified Responsive Flex direction**
Before:
<img width="291" alt="image" src="https://github.com/user-attachments/assets/b0f2a806-1ccc-4ace-bc38-473bdc37e195" />

After:
<img width="590" alt="image" src="https://github.com/user-attachments/assets/a4920040-21d4-40a6-8c9c-f123ded8d6f1" />
<img width="317" alt="image" src="https://github.com/user-attachments/assets/b2dba5a6-39f3-4c10-b0dc-e1bb8746e84b" />



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a7fb345-nikolaik   --name openhands-app-a7fb345   docker.all-hands.dev/all-hands-ai/openhands:a7fb345
```