### PR TITLE
Fix: Increase Entropy Requirement for Secret Redaction to Reduce False Positives

### DIFF
--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -221,8 +221,10 @@ class SensitiveDataFilter(logging.Filter):
         sensitive_values = []
         for key, value in os.environ.items():
             key_upper = key.upper()
-            if len(value) >= 8 and any(
-                s in key_upper for s in ('SECRET', 'KEY', 'CODE', 'TOKEN')
+            if (
+                len(value) > 2
+                and value != 'default'
+                and any(s in key_upper for s in ('SECRET', 'KEY', 'CODE', 'TOKEN'))
             ):
                 sensitive_values.append(value)
 

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -221,7 +221,7 @@ class SensitiveDataFilter(logging.Filter):
         sensitive_values = []
         for key, value in os.environ.items():
             key_upper = key.upper()
-            if len(value) > 2 and any(
+            if len(value) >= 8 and any(
                 s in key_upper for s in ('SECRET', 'KEY', 'CODE', 'TOKEN')
             ):
                 sensitive_values.append(value)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

If a value has less than 8 characters, it will not be considered a secret as it does not have enough entropy

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
The new logging filters can sometimes lead to unusual outcomes - we look at the environment for any variable with a name containing the terms `KEY`, `CODE`, `SECRET` or `TOKEN` and replace those values with ****** in the logs - it seems in my env my `AWS_ACCESS_KEY_ID` was set to `default`, so any time the word `default` appeared in the logs it was redacted! By increasing the entropy requirement we remove false positives.


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4981063-nikolaik   --name openhands-app-4981063   docker.all-hands.dev/all-hands-ai/openhands:4981063
```