### PR TITLE
feat: prompt instructions for runtimes

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/additional_info.j2
+++ b/openhands/agenthub/codeact_agent/prompts/additional_info.j2
@@ -8,7 +8,7 @@ At the user's request, repository {{ repository_info.repo_name }} has been clone
 {{ repository_instructions }}
 </REPOSITORY_INSTRUCTIONS>
 {% endif %}
-{% if runtime_info and (runtime_info.available_hosts or runtime_info.additional_instructions) -%}
+{% if runtime_info and (runtime_info.available_hosts or runtime_info.additional_agent_instructions) -%}
 <RUNTIME_INFORMATION>
 {% if runtime_info.available_hosts %}
 The user has access to the following hosts for accessing a web application,
@@ -20,6 +20,6 @@ When starting a web server, use the corresponding ports. You should also
 set any options to allow iframes and CORS requests, and allow the server to
 be accessed from any host (e.g. 0.0.0.0).
 {% endif %}
-{{ runtime_info.additional_instructions }}
+{{ runtime_info.additional_agent_instructions }}
 </RUNTIME_INFORMATION>
 {% endif %}

--- a/openhands/agenthub/codeact_agent/prompts/additional_info.j2
+++ b/openhands/agenthub/codeact_agent/prompts/additional_info.j2
@@ -8,8 +8,9 @@ At the user's request, repository {{ repository_info.repo_name }} has been clone
 {{ repository_instructions }}
 </REPOSITORY_INSTRUCTIONS>
 {% endif %}
-{% if runtime_info and runtime_info.available_hosts -%}
+{% if runtime_info and (runtime_info.available_hosts or runtime_info.additional_instructions) -%}
 <RUNTIME_INFORMATION>
+{% if runtime_info.available_hosts %}
 The user has access to the following hosts for accessing a web application,
 each of which has a corresponding port:
 {% for host, port in runtime_info.available_hosts.items() -%}
@@ -18,5 +19,7 @@ each of which has a corresponding port:
 When starting a web server, use the corresponding ports. You should also
 set any options to allow iframes and CORS requests, and allow the server to
 be accessed from any host (e.g. 0.0.0.0).
+{% endif %}
+{{ runtime_info.additional_instructions }}
 </RUNTIME_INFORMATION>
 {% endif %}

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -489,5 +489,5 @@ class Runtime(FileEditRuntimeMixin):
         return {}
 
     @property
-    def additional_instructions(self) -> str:
+    def additional_agent_instructions(self) -> str:
         return ''

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -487,3 +487,7 @@ class Runtime(FileEditRuntimeMixin):
     @property
     def web_hosts(self) -> dict[str, int]:
         return {}
+
+    @property
+    def additional_instructions(self) -> str:
+        return ''

--- a/openhands/runtime/impl/daytona/daytona_runtime.py
+++ b/openhands/runtime/impl/daytona/daytona_runtime.py
@@ -262,5 +262,5 @@ class DaytonaRuntime(ActionExecutionClient):
         return self._vscode_url
 
     @property
-    def additional_instructions(self) -> str:
+    def additional_agent_instructions(self) -> str:
         return f'When showing endpoints to access applications for any port, e.g. port 3000, instead of localhost:3000, use this format: {self._construct_api_url(3000)}.'

--- a/openhands/runtime/impl/daytona/daytona_runtime.py
+++ b/openhands/runtime/impl/daytona/daytona_runtime.py
@@ -260,3 +260,7 @@ class DaytonaRuntime(ActionExecutionClient):
         )
 
         return self._vscode_url
+
+    @property
+    def additional_instructions(self) -> str:
+        return f'When showing endpoints to access applications for any port, e.g. port 3000, instead of localhost:3000, use this format: {self._construct_api_url(3000)}.'

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -19,7 +19,7 @@ from openhands.runtime.base import Runtime
 @dataclass
 class RuntimeInfo:
     available_hosts: dict[str, int]
-    additional_instructions: str
+    additional_agent_instructions: str
 
 
 @dataclass
@@ -57,7 +57,9 @@ class PromptManager:
         self.user_template: Template = self._load_template('user_prompt')
         self.additional_info_template: Template = self._load_template('additional_info')
         self.microagent_info_template: Template = self._load_template('microagent_info')
-        self.runtime_info = RuntimeInfo(available_hosts={}, additional_instructions='')
+        self.runtime_info = RuntimeInfo(
+            available_hosts={}, additional_agent_instructions=''
+        )
 
         self.knowledge_microagents: dict[str, KnowledgeMicroAgent] = {}
         self.repo_microagents: dict[str, RepoMicroAgent] = {}
@@ -114,7 +116,9 @@ class PromptManager:
 
     def set_runtime_info(self, runtime: Runtime) -> None:
         self.runtime_info.available_hosts = runtime.web_hosts
-        self.runtime_info.additional_instructions = runtime.additional_instructions
+        self.runtime_info.additional_agent_instructions = (
+            runtime.additional_agent_instructions
+        )
 
     def set_repository_info(
         self,

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -19,6 +19,7 @@ from openhands.runtime.base import Runtime
 @dataclass
 class RuntimeInfo:
     available_hosts: dict[str, int]
+    additional_instructions: str
 
 
 @dataclass
@@ -56,7 +57,7 @@ class PromptManager:
         self.user_template: Template = self._load_template('user_prompt')
         self.additional_info_template: Template = self._load_template('additional_info')
         self.microagent_info_template: Template = self._load_template('microagent_info')
-        self.runtime_info = RuntimeInfo(available_hosts={})
+        self.runtime_info = RuntimeInfo(available_hosts={}, additional_instructions='')
 
         self.knowledge_microagents: dict[str, KnowledgeMicroAgent] = {}
         self.repo_microagents: dict[str, RepoMicroAgent] = {}
@@ -113,6 +114,7 @@ class PromptManager:
 
     def set_runtime_info(self, runtime: Runtime) -> None:
         self.runtime_info.available_hosts = runtime.web_hosts
+        self.runtime_info.additional_instructions = runtime.additional_instructions
 
     def set_repository_info(
         self,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Tells the agent which URLs to use when responding with links for reaching running apps on Daytona.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


This PR adds an `additional_instructions` property to runtimes which then gets forwarded to the `PromptManager`.
For Daytona, it is used to pass this message: 

> "When showing endpoints to access applications for any port, e.g. port 3000, instead of localhost:3000, use this format: <port>.<workspace_id>.<node_domain>"

which shows the user a correct link to access the preview URL for a running application.

---
**Link of any specific issues this addresses.**

Discussed briefly in #6863
