### PR TITLE
Refactor: Moving ConversationInfo to server module

### DIFF
--- a/openhands/server/data_models/conversation_info.py
+++ b/openhands/server/data_models/conversation_info.py
@@ -8,7 +8,7 @@ from openhands.storage.data_models.conversation_status import ConversationStatus
 class ConversationInfo:
     """
     Information about a conversation. This combines conversation metadata with
-    information on whetehr a conversation is currently running
+    information on whether a conversation is currently running
     """
 
     conversation_id: str

--- a/openhands/server/data_models/conversation_info.py
+++ b/openhands/server/data_models/conversation_info.py
@@ -6,7 +6,10 @@ from openhands.storage.data_models.conversation_status import ConversationStatus
 
 @dataclass
 class ConversationInfo:
-    """Information about a conversation"""
+    """
+    Information about a conversation. This combines conversation metadata with
+    information on whetehr a conversation is currently running
+    """
 
     conversation_id: str
     title: str

--- a/openhands/server/data_models/conversation_info_result_set.py
+++ b/openhands/server/data_models/conversation_info_result_set.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from openhands.storage.data_models.conversation_info import ConversationInfo
+from openhands.server.data_models.conversation_info import ConversationInfo
 
 
 @dataclass

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -12,6 +12,10 @@ from openhands.events.stream import EventStreamSubscriber
 from openhands.integrations.github.github_service import GithubServiceImpl
 from openhands.runtime import get_runtime_cls
 from openhands.server.auth import get_github_token, get_user_id
+from openhands.server.data_models.conversation_info import ConversationInfo
+from openhands.server.data_models.conversation_info_result_set import (
+    ConversationInfoResultSet,
+)
 from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.server.shared import (
     ConversationStoreImpl,
@@ -21,10 +25,6 @@ from openhands.server.shared import (
     monitoring_listener,
 )
 from openhands.server.types import LLMAuthenticationError, MissingSettingsError
-from openhands.storage.data_models.conversation_info import ConversationInfo
-from openhands.storage.data_models.conversation_info_result_set import (
-    ConversationInfoResultSet,
-)
 from openhands.storage.data_models.conversation_metadata import ConversationMetadata
 from openhands.storage.data_models.conversation_status import ConversationStatus
 from openhands.utils.async_utils import (

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -6,15 +6,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from openhands.runtime.impl.docker.docker_runtime import DockerRuntime
+from openhands.server.data_models.conversation_info import ConversationInfo
+from openhands.server.data_models.conversation_info_result_set import (
+    ConversationInfoResultSet,
+)
 from openhands.server.routes.manage_conversations import (
     delete_conversation,
     get_conversation,
     search_conversations,
     update_conversation,
-)
-from openhands.storage.data_models.conversation_info import ConversationInfo
-from openhands.storage.data_models.conversation_info_result_set import (
-    ConversationInfoResultSet,
 )
 from openhands.storage.data_models.conversation_status import ConversationStatus
 from openhands.storage.memory import InMemoryFileStore


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

It was noted that having both a `ConversationMetadata` and a `ConversationInfo` is confusing. Since the conversation info is only used from inside the server package, we move the info models here, and add a note about what they are for. (Combining metadata with whether or not the conversation is running)


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:138c1cb-nikolaik   --name openhands-app-138c1cb   docker.all-hands.dev/all-hands-ai/openhands:138c1cb
```