### PR TITLE
hotfix(frontend): Truncate long conversation card titles

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Tooltip } from "@heroui/react";
 import { formatTimeDelta } from "#/utils/format-time-delta";
 import { ConversationRepoLink } from "./conversation-repo-link";
 import {

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Tooltip } from "@heroui/react";
 import { formatTimeDelta } from "#/utils/format-time-delta";
 import { ConversationRepoLink } from "./conversation-repo-link";
 import {
@@ -101,9 +102,11 @@ export function ConversationCard({
           "h-auto w-fit rounded-xl border border-[#525252]",
       )}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 w-full">
-          {isActive && <span className="w-2 h-2 bg-blue-500 rounded-full" />}
+      <div className="flex items-center justify-between w-full">
+        <div className="flex items-center gap-2 flex-1 min-w-0 overflow-hidden mr-2">
+          {isActive && (
+            <span className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0" />
+          )}
           {titleMode === "edit" && (
             <input
               ref={inputRef}
@@ -119,7 +122,8 @@ export function ConversationCard({
           {titleMode === "view" && (
             <p
               data-testid="conversation-card-title"
-              className="text-sm leading-6 font-semibold bg-transparent w-full"
+              className="text-sm leading-6 font-semibold bg-transparent truncate overflow-hidden"
+              title={title}
             >
               {title}
             </p>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Before:
![image](https://github.com/user-attachments/assets/5a492341-b401-4051-adec-68612475a06e)

After:
![image](https://github.com/user-attachments/assets/3a5ae4ef-3d4b-4f6c-881c-317acc038bae)


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:05cabb1-nikolaik   --name openhands-app-05cabb1   docker.all-hands.dev/all-hands-ai/openhands:05cabb1
```