### PR TITLE
Fix argument in swe-bench grading scripts

### DIFF
--- a/evaluation/benchmarks/swe_bench/eval_infer.py
+++ b/evaluation/benchmarks/swe_bench/eval_infer.py
@@ -288,7 +288,7 @@ def process_instance(
                                     'model_patch': model_patch,
                                     'instance_id': instance_id,
                                 },
-                                log_path=test_output_path,
+                                test_log_path=test_output_path,
                                 include_tests_status=True,
                             )
                             report = _report[instance_id]


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Tiny thing that fails eval: swe-bench has changed the name of an argument to `get_eval_report()` so the remote eval attached to [this PR](https://github.com/All-Hands-AI/OpenHands/pull/7036) failed with:

```
2025-03-01 17:22:32,692 - INFO - [django__django-14434] Grading answer...
2025-03-01 17:22:32,693 - ERROR - [django__django-14434] Error when getting eval report: get_eval_report() got an unexpected keyword argument 'log_path'
```

SWE-bench change is [here](https://github.com/SWE-bench/SWE-bench/commit/d83e1001739f4d96add351d9ec0d56f4594a0d82#diff-9126e88e41c90ad14bc07c4ae5aefca11eb9194e51c29b3079e5b4d31e06c4d8R212),

This worked locally.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:aa7af10-nikolaik   --name openhands-app-aa7af10   docker.all-hands.dev/all-hands-ai/openhands:aa7af10
```