### PR TITLE
Fix URL for staging stack

### DIFF
--- a/frontend/src/utils/generate-github-auth-url.ts
+++ b/frontend/src/utils/generate-github-auth-url.ts
@@ -10,8 +10,7 @@ export const generateGitHubAuthUrl = (clientId: string, requestUrl: URL) => {
     .replace("https://", "")
     .replace("http://", "");
   const authUrl = baseUrl
-    .replace(/(^|\.)staging\.all-hands\.dev$/, ".auth.staging.all-hands.dev")
-    .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev");
-  const scope = "openid email profile";
+    .replace(/(^|\.)staging\.all-hands\.dev$/, "$1auth.staging.all-hands.dev")
+    .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev");  const scope = "openid email profile";
   return `https://${authUrl}/realms/allhands/protocol/openid-connect/auth?client_id=github&response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}`;
 };

--- a/frontend/src/utils/generate-github-auth-url.ts
+++ b/frontend/src/utils/generate-github-auth-url.ts
@@ -11,6 +11,7 @@ export const generateGitHubAuthUrl = (clientId: string, requestUrl: URL) => {
     .replace("http://", "");
   const authUrl = baseUrl
     .replace(/(^|\.)staging\.all-hands\.dev$/, "$1auth.staging.all-hands.dev")
-    .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev");  const scope = "openid email profile";
+    .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev");
+  const scope = "openid email profile";
   return `https://${authUrl}/realms/allhands/protocol/openid-connect/auth?client_id=github&response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}`;
 };


### PR DESCRIPTION
Fix so URL for auth staging is auth.staging.all-hands.dev and not .auth.staging.all-hands.dev

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0fa8b7f-nikolaik   --name openhands-app-0fa8b7f   docker.all-hands.dev/all-hands-ai/openhands:0fa8b7f
```