### PR TITLE
Backport conversation memory from PR #6909

### DIFF
--- a/openhands/memory/__init__.py
+++ b/openhands/memory/__init__.py
@@ -1,4 +1,5 @@
 from openhands.memory.condenser import Condenser
+from openhands.memory.conversation_memory import ConversationMemory
 from openhands.memory.long_term_memory import LongTermMemory
 
-__all__ = ['LongTermMemory', 'Condenser']
+__all__ = ['LongTermMemory', 'Condenser', 'ConversationMemory']

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -1,0 +1,198 @@
+from openhands.core.logger import openhands_logger as logger
+from openhands.core.message import Message, TextContent
+from openhands.events.event import Event, EventSource
+from openhands.events.action.message import MessageAction
+from openhands.events.stream import EventStream, EventStreamSubscriber
+from openhands.microagent import (
+    BaseMicroAgent,
+    KnowledgeMicroAgent,
+    RepoMicroAgent,
+    load_microagents_from_dir,
+)
+from openhands.utils.prompt import PromptManager, RepositoryInfo, RuntimeInfo
+
+
+class ConversationMemory:
+    """
+    ConversationMemory is a component that listens to the EventStream for user MessageAction
+    and enhances them with additional context from microagents.
+    """
+
+    def __init__(
+        self,
+        event_stream: EventStream,
+        microagents_dir: str,
+        disabled_microagents: list[str] | None = None,
+    ):
+        self.event_stream = event_stream
+        self.microagents_dir = microagents_dir
+        self.disabled_microagents = disabled_microagents or []
+        # Subscribe to events
+        self.event_stream.subscribe(
+            EventStreamSubscriber.MEMORY,
+            self.on_event,
+            'ConversationMemory',
+        )
+        # Load global microagents (Knowledge + Repo).
+        self._load_global_microagents()
+
+        # Additional placeholders to store user workspace microagents if needed
+        self.repo_microagents: dict[str, RepoMicroAgent] = {}
+        self.knowledge_microagents: dict[str, KnowledgeMicroAgent] = {}
+
+        # Track whether we've seen the first user message
+        self._first_user_message_seen = False
+
+        # Store repository / runtime info to send them to the templating later
+        self.repository_info: RepositoryInfo | None = None
+        self.runtime_info: RuntimeInfo | None = None
+
+    def _load_global_microagents(self) -> None:
+        """
+        Loads microagents from the global microagents_dir.
+        This is effectively what used to happen in PromptManager.
+        """
+        repo_agents, knowledge_agents, _ = load_microagents_from_dir(
+            self.microagents_dir
+        )
+        for name, agent in knowledge_agents.items():
+            if name in self.disabled_microagents:
+                continue
+            if isinstance(agent, KnowledgeMicroAgent):
+                self.knowledge_microagents[name] = agent
+        for name, agent in repo_agents.items():
+            if name in self.disabled_microagents:
+                continue
+            if isinstance(agent, RepoMicroAgent):
+                self.repo_microagents[name] = agent
+
+    def set_repository_info(self, repo_name: str, repo_directory: str) -> None:
+        """Store repository info so we can reference it in an observation."""
+        self.repository_info = RepositoryInfo(repo_name, repo_directory)
+        self.prompt_manager.set_repository_info(self.repository_info)
+
+    def set_runtime_info(self, runtime_hosts: dict[str, int]) -> None:
+        """Store runtime info (web hosts, ports, etc.)."""
+        # e.g. { '127.0.0.1': 8080 }
+        self.runtime_info = RuntimeInfo(available_hosts=runtime_hosts)
+        self.prompt_manager.set_runtime_info(self.runtime_info)
+
+    def on_event(self, event: Event):
+        """Handle an event from the event stream."""
+        if isinstance(event, MessageAction):
+            if event.source == 'user':
+                # If this is the first user message, add repository and runtime info
+                if not self._first_user_message_seen:
+                    self._first_user_message_seen = True
+                    self._on_first_user_message(event)
+                # Enhance the message with microagent content
+                self._on_user_message_action(event)
+
+    def _on_first_user_message(self, event: MessageAction):
+        """Add repository and runtime info to the first user message."""
+        # Convert MessageAction to Message for compatibility with existing code
+        message = Message(role='user', content=[TextContent(text=event.content)])
+        
+        # Build the repository instructions
+        repo_instructions = ''
+        assert (
+            len(self.repo_microagents) <= 1
+        ), f'Expecting at most one repo microagent, but found {len(self.repo_microagents)}: {self.repo_microagents.keys()}'
+        for microagent in self.repo_microagents.values():
+            # We assume these are the repo instructions
+            if repo_instructions:
+                repo_instructions += '\n\n'
+            repo_instructions += microagent.content
+
+        # Add the info to the message
+        self.prompt_manager.add_info_to_initial_message(message)
+        
+        # Update the original event content
+        if message.content and len(message.content) > 1:
+            # Combine all TextContent into a single string
+            combined_text = ""
+            for content in message.content:
+                if isinstance(content, TextContent):
+                    combined_text += content.text + "\n"
+            event.content = combined_text.strip()
+
+    def _on_user_message_action(self, event: MessageAction):
+        """Enhance user message with microagent content."""
+        if event.source != 'user':
+            return
+
+        # If there's no text, do nothing
+        user_text = event.content.strip()
+        if not user_text:
+            return
+            
+        # Convert MessageAction to Message for compatibility with existing code
+        message = Message(role='user', content=[TextContent(text=user_text)])
+        
+        # Enhance the message with microagent content
+        self.enhance_message(message)
+        
+        # Update the original event content if it was enhanced
+        if len(message.content) > 1:
+            # Combine all TextContent into a single string
+            combined_text = ""
+            for content in message.content:
+                if isinstance(content, TextContent):
+                    combined_text += content.text + "\n"
+            event.content = combined_text.strip()
+
+    def enhance_message(self, message: Message) -> None:
+        """Enhance the user message with additional context.
+
+        This method is used to enhance the user message with additional context
+        about the user's task. The additional context will convert the current
+        generic agent into a more specialized agent that is tailored to the user's task.
+        """
+        if not message.content:
+            return
+
+        # if there were other texts included, they were before the user message
+        # so the last TextContent is the user message
+        # content can be a list of TextContent or ImageContent
+        message_content = ''
+        for content in reversed(message.content):
+            if isinstance(content, TextContent):
+                message_content = content.text
+                break
+
+        if not message_content:
+            return
+
+        for microagent in self.knowledge_microagents.values():
+            trigger = microagent.match_trigger(message_content)
+            if trigger:
+                logger.info(
+                    "Microagent '%s' triggered by keyword '%s'",
+                    microagent.name,
+                    trigger,
+                )
+                micro_text = f'<extra_info>\nThe following information has been included based on a keyword match for "{trigger}". It may or may not be relevant to the user\'s request.'
+                micro_text += '\n\n' + microagent.content
+                micro_text += '\n</extra_info>'
+                message.content.append(TextContent(text=micro_text))
+
+    def load_user_workspace_microagents(
+        self, user_microagents: list[BaseMicroAgent]
+    ) -> None:
+        """
+        If you want to load microagents from a user's cloned repo or workspace directory,
+        call this from agent_session or setup once the workspace is cloned.
+        """
+        logger.info(
+            'Loading user workspace microagents: %s', [m.name for m in user_microagents]
+        )
+        for ma in user_microagents:
+            if ma.name in self.disabled_microagents:
+                continue
+            if isinstance(ma, KnowledgeMicroAgent):
+                self.knowledge_microagents[ma.name] = ma
+            elif isinstance(ma, RepoMicroAgent):
+                self.repo_microagents[ma.name] = ma
+
+    def set_prompt_manager(self, prompt_manager: PromptManager):
+        self.prompt_manager = prompt_manager

