### PR TITLE
fix(frontend): Hide modal when in settings page if first time

### DIFF
--- a/frontend/__tests__/routes/home.test.tsx
+++ b/frontend/__tests__/routes/home.test.tsx
@@ -89,8 +89,6 @@ describe("Home Screen", () => {
       expect(settingsModal).toBeInTheDocument();
     });
 
-    it.todo("should not be able to close the settings modal");
-
     it("should navigate to the settings screen when clicking the advanced settings button", async () => {
       const error = createAxiosNotFoundErrorObject();
       getSettingsSpy.mockRejectedValue(error);

--- a/frontend/__tests__/routes/home.test.tsx
+++ b/frontend/__tests__/routes/home.test.tsx
@@ -39,11 +39,11 @@ describe("Home Screen", () => {
           Component: Home,
           path: "/",
         },
+        {
+          Component: SettingsScreen,
+          path: "/settings",
+        },
       ],
-    },
-    {
-      Component: SettingsScreen,
-      path: "/settings",
     },
   ]);
 
@@ -89,12 +89,17 @@ describe("Home Screen", () => {
       expect(settingsModal).toBeInTheDocument();
     });
 
+    it.todo("should not be able to close the settings modal");
+
     it("should navigate to the settings screen when clicking the advanced settings button", async () => {
       const error = createAxiosNotFoundErrorObject();
       getSettingsSpy.mockRejectedValue(error);
 
       const user = userEvent.setup();
       renderWithProviders(<RouterStub initialEntries={["/"]} />);
+
+      const settingsScreen = screen.queryByTestId("settings-screen");
+      expect(settingsScreen).not.toBeInTheDocument();
 
       const settingsModal = await screen.findByTestId("ai-config-modal");
       expect(settingsModal).toBeInTheDocument();
@@ -104,11 +109,11 @@ describe("Home Screen", () => {
       );
       await user.click(advancedSettingsButton);
 
+      const settingsScreenAfter = await screen.findByTestId("settings-screen");
+      expect(settingsScreenAfter).toBeInTheDocument();
+
       const settingsModalAfter = screen.queryByTestId("ai-config-modal");
       expect(settingsModalAfter).not.toBeInTheDocument();
-
-      const settingsScreen = await screen.findByTestId("settings-screen");
-      expect(settingsScreen).toBeInTheDocument();
     });
   });
 });

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -904,5 +904,20 @@ describe("Settings Screen", () => {
         expect.objectContaining({ llm_api_key: undefined }),
       );
     });
+
+    it("should submit the LLM API Key if it is the first time the user sets it", async () => {
+      const user = userEvent.setup();
+      renderSettingsScreen();
+
+      const input = await screen.findByTestId("llm-api-key-input");
+      await user.type(input, "new-api-key");
+
+      const saveButton = screen.getByText("Save Changes");
+      await user.click(saveButton);
+
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ llm_api_key: "new-api-key" }),
+      );
+    });
   });
 });

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -665,7 +665,7 @@ describe("Settings Screen", () => {
 
       expect(saveSettingsSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          llm_api_key: undefined,
+          llm_api_key: "", // empty because it's not set previously
           github_token: undefined,
           language: "no",
         }),
@@ -704,7 +704,7 @@ describe("Settings Screen", () => {
       expect(saveSettingsSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           github_token: undefined,
-          llm_api_key: undefined,
+          llm_api_key: "", // empty because it's not set previously
           llm_model: "openai/gpt-4o",
         }),
       );
@@ -867,6 +867,41 @@ describe("Settings Screen", () => {
         expect.objectContaining({
           enable_default_condenser: true,
         }),
+      );
+    });
+
+    it("should send an empty LLM API Key if the user submits an empty string", async () => {
+      const user = userEvent.setup();
+      renderSettingsScreen();
+
+      const input = await screen.findByTestId("llm-api-key-input");
+      expect(input).toHaveValue("");
+
+      const saveButton = screen.getByText("Save Changes");
+      await user.click(saveButton);
+
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ llm_api_key: "" }),
+      );
+    });
+
+    it("should not send an empty LLM API Key if the user submits an empty string but already has it set", async () => {
+      const user = userEvent.setup();
+      getSettingsSpy.mockResolvedValue({
+        ...MOCK_DEFAULT_USER_SETTINGS,
+        llm_api_key: "**********",
+      });
+
+      renderSettingsScreen();
+
+      const input = await screen.findByTestId("llm-api-key-input");
+      expect(input).toHaveValue("");
+
+      const saveButton = screen.getByText("Save Changes");
+      await user.click(saveButton);
+
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ llm_api_key: undefined }),
       );
     });
   });

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -3,7 +3,7 @@ import { FaListUl } from "react-icons/fa";
 import { useDispatch } from "react-redux";
 import posthog from "posthog-js";
 import toast from "react-hot-toast";
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import { useGitHubUser } from "#/hooks/query/use-github-user";
 import { UserActions } from "./user-actions";
 import { AllHandsLogoButton } from "#/components/shared/buttons/all-hands-logo-button";
