### PR TITLE
Add type annotations to server directory files

### DIFF
--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -1,5 +1,6 @@
 import warnings
 from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
@@ -25,7 +26,7 @@ from openhands.server.shared import conversation_manager
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI):
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with conversation_manager:
         yield
 
@@ -39,7 +40,7 @@ app = FastAPI(
 
 
 @app.get('/health')
-async def health():
+async def health() -> str:
     return 'OK'
 
 

--- a/openhands/server/routes/security.py
+++ b/openhands/server/routes/security.py
@@ -1,3 +1,4 @@
+from typing import Any
 from fastapi import (
     APIRouter,
     HTTPException,
@@ -8,7 +9,7 @@ app = APIRouter(prefix='/api/conversations/{conversation_id}')
 
 
 @app.route('/security/{path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-async def security_api(request: Request):
+async def security_api(request: Request) -> dict[str, Any]:
     """Catch-all route for security analyzer API requests.
 
     Each request is handled directly to the security analyzer.
@@ -17,7 +18,7 @@ async def security_api(request: Request):
         request (Request): The incoming FastAPI request object.
 
     Returns:
-        Any: The response from the security analyzer.
+        dict[str, Any]: The response from the security analyzer.
 
     Raises:
         HTTPException: If the security analyzer is not initialized.
@@ -25,6 +26,9 @@ async def security_api(request: Request):
     if not request.state.conversation.security_analyzer:
         raise HTTPException(status_code=404, detail='Security analyzer not initialized')
 
-    return await request.state.conversation.security_analyzer.handle_api_request(
+    response = await request.state.conversation.security_analyzer.handle_api_request(
         request
     )
+    if not isinstance(response, dict):
+        raise HTTPException(status_code=500, detail='Invalid response from security analyzer')
+    return response

--- a/openhands/server/static.py
+++ b/openhands/server/static.py
@@ -1,10 +1,13 @@
 from typing import Any, MutableMapping
+
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import Response
 
 
 class SPAStaticFiles(StaticFiles):
-    async def get_response(self, path: str, scope: MutableMapping[str, Any]) -> Response:
+    async def get_response(
+        self, path: str, scope: MutableMapping[str, Any]
+    ) -> Response:
         try:
             return await super().get_response(path, scope)
         except Exception:

--- a/openhands/server/static.py
+++ b/openhands/server/static.py
@@ -1,8 +1,10 @@
+from typing import Any, MutableMapping
 from fastapi.staticfiles import StaticFiles
+from starlette.responses import Response
 
 
 class SPAStaticFiles(StaticFiles):
-    async def get_response(self, path: str, scope):
+    async def get_response(self, path: str, scope: MutableMapping[str, Any]) -> Response:
         try:
             return await super().get_response(path, scope)
         except Exception:


### PR DESCRIPTION
Add proper type annotations to files in the server directory to fix mypy strict type checking issues.

Changes:
- Added proper type hints for `get_response` method in `static.py`
- Added proper type hints for `security_api` function in `security.py`
- Added runtime type checking for security analyzer response
- Added missing imports for typing

Part of #6397 

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c5f5a42-nikolaik   --name openhands-app-c5f5a42   docker.all-hands.dev/all-hands-ai/openhands:c5f5a42
```