### PR TITLE
Fix: File Descriptor leak

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -232,10 +232,14 @@ class LLM(RetryMixin, DebugMixin):
             # Record start time for latency measurement
             start_time = time.time()
 
-            # we don't support streaming here, thus we get a ModelResponse
+            # LiteLLM currently have an issue where HttpHandlers are being created but not
+            # closed. We have submitted a PR to them, (https://github.com/BerriAI/litellm/pull/8711)
+            # and their dev team say they are in the process of a refactor that will fix this.
+            # In the meantime, we manage the lifecycle of the HTTPHandler manually.
             handler = HTTPHandler(timeout=self.config.timeout)
             kwargs['client'] = handler
             try:
+                # we don't support streaming here, thus we get a ModelResponse
                 resp: ModelResponse = self._completion_unwrapped(*args, **kwargs)
             finally:
                 handler.close()


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

Fix for issue where litellm http handler is not closed, leading to File Descriptor leak

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
We now close all http resources explicitly after use. This is NOT that different from the previous functionality, where we would constantly create new httpx clients but not close them due to a bug in LiteLLM.

Testing this can be accomplished with running openhands and particularly doing things that cause litellm to error out, while running the script below which will count open file descriptors:
```while true; do ls -l /proc/*/fd | wc -l; sleep 5; done```



---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:75dce30-nikolaik   --name openhands-app-75dce30   docker.all-hands.dev/all-hands-ai/openhands:75dce30
```