### PR TITLE
[Bug]: Fix workflow definition for installation phase of resolver

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -88,12 +88,10 @@ jobs:
         run: |
           python -m pip index versions openhands-ai > openhands_versions.txt
           OPENHANDS_VERSION=$(head -n 1 openhands_versions.txt | awk '{print $2}' | tr -d '()')
-          # Ensure requirements.txt ends with newline before appending
-          if [ -f requirements.txt ] && [ -s requirements.txt ]; then
-            sed -i -e '$a\' requirements.txt
-          fi
-          echo "openhands-ai==${OPENHANDS_VERSION}" >> requirements.txt
-          cat requirements.txt
+
+          # Create a new requirements.txt locally within the workflow, ensuring no reference to the repo's file
+          echo "openhands-ai==${OPENHANDS_VERSION}" > /tmp/requirements.txt
+          cat /tmp/requirements.txt
 
       - name: Cache pip dependencies
         if: |
@@ -111,9 +109,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}/lib/python3.12/site-packages/*
-          key: ${{ runner.os }}-pip-openhands-resolver-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-pip-openhands-resolver-${{ hashFiles('/tmp/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-openhands-resolver-${{ hashFiles('requirements.txt') }}
+            ${{ runner.os }}-pip-openhands-resolver-${{ hashFiles('/tmp/requirements.txt') }}
 
       - name: Check required environment variables
         env:
@@ -225,7 +223,7 @@ jobs:
             } else {
               console.log("Installing from requirements.txt...");
               await exec.exec("python -m pip install --upgrade pip");
-              await exec.exec("pip install -r requirements.txt");
+              await exec.exec("pip install -r /tmp/requirements.txt");
             }
 
       - name: Attempt to resolve issue


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR changes all references of `requirements.txt` to `/tmp/requirements.txt`. This ensures that we're using a `requirements.txt` file that is local to the workflow and is not shared with the `requirements.txt` in the user's root level repo.


Context for why we would want to do this is included in #6859

---
**Link of any specific issues this addresses**
#6859

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7b1e282-nikolaik   --name openhands-app-7b1e282   docker.all-hands.dev/all-hands-ai/openhands:7b1e282
```