### PR TITLE
fix: LLM summarization prompt handles user messages

### DIFF
--- a/openhands/memory/condenser/impl/llm_summarizing_condenser.py
+++ b/openhands/memory/condenser/impl/llm_summarizing_condenser.py
@@ -57,22 +57,29 @@ class LLMSummarizingCondenser(RollingCondenser):
         # Construct prompt for summarization
         prompt = """You are maintaining state history for an LLM-based code agent. Track:
 
+USER_CONTEXT: (Preserve full user messages, requirements, and problem context verbatim - no length limit or structure requirements)
+
 STATE: {File paths, function signatures, data structures}
 TESTS: {Failing cases, error messages, outputs}
 CHANGES: {Code edits, variable updates}
 DEPS: {Dependencies, imports, external calls}
 INTENT: {Why changes were made, acceptance criteria}
 
-SKIP: {Git clones, build logs}
-SUMMARIZE: {File listings}
-MAX_LENGTH: Keep summaries under 1000 words
+PRIORITIZE:
+1. Preserve complete user context and messages
+2. Track implementation state and results
+3. Keep technical details concise
+
+SKIP: {Git clones, build logs, file listings}
 
 Example history format:
+USER_CONTEXT: User reported that FITS card float values have unnecessary precision causing comment truncation. They provided example showing "0.009125" being expanded to "0.009124999999999999". User requested using Python's default str() representation when possible. Later clarified that FITS standard compliance must be maintained.
+
 STATE: mod_float() in card.py updated
 TESTS: test_format() passed
 CHANGES: str(val) replaces f"{val:.16G}"
 DEPS: None modified
-INTENT: Fix float precision overflow"""
+INTENT: Fix precision while maintaining FITS compliance"""
 
         prompt + '\n\n'
 

--- a/openhands/memory/condenser/impl/llm_summarizing_condenser.py
+++ b/openhands/memory/condenser/impl/llm_summarizing_condenser.py
@@ -57,7 +57,7 @@ class LLMSummarizingCondenser(RollingCondenser):
         # Construct prompt for summarization
         prompt = """You are maintaining state history for an LLM-based code agent. Track:
 
-USER_CONTEXT: (Preserve full user messages, requirements, and problem context verbatim - no length limit or structure requirements)
+USER_CONTEXT: (Preserve essential user requirements, problem descriptions, and clarifications in concise form)
 
 STATE: {File paths, function signatures, data structures}
 TESTS: {Failing cases, error messages, outputs}
@@ -66,14 +66,14 @@ DEPS: {Dependencies, imports, external calls}
 INTENT: {Why changes were made, acceptance criteria}
 
 PRIORITIZE:
-1. Preserve complete user context and messages
-2. Track implementation state and results
-3. Keep technical details concise
+1. Capture key user requirements and constraints
+2. Maintain critical problem context
+3. Keep all sections concise
 
 SKIP: {Git clones, build logs, file listings}
 
 Example history format:
-USER_CONTEXT: User reported that FITS card float values have unnecessary precision causing comment truncation. They provided example showing "0.009125" being expanded to "0.009124999999999999". User requested using Python's default str() representation when possible. Later clarified that FITS standard compliance must be maintained.
+USER_CONTEXT: Fix FITS card float representation - "0.009125" becomes "0.009124999999999999" causing comment truncation. Use Python's str() when possible while maintaining FITS compliance.
 
 STATE: mod_float() in card.py updated
 TESTS: test_format() passed


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

There's anecdotal evidence that the current summarization prompt does a poor job of summarizing user messages. This updated prompt seems to perform better (but we don't have any good benchmarks involving lots of user messages), and shows no performance degradation over SWE-bench.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Link of any specific issues this addresses**
