### PR TITLE
Add process termination to stop button functionality

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -472,6 +472,9 @@ class AgentController:
             # sync existing metrics BEFORE resetting the agent
             await self.update_state_after_step()
             self.state.metrics.merge(self.state.local_metrics)
+            if new_state == AgentState.STOPPED:
+                # Terminate processes through runtime
+                await self.runtime.terminate_processes()
             self._reset()
         elif (
             new_state == AgentState.RUNNING

--- a/tests/unit/test_local_runtime.py
+++ b/tests/unit/test_local_runtime.py
@@ -1,0 +1,114 @@
+import asyncio
+import os
+import signal
+import subprocess
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from openhands.core.config import AppConfig
+from openhands.events import EventStream
+from openhands.runtime.impl.local.local_runtime import LocalRuntime
+from openhands.storage.memory import InMemoryFileStore
+
+
+@pytest.fixture
+def config():
+    return AppConfig()
+
+
+@pytest.fixture
+def event_stream():
+    return EventStream("test", file_store=InMemoryFileStore({}))
+
+
+@pytest.fixture
+def local_runtime(config, event_stream):
+    runtime = LocalRuntime(config, event_stream)
+    yield runtime
+    runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_processes_graceful(local_runtime):
+    # Start a process that handles SIGTERM gracefully
+    process = subprocess.Popen([
+        "python3", "-c",
+        "import signal, time; signal.signal(signal.SIGTERM, lambda s,f: exit(0)); time.sleep(10)"
+    ])
+    
+    # Wait for process to start
+    await asyncio.sleep(0.1)
+    
+    start = time.time()
+    await local_runtime.terminate_processes()
+    duration = time.time() - start
+    
+    assert process.poll() is not None  # Process terminated
+    assert duration < 1  # Should terminate quickly
+    assert process.returncode == 0  # Graceful termination
+
+
+@pytest.mark.asyncio
+async def test_terminate_processes_force(local_runtime):
+    # Start a process that ignores SIGTERM
+    process = subprocess.Popen([
+        "python3", "-c",
+        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(10)"
+    ])
+    
+    # Wait for process to start
+    await asyncio.sleep(0.1)
+    
+    start = time.time()
+    await local_runtime.terminate_processes()
+    duration = time.time() - start
+    
+    assert process.poll() is not None  # Process terminated
+    assert duration < 1  # Should not wait full timeout
+    assert process.returncode != 0  # Force killed
+
+
+@pytest.mark.asyncio
+async def test_terminate_processes_nested(local_runtime):
+    # Start a parent process that spawns a child process
+    parent = subprocess.Popen([
+        "python3", "-c",
+        """
+import subprocess, signal, time
+child = subprocess.Popen(['python3', '-c', 'import time; time.sleep(20)'])
+signal.signal(signal.SIGTERM, lambda s,f: exit(0))
+time.sleep(10)
+        """
+    ])
+    
+    # Wait for processes to start
+    await asyncio.sleep(0.1)
+    
+    # Get child process
+    ps_output = subprocess.check_output(['ps', '--ppid', str(parent.pid), '-o', 'pid', '--no-headers']).decode()
+    child_pid = int(ps_output.strip())
+    
+    await local_runtime.terminate_processes()
+    
+    assert parent.poll() is not None  # Parent terminated
+    assert not os.path.exists(f'/proc/{child_pid}')  # Child terminated
+
+
+@pytest.mark.asyncio
+async def test_terminate_processes_concurrent(local_runtime):
+    # Start multiple processes
+    processes = [
+        subprocess.Popen(["python3", "-c", "import time; time.sleep(10)"])
+        for _ in range(5)
+    ]
+    
+    # Wait for processes to start
+    await asyncio.sleep(0.1)
+    
+    await local_runtime.terminate_processes()
+    
+    # All processes should be terminated
+    for p in processes:
+        assert p.poll() is not None


### PR DESCRIPTION
This PR adds process termination functionality to the stop button. When the stop button is clicked:

1. The agent state is changed to `STOPPED`
2. The runtime terminates all processes in its environment:
   - LocalRuntime: Uses `ps` and `kill` to manage local processes
   - DockerRuntime: Uses `pkill` inside the container
   - ModalRuntime: Uses sandbox termination
   - RemoteRuntime: Uses API calls

Each runtime handles process termination in a way appropriate to its environment, with graceful termination (SIGTERM) followed by force kill (SIGKILL) if needed.

Tested with:
- Processes that handle SIGTERM gracefully
- Processes that ignore SIGTERM
- Nested processes (parent/child)
- Multiple concurrent processes

Fixes #6848

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:411cfa9-nikolaik   --name openhands-app-411cfa9   docker.all-hands.dev/all-hands-ai/openhands:411cfa9
```