### PR TITLE
Fix GitLab CI environment variable check (issue #7050)

### DIFF
--- a/openhands/resolver/resolve_issue.py
+++ b/openhands/resolver/resolve_issue.py
@@ -202,7 +202,7 @@ async def process_issue(
         timeout=300,
     )
 
-    if os.getenv('GITLAB_CI') == 'True':
+    if os.getenv('GITLAB_CI') == 'true':
         sandbox_config.local_runtime_url = os.getenv(
             'LOCAL_RUNTIME_URL', 'http://localhost'
         )


### PR DESCRIPTION
(openhands-ai)

This PR fixes #7050.

Line 205 in resolve_issue.py now correctly uses lowercase "true" instead of uppercase "True" for the GitLab CI environment variable check.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:26c2421-nikolaik   --name openhands-app-26c2421   docker.all-hands.dev/all-hands-ai/openhands:26c2421
```