### PR TITLE
[Resolver]: Add Git LFS and clone depth support

### DIFF
--- a/tests/unit/test_git_lfs.py
+++ b/tests/unit/test_git_lfs.py
@@ -1,0 +1,91 @@
+import os
+import subprocess
+import tempfile
+from unittest import mock
+
+import pytest
+
+from openhands.resolver.resolve_issue import resolve_issue
+from openhands.resolver.utils import Platform
+
+
+@pytest.mark.asyncio
+async def test_git_lfs_skip_smudge():
+    # Create a temporary directory for the test
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Mock environment variables
+        with mock.patch.dict(os.environ, {'GIT_LFS_SKIP_SMUDGE': '1'}):
+            # Mock subprocess.check_output to verify git config is called
+            with mock.patch('subprocess.check_output') as mock_check_output:
+                # Mock issue handler
+                mock_handler = mock.MagicMock()
+                mock_handler.get_clone_url.return_value = 'https://github.com/test/repo.git'
+                mock_handler.get_converted_issues.return_value = [mock.MagicMock()]
+
+                # Mock issue_handler_factory to return our mock handler
+                with mock.patch('openhands.resolver.resolve_issue.issue_handler_factory', return_value=mock_handler):
+                    # Call resolve_issue with test parameters
+                    await resolve_issue(
+                        owner='test',
+                        repo='repo',
+                        token='token',
+                        username='username',
+                        platform=Platform.GITHUB,
+                        max_iterations=1,
+                        output_dir=temp_dir,
+                        llm_config=mock.MagicMock(),
+                        runtime_container_image=None,
+                        prompt_template='',
+                        issue_type='issue',
+                        repo_instruction=None,
+                        issue_number=1,
+                        comment_id=None,
+                    )
+
+                    # Verify git config was called with correct parameters
+                    mock_check_output.assert_any_call(['git', 'config', '--global', 'filter.lfs.smudge', 'git-lfs smudge --skip'])
+                    mock_check_output.assert_any_call(['git', 'config', '--global', 'filter.lfs.process', 'git-lfs filter-process --skip'])
+
+
+@pytest.mark.asyncio
+async def test_git_clone_depth():
+    # Create a temporary directory for the test
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Mock environment variables
+        with mock.patch.dict(os.environ, {'GIT_CLONE_DEPTH': '1'}):
+            # Mock subprocess.check_output to verify git clone is called with --depth
+            with mock.patch('subprocess.check_output') as mock_check_output:
+                # Mock issue handler
+                mock_handler = mock.MagicMock()
+                mock_handler.get_clone_url.return_value = 'https://github.com/test/repo.git'
+                mock_handler.get_converted_issues.return_value = [mock.MagicMock()]
+
+                # Mock issue_handler_factory to return our mock handler
+                with mock.patch('openhands.resolver.resolve_issue.issue_handler_factory', return_value=mock_handler):
+                    # Call resolve_issue with test parameters
+                    await resolve_issue(
+                        owner='test',
+                        repo='repo',
+                        token='token',
+                        username='username',
+                        platform=Platform.GITHUB,
+                        max_iterations=1,
+                        output_dir=temp_dir,
+                        llm_config=mock.MagicMock(),
+                        runtime_container_image=None,
+                        prompt_template='',
+                        issue_type='issue',
+                        repo_instruction=None,
+                        issue_number=1,
+                        comment_id=None,
+                    )
+
+                    # Verify git clone was called with --depth
+                    mock_check_output.assert_any_call([
+                        'git',
+                        'clone',
+                        '--depth',
+                        '1',
+                        'https://github.com/test/repo.git',
+                        f'{temp_dir}/repo',
+                    ])


### PR DESCRIPTION
Fixes #6156

This PR adds support for:
1. Skipping Git LFS files during clone by setting `GIT_LFS_SKIP_SMUDGE=1`
2. Shallow cloning by setting `GIT_CLONE_DEPTH=N` where N is the desired depth

The changes:
- Add Git LFS configuration before cloning when `GIT_LFS_SKIP_SMUDGE=1` is set
- Add `--depth` parameter to git clone when `GIT_CLONE_DEPTH` is set
- Add unit tests to verify both features work correctly

Example workflow file:
```yaml
env:
  GIT_LFS_SKIP_SMUDGE: '1'
  GIT_CLONE_DEPTH: '1'
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:164fab0-nikolaik   --name openhands-app-164fab0   docker.all-hands.dev/all-hands-ai/openhands:164fab0
```