### PR TITLE
Fix image tag inconsistency in forked-PR workflows

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -127,11 +127,15 @@ jobs:
         run: |
           ./containers/build.sh -i runtime -o ${{ github.repository_owner }} --push -t ${{ matrix.base_image.tag }}
       # Forked repos can't push to GHCR, so we need to upload the image as an artifact
+      - name: Lowercase Repository Owner
+        if: github.event.pull_request.head.repo.fork
+        run: |
+          echo REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       - name: Build runtime image ${{ matrix.base_image.image }} for fork
         if: github.event.pull_request.head.repo.fork
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/all-hands-ai/runtime:${{ env.RELEVANT_SHA }}-${{ matrix.base_image.tag }}
+          tags: ghcr.io/${{ env.REPO_OWNER }}/runtime:${{ env.RELEVANT_SHA }}-${{ matrix.base_image.tag }}
           outputs: type=docker,dest=/tmp/runtime-${{ matrix.base_image.tag }}.tar
           context: containers/runtime
       - name: Upload runtime image for fork


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces.**

When work on on a PR in a forked repo, the ghcr-build.yml workflow will upload the runtime image as an artifact in `ghcr_build_runtime` and download the runtime image in `test_runtime_root` and `test_runtime_oh`. However, the image names are not used consistently:
1. In `ghcr_build_runtime`, the org component of the image name is hard coded to `all-hands-ai`.
2. In `test_runtime_root` and `test_runtime_oh`, it's `${{ github.repository_owner }}`.

As a result, tests will fail due to not finding the image locally: 
1. example log for `ghcr_build_runtime`: https://github.com/zchn/OpenHands/actions/runs/13568952707/job/37928680266#step:12:176
2. failure in example log for `test_runtime_root`: load: https://github.com/zchn/OpenHands/actions/runs/13568952707/job/37929035901#step:5:8 use: https://github.com/zchn/OpenHands/actions/runs/13568952707/job/37929035901#step:10:55

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR updates the image name in `ghcr_build_runtime` to also use `${{ github.repository_owner }}` for consistency. More specifically:
1. Use a consistent way to get a lowercased repository owner into the REPO_OWNER environment variable.
2. Use REPO_OWNER in `ghcr_build_runtime`.
