### PR TITLE
hotfix: Conversation panel toggle should change color given state

### DIFF
--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -22,6 +22,7 @@ import { TooltipButton } from "#/components/shared/buttons/tooltip-button";
 import { ConversationPanelWrapper } from "../conversation-panel/conversation-panel-wrapper";
 import { useLogout } from "#/hooks/mutation/use-logout";
 import { useConfig } from "#/hooks/query/use-config";
+import { cn } from "#/utils/utils";
 
 export function Sidebar() {
   const dispatch = useDispatch();
@@ -83,7 +84,12 @@ export function Sidebar() {
               ariaLabel="Conversations"
               onClick={() => setConversationPanelIsOpen((prev) => !prev)}
             >
-              <FaListUl size={22} />
+              <FaListUl
+                size={22}
+                className={cn(
+                  conversationPanelIsOpen ? "text-white" : "text-[#9099AC]",
+                )}
+              />
             </TooltipButton>
             <DocsButton />
           </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/56de580d-7c0e-4612-b897-2e784f23aa51)
![image](https://github.com/user-attachments/assets/ab0bb4cf-92e4-4121-adb4-abf30f564889)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:eb113ab-nikolaik   --name openhands-app-eb113ab   docker.all-hands.dev/all-hands-ai/openhands:eb113ab
```