### PR TITLE
Keep the first user message by default in condensers

### DIFF
--- a/openhands/core/config/condenser_config.py
+++ b/openhands/core/config/condenser_config.py
@@ -27,7 +27,7 @@ class RecentEventsCondenserConfig(BaseModel):
 
     type: Literal['recent'] = Field('recent')
     keep_first: int = Field(
-        default=0,
+        default=1,
         description='The number of initial events to condense.',
         ge=0,
     )
@@ -63,7 +63,7 @@ class AmortizedForgettingCondenserConfig(BaseModel):
         ge=2,
     )
     keep_first: int = Field(
-        default=0,
+        default=1,
         description='Number of initial events to always keep in history.',
         ge=0,
     )
@@ -82,7 +82,7 @@ class LLMAttentionCondenserConfig(BaseModel):
         ge=2,
     )
     keep_first: int = Field(
-        default=0,
+        default=1,
         description='Number of initial events to always keep in history.',
         ge=0,
     )

--- a/openhands/core/config/condenser_config.py
+++ b/openhands/core/config/condenser_config.py
@@ -26,6 +26,8 @@ class RecentEventsCondenserConfig(BaseModel):
     """Configuration for RecentEventsCondenser."""
 
     type: Literal['recent'] = Field('recent')
+
+    # at least one event by default, because the best guess is that it is the user task
     keep_first: int = Field(
         default=1,
         description='The number of initial events to condense.',
@@ -43,6 +45,8 @@ class LLMSummarizingCondenserConfig(BaseModel):
     llm_config: LLMConfig = Field(
         ..., description='Configuration for the LLM to use for condensing.'
     )
+
+    # at least one event by default, because the best guess is that it's the user task
     keep_first: int = Field(
         default=1,
         description='The number of initial events to condense.',
@@ -62,6 +66,8 @@ class AmortizedForgettingCondenserConfig(BaseModel):
         description='Maximum size of the condensed history before triggering forgetting.',
         ge=2,
     )
+
+    # at least one event by default, because the best guess is that it's the user task
     keep_first: int = Field(
         default=1,
         description='Number of initial events to always keep in history.',
@@ -81,6 +87,8 @@ class LLMAttentionCondenserConfig(BaseModel):
         description='Maximum size of the condensed history before triggering forgetting.',
         ge=2,
     )
+
+    # at least one event by default, because the best guess is that it's the user task
     keep_first: int = Field(
         default=1,
         description='Number of initial events to always keep in history.',

--- a/openhands/memory/condenser/impl/llm_attention_condenser.py
+++ b/openhands/memory/condenser/impl/llm_attention_condenser.py
@@ -18,7 +18,7 @@ class ImportantEventSelection(BaseModel):
 class LLMAttentionCondenser(RollingCondenser):
     """Rolling condenser strategy that uses an LLM to select the most important events when condensing the history."""
 
-    def __init__(self, llm: LLM, max_size: int = 100, keep_first: int = 0):
+    def __init__(self, llm: LLM, max_size: int = 100, keep_first: int = 1):
         if keep_first >= max_size // 2:
             raise ValueError(
                 f'keep_first ({keep_first}) must be less than half of max_size ({max_size})'

--- a/openhands/memory/condenser/impl/recent_events_condenser.py
+++ b/openhands/memory/condenser/impl/recent_events_condenser.py
@@ -8,7 +8,7 @@ from openhands.memory.condenser.condenser import Condenser
 class RecentEventsCondenser(Condenser):
     """A condenser that only keeps a certain number of the most recent events."""
 
-    def __init__(self, keep_first: int = 0, max_events: int = 10):
+    def __init__(self, keep_first: int = 1, max_events: int = 10):
         self.keep_first = keep_first
         self.max_events = max_events
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR proposes to set the default `keep_first` to 1 everywhere in condensers, in a best effort attempt to preserve the first user message. We already did this in one of the condensers, this does it in all.

The limit is configurable and accepts 0, but the use cases for 0 seem maybe eval cases or specific cases, while the first user message is important also because currently, we hook prompt extensions into it.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b6391d4-nikolaik   --name openhands-app-b6391d4   docker.all-hands.dev/all-hands-ai/openhands:b6391d4
```