### PR TITLE
hotfix azure

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -102,3 +102,9 @@ class LLMConfig(BaseModel):
             os.environ['OR_SITE_URL'] = self.openrouter_site_url
         if self.openrouter_app_name:
             os.environ['OR_APP_NAME'] = self.openrouter_app_name
+
+        # Assign an API version for Azure models
+        # While it doesn't seem required, the format supported by the API without version seems old and will likely break.
+        # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/6777
+        if self.model.startswith('azure') and self.api_version is None:
+            self.api_version = '2024-02-15-preview'

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -107,4 +107,4 @@ class LLMConfig(BaseModel):
         # While it doesn't seem required, the format supported by the API without version seems old and will likely break.
         # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/6777
         if self.model.startswith('azure') and self.api_version is None:
-            self.api_version = '2024-02-15-preview'
+            self.api_version = '2024-08-01-preview'

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -146,6 +146,7 @@ class LLM(RetryMixin, DebugMixin):
             )  # temperature is not supported for reasoning models
         # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/6777
         if self.config.model.startswith('azure'):
+            kwargs['max_tokens'] = self.config.max_output_tokens
             kwargs.pop('max_completion_tokens')
 
         self._completion = partial(

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -134,7 +134,6 @@ class LLM(RetryMixin, DebugMixin):
         # set up the completion function
         kwargs: dict[str, Any] = {
             'temperature': self.config.temperature,
-            'max_completion_tokens': self.config.max_output_tokens,
         }
         if (
             self.config.model.lower() in REASONING_EFFORT_SUPPORTED_MODELS
@@ -144,9 +143,6 @@ class LLM(RetryMixin, DebugMixin):
             kwargs.pop(
                 'temperature'
             )  # temperature is not supported for reasoning models
-        # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/6777
-        if self.config.model.startswith('azure'):
-            kwargs.pop('max_completion_tokens')
 
         self._completion = partial(
             litellm_completion,
@@ -157,6 +153,7 @@ class LLM(RetryMixin, DebugMixin):
             base_url=self.config.base_url,
             api_version=self.config.api_version,
             custom_llm_provider=self.config.custom_llm_provider,
+            max_completion_tokens=self.config.max_output_tokens,
             timeout=self.config.timeout,
             top_p=self.config.top_p,
             drop_params=self.config.drop_params,

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -146,7 +146,6 @@ class LLM(RetryMixin, DebugMixin):
             )  # temperature is not supported for reasoning models
         # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/6777
         if self.config.model.startswith('azure'):
-            kwargs['max_tokens'] = self.config.max_output_tokens
             kwargs.pop('max_completion_tokens')
 
         self._completion = partial(

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -134,6 +134,7 @@ class LLM(RetryMixin, DebugMixin):
         # set up the completion function
         kwargs: dict[str, Any] = {
             'temperature': self.config.temperature,
+            'max_completion_tokens': self.config.max_output_tokens,
         }
         if (
             self.config.model.lower() in REASONING_EFFORT_SUPPORTED_MODELS
@@ -143,6 +144,9 @@ class LLM(RetryMixin, DebugMixin):
             kwargs.pop(
                 'temperature'
             )  # temperature is not supported for reasoning models
+        # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/6777
+        if self.config.model.startswith('azure'):
+            kwargs.pop('max_completion_tokens')
 
         self._completion = partial(
             litellm_completion,
@@ -153,7 +157,6 @@ class LLM(RetryMixin, DebugMixin):
             base_url=self.config.base_url,
             api_version=self.config.api_version,
             custom_llm_provider=self.config.custom_llm_provider,
-            max_completion_tokens=self.config.max_output_tokens,
             timeout=self.config.timeout,
             top_p=self.config.top_p,
             drop_params=self.config.drop_params,


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
Fix error on Azure for unsupported `max_completion_tokens`

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We have a bug report on `max_completion_tokens` on Azure with GPT-4o : apparently litellm has it in its [supported](https://github.com/BerriAI/litellm/blob/d1ba04d9d96aff43dfa303137ac06c7641ce9082/litellm/llms/azure/chat/gpt_transformation.py#L83) list, but the Azure error is complaining about it:
```
    raise BadRequestError(
litellm.exceptions.BadRequestError: litellm.BadRequestError: AzureException BadRequestError - Error code: 400 - {'error': {'message': 'Unrecognized request argument supplied: max_completion_tokens', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```

---

**Link of any specific issues this addresses**
Fix https://github.com/All-Hands-AI/OpenHands/issues/6777

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1ea1703-nikolaik   --name openhands-app-1ea1703   docker.all-hands.dev/all-hands-ai/openhands:1ea1703
```