### PR TITLE
Fix: Less squashed logo

### DIFF
--- a/frontend/src/components/shared/buttons/all-hands-logo-button.tsx
+++ b/frontend/src/components/shared/buttons/all-hands-logo-button.tsx
@@ -12,7 +12,7 @@ export function AllHandsLogoButton({ onClick }: AllHandsLogoButtonProps) {
       ariaLabel="All Hands Logo"
       onClick={onClick}
     >
-      <AllHandsLogo width={34} height={23} />
+      <AllHandsLogo width={34} height={34} />
     </TooltipButton>
   );
 }


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Made the logo square improving the visuals slightly.

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
This has been annoying me every time I click on the menu. Making this button square like the rest means it looks less squashed.

Before:
![image](https://github.com/user-attachments/assets/5d171253-91b7-411c-a4d2-6e837befa2a3)

After:
![image](https://github.com/user-attachments/assets/f429667f-e1bf-430b-9e52-a0b3242a73d8)


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:768a46e-nikolaik   --name openhands-app-768a46e   docker.all-hands.dev/all-hands-ai/openhands:768a46e
```