### PR TITLE
OpenAI models fixes

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -217,9 +217,8 @@ class LLM(RetryMixin, DebugMixin):
                     kwargs['stop'] = STOP_WORDS
 
                 mock_fncall_tools = kwargs.pop('tools')
-                kwargs['tool_choice'] = (
-                    'none'  # force no tool calling because we're mocking it - without it, it will cause issue with sglang
-                )
+                # tool_choice should not be specified when mocking function calling
+                kwargs.pop('tool_choice', None)
 
             # if we have no messages, something went very wrong
             if not messages:

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -76,6 +76,8 @@ REASONING_EFFORT_SUPPORTED_MODELS = [
 MODELS_WITHOUT_STOP_WORDS = [
     'o1-mini',
     'o1-preview',
+    'o1',
+    'o1-2024-12-17',
 ]
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

Fix for `tool_choice` error on OpenAI models; attempted fix for "model has produced invalid output".

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes fixes for a couple of issues with openai models:
- remove the `tool_choice` kwarg for models without native function calling enabled (reported on [slack](https://openhands-ai.slack.com/archives/C06U8UTKSAD/p1740830463105659) too)
- exclude stop words from other `o1` models (more models than we already do). This may be the cause of intermittent, but quite often "model has produced invalid output" errors.

The `tool_choice` error:
```
OpenAIException - Error code: 400 - {'error': {'message': "Invalid value for 'tool_choice': 'tool_choice' is only allowed when 'tools' are specified.", 'type': 'invalid_request_error', 'param': 'tool_choice', 'code': None}}
```

---
**Link of any specific issues this addresses.**
Fix https://github.com/All-Hands-AI/OpenHands/issues/7039
Attempt to fix https://github.com/All-Hands-AI/OpenHands/issues/5876 
fix https://github.com/All-Hands-AI/OpenHands/issues/6808
fix https://github.com/All-Hands-AI/OpenHands/issues/6469

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9e1f57f-nikolaik   --name openhands-app-9e1f57f   docker.all-hands.dev/all-hands-ai/openhands:9e1f57f
```