### PR TITLE
Fix fd leak

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 import requests
 
 from openhands.core.config import LLMConfig
-from openhands.utils.ensure_httpx_close import EnsureHttpxClose
+from openhands.utils.ensure_httpx_close import ensure_httpx_close
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
@@ -231,7 +231,7 @@ class LLM(RetryMixin, DebugMixin):
 
             # Record start time for latency measurement
             start_time = time.time()
-            with EnsureHttpxClose():
+            with ensure_httpx_close():
                 # we don't support streaming here, thus we get a ModelResponse
                 resp: ModelResponse = self._completion_unwrapped(*args, **kwargs)
 

--- a/openhands/utils/ensure_httpx_close.py
+++ b/openhands/utils/ensure_httpx_close.py
@@ -1,0 +1,43 @@
+"""
+LiteLLM currently have an issue where HttpHandlers are being created but not
+closed. We have submitted a PR to them, (https://github.com/BerriAI/litellm/pull/8711)
+and their dev team say they are in the process of a refactor that will fix this, but
+in the meantime, we need to manage the lifecycle of the httpx.Client manually.
+
+We can't simply pass in our own client object, because all the different implementations use
+different types of client object.
+
+So we monkey patch the httpx.Client class to track newly created instances and close these
+when the operations complete. (This is relatively safe, as if the client is reused after this
+then is will transparently reopen)
+
+Hopefully, this will be fixed soon and we can remove this abomination.
+"""
+
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Callable
+
+from httpx import Client
+
+
+@dataclass
+class EnsureHttpxClose:
+    clients: list[Client] = field(default_factory=list)
+    original_init: Callable | None = None
+
+    def __enter__(self):
+        self.original_init = Client.__init__
+
+        @wraps(Client.__init__)
+        def init_wrapper(*args, **kwargs):
+            self.clients.append(args[0])
+            return self.original_init(*args, **kwargs)  # type: ignore
+
+        Client.__init__ = init_wrapper
+
+    def __exit__(self, type, value, traceback):
+        Client.__init__ = self.original_init
+        while self.clients:
+            client = self.clients.pop()
+            client.close()

--- a/openhands/utils/ensure_httpx_close.py
+++ b/openhands/utils/ensure_httpx_close.py
@@ -35,11 +35,12 @@ def ensure_httpx_close():
         client_constructor: Callable
         args: tuple
         kwargs: dict
-        client: httpx.Client = None
+        client: httpx.Client
 
         def __init__(self, *args, **kwargs):
             self.args = args
             self.kwargs = kwargs
+            self.client = wrapped_class(*self.args, **self.kwargs)
             proxys.append(self)
 
         def __getattr__(self, name):

--- a/tests/unit/test_ensure_httpx_close.py
+++ b/tests/unit/test_ensure_httpx_close.py
@@ -1,0 +1,84 @@
+from httpx import Client
+
+from openhands.utils.ensure_httpx_close import EnsureHttpxClose
+
+
+def test_ensure_httpx_close_basic():
+    """Test basic functionality of EnsureHttpxClose."""
+    clients = []
+    ctx = EnsureHttpxClose()
+    with ctx:
+        # Create a client - should be tracked
+        client = Client()
+        assert client in ctx.clients
+        assert len(ctx.clients) == 1
+        clients.append(client)
+
+    # After context exit, client should be closed
+    assert client.is_closed
+
+
+def test_ensure_httpx_close_multiple_clients():
+    """Test EnsureHttpxClose with multiple clients."""
+    ctx = EnsureHttpxClose()
+    with ctx:
+        client1 = Client()
+        client2 = Client()
+        assert len(ctx.clients) == 2
+        assert client1 in ctx.clients
+        assert client2 in ctx.clients
+
+    assert client1.is_closed
+    assert client2.is_closed
+
+
+def test_ensure_httpx_close_nested():
+    """Test nested usage of EnsureHttpxClose."""
+    outer_ctx = EnsureHttpxClose()
+    with outer_ctx:
+        client1 = Client()
+        assert client1 in outer_ctx.clients
+
+        inner_ctx = EnsureHttpxClose()
+        with inner_ctx:
+            client2 = Client()
+            assert client2 in inner_ctx.clients
+            # Since both contexts are using the same monkey-patched __init__,
+            # both contexts will track all clients created while they are active
+            assert client2 in outer_ctx.clients
+
+        # After inner context, client2 should be closed
+        assert client2.is_closed
+        # client1 should still be open since outer context is still active
+        assert not client1.is_closed
+
+    # After outer context, both clients should be closed
+    assert client1.is_closed
+    assert client2.is_closed
+
+
+def test_ensure_httpx_close_exception():
+    """Test EnsureHttpxClose when an exception occurs."""
+    client = None
+    ctx = EnsureHttpxClose()
+    try:
+        with ctx:
+            client = Client()
+            raise ValueError('Test exception')
+    except ValueError:
+        pass
+
+    # Client should be closed even if an exception occurred
+    assert client is not None
+    assert client.is_closed
+
+
+def test_ensure_httpx_close_restore_init():
+    """Test that the original __init__ is restored after context exit."""
+    original_init = Client.__init__
+    ctx = EnsureHttpxClose()
+    with ctx:
+        assert Client.__init__ != original_init
+
+    # Original __init__ should be restored
+    assert Client.__init__ == original_init

--- a/tests/unit/test_ensure_httpx_close.py
+++ b/tests/unit/test_ensure_httpx_close.py
@@ -1,51 +1,38 @@
-from httpx import Client
+import httpx
 
-from openhands.utils.ensure_httpx_close import EnsureHttpxClose
+from openhands.utils.ensure_httpx_close import ensure_httpx_close
 
 
 def test_ensure_httpx_close_basic():
-    """Test basic functionality of EnsureHttpxClose."""
-    clients = []
-    ctx = EnsureHttpxClose()
+    """Test basic functionality of ensure_httpx_close."""
+    ctx = ensure_httpx_close()
     with ctx:
         # Create a client - should be tracked
-        client = Client()
-        assert client in ctx.clients
-        assert len(ctx.clients) == 1
-        clients.append(client)
+        client = httpx.Client()
 
     # After context exit, client should be closed
     assert client.is_closed
 
 
 def test_ensure_httpx_close_multiple_clients():
-    """Test EnsureHttpxClose with multiple clients."""
-    ctx = EnsureHttpxClose()
+    """Test ensure_httpx_close with multiple clients."""
+    ctx = ensure_httpx_close()
     with ctx:
-        client1 = Client()
-        client2 = Client()
-        assert len(ctx.clients) == 2
-        assert client1 in ctx.clients
-        assert client2 in ctx.clients
+        client1 = httpx.Client()
+        client2 = httpx.Client()
 
     assert client1.is_closed
     assert client2.is_closed
 
 
 def test_ensure_httpx_close_nested():
-    """Test nested usage of EnsureHttpxClose."""
-    outer_ctx = EnsureHttpxClose()
-    with outer_ctx:
-        client1 = Client()
-        assert client1 in outer_ctx.clients
+    """Test nested usage of ensure_httpx_close."""
+    with ensure_httpx_close():
+        client1 = httpx.Client()
 
-        inner_ctx = EnsureHttpxClose()
-        with inner_ctx:
-            client2 = Client()
-            assert client2 in inner_ctx.clients
-            # Since both contexts are using the same monkey-patched __init__,
-            # both contexts will track all clients created while they are active
-            assert client2 in outer_ctx.clients
+        with ensure_httpx_close():
+            client2 = httpx.Client()
+            assert not client2.is_closed
 
         # After inner context, client2 should be closed
         assert client2.is_closed
@@ -58,12 +45,11 @@ def test_ensure_httpx_close_nested():
 
 
 def test_ensure_httpx_close_exception():
-    """Test EnsureHttpxClose when an exception occurs."""
+    """Test ensure_httpx_close when an exception occurs."""
     client = None
-    ctx = EnsureHttpxClose()
     try:
-        with ctx:
-            client = Client()
+        with ensure_httpx_close():
+            client = httpx.Client()
             raise ValueError('Test exception')
     except ValueError:
         pass
@@ -73,12 +59,11 @@ def test_ensure_httpx_close_exception():
     assert client.is_closed
 
 
-def test_ensure_httpx_close_restore_init():
-    """Test that the original __init__ is restored after context exit."""
-    original_init = Client.__init__
-    ctx = EnsureHttpxClose()
-    with ctx:
-        assert Client.__init__ != original_init
+def test_ensure_httpx_close_restore_client():
+    """Test that the original client is restored after context exit."""
+    original_client = httpx.Client
+    with ensure_httpx_close():
+        assert httpx.Client != original_client
 
     # Original __init__ should be restored
-    assert Client.__init__ == original_init
+    assert httpx.Client == original_client

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,4 +1,6 @@
 import copy
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -489,3 +491,27 @@ def test_llm_token_usage(mock_litellm_completion, default_config):
     assert usage_entry_2['cache_read_tokens'] == 1
     assert usage_entry_2['cache_write_tokens'] == 3
     assert usage_entry_2['response_id'] == 'test-response-usage-2'
+
+
+@patch('openhands.llm.llm.litellm_completion')
+def test_completion_with_log_completions(mock_litellm_completion, default_config):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        default_config.log_completions = True
+        default_config.log_completions_folder = temp_dir
+        mock_response = {
+            'choices': [{'message': {'content': 'This is a mocked response.'}}]
+        }
+        mock_litellm_completion.return_value = mock_response
+
+        test_llm = LLM(config=default_config)
+        response = test_llm.completion(
+            messages=[{'role': 'user', 'content': 'Hello!'}],
+            stream=False,
+            drop_params=True,
+        )
+        assert (
+            response['choices'][0]['message']['content'] == 'This is a mocked response.'
+        )
+        files = list(Path(temp_dir).iterdir())
+        # Expect a log to be generated
+        assert len(files) == 1


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
This is ongoing work in file descriptor leaks, related to multiple PRs:
* https://github.com/All-Hands-AI/OpenHands/pull/6921
* https://github.com/All-Hands-AI/OpenHands/pull/6897
* https://github.com/All-Hands-AI/OpenHands/pull/6883

The previous issue was that there was some LiteLLM implementations which created multiple httpx clients and never closed any of them (Claude), some which closed their connections (Proxy), and some which used a semi global shared httpx client which is never closed (OpenAI).

In the last incarnation, the OpenAI model caused issues, which should now be resolved using the proxy client. The proxy client will close connections when asked, but transparently reopen them if requested (Similar to the requests library)

Once our LiteLLM PR is merged, we will be able to revisit (and hopefully remove) this.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ae498b8-nikolaik   --name openhands-app-ae498b8   docker.all-hands.dev/all-hands-ai/openhands:ae498b8
```