### PR TITLE
Add sort_order to ConversationStore and update FileConversationStore search method

### DIFF
--- a/openhands/storage/conversation/conversation_store.py
+++ b/openhands/storage/conversation/conversation_store.py
@@ -7,6 +7,16 @@ from openhands.storage.data_models.conversation_metadata import ConversationMeta
 from openhands.storage.data_models.conversation_metadata_result_set import (
     ConversationMetadataResultSet,
 )
+from enum import Enum
+
+class SortOrder(Enum):
+    title = "title"
+    title_desc = "title_desc"
+    created_at = "created_at"
+    created_at_desc = "created_at_desc"
+    last_updated_at = "last_updated_at"
+    last_updated_at_desc = "last_updated_at_desc"
+
 
 
 class ConversationStore(ABC):
@@ -35,6 +45,7 @@ class ConversationStore(ABC):
         self,
         page_id: str | None = None,
         limit: int = 20,
+        sort_order: SortOrder = SortOrder.created_at_desc,
     ) -> ConversationMetadataResultSet:
         """Search conversations"""
 

--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -9,7 +9,10 @@ from pydantic import TypeAdapter
 from openhands.core.config.app_config import AppConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.storage import get_file_store
-from openhands.storage.conversation.conversation_store import ConversationStore, SortOrder
+from openhands.storage.conversation.conversation_store import (
+    ConversationStore,
+    SortOrder,
+)
 from openhands.storage.data_models.conversation_metadata import ConversationMetadata
 from openhands.storage.data_models.conversation_metadata_result_set import (
     ConversationMetadataResultSet,
@@ -89,7 +92,11 @@ class FileConversationStore(ConversationStore):
                 logger.error(
                     f'Error loading conversation: {conversation_id}',
                 )
-        reverse = sort_order in (SortOrder.created_at_desc, SortOrder.title_desc, SortOrder.last_updated_at_desc)
+        reverse = sort_order in (
+            SortOrder.created_at_desc,
+            SortOrder.title_desc,
+            SortOrder.last_updated_at_desc,
+        )
         conversations.sort(key=lambda c: _get_sort_key(c, sort_order), reverse=reverse)
         conversations = conversations[start:end]
         next_page_id = offset_to_page_id(end, end < num_conversations)
@@ -111,12 +118,12 @@ class FileConversationStore(ConversationStore):
 
 def _get_sort_key(conversation: ConversationMetadata, sort_order: SortOrder) -> str:
     if sort_order in (SortOrder.created_at, SortOrder.created_at_desc):
-        return conversation.created_at.isoformat() if conversation.created_at else ""
+        return conversation.created_at.isoformat() if conversation.created_at else ''
     elif sort_order in (SortOrder.title, SortOrder.title_desc):
-        return conversation.title if conversation.title else ""
+        return conversation.title if conversation.title else ''
     elif sort_order in (SortOrder.last_updated_at, SortOrder.last_updated_at_desc):
         if hasattr(conversation, 'last_updated_at') and conversation.last_updated_at:
             return conversation.last_updated_at.isoformat()
         elif conversation.created_at:
             return conversation.created_at.isoformat()
-        return ""
+    return conversation.created_at.isoformat()

--- a/tests/unit/test_file_conversation_store.py
+++ b/tests/unit/test_file_conversation_store.py
@@ -2,11 +2,10 @@ import json
 
 import pytest
 
+from openhands.storage.conversation.conversation_store import SortOrder
 from openhands.storage.conversation.file_conversation_store import FileConversationStore
 from openhands.storage.data_models.conversation_metadata import ConversationMetadata
 from openhands.storage.memory import InMemoryFileStore
-
-from openhands.storage.conversation.conversation_store import SortOrder
 
 
 @pytest.mark.asyncio
@@ -169,66 +168,90 @@ async def test_search_with_invalid_conversation():
 @pytest.mark.asyncio
 async def test_search_sort_order_title():
     store = FileConversationStore(
-        InMemoryFileStore({
-            'sessions/conv1/metadata.json': json.dumps({
-                'conversation_id': 'conv1',
-                'github_user_id': 'user1',
-                'selected_repository': 'repo1',
-                'title': 'Banana',
-                'created_at': '2025-01-16T19:51:04Z'
-            }),
-            'sessions/conv2/metadata.json': json.dumps({
-                'conversation_id': 'conv2',
-                'github_user_id': 'user1',
-                'selected_repository': 'repo1',
-                'title': 'Apple',
-                'created_at': '2025-01-16T19:51:04Z'
-            }),
-            'sessions/conv3/metadata.json': json.dumps({
-                'conversation_id': 'conv3',
-                'github_user_id': 'user1',
-                'selected_repository': 'repo1',
-                'title': 'Cherry',
-                'created_at': '2025-01-16T19:51:04Z'
-            }),
-        })
+        InMemoryFileStore(
+            {
+                'sessions/conv1/metadata.json': json.dumps(
+                    {
+                        'conversation_id': 'conv1',
+                        'github_user_id': 'user1',
+                        'selected_repository': 'repo1',
+                        'title': 'Banana',
+                        'created_at': '2025-01-16T19:51:04Z',
+                    }
+                ),
+                'sessions/conv2/metadata.json': json.dumps(
+                    {
+                        'conversation_id': 'conv2',
+                        'github_user_id': 'user1',
+                        'selected_repository': 'repo1',
+                        'title': 'Apple',
+                        'created_at': '2025-01-16T19:51:04Z',
+                    }
+                ),
+                'sessions/conv3/metadata.json': json.dumps(
+                    {
+                        'conversation_id': 'conv3',
+                        'github_user_id': 'user1',
+                        'selected_repository': 'repo1',
+                        'title': 'Cherry',
+                        'created_at': '2025-01-16T19:51:04Z',
+                    }
+                ),
+            }
+        )
     )
     result = await store.search(sort_order=SortOrder.title)
     # Expected ascending order by title: Apple, Banana, Cherry
-    assert [conv.conversation_id for conv in result.results] == ['conv2', 'conv1', 'conv3']
+    assert [conv.conversation_id for conv in result.results] == [
+        'conv2',
+        'conv1',
+        'conv3',
+    ]
     result_desc = await store.search(sort_order=SortOrder.title_desc)
     # Expected descending order: Cherry, Banana, Apple
-    assert [conv.conversation_id for conv in result_desc.results] == ['conv3', 'conv1', 'conv2']
+    assert [conv.conversation_id for conv in result_desc.results] == [
+        'conv3',
+        'conv1',
+        'conv2',
+    ]
 
 
 @pytest.mark.asyncio
 async def test_search_sort_order_last_updated():
     store = FileConversationStore(
-        InMemoryFileStore({
-            'sessions/conv1/metadata.json': json.dumps({
-                'conversation_id': 'conv1',
-                'github_user_id': 'user1',
-                'selected_repository': 'repo1',
-                'title': 'A',
-                'created_at': '2025-01-16T19:51:04Z',
-                'last_updated_at': '2025-01-16T19:51:04Z'
-            }),
-            'sessions/conv2/metadata.json': json.dumps({
-                'conversation_id': 'conv2',
-                'github_user_id': 'user1',
-                'selected_repository': 'repo1',
-                'title': 'B',
-                'created_at': '2025-01-16T19:51:04Z',
-                'last_updated_at': '2025-01-17T19:51:04Z'
-            }),
-            'sessions/conv3/metadata.json': json.dumps({
-                'conversation_id': 'conv3',
-                'github_user_id': 'user1',
-                'selected_repository': 'repo1',
-                'title': 'C',
-                'created_at': '2025-01-16T19:51:04Z'
-            }),
-        })
+        InMemoryFileStore(
+            {
+                'sessions/conv1/metadata.json': json.dumps(
+                    {
+                        'conversation_id': 'conv1',
+                        'github_user_id': 'user1',
+                        'selected_repository': 'repo1',
+                        'title': 'A',
+                        'created_at': '2025-01-16T19:51:04Z',
+                        'last_updated_at': '2025-01-16T19:51:04Z',
+                    }
+                ),
+                'sessions/conv2/metadata.json': json.dumps(
+                    {
+                        'conversation_id': 'conv2',
+                        'github_user_id': 'user1',
+                        'selected_repository': 'repo1',
+                        'title': 'B',
+                        'created_at': '2025-01-16T19:51:04Z',
+                        'last_updated_at': '2025-01-17T19:51:04Z',
+                    }
+                ),
+                'sessions/conv3/metadata.json': json.dumps(
+                    {
+                        'conversation_id': 'conv3',
+                        'github_user_id': 'user1',
+                        'selected_repository': 'repo1',
+                        'title': 'C',
+                        'created_at': '2025-01-16T19:51:04Z',
+                    }
+                ),
+            }
+        )
     )
     result_asc = await store.search(sort_order=SortOrder.last_updated_at)
     ids = [conv.conversation_id for conv in result_asc.results]
@@ -238,4 +261,3 @@ async def test_search_sort_order_last_updated():
     ids_desc = [conv.conversation_id for conv in result_desc.results]
     # In descending order, conv2 should come first
     assert ids_desc[0] == 'conv2'
-

--- a/tests/unit/test_file_conversation_store.py
+++ b/tests/unit/test_file_conversation_store.py
@@ -6,6 +6,8 @@ from openhands.storage.conversation.file_conversation_store import FileConversat
 from openhands.storage.data_models.conversation_metadata import ConversationMetadata
 from openhands.storage.memory import InMemoryFileStore
 
+from openhands.storage.conversation.conversation_store import SortOrder
+
 
 @pytest.mark.asyncio
 async def test_load_store():
@@ -162,3 +164,78 @@ async def test_search_with_invalid_conversation():
     assert len(result.results) == 1
     assert result.results[0].conversation_id == 'conv1'
     assert result.next_page_id is None
+
+
+@pytest.mark.asyncio
+async def test_search_sort_order_title():
+    store = FileConversationStore(
+        InMemoryFileStore({
+            'sessions/conv1/metadata.json': json.dumps({
+                'conversation_id': 'conv1',
+                'github_user_id': 'user1',
+                'selected_repository': 'repo1',
+                'title': 'Banana',
+                'created_at': '2025-01-16T19:51:04Z'
+            }),
+            'sessions/conv2/metadata.json': json.dumps({
+                'conversation_id': 'conv2',
+                'github_user_id': 'user1',
+                'selected_repository': 'repo1',
+                'title': 'Apple',
+                'created_at': '2025-01-16T19:51:04Z'
+            }),
+            'sessions/conv3/metadata.json': json.dumps({
+                'conversation_id': 'conv3',
+                'github_user_id': 'user1',
+                'selected_repository': 'repo1',
+                'title': 'Cherry',
+                'created_at': '2025-01-16T19:51:04Z'
+            }),
+        })
+    )
+    result = await store.search(sort_order=SortOrder.title)
+    # Expected ascending order by title: Apple, Banana, Cherry
+    assert [conv.conversation_id for conv in result.results] == ['conv2', 'conv1', 'conv3']
+    result_desc = await store.search(sort_order=SortOrder.title_desc)
+    # Expected descending order: Cherry, Banana, Apple
+    assert [conv.conversation_id for conv in result_desc.results] == ['conv3', 'conv1', 'conv2']
+
+
+@pytest.mark.asyncio
+async def test_search_sort_order_last_updated():
+    store = FileConversationStore(
+        InMemoryFileStore({
+            'sessions/conv1/metadata.json': json.dumps({
+                'conversation_id': 'conv1',
+                'github_user_id': 'user1',
+                'selected_repository': 'repo1',
+                'title': 'A',
+                'created_at': '2025-01-16T19:51:04Z',
+                'last_updated_at': '2025-01-16T19:51:04Z'
+            }),
+            'sessions/conv2/metadata.json': json.dumps({
+                'conversation_id': 'conv2',
+                'github_user_id': 'user1',
+                'selected_repository': 'repo1',
+                'title': 'B',
+                'created_at': '2025-01-16T19:51:04Z',
+                'last_updated_at': '2025-01-17T19:51:04Z'
+            }),
+            'sessions/conv3/metadata.json': json.dumps({
+                'conversation_id': 'conv3',
+                'github_user_id': 'user1',
+                'selected_repository': 'repo1',
+                'title': 'C',
+                'created_at': '2025-01-16T19:51:04Z'
+            }),
+        })
+    )
+    result_asc = await store.search(sort_order=SortOrder.last_updated_at)
+    ids = [conv.conversation_id for conv in result_asc.results]
+    # In ascending order, conv2 (with last_updated_at 2025-01-17) should come last
+    assert ids[-1] == 'conv2'
+    result_desc = await store.search(sort_order=SortOrder.last_updated_at_desc)
+    ids_desc = [conv.conversation_id for conv in result_desc.results]
+    # In descending order, conv2 should come first
+    assert ids_desc[0] == 'conv2'
+


### PR DESCRIPTION
This PR adds sort_order supported enum to ConversationStore and updates the FileConversationStore search method to support sorting by sort_order. Also, corresponding unit tests have been updated to validate the new functionality.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f9caed7-nikolaik   --name openhands-app-f9caed7   docker.all-hands.dev/all-hands-ai/openhands:f9caed7
```