--- a/tests/unit/test_conversation_memory.py
+++ b/tests/unit/test_conversation_memory.py
@@ -1,0 +1,146 @@
+import os
+import shutil
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openhands.core.message import Message, TextContent
+from openhands.events.action.message import MessageAction
+from openhands.events.event import EventSource
+from openhands.events.stream import EventStream
+from openhands.memory.conversation_memory import ConversationMemory
+from openhands.utils.prompt import PromptManager
+
+
+@pytest.fixture
+def prompt_dir(tmp_path):
+    # Copy contents from "openhands/agenthub/codeact_agent" to the temp directory
+    shutil.copytree(
+        'openhands/agenthub/codeact_agent/prompts', tmp_path, dirs_exist_ok=True
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def microagent_dir(tmp_path):
+    # Create a temporary directory for microagents
+    microagent_dir = tmp_path / "microagents"
+    microagent_dir.mkdir()
+    
+    # Create a test knowledge microagent
+    knowledge_microagent = """
+---
+name: Test Knowledge Microagent
+type: knowledge
+agent: CodeActAgent
+triggers:
+- test_keyword
+---
+
+This is test knowledge microagent content.
+"""
+    
+    # Create a test repo microagent
+    repo_microagent = """
+---
+name: Test Repo Microagent
+type: repo
+agent: CodeActAgent
+---
+
+This is test repo microagent content.
+"""
+    
+    with open(microagent_dir / "knowledge_microagent.md", "w") as f:
+        f.write(knowledge_microagent)
+    
+    with open(microagent_dir / "repo_microagent.md", "w") as f:
+        f.write(repo_microagent)
+    
+    return str(microagent_dir)
+
+
+def test_conversation_memory_initialization(microagent_dir):
+    event_stream = EventStream()
+    memory = ConversationMemory(
+        event_stream=event_stream,
+        microagents_dir=microagent_dir,
+    )
+    
+    # Check that microagents were loaded
+    assert len(memory.knowledge_microagents) == 1
+    assert len(memory.repo_microagents) == 1
+    assert "Test Knowledge Microagent" in memory.knowledge_microagents
+    assert "Test Repo Microagent" in memory.repo_microagents
+
+
+def test_conversation_memory_first_user_message(microagent_dir, prompt_dir):
+    event_stream = EventStream()
+    memory = ConversationMemory(
+        event_stream=event_stream,
+        microagents_dir=microagent_dir,
+    )
+    
+    # Create a prompt manager and set it in the memory
+    prompt_manager = PromptManager(prompt_dir=prompt_dir)
+    memory.set_prompt_manager(prompt_manager)
+    
+    # Set repository info
+    memory.set_repository_info("test/repo", "/workspace/test")
+    
+    # Create a mock for add_info_to_initial_message
+    with patch.object(prompt_manager, 'add_info_to_initial_message') as mock_add_info:
+        # Create a user message
+        user_message = MessageAction(content="Hello", source="user")
+        
+        # Process the first user message
+        memory.on_event(user_message)
+        
+        # Check that add_info_to_initial_message was called
+        mock_add_info.assert_called_once()
+
+
+def test_conversation_memory_enhance_message(microagent_dir, prompt_dir):
+    event_stream = EventStream()
+    memory = ConversationMemory(
+        event_stream=event_stream,
+        microagents_dir=microagent_dir,
+    )
+    
+    # Create a prompt manager and set it in the memory
+    prompt_manager = PromptManager(prompt_dir=prompt_dir)
+    memory.set_prompt_manager(prompt_manager)
+    
+    # Create a user message with the trigger keyword
+    user_message = MessageAction(content="This contains test_keyword in it", source="user")
+    
+    # Process the user message
+    memory.on_event(user_message)
+    
+    # Check that the message was enhanced
+    assert "extra_info" in user_message.content
+    assert "test knowledge microagent content" in user_message.content.lower()
+
+
+def test_conversation_memory_load_user_workspace_microagents(microagent_dir):
+    event_stream = EventStream()
+    memory = ConversationMemory(
+        event_stream=event_stream,
+        microagents_dir=microagent_dir,
+    )
+    
+    # Create mock microagents
+    knowledge_microagent = MagicMock()
+    knowledge_microagent.name = "User Knowledge Microagent"
+    knowledge_microagent.__class__.__name__ = "KnowledgeMicroAgent"
+    
+    repo_microagent = MagicMock()
+    repo_microagent.name = "User Repo Microagent"
+    repo_microagent.__class__.__name__ = "RepoMicroAgent"
+    
+    # Load the microagents
+    memory.load_user_workspace_microagents([knowledge_microagent, repo_microagent])
+    
+    # Check that the microagents were loaded
+    assert "User Knowledge Microagent" in memory.knowledge_microagents
+    assert "User Repo Microagent" in memory.repo_microagents


### PR DESCRIPTION
This PR backports the conversation memory functionality from PR #6909.

It adds:
- A new `ConversationMemory` class that listens to the event stream and enhances user messages with microagent content
- Updates to `codeact_agent.py` to use the new `ConversationMemory` class
- Unit tests for the new functionality

This backport does not include RecallObservations or any changes to prompt_manager.py beyond what was necessary to support the new functionality.