### PR TITLE
Add Docker and Kubernetes microagents

### DIFF
--- a/microagents/knowledge/docker.md
+++ b/microagents/knowledge/docker.md
@@ -1,0 +1,141 @@
+---
+name: docker
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+- docker
+- container
+---
+
+# Docker Installation and Usage Guide
+
+## Installation on Debian/Ubuntu Systems
+
+To install Docker on a Debian/Ubuntu system, follow these steps:
+
+```bash
+# Update package index
+sudo apt-get update
+
+# Install prerequisites
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
+
+# Add Docker's official GPG key
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+# Set up the stable repository
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Update package index again
+sudo apt-get update
+
+# Install Docker Engine
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+```
+
+## Starting Docker in Container Environments
+
+If you're in a container environment without systemd (like this workspace), start Docker with:
+
+```bash
+# Start Docker daemon in the background
+sudo dockerd > /tmp/docker.log 2>&1 &
+
+# Wait for Docker to initialize
+sleep 5
+```
+
+## Basic Docker Commands
+
+```bash
+# Pull an image
+docker pull nginx:latest
+
+# Run a container
+docker run -d -p 8080:80 --name my-nginx nginx:latest
+
+# List running containers
+docker ps
+
+# Stop a container
+docker stop my-nginx
+
+# Remove a container
+docker rm my-nginx
+
+# List images
+docker images
+
+# Remove an image
+docker rmi nginx:latest
+
+# Build an image from a Dockerfile
+docker build -t my-app:latest .
+```
+
+## Docker Compose
+
+Create a `docker-compose.yml` file:
+
+```yaml
+version: '3'
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "8080:80"
+  db:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: example
+```
+
+Run with:
+
+```bash
+docker-compose up -d
+```
+
+Stop with:
+
+```bash
+docker-compose down
+```
+
+## Docker Networking
+
+```bash
+# Create a network
+docker network create my-network
+
+# Run containers on the network
+docker run -d --network my-network --name db postgres:latest
+docker run -d --network my-network --name web nginx:latest
+
+# Inspect network
+docker network inspect my-network
+```
+
+## Docker Volumes
+
+```bash
+# Create a volume
+docker volume create my-volume
+
+# Run a container with a volume
+docker run -d -v my-volume:/data --name my-container nginx:latest
+
+# Inspect volume
+docker volume inspect my-volume
+```
+
+## Best Practices
+
+1. Use official images when possible
+2. Keep images small by using multi-stage builds
+3. Use .dockerignore to exclude unnecessary files
+4. Don't run containers as root
+5. Use environment variables for configuration
+6. Tag images with specific versions
+7. Use health checks to monitor container status

--- a/microagents/knowledge/kubernetes.md
+++ b/microagents/knowledge/kubernetes.md
@@ -1,0 +1,135 @@
+---
+name: kubernetes
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+- kubernetes
+- k8s
+- kind
+---
+
+# Kubernetes Local Development with KIND
+
+## KIND Installation and Setup
+
+KIND (Kubernetes IN Docker) is a tool for running local Kubernetes clusters using Docker containers as nodes. It's designed for testing Kubernetes applications locally.
+
+### Installation
+
+To install KIND on a Debian/Ubuntu system:
+
+```bash
+# Download KIND binary
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64
+# Make it executable
+chmod +x ./kind
+# Move to a directory in your PATH
+sudo mv ./kind /usr/local/bin/
+```
+
+To install kubectl:
+
+```bash
+# Download kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+# Make it executable
+chmod +x kubectl
+# Move to a directory in your PATH
+sudo mv ./kubectl /usr/local/bin/
+```
+
+### Creating a Cluster
+
+Create a basic KIND cluster:
+
+```bash
+kind create cluster
+```
+
+For a more customized setup, create a configuration file:
+
+```yaml
+# kind-config.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30000
+    hostPort: 30000
+    protocol: TCP
+- role: worker
+```
+
+Then create the cluster with:
+
+```bash
+kind create cluster --config kind-config.yaml
+```
+
+### Working with the Cluster
+
+After creating a cluster, kubectl is automatically configured to use it:
+
+```bash
+# Verify the cluster is running
+kubectl cluster-info
+
+# Create a namespace
+kubectl create namespace my-namespace
+
+# Apply Kubernetes manifests
+kubectl apply -f my-deployment.yaml
+
+# View resources
+kubectl get pods -n my-namespace
+```
+
+### Loading Docker Images
+
+When working with local images, load them directly into KIND:
+
+```bash
+# Build your Docker image
+docker build -t my-app:latest .
+
+# Load the image into KIND
+kind load docker-image my-app:latest
+```
+
+### Creating Kubernetes Secrets
+
+Create secrets for Docker registry authentication:
+
+```bash
+kubectl create secret docker-registry regcred \
+  --docker-server=<your-registry-server> \
+  --docker-username=<your-username> \
+  --docker-password=<your-password> \
+  --docker-email=<your-email>
+```
+
+Create generic secrets:
+
+```bash
+kubectl create secret generic my-secret \
+  --from-literal=key1=value1 \
+  --from-literal=key2=value2
+```
+
+### Deleting the Cluster
+
+When you're done, delete the cluster:
+
+```bash
+kind delete cluster
+```
+
+## Best Practices
+
+1. Use namespaces to organize resources
+2. Set resource limits for deployments
+3. Use ConfigMaps and Secrets for configuration
+4. Implement health checks with liveness and readiness probes
+5. Use port-forwarding for local access to services


### PR DESCRIPTION
This PR adds two new microagents:

1. Docker microagent - Provides installation instructions and common Docker commands
2. Kubernetes microagent - Provides guidance on setting up KIND for local Kubernetes development

These microagents will help users set up local development environments for containerized applications.