### PR TITLE
chore: Make remote runtime class default to None

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -53,11 +53,11 @@ class SandboxConfig(BaseModel):
     remote_runtime_api_timeout: int = Field(default=10)
     remote_runtime_enable_retries: bool = Field(default=False)
     remote_runtime_class: str | None = Field(
-        default='sysbox'
+        default=None
     )  # can be "None" (default to gvisor) or "sysbox" (support docker inside runtime + more stable)
     enable_auto_lint: bool = Field(
-        default=False  # once enabled, OpenHands would lint files after editing
-    )
+        default=False
+    )  # once enabled, OpenHands would lint files after editing
     use_host_network: bool = Field(default=False)
     runtime_extra_build_args: list[str] | None = Field(default=None)
     initialize_plugins: bool = Field(default=True)


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We can leave config to use gvisor for default, then try to customize it to sysbox in the cloud version via env var.

---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3733cc0-nikolaik   --name openhands-app-3733cc0   docker.all-hands.dev/all-hands-ai/openhands:3733cc0
```