@@ -24,6 +24,7 @@ import { useLogout } from "#/hooks/mutation/use-logout";
 import { useConfig } from "#/hooks/query/use-config";
 
 export function Sidebar() {
+  const location = useLocation();
   const dispatch = useDispatch();
   const endSession = useEndSession();
   const user = useGitHubUser();
@@ -42,20 +43,27 @@ export function Sidebar() {
     React.useState(false);
 
   React.useEffect(() => {
-    // We don't show toast errors for settings in the global error handler
-    // because we have a special case for 404 errors
-    if (
+    if (location.pathname.startsWith("/settings")) {
+      setSettingsModalIsOpen(false);
+    } else if (
       !isFetchingSettings &&
       settingsIsError &&
       settingsError?.status !== 404
     ) {
+      // We don't show toast errors for settings in the global error handler
+      // because we have a special case for 404 errors
       toast.error(
         "Something went wrong while fetching settings. Please reload the page.",
       );
     } else if (settingsError?.status === 404) {
       setSettingsModalIsOpen(true);
     }
-  }, [settingsError?.status, settingsError, isFetchingSettings]);
+  }, [
+    settingsError?.status,
+    settingsError,
+    isFetchingSettings,
+    location.pathname,
+  ]);
 
   const handleEndSession = () => {
     dispatch(setCurrentAgentState(AgentState.LOADING));

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -43,7 +43,7 @@ export function Sidebar() {
     React.useState(false);
 
   React.useEffect(() => {
-    if (location.pathname.startsWith("/settings")) {
+    if (location.pathname === "/settings") {
       setSettingsModalIsOpen(false);
     } else if (
       !isFetchingSettings &&

--- a/frontend/src/components/shared/modals/settings/settings-modal.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-modal.tsx
@@ -18,7 +18,7 @@ export function SettingsModal({ onClose, settings }: SettingsModalProps) {
   const { t } = useTranslation();
 
   return (
-    <ModalBackdrop onClose={onClose}>
+    <ModalBackdrop>
       <div
         data-testid="ai-config-modal"
         className="bg-root-primary min-w-[384px] p-6 rounded-xl flex flex-col gap-2"

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -131,7 +131,10 @@ function SettingsScreen() {
         user_consents_to_analytics: userConsentsToAnalytics,
         LLM_MODEL: customLlmModel || fullLlmModel,
         LLM_BASE_URL: formData.get("base-url-input")?.toString() || "",
-        LLM_API_KEY: formData.get("llm-api-key-input")?.toString() || undefined,
+        LLM_API_KEY:
+          formData.get("llm-api-key-input")?.toString() || isLLMKeySet
+            ? undefined // don't update if it's already set
+            : "", // reset if it's first time save to avoid 500 error
         AGENT: formData.get("agent-input")?.toString(),
         SECURITY_ANALYZER:
           formData.get("security-analyzer-input")?.toString() || "",

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -132,9 +132,10 @@ function SettingsScreen() {
         LLM_MODEL: customLlmModel || fullLlmModel,
         LLM_BASE_URL: formData.get("base-url-input")?.toString() || "",
         LLM_API_KEY:
-          formData.get("llm-api-key-input")?.toString() || isLLMKeySet
+          formData.get("llm-api-key-input")?.toString() ||
+          (isLLMKeySet
             ? undefined // don't update if it's already set
-            : "", // reset if it's first time save to avoid 500 error
+            : ""), // reset if it's first time save to avoid 500 error
         AGENT: formData.get("agent-input")?.toString(),
         SECURITY_ANALYZER:
           formData.get("security-analyzer-input")?.toString() || "",


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
- If the user sees the first-time settings modal and clicks advanced; they redirect to /settings but the modal doesnt close
- User can close modal by clicking backdrop

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
- Close modal if in /settings. but show it again if otherwise and the settings still isnt set
- Dont close modal on backdrop click


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:de0dc84-nikolaik   --name openhands-app-de0dc84   docker.all-hands.dev/all-hands-ai/openhands:de0dc84
```