### PR TITLE
Fix #7060: Remove obsolete micro_agent_name attribute from test_long_term_memory.py

### DIFF
--- a/tests/unit/test_long_term_memory.py
+++ b/tests/unit/test_long_term_memory.py
@@ -23,7 +23,6 @@ def mock_llm_config() -> LLMConfig:
 @pytest.fixture
 def mock_agent_config() -> AgentConfig:
     config = AgentConfig(
-        micro_agent_name='test_micro_agent',
         memory_enabled=True,
         memory_max_threads=4,
         llm_config='test_llm_config',


### PR DESCRIPTION
This PR fixes issue #7060 by removing the obsolete `micro_agent_name` attribute from the `mock_agent_config` fixture in `test_long_term_memory.py`. The attribute is no longer part of the `AgentConfig` class and was causing issues in the tests.