### PR TITLE
Fix microagent matching to the user message, not previous enhancements

### DIFF
--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 
 from openhands.controller.state.state import State
 from openhands.core.logger import openhands_logger
-from openhands.core.message import Message, TextContent
+from openhands.core.message import ImageContent, Message, TextContent
 from openhands.microagent import (
     BaseMicroAgent,
     KnowledgeMicroAgent,
@@ -177,7 +177,22 @@ class PromptManager:
         """
         if not message.content:
             return
-        message_content = message.content[0].text
+
+        # if there were other texts included, they were before the user message
+        # so the last TextContent is the user message
+        # content can be a list of TextContent or ImageContent
+        # we only want the text from the last TextContent
+        message_content = ''
+        for content in reversed(message.content):
+            if isinstance(content, TextContent):
+                message_content = content.text
+                break
+            elif isinstance(content, ImageContent):
+                continue
+
+        if not message_content:
+            return
+
         for microagent in self.knowledge_microagents.values():
             trigger = microagent.match_trigger(message_content)
             if trigger:

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -181,7 +181,6 @@ class PromptManager:
         # if there were other texts included, they were before the user message
         # so the last TextContent is the user message
         # content can be a list of TextContent or ImageContent
-        # we only want the text from the last TextContent
         message_content = ''
         for content in reversed(message.content):
             if isinstance(content, TextContent):

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 
 from openhands.controller.state.state import State
 from openhands.core.logger import openhands_logger
-from openhands.core.message import ImageContent, Message, TextContent
+from openhands.core.message import Message, TextContent
 from openhands.microagent import (
     BaseMicroAgent,
     KnowledgeMicroAgent,

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -186,8 +186,6 @@ class PromptManager:
             if isinstance(content, TextContent):
                 message_content = content.text
                 break
-            elif isinstance(content, ImageContent):
-                continue
 
         if not message_content:
             return

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -3,7 +3,7 @@ import shutil
 
 import pytest
 
-from openhands.core.message import Message, TextContent
+from openhands.core.message import ImageContent, Message, TextContent
 from openhands.microagent import BaseMicroAgent
 from openhands.utils.prompt import PromptManager, RepositoryInfo
 
@@ -201,3 +201,215 @@ Test microagent 2 content
     # Clean up temporary files
     os.remove(os.path.join(prompt_dir, 'micro', f'{microagent1_name}.md'))
     os.remove(os.path.join(prompt_dir, 'micro', f'{microagent2_name}.md'))
+
+
+def test_enhance_message_with_multiple_text_contents(prompt_dir):
+    # Create a test microagent that triggers on a specific keyword
+    microagent_name = 'keyword_microagent'
+    microagent_content = """
+---
+name: KeywordMicroAgent
+type: knowledge
+agent: CodeActAgent
+triggers:
+- triggerkeyword
+---
+
+This is special information about the triggerkeyword.
+"""
+
+    # Create the microagent file
+    os.makedirs(os.path.join(prompt_dir, 'micro'), exist_ok=True)
+    with open(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'), 'w') as f:
+        f.write(microagent_content)
+
+    manager = PromptManager(
+        prompt_dir=prompt_dir, microagent_dir=os.path.join(prompt_dir, 'micro')
+    )
+
+    # Test that it matches the trigger in the last TextContent
+    message = Message(
+        role='user',
+        content=[
+            TextContent(text='This is some initial context.'),
+            TextContent(text='This is a message without triggers.'),
+            TextContent(text='This contains the triggerkeyword that should match.'),
+        ],
+    )
+
+    manager.enhance_message(message)
+
+    # Should have added a TextContent with the microagent info
+    assert len(message.content) == 4
+    assert 'special information about the triggerkeyword' in message.content[3].text
+
+    # Clean up
+    os.remove(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'))
+
+
+def test_enhance_message_with_image_content(prompt_dir):
+    # Create a test microagent that triggers on a specific keyword
+    microagent_name = 'image_test_microagent'
+    microagent_content = """
+---
+name: ImageTestMicroAgent
+type: knowledge
+agent: CodeActAgent
+triggers:
+- imagekeyword
+---
+
+This is information related to imagekeyword.
+"""
+
+    # Create the microagent file
+    os.makedirs(os.path.join(prompt_dir, 'micro'), exist_ok=True)
+    with open(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'), 'w') as f:
+        f.write(microagent_content)
+
+    manager = PromptManager(
+        prompt_dir=prompt_dir, microagent_dir=os.path.join(prompt_dir, 'micro')
+    )
+
+    # Test with mix of ImageContent and TextContent
+    message = Message(
+        role='user',
+        content=[
+            TextContent(text='This is some initial text.'),
+            ImageContent(url='https://example.com/image.jpg'),
+            TextContent(text='This mentions imagekeyword that should match.'),
+        ],
+    )
+
+    manager.enhance_message(message)
+
+    # Should have added a TextContent with the microagent info
+    assert len(message.content) == 4
+    assert 'information related to imagekeyword' in message.content[3].text
+
+    # Clean up
+    os.remove(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'))
+
+
+def test_enhance_message_with_only_image_content(prompt_dir):
+    # Create a test microagent
+    microagent_name = 'image_only_microagent'
+    microagent_content = """
+---
+name: ImageOnlyMicroAgent
+type: knowledge
+agent: CodeActAgent
+triggers:
+- anytrigger
+---
+
+This should not appear in the enhanced message.
+"""
+
+    # Create the microagent file
+    os.makedirs(os.path.join(prompt_dir, 'micro'), exist_ok=True)
+    with open(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'), 'w') as f:
+        f.write(microagent_content)
+
+    manager = PromptManager(
+        prompt_dir=prompt_dir, microagent_dir=os.path.join(prompt_dir, 'micro')
+    )
+
+    # Test with only ImageContent
+    message = Message(
+        role='user',
+        content=[
+            ImageContent(url='https://example.com/image1.jpg'),
+            ImageContent(url='https://example.com/image2.jpg'),
+        ],
+    )
+
+    # Should not raise any exceptions
+    manager.enhance_message(message)
+
+    # Should not have added any content
+    assert len(message.content) == 2
+
+    # Clean up
+    os.remove(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'))
+
+
+def test_enhance_message_with_reversed_order(prompt_dir):
+    # Create a test microagent
+    microagent_name = 'reversed_microagent'
+    microagent_content = """
+---
+name: ReversedMicroAgent
+type: knowledge
+agent: CodeActAgent
+triggers:
+- lasttrigger
+---
+
+This is specific information about the lasttrigger.
+"""
+
+    # Create the microagent file
+    os.makedirs(os.path.join(prompt_dir, 'micro'), exist_ok=True)
+    with open(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'), 'w') as f:
+        f.write(microagent_content)
+
+    manager = PromptManager(
+        prompt_dir=prompt_dir, microagent_dir=os.path.join(prompt_dir, 'micro')
+    )
+
+    # Test where the last text content is not at the end of the list
+    message = Message(
+        role='user',
+        content=[
+            ImageContent(url='https://example.com/image1.jpg'),
+            TextContent(text='This contains the lasttrigger word.'),
+            ImageContent(url='https://example.com/image2.jpg'),
+        ],
+    )
+
+    manager.enhance_message(message)
+
+    # Should have added a TextContent with the microagent info
+    assert len(message.content) == 4
+    assert 'specific information about the lasttrigger' in message.content[3].text
+
+    # Clean up
+    os.remove(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'))
+
+
+def test_enhance_message_with_empty_content(prompt_dir):
+    # Create a test microagent
+    microagent_name = 'empty_microagent'
+    microagent_content = """
+---
+name: EmptyMicroAgent
+type: knowledge
+agent: CodeActAgent
+triggers:
+- emptytrigger
+---
+
+This should not appear in the enhanced message.
+"""
+
+    # Create the microagent file
+    os.makedirs(os.path.join(prompt_dir, 'micro'), exist_ok=True)
+    with open(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'), 'w') as f:
+        f.write(microagent_content)
+
+    manager = PromptManager(
+        prompt_dir=prompt_dir, microagent_dir=os.path.join(prompt_dir, 'micro')
+    )
+
+    # Test with empty content
+    message = Message(role='user', content=[])
+
+    # Should not raise any exceptions
+    manager.enhance_message(message)
+
+    # Should not have added any content
+    assert len(message.content) == 0
+
+    # Clean up
+    os.remove(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'))

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -276,7 +276,7 @@ This is information related to imagekeyword.
         role='user',
         content=[
             TextContent(text='This is some initial text.'),
-            ImageContent(url='https://example.com/image.jpg'),
+            ImageContent(image_urls=['https://example.com/image.jpg']),
             TextContent(text='This mentions imagekeyword that should match.'),
         ],
     )
@@ -319,8 +319,12 @@ This should not appear in the enhanced message.
     message = Message(
         role='user',
         content=[
-            ImageContent(url='https://example.com/image1.jpg'),
-            ImageContent(url='https://example.com/image2.jpg'),
+            ImageContent(
+                image_urls=[
+                    'https://example.com/image1.jpg',
+                    'https://example.com/image2.jpg',
+                ]
+            ),
         ],
     )
 
@@ -328,7 +332,7 @@ This should not appear in the enhanced message.
     manager.enhance_message(message)
 
     # Should not have added any content
-    assert len(message.content) == 2
+    assert len(message.content) == 1
 
     # Clean up
     os.remove(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'))
@@ -362,9 +366,9 @@ This is specific information about the lasttrigger.
     message = Message(
         role='user',
         content=[
-            ImageContent(url='https://example.com/image1.jpg'),
+            ImageContent(image_urls=['https://example.com/image1.jpg']),
             TextContent(text='This contains the lasttrigger word.'),
-            ImageContent(url='https://example.com/image2.jpg'),
+            ImageContent(image_urls=['https://example.com/image2.jpg']),
         ],
     )
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below
Fix prompt extensions matching on the first user message.

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

There is a bug with micro agent keyword-matching on the first user message:
- currently it inserts repo_instructions first
- then it finds its own repo_instructions in the content, which include "npm" for `openhands` repo, and is triggered on it
- so our prompts contain the "npm" micro agent 
```
 openhands:INFO: prompt.py:184 - Microagent 'npm' triggered by keyword 'npm'
```

This PR proposes a fix for that.
- additionally, handle ImageContent (maybe we shouldn't assume there's always 'text')

Found and split out of 
- https://github.com/All-Hands-AI/OpenHands/pull/6909

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8936390-nikolaik   --name openhands-app-8936390   docker.all-hands.dev/all-hands-ai/openhands:8936390
```