### PR TITLE
Fix: Update context window exceeded detection

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -697,12 +697,13 @@ class AgentController:
             except (ContextWindowExceededError, BadRequestError, OpenAIError) as e:
                 # FIXME: this is a hack until a litellm fix is confirmed
                 # Check if this is a nested context window error
+                # We have to rely on string-matching because LiteLLM doesn't consistently
+                # wrap the failure in a ContextWindowExceededError
                 error_str = str(e).lower()
                 if (
                     'contextwindowexceedederror' in error_str
                     or 'prompt is too long' in error_str
-                    or 'input length and `max_tokens` exceed context limit'
-                    in error_str
+                    or 'input length and `max_tokens` exceed context limit' in error_str
                     or isinstance(e, ContextWindowExceededError)
                 ):
                     if self.agent.config.enable_history_truncation:

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -701,7 +701,7 @@ class AgentController:
                 if (
                     'contextwindowexceedederror' in error_str
                     or 'prompt is too long' in error_str
-                    or 'input length and `max_tokens` exceed context limit in error_str'
+                    or 'input length and `max_tokens` exceed context limit'
                     in error_str
                     or isinstance(e, ContextWindowExceededError)
                 ):

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -701,6 +701,8 @@ class AgentController:
                 if (
                     'contextwindowexceedederror' in error_str
                     or 'prompt is too long' in error_str
+                    or 'input length and `max_tokens` exceed context limit in error_str'
+                    in error_str
                     or isinstance(e, ContextWindowExceededError)
                 ):
                     if self.agent.config.enable_history_truncation:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Anthropic updated the error message they send when a context window limitation has been exceeded, which broke our context window truncation. This PR adds a new case which should capture the new error message.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

#7023 