### PR TITLE
Revert "Fix: File Descriptor leak"

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -20,7 +20,6 @@ from litellm import completion_cost as litellm_completion_cost
 from litellm.exceptions import (
     RateLimitError,
 )
-from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.types.utils import CostPerToken, ModelResponse, Usage
 from litellm.utils import create_pretrained_tokenizer
 
@@ -232,17 +231,8 @@ class LLM(RetryMixin, DebugMixin):
             # Record start time for latency measurement
             start_time = time.time()
 
-            # LiteLLM currently have an issue where HttpHandlers are being created but not
-            # closed. We have submitted a PR to them, (https://github.com/BerriAI/litellm/pull/8711)
-            # and their dev team say they are in the process of a refactor that will fix this.
-            # In the meantime, we manage the lifecycle of the HTTPHandler manually.
-            handler = HTTPHandler(timeout=self.config.timeout)
-            kwargs['client'] = handler
-            try:
-                # we don't support streaming here, thus we get a ModelResponse
-                resp: ModelResponse = self._completion_unwrapped(*args, **kwargs)
-            finally:
-                handler.close()
+            # we don't support streaming here, thus we get a ModelResponse
+            resp: ModelResponse = self._completion_unwrapped(*args, **kwargs)
 
             # Calculate and record latency
             latency = time.time() - start_time


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#6883

Sorry, I can't run `main` this morning, and the interesting part is that the errors are different for different providers. It must be working fine with Anthropic without proxy (direct API call), but not via `litellm_proxy`, _and_ with `log_completions` disabled (I have it enabled).

With Claude, directly
```
 File "/Users/enyst/repos/odie/openhands/llm/llm.py", line 314, in wrapper
    f.write(json.dumps(_d))
...
  File "/Users/enyst/.pyenv/versions/3.12.6/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type HTTPHandler is not JSON serializable
```

With Claude, via litellm proxy:
```
litellm.exceptions.APIError: litellm.APIError: APIError: Litellm_proxyException - 'HTTPHandler' object has no attribute 'api_key'
```

With o3-mini, directly:
```
litellm.exceptions.APIError: litellm.APIError: APIError: OpenAIException - 'HTTPHandler' object has no attribute 'api_key'
```

The first can be fixed by just popping out of kwargs the new `client` after the call, but the other two are non-obvious to me at first sight, WDYT?

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bcf7b37-nikolaik   --name openhands-app-bcf7b37   docker.all-hands.dev/all-hands-ai/openhands:bcf7b37
```