### PR TITLE
Add Docker network option

### DIFF
--- a/docs/modules/usage/configuration-options.md
+++ b/docs/modules/usage/configuration-options.md
@@ -385,6 +385,11 @@ To use these with the docker command, pass in `-e SANDBOX_<option>`. Example: `-
   - Default: `false`
   - Description: Use host network
 
+- `network_name`
+  - Type: `str`
+  - Default: `None`
+  - Description: The (docker) network to use for the sandbox. Incompatible with `use_host_network`.
+
 - `runtime_binding_address`
   - Type: `str`
   - Default: `127.0.0.1`

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -17,6 +17,7 @@ class SandboxConfig(BaseModel):
         remote_runtime_api_timeout: The timeout for the remote runtime API requests.
         enable_auto_lint: Whether to enable auto-lint.
         use_host_network: Whether to use the host network.
+        network_name: If not using the host network, the network to use for the runtime container.
         runtime_binding_address: The binding address for the runtime ports.  It specifies which network interface on the host machine Docker should bind the runtime ports to.
         initialize_plugins: Whether to initialize plugins.
         force_rebuild_runtime: Whether to force rebuild the runtime image.
@@ -61,6 +62,7 @@ class SandboxConfig(BaseModel):
         default=False
     )  # once enabled, OpenHands would lint files after editing
     use_host_network: bool = Field(default=False)
+    network_name: str | None = Field(default=None)
     runtime_binding_address: str = Field(default='127.0.0.1')
     runtime_extra_build_args: list[str] | None = Field(default=None)
     initialize_plugins: bool = Field(default=True)

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -196,6 +196,9 @@ class DockerRuntime(ActionExecutionClient):
 
         use_host_network = self.config.sandbox.use_host_network
         network_mode: str | None = 'host' if use_host_network else None
+        network: str | None = None if use_host_network else self.config.sandbox.network_name
+        if network_mode is not None and network is not None:
+            logger.error('Cannot specify both host network mode and a docker network name')
 
         # Initialize port mappings
         port_mapping: dict[str, list[dict[str, str]]] | None = None


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/ (included in PR)
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Add the ability to associate runtime containers with a virtual Docker network.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Adds a `network_name` sandbox config option which is passed through to `container.run` as `network`.

---
**Link of any specific issues this addresses.**

#6637 
