### PR TITLE
hotfix(frontend): Input set/unset state and disable runtime input

### DIFF
--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -76,7 +76,8 @@ describe("Settings Screen", () => {
       });
     });
 
-    it("should render an indicator if the GitHub token is not set", async () => {
+    // TODO: Set a better unset indicator
+    it.skip("should render an indicator if the GitHub token is not set", async () => {
       getSettingsSpy.mockResolvedValue({
         ...MOCK_DEFAULT_USER_SETTINGS,
         github_token_is_set: false,
@@ -94,6 +95,20 @@ describe("Settings Screen", () => {
         } else {
           throw new Error("GitHub token input parent not found");
         }
+      });
+    });
+
+    it("should set asterik placeholder if the GitHub token is set", async () => {
+      getSettingsSpy.mockResolvedValue({
+        ...MOCK_DEFAULT_USER_SETTINGS,
+        github_token_is_set: true,
+      });
+
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        const input = screen.getByTestId("github-token-input");
+        expect(input).toHaveProperty("placeholder", "**********");
       });
     });
 
@@ -314,7 +329,8 @@ describe("Settings Screen", () => {
       // screen.getByTestId("security-analyzer-input");
     });
 
-    it("should render an indicator if the LLM API key is not set", async () => {
+    // TODO: Set a better unset indicator
+    it.skip("should render an indicator if the LLM API key is not set", async () => {
       getSettingsSpy.mockResolvedValueOnce({
         ...MOCK_DEFAULT_USER_SETTINGS,
         llm_api_key: null,
@@ -443,7 +459,22 @@ describe("Settings Screen", () => {
         expect(input).toHaveValue("1x (2 core, 8G)");
       });
 
-      it("should save the runtime settings when the 'Save Changes' button is clicked", async () => {
+      it("should always have the runtime input disabled", async () => {
+        getConfigSpy.mockResolvedValue({
+          APP_MODE: "saas",
+          GITHUB_CLIENT_ID: "123",
+          POSTHOG_CLIENT_KEY: "456",
+        });
+
+        renderSettingsScreen();
+
+        await toggleAdvancedSettings(userEvent.setup());
+
+        const input = await screen.findByTestId("runtime-settings-input");
+        expect(input).toBeDisabled();
+      });
+
+      it.skip("should save the runtime settings when the 'Save Changes' button is clicked", async () => {
         const user = userEvent.setup();
         getConfigSpy.mockResolvedValue({
           APP_MODE: "saas",

--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -75,7 +75,7 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
     }
   };
 
-  const isLLMKeySet = settings.LLM_API_KEY !== "**********";
+  const isLLMKeySet = settings.LLM_API_KEY === "**********";
 
   return (
     <div>
@@ -97,7 +97,7 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
             label="API Key"
             type="password"
             className="w-[680px]"
-            startContent={<KeyStatusIcon isSet={isLLMKeySet} />}
+            startContent={isLLMKeySet && <KeyStatusIcon isSet={isLLMKeySet} />}
           />
 
           <HelpLink

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -257,7 +257,9 @@ function SettingsScreen() {
                 label="API Key"
                 type="password"
                 className="w-[680px]"
-                startContent={<KeyStatusIcon isSet={isLLMKeySet} />}
+                startContent={
+                  isLLMKeySet && <KeyStatusIcon isSet={isLLMKeySet} />
+                }
                 placeholder={isLLMKeySet ? "**********" : ""}
               />
 
@@ -291,6 +293,7 @@ function SettingsScreen() {
                   label="Runtime Settings"
                   items={REMOTE_RUNTIME_OPTIONS}
                   defaultSelectedKey={settings.REMOTE_RUNTIME_RESOURCE_FACTOR?.toString()}
+                  isDisabled
                   isClearable={false}
                 />
               )}
@@ -348,7 +351,12 @@ function SettingsScreen() {
                     label="GitHub Token"
                     type="password"
                     className="w-[680px]"
-                    startContent={<KeyStatusIcon isSet={!!isGitHubTokenSet} />}
+                    startContent={
+                      isGitHubTokenSet && (
+                        <KeyStatusIcon isSet={!!isGitHubTokenSet} />
+                      )
+                    }
+                    placeholder={isGitHubTokenSet ? "**********" : ""}
                   />
 
                   <HelpLink


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- Unset indicator could be confusing (red checkmark)
- Runtime input should not be yet enabled in saas
- Initial settings modal would indicate LLM key was set when it wasnt

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Remove unset indicator - keep green set checkmark
- Fix initial settings modal key state
- Disable runtime input always


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fb9b63a-nikolaik   --name openhands-app-fb9b63a   docker.all-hands.dev/all-hands-ai/openhands:fb9b63a
```