### PR TITLE
feat(llm): Add Claude 3.7 backend configurations

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -42,6 +42,7 @@ LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (RateLimitError,)
 # cache prompt supporting models
 # remove this when we gemini and deepseek are supported
 CACHE_PROMPT_SUPPORTED_MODELS = [
+    'claude-3-7-sonnet-20250219',
     'claude-3-5-sonnet-20241022',
     'claude-3-5-sonnet-20240620',
     'claude-3-5-haiku-20241022',
@@ -51,6 +52,7 @@ CACHE_PROMPT_SUPPORTED_MODELS = [
 
 # function calling supporting models
 FUNCTION_CALLING_SUPPORTED_MODELS = [
+    'claude-3-7-sonnet-20250219',
     'claude-3-5-sonnet',
     'claude-3-5-sonnet-20240620',
     'claude-3-5-sonnet-20241022',


### PR DESCRIPTION
This PR adds Claude 3.7 to the backend configurations in `llm.py` to enable:

- Cache prompt support
- Function calling support

This complements PR #6931 which only added Claude 3.7 to the frontend verified models list.

Resolves #6925

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6106239-nikolaik   --name openhands-app-6106239   docker.all-hands.dev/all-hands-ai/openhands:6106239
```