### PR TITLE
Fix for regression where conversations are not clickable

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -75,9 +75,9 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
       data-testid="conversation-panel"
       className="w-[350px] h-full border border-neutral-700 bg-base-secondary rounded-xl overflow-y-auto absolute"
     >
-      <div className="w-full h-full absolute flex justify-center items-center">
-        {isFetching && <LoadingSpinner size="small" />}
-      </div>
+      {isFetching && <div className="w-full h-full absolute flex justify-center items-center">
+        <LoadingSpinner size="small" />
+      </div>}
       {error && (
         <div className="flex flex-col items-center justify-center h-full">
           <p className="text-danger">{error.message}</p>

--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -75,9 +75,11 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
       data-testid="conversation-panel"
       className="w-[350px] h-full border border-neutral-700 bg-base-secondary rounded-xl overflow-y-auto absolute"
     >
-      {isFetching && <div className="w-full h-full absolute flex justify-center items-center">
-        <LoadingSpinner size="small" />
-      </div>}
+      {isFetching && (
+        <div className="w-full h-full absolute flex justify-center items-center">
+          <LoadingSpinner size="small" />
+        </div>
+      )}
       {error && (
         <div className="flex flex-col items-center justify-center h-full">
           <p className="text-danger">{error.message}</p>


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
This was caused by a change yesterday which stopped the loading icon making the conversations jump. With this PR, we now remove the whole loading div when the conversations are not loading


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:22dd122-nikolaik   --name openhands-app-22dd122   docker.all-hands.dev/all-hands-ai/openhands:22dd122
```