### PR TITLE
Add info logs for microagent loading and triggering

### DIFF
--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -1,8 +1,11 @@
+import logging
 import os
 from dataclasses import dataclass
 from itertools import islice
 
 from jinja2 import Template
+
+from openhands.core.logger import openhands_logger
 
 from openhands.controller.state.state import State
 from openhands.core.message import Message, TextContent
@@ -114,6 +117,7 @@ class PromptManager:
 
         This is typically used when loading microagents from inside a repo.
         """
+        openhands_logger.info("Loading microagents: %s", [m.name for m in microagents])
         # Only keep KnowledgeMicroAgents and RepoMicroAgents
         for microagent in microagents:
             if microagent.name in self.disabled_microagents:
@@ -179,6 +183,7 @@ class PromptManager:
         for microagent in self.knowledge_microagents.values():
             trigger = microagent.match_trigger(message_content)
             if trigger:
+                openhands_logger.info("Microagent '%s' triggered by keyword '%s'", microagent.name, trigger)
                 micro_text = f'<extra_info>\nThe following information has been included based on a keyword match for "{trigger}". It may or may not be relevant to the user\'s request.'
                 micro_text += '\n\n' + microagent.content
                 micro_text += '\n</extra_info>'

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -1,13 +1,11 @@
-import logging
 import os
 from dataclasses import dataclass
 from itertools import islice
 
 from jinja2 import Template
 
-from openhands.core.logger import openhands_logger
-
 from openhands.controller.state.state import State
+from openhands.core.logger import openhands_logger
 from openhands.core.message import Message, TextContent
 from openhands.microagent import (
     BaseMicroAgent,
@@ -117,7 +115,7 @@ class PromptManager:
 
         This is typically used when loading microagents from inside a repo.
         """
-        openhands_logger.info("Loading microagents: %s", [m.name for m in microagents])
+        openhands_logger.info('Loading microagents: %s', [m.name for m in microagents])
         # Only keep KnowledgeMicroAgents and RepoMicroAgents
         for microagent in microagents:
             if microagent.name in self.disabled_microagents:
@@ -183,7 +181,11 @@ class PromptManager:
         for microagent in self.knowledge_microagents.values():
             trigger = microagent.match_trigger(message_content)
             if trigger:
-                openhands_logger.info("Microagent '%s' triggered by keyword '%s'", microagent.name, trigger)
+                openhands_logger.info(
+                    "Microagent '%s' triggered by keyword '%s'",
+                    microagent.name,
+                    trigger,
+                )
                 micro_text = f'<extra_info>\nThe following information has been included based on a keyword match for "{trigger}". It may or may not be relevant to the user\'s request.'
                 micro_text += '\n\n' + microagent.content
                 micro_text += '\n</extra_info>'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ reportlab = "*"
 [tool.coverage.run]
 concurrency = ["gevent"]
 
+
 [tool.poetry.group.runtime.dependencies]
 jupyterlab = "*"
 notebook = "*"
@@ -135,6 +136,7 @@ ignore = ["D1"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
 
 [tool.poetry.group.evaluation.dependencies]
 streamlit = "*"


### PR DESCRIPTION
This PR adds info logs to show when microagents are loaded and triggered in `openhands/utils/prompt.py`.

Changes:
- Added import for `openhands_logger` from `openhands.core.logger`
- Added info log when microagents are loaded showing which microagents are being loaded
- Added info log when a microagent is triggered showing which microagent was triggered and by what keyword

The logs will be properly integrated with OpenHands logging system, including:
- Console output with proper formatting and colors
- File logging when LOG_TO_FILE is enabled
- Proper log level handling based on LOG_LEVEL environment variable
- Sensitive data filtering

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:416d67b-nikolaik   --name openhands-app-416d67b   docker.all-hands.dev/all-hands-ai/openhands:416d67b
```