### PR TITLE
Fix for issue Runtime Errors in Action Execution result in an Unrecoverable Conversation

### DIFF
--- a/openhands/core/message_utils.py
+++ b/openhands/core/message_utils.py
@@ -358,10 +358,11 @@ def apply_prompt_caching(messages: list[Message]) -> None:
     breakpoints_remaining = 3  # remaining 1 for system/tool
     for message in reversed(messages):
         if message.role in ('user', 'tool'):
-            if breakpoints_remaining > 0:
-                message.content[
-                    -1
-                ].cache_prompt = True  # Last item inside the message content
-                breakpoints_remaining -= 1
-            else:
-                break
+            if message.tool_call_id:
+                continue
+            message.content[
+                -1
+            ].cache_prompt = True  # Last item inside the message content
+            breakpoints_remaining -= 1
+            if not breakpoints_remaining:
+                return


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Before this change, if the runtime went offline during a tool call, the system would enter an unrecoverable state where accessing the LLM would fail. (At least with Anthropic). The major change here is that we no longer consider tool call responses (Which may be errors) as cacheable.

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Fixed an issue where the AI assistant could fail after recovering from a previous error, making the system more resilient and stable.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR modifies the prompt caching logic in `message_utils.py` to:
1. Skip tool call messages when applying prompt caching breakpoints
2. Continue processing messages even after finding a breakpoint, ensuring we don't miss important context
3. Use an early return when we've used all breakpoints for better code clarity

**Steps to Reproduce Error**

I have only been able to reproduce this with the remote runtime.

1. Create a new conversation with the prompt: `I'm going to be testing the environment in which you run bash scripts.  Please execute a bash script that prints "Hello World"`
2. Once the prompt completes, stop the runtime using the runtime API. e.g.:
```
curl -X POST https://runtime.staging.all-hands.dev/stop \
-H "X-API-Key: ******" \
-H "Content-Type: application/json" \
--data-binary @- << EOF
{
  "runtime_id": "olynpucajoqyxrzk"
}
EOF
```
3. Prompt the agent again with `Please execute the same script again. I've stopped the bash environment so it should throw an error this time`. This will indeed yield an error telling you to refresh the page. *NOTE: Currently refreshing the page does not clear this error (I have a separate PR in progress for that.). Right now you need to go back to the splash screen and wait for the Conversation to end (15 seconds by default).*
4. Re-enter the conversation and prompt it with: `Please execute the same script again. I've restarted the bash environment so it should no longer throw an error`. You should see a message like this, and the conversation is unrecoverable:
![image](https://github.com/user-attachments/assets/51146771-5b53-4469-808f-25d9500eb88b)

Behind the scenes, you get a stack trace like this:
```
09:56:31 - openhands:ERROR: agent_controller.py:240 - [Agent Controller aca8cbb8acb94687ae53d4302bf502ef] Error while running the agent (session ID: aca8cbb8acb94687ae53d4302bf502ef): litellm.InternalServerError: AnthropicException - {"error":{"message":"litellm.APIConnectionError: BedrockException - {"message":"You do not have access to explicit prompt caching"}\nReceived Model Group=claude-3-5-sonnet-20241022\nAvailable Model Group Fallbacks=['anthropic/claude-3-5-sonnet-20241022']\nError doing the fallback: litellm.BadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"messages.26: Did not find 1 tool_result block(s) at the beginning of this message. Messages following tool_use blocks must begin with a matching number of tool_result blocks."}}\nReceived Model Group=anthropic/claude-3-5-sonnet-20241022\nAvailable Model Group Fallbacks=['anthropic/claude-3-5-sonnet-20241022']\nError doing the fallback: litellm.BadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"messages.26: Did not find 1 tool_result block(s) at the beginning of this message. Messages following tool_use blocks must begin with a matching number of tool_result blocks."}} LiteLLM Retried: 2 times, LiteLLM Max Retries: 3 LiteLLM Retried: 2 times, LiteLLM Max Retries: 3","type":null,"param":null,"code":"500"}}. Handle with litellm.InternalServerError.. Traceback: Traceback (most recent call last):

File "/app/.venv/lib/python3.12/site-packages/litellm/llms/anthropic/chat/handler.py", line 412, in completion

response = client.post(

^^^^^^^^^^^^

File "/app/.venv/lib/python3.12/site-packages/litellm/llms/custom_httpx/http_handler.py", line 557, in post

raise e

File "/app/.venv/lib/python3.12/site-packages/litellm/llms/custom_httpx/http_handler.py", line 538, in post

response.raise_for_status()

File "/app/.venv/lib/python3.12/site-packages/httpx/_models.py", line 829, in raise_for_status

raise HTTPStatusError(message, request=request, response=self)

httpx.HTTPStatusError: Server error '500 Internal Server Error' for url 'https://llm-proxy.staging.all-hands.dev/v1/messages'

For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500

During handling of the above exception, another exception occurred:

Traceback (most recent call last):

File "/app/.venv/lib/python3.12/site-packages/litellm/main.py", line 1878, in completion

response = anthropic_chat_completions.completion(

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/app/.venv/lib/python3.12/site-packages/litellm/llms/anthropic/chat/handler.py", line 427, in completion

raise AnthropicError(

litellm.llms.anthropic.common_utils.AnthropicError: {"error":{"message":"litellm.APIConnectionError: BedrockException - {"message":"You do not have access to explicit prompt caching"}\nReceived Model Group=claude-3-5-sonnet-20241022\nAvailable Model Group Fallbacks=['anthropic/claude-3-5-sonnet-20241022']\nError doing the fallback: litellm.BadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"messages.26: Did not find 1 tool_result block(s) at the beginning of this message. Messages following tool_use blocks must begin with a matching number of tool_result blocks."}}\nReceived Model Group=anthropic/claude-3-5-sonnet-20241022\nAvailable Model Group Fallbacks=['anthropic/claude-3-5-sonnet-20241022']\nError doing the fallback: litellm.BadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"messages.26: Did not find 1 tool_result block(s) at the beginning of this message. Messages following tool_use blocks must begin with a matching number of tool_result blocks."}} LiteLLM Retried: 2 times, LiteLLM Max Retries: 3 LiteLLM Retried: 2 times, LiteLLM Max Retries: 3","type":null,"param":null,"code":"500"}}
```

---
**Link of any specific issues this addresses**

This addresses the error recovery stability issues reported in production environments.
