### PR TITLE
chore(frontend): Claude 3.7 is visible in dropdown for selection

### DIFF
--- a/frontend/__tests__/utils/extract-model-and-provider.test.ts
+++ b/frontend/__tests__/utils/extract-model-and-provider.test.ts
@@ -65,6 +65,12 @@ describe("extractModelAndProvider", () => {
       separator: "/",
     });
 
+    expect(extractModelAndProvider("claude-3-7-sonnet-20250219")).toEqual({
+      provider: "anthropic",
+      model: "claude-3-7-sonnet-20250219",
+      separator: "/",
+    });
+
     expect(extractModelAndProvider("claude-3-haiku-20240307")).toEqual({
       provider: "anthropic",
       model: "claude-3-haiku-20240307",

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -3,6 +3,7 @@ export const VERIFIED_PROVIDERS = ["openai", "azure", "anthropic", "deepseek"];
 export const VERIFIED_MODELS = [
   "o3-mini-2025-01-31",
   "claude-3-5-sonnet-20241022",
+  "claude-3-7-sonnet-20250219",
   "deepseek-chat",
 ];
 
@@ -31,4 +32,5 @@ export const VERIFIED_ANTHROPIC_MODELS = [
   "claude-3-haiku-20240307",
   "claude-3-opus-20240229",
   "claude-3-sonnet-20240229",
+  "claude-3-7-sonnet-20250219",
 ];


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Allow selecting the Claude 3.7 model from via the Anthropic provider

![Screenshot 2025-02-25 at 10 30 25 AM](https://github.com/user-attachments/assets/e70559c7-9bfe-4f7b-96bf-161722425504)

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**
Resolves #6925 

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:aeaa97e-nikolaik   --name openhands-app-aeaa97e   docker.all-hands.dev/all-hands-ai/openhands:aeaa97e
```