### PR TITLE
Fix issue #6940: [Bug]: Incorrect Provider Name on Advanced Setting Toggle

### DIFF
--- a/frontend/__tests__/components/modals/settings/model-selector.test.tsx
+++ b/frontend/__tests__/components/modals/settings/model-selector.test.tsx
@@ -133,4 +133,30 @@ describe("ModelSelector", () => {
     expect(screen.getByLabelText("LLM Provider")).toHaveValue("Azure");
     expect(screen.getByLabelText("LLM Model")).toHaveValue("ada");
   });
+
+  it("should handle Mistral AI provider selection correctly", async () => {
+    const mistralModels = {
+      mistral: {
+        separator: "/",
+        models: ["mistral-tiny", "mistral-small", "mistral-medium"],
+      },
+    };
+
+    const user = userEvent.setup();
+    render(<ModelSelector models={mistralModels} />);
+
+    const providerSelector = screen.getByLabelText("LLM Provider");
+    await user.click(providerSelector);
+
+    // Select Mistral AI (display name)
+    const mistralOption = screen.getByText("Mistral AI");
+    await user.click(mistralOption);
+
+    // Verify model dropdown is enabled and shows correct models
+    const modelSelector = screen.getByLabelText("LLM Model");
+    expect(modelSelector).not.toBeDisabled();
+
+    await user.click(modelSelector);
+    expect(screen.getByText("mistral-tiny")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/shared/modals/settings/model-selector.tsx
+++ b/frontend/src/components/shared/modals/settings/model-selector.tsx
@@ -6,7 +6,7 @@ import {
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
-import { mapProvider } from "#/utils/map-provider";
+import { mapProvider, MAP_PROVIDER } from "#/utils/map-provider";
 import { VERIFIED_MODELS, VERIFIED_PROVIDERS } from "#/utils/verified-models";
 import { extractModelAndProvider } from "#/utils/extract-model-and-provider";
 
@@ -39,11 +39,16 @@ export function ModelSelector({
   }, [currentModel]);
 
   const handleChangeProvider = (provider: string) => {
-    setSelectedProvider(provider);
+    // Find the actual provider key from MAP_PROVIDER if a display name was provided
+    const providerKey = Object.entries(MAP_PROVIDER).find(
+      ([_, displayName]) => displayName === provider
+    )?.[0] || provider;
+
+    setSelectedProvider(providerKey);
     setSelectedModel(null);
 
-    const separator = models[provider]?.separator || "";
-    setLitellmId(provider + separator);
+    const separator = models[providerKey]?.separator || "";
+    setLitellmId(providerKey + separator);
   };
 
   const handleChangeModel = (model: string) => {


### PR DESCRIPTION
This pull request fixes #6940.

The issue has been successfully resolved based on the following concrete changes and their effects:

1. The core bug was fixed by modifying the `handleChangeProvider` function to properly map display names to internal provider keys. When "Mistral AI" is selected, it now correctly maps to "mistral" internally through the new lookup logic:
```javascript
const providerKey = Object.entries(MAP_PROVIDER).find(
  ([_, displayName]) => displayName === provider
)?.[0] || provider;
```

2. The changes ensure that the internal state uses the correct provider key ("mistral") while maintaining the display name ("Mistral AI") in the UI, preventing the settings page from incorrectly switching to advanced mode.

3. The fix was verified with a new test case that specifically checks the Mistral AI provider selection workflow, confirming:
- Provider selection works correctly
- Model dropdown becomes enabled
- Correct Mistral models are available

4. The implementation addresses both reported issues:
- Prevents unwanted switching to advanced mode by using correct internal provider keys
- Fixes the provider name changing to incorrect values by properly maintaining the mapping between display names and internal keys

The changes directly target and resolve the reported behavior problems through proper provider name handling and state management.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:38f1b56-nikolaik   --name openhands-app-38f1b56   docker.all-hands.dev/all-hands-ai/openhands:38f1b56
```