### PR TITLE
Re-add separators between user messages

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -35,7 +35,7 @@ class CodeActAgent(Agent):
 
     ### Overview
 
-    This agent implements the CodeAct idea ([paper](https://arxiv.org/abs/2402.01030), [tweet](https://twitter.com/xingyaow_/status/1754556835703751087)) that consolidates LLM agents’ **act**ions into a unified **code** action space for both *simplicity* and *performance* (see paper for more details).
+    This agent implements the CodeAct idea ([paper](https://arxiv.org/abs/2402.01030), [tweet](https://twitter.com/xingyaow_/status/1754556835703751087)) that consolidates LLM agents' **act**ions into a unified **code** action space for both *simplicity* and *performance* (see paper for more details).
 
     The conceptual idea is illustrated below. At each turn, the agent can:
 
@@ -216,6 +216,7 @@ class CodeActAgent(Agent):
 
         results: list[Message] = []
         is_first_message_handled = False
+        prev_role = None
 
         for msg in messages:
             if msg.role == 'user' and not is_first_message_handled:
@@ -231,6 +232,17 @@ class CodeActAgent(Agent):
             if msg.role == 'user':
                 self.prompt_manager.enhance_message(msg)
 
+                # Add double newline between consecutive user messages
+                # This prevents messages from being "smooshed together" without separation
+                if prev_role == 'user' and len(msg.content) > 0:
+                    # Find the first TextContent in the message to add newlines
+                    for content_item in msg.content:
+                        if isinstance(content_item, TextContent):
+                            # If the previous message was also from a user, prepend two newlines to ensure separation
+                            content_item.text = '\n\n' + content_item.text
+                            break
+
             results.append(msg)
+            prev_role = msg.role
 
         return results

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -233,7 +233,6 @@ class CodeActAgent(Agent):
                 self.prompt_manager.enhance_message(msg)
 
                 # Add double newline between consecutive user messages
-                # This prevents messages from being "smooshed together" without separation
                 if prev_role == 'user' and len(msg.content) > 0:
                     # Find the first TextContent in the message to add newlines
                     for content_item in msg.content:

--- a/tests/unit/test_codeact_agent.py
+++ b/tests/unit/test_codeact_agent.py
@@ -21,6 +21,7 @@ from openhands.agenthub.codeact_agent.tools.browser import (
 from openhands.controller.state.state import State
 from openhands.core.config import AgentConfig, LLMConfig
 from openhands.core.exceptions import FunctionCallNotExistsError
+from openhands.core.message import ImageContent, Message, TextContent
 from openhands.events.action import (
     CmdRunAction,
     MessageAction,
@@ -311,3 +312,66 @@ def test_mismatched_tool_call_events(mock_state: State):
     mock_state.history = [observation]
     messages = agent._get_messages(mock_state)
     assert len(messages) == 1
+
+
+def test_enhance_messages_adds_newlines_between_consecutive_user_messages(
+    agent: CodeActAgent,
+):
+    """Test that _enhance_messages adds newlines between consecutive user messages."""
+    # Set up the prompt manager
+    agent.prompt_manager = Mock()
+    agent.prompt_manager.add_examples_to_initial_message = Mock()
+    agent.prompt_manager.add_info_to_initial_message = Mock()
+    agent.prompt_manager.enhance_message = Mock()
+
+    # Create consecutive user messages with various content types
+    messages = [
+        # First user message with TextContent only
+        Message(role='user', content=[TextContent(text='First user message')]),
+        # Second user message with TextContent only - should get newlines added
+        Message(role='user', content=[TextContent(text='Second user message')]),
+        # Assistant message
+        Message(role='assistant', content=[TextContent(text='Assistant response')]),
+        # Third user message with TextContent only - shouldn't get newlines
+        Message(role='user', content=[TextContent(text='Third user message')]),
+        # Fourth user message with ImageContent first, TextContent second - should get newlines
+        Message(
+            role='user',
+            content=[
+                ImageContent(image_urls=['https://example.com/image.jpg']),
+                TextContent(text='Fourth user message with image'),
+            ],
+        ),
+        # Fifth user message with only ImageContent - no TextContent to modify
+        Message(
+            role='user',
+            content=[
+                ImageContent(image_urls=['https://example.com/another-image.jpg'])
+            ],
+        ),
+    ]
+
+    # Call _enhance_messages
+    enhanced_messages = agent._enhance_messages(messages)
+
+    # Verify newlines were added correctly
+    assert enhanced_messages[1].content[0].text.startswith('\n\n')
+    assert enhanced_messages[1].content[0].text == '\n\nSecond user message'
+
+    # Third message follows assistant, so shouldn't have newlines
+    assert not enhanced_messages[3].content[0].text.startswith('\n\n')
+    assert enhanced_messages[3].content[0].text == 'Third user message'
+
+    # Fourth message follows user, so should have newlines in its TextContent
+    assert enhanced_messages[4].content[1].text.startswith('\n\n')
+    assert enhanced_messages[4].content[1].text == '\n\nFourth user message with image'
+
+    # Fifth message only has ImageContent, no TextContent to modify
+    assert len(enhanced_messages[5].content) == 1
+    assert isinstance(enhanced_messages[5].content[0], ImageContent)
+
+    # Verify prompt manager methods were called as expected
+    assert agent.prompt_manager.add_examples_to_initial_message.call_count == 1
+    assert (
+        agent.prompt_manager.enhance_message.call_count == 5
+    )  # Called for each user message


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes a way to re-add separators between user messages.

Unit-tested, to keep an eye on it.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f6840dd-nikolaik   --name openhands-app-f6840dd   docker.all-hands.dev/all-hands-ai/openhands:f6840dd
```