### PR TITLE
add add_agent.md

### DIFF
--- a/microagents/knowledge/add_agent.md
+++ b/microagents/knowledge/add_agent.md
@@ -24,6 +24,9 @@ Microagents are specialized prompts that provide context and capabilities for sp
 When creating a new microagent:
 * Create a markdown file in `.openhands/microagents/` with an appropriate name (e.g., `github.md`, `google_workspace.md`)
 * Include YAML frontmatter with metadata (name, type, version, agent, triggers)
+* type is by DEFAULT knowledge
+* version is DEFAULT 1.0.0
+* agent is by DEFAULT CodeActAgent
 * Document any credentials, environment variables, or API access needed
 * Keep trigger words specific to avoid false activations
 * Include error handling guidance and limitations

--- a/microagents/knowledge/add_agent.md
+++ b/microagents/knowledge/add_agent.md
@@ -1,0 +1,119 @@
+# Add Microagent Helper
+
+This agent helps create new microagents in the `.openhands/microagents` directory by providing guidance and templates.
+
+## Triggers
+The agent activates when the conversation includes:
+- "new agent"
+- "new microagent"
+- "create agent"
+- "create an agent"
+- "create microagent"
+- "create a microagent"
+- "add agent"
+- "add an agent"
+- "add microagent"
+- "add a microagent"
+- "microagent template"
+
+## What are Microagents?
+
+Microagents are specialized prompts that provide context and capabilities for specific domains or tasks. They are activated by trigger words in the conversation and help the AI assistant understand:
+- What capabilities are available
+- How to use specific APIs or tools
+- What limitations exist
+- How to handle common scenarios
+
+For detailed information, see:
+- [Microagents Overview](https://docs.all-hands.dev/modules/usage/prompting/microagents-overview)
+- [Example GitHub Microagent](https://github.com/All-Hands-AI/OpenHands/blob/main/microagents/knowledge/github.md)
+
+## Template Structure
+
+A microagent markdown file should include:
+
+```markdown
+# Agent Name
+
+Brief description of what this agent does.
+
+## Triggers
+List of words/phrases that activate this agent:
+- "trigger word 1"
+- "trigger word 2"
+
+## Capabilities
+What the agent can do, including:
+- Available APIs
+- Environment variables
+- Tools or commands
+
+## Usage Examples
+```code
+Example code or usage
+```
+
+## Important Notes
+- Limitations
+- Security considerations
+- Best practices
+
+## Error Handling
+Common errors and how to handle them
+```
+
+## Creating a New Agent
+
+To create a new microagent:
+1. Create a markdown file in `.openhands/microagents/`
+2. Name it appropriately (e.g., `github.md`, `google_workspace.md`)
+3. Include all required sections
+4. Ensure trigger words are specific and relevant
+5. Document any credentials or environment variables
+6. Provide clear usage examples
+
+## Best Practices
+
+- Keep trigger words specific to avoid false activations
+- Document all credentials and access tokens
+- Include error handling guidance
+- Provide working code examples
+- Reference external documentation when available
+- Consider security implications
+- Keep the prompt focused and concise
+
+## Example Implementation
+
+Here's a minimal example:
+
+```markdown
+# Example Agent
+
+Handles interaction with ExampleService API.
+
+## Triggers
+- "example service"
+- "example api"
+
+## Capabilities
+Access to ExampleService API:
+- API_KEY: ${EXAMPLE_API_KEY}
+- Base URL: https://api.example.com
+
+## Usage Examples
+```python
+import requests
+response = requests.get(
+    "https://api.example.com/data",
+    headers={"Authorization": "Bearer ${EXAMPLE_API_KEY}"}
+)
+```
+
+## Important Notes
+- Rate limited to 100 requests/minute
+- Requires valid API key
+
+## Error Handling
+- 401: Check API key
+- 429: Rate limit exceeded
+```

--- a/microagents/knowledge/add_agent.md
+++ b/microagents/knowledge/add_agent.md
@@ -1,119 +1,31 @@
-# Add Microagent Helper
+---
+name: add_agent
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+- new agent
+- new microagent
+- create agent
+- create microagent
+- add agent
+- add microagent
+- microagent template
+---
 
 This agent helps create new microagents in the `.openhands/microagents` directory by providing guidance and templates.
 
-## Triggers
-The agent activates when the conversation includes:
-- "new agent"
-- "new microagent"
-- "create agent"
-- "create an agent"
-- "create microagent"
-- "create a microagent"
-- "add agent"
-- "add an agent"
-- "add microagent"
-- "add a microagent"
-- "microagent template"
+Microagents are specialized prompts that provide context and capabilities for specific domains or tasks. They are activated by trigger words in the conversation and help the AI assistant understand what capabilities are available, how to use specific APIs or tools, what limitations exist, and how to handle common scenarios.
 
-## What are Microagents?
-
-Microagents are specialized prompts that provide context and capabilities for specific domains or tasks. They are activated by trigger words in the conversation and help the AI assistant understand:
-- What capabilities are available
-- How to use specific APIs or tools
-- What limitations exist
-- How to handle common scenarios
+When creating a new microagent:
+* Create a markdown file in `.openhands/microagents/` with an appropriate name (e.g., `github.md`, `google_workspace.md`)
+* Include YAML frontmatter with metadata (name, type, version, agent, triggers)
+* Document any credentials, environment variables, or API access needed
+* Keep trigger words specific to avoid false activations
+* Include error handling guidance and limitations
+* Provide clear usage examples
+* Keep the prompt focused and concise
 
 For detailed information, see:
-- [Microagents Overview](https://docs.all-hands.dev/modules/usage/prompting/microagents-overview)
-- [Example GitHub Microagent](https://github.com/All-Hands-AI/OpenHands/blob/main/microagents/knowledge/github.md)
-
-## Template Structure
-
-A microagent markdown file should include:
-
-```markdown
-# Agent Name
-
-Brief description of what this agent does.
-
-## Triggers
-List of words/phrases that activate this agent:
-- "trigger word 1"
-- "trigger word 2"
-
-## Capabilities
-What the agent can do, including:
-- Available APIs
-- Environment variables
-- Tools or commands
-
-## Usage Examples
-```code
-Example code or usage
-```
-
-## Important Notes
-- Limitations
-- Security considerations
-- Best practices
-
-## Error Handling
-Common errors and how to handle them
-```
-
-## Creating a New Agent
-
-To create a new microagent:
-1. Create a markdown file in `.openhands/microagents/`
-2. Name it appropriately (e.g., `github.md`, `google_workspace.md`)
-3. Include all required sections
-4. Ensure trigger words are specific and relevant
-5. Document any credentials or environment variables
-6. Provide clear usage examples
-
-## Best Practices
-
-- Keep trigger words specific to avoid false activations
-- Document all credentials and access tokens
-- Include error handling guidance
-- Provide working code examples
-- Reference external documentation when available
-- Consider security implications
-- Keep the prompt focused and concise
-
-## Example Implementation
-
-Here's a minimal example:
-
-```markdown
-# Example Agent
-
-Handles interaction with ExampleService API.
-
-## Triggers
-- "example service"
-- "example api"
-
-## Capabilities
-Access to ExampleService API:
-- API_KEY: ${EXAMPLE_API_KEY}
-- Base URL: https://api.example.com
-
-## Usage Examples
-```python
-import requests
-response = requests.get(
-    "https://api.example.com/data",
-    headers={"Authorization": "Bearer ${EXAMPLE_API_KEY}"}
-)
-```
-
-## Important Notes
-- Rate limited to 100 requests/minute
-- Requires valid API key
-
-## Error Handling
-- 401: Check API key
-- 429: Rate limit exceeded
-```
+* [Microagents Overview](https://docs.all-hands.dev/modules/usage/prompting/microagents-overview)
+* [Example GitHub Microagent](https://github.com/All-Hands-AI/OpenHands/blob/main/microagents/knowledge/github.md)

--- a/microagents/knowledge/add_agent.md
+++ b/microagents/knowledge/add_agent.md
@@ -7,9 +7,13 @@ triggers:
 - new agent
 - new microagent
 - create agent
+- create an agent
 - create microagent
+- create a microagent
 - add agent
+- add an agent
 - add microagent
+- add a microagent
 - microagent template
 ---
 


### PR DESCRIPTION
Right now there's not a clear way to easily extend the agent's capabilities through the agent itself. This PR introduces a public microagent to help standardize the creation of new microagents with the documented structure and practices.

- [x] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

Release Note: Added a new microagent template system that helps users create properly structured domain-specific agents. Simply mention "new agent" or "new microagent" to easily add a repository agent and extend OpenHands' capabilities.

## Summary
Creates add_agent.md microagent that explains:
- What is a microagent
- Where to put it in the local repository
- Links to microagent documentation and examples

## Example Usage
`create an agent for google docs with my api key: <key>`
`create an agent to interface with codeburg`