### PR TITLE
fix: `task_str` validation not required for trajectory replay

### DIFF
--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -247,17 +247,18 @@ if __name__ == '__main__':
     # Read task from file, CLI args, or stdin
     task_str = read_task(args, config.cli_multiline_input)
 
+    initial_user_action: Action = NullAction()
     if config.replay_trajectory_path:
         if task_str:
             raise ValueError(
                 'User-specified task is not supported under trajectory replay mode'
             )
+    else:
+        if not task_str:
+            raise ValueError('No task provided. Please specify a task through -t, -f.')
 
-    if not task_str:
-        raise ValueError('No task provided. Please specify a task through -t, -f.')
-
-    # Create initial user action
-    initial_user_action: MessageAction = MessageAction(content=task_str)
+        # Create actual initial user action
+        initial_user_action = MessageAction(content=task_str)
 
     # Set session name
     session_name = args.name


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR is to fix broken trajectory replay feature due to incorrect `task_str` argument validation.

---
**Link of any specific issues this addresses.**
