### PR TITLE
[Bugfix] Add github_token verification in resolver utils

### DIFF
--- a/openhands/resolver/resolve_issue.py
+++ b/openhands/resolver/resolve_issue.py
@@ -651,7 +651,7 @@ def main() -> None:
     if not token:
         raise ValueError('Token is required.')
 
-    platform = identify_token(token)
+    platform = identify_token(token, repo)
     if platform == Platform.INVALID:
         raise ValueError('Token is invalid.')
 

--- a/openhands/resolver/utils.py
+++ b/openhands/resolver/utils.py
@@ -22,18 +22,32 @@ class Platform(Enum):
     GITLAB = 2
 
 
-def identify_token(token: str) -> Platform:
+def identify_token(token: str, repo: str = None) -> Platform:
     """
     Identifies whether a token belongs to GitHub or GitLab.
 
     Parameters:
         token (str): The personal access token to check.
+        repo (str): Repository in format "owner/repo" for GitHub Actions token validation.
 
     Returns:
         Platform: "GitHub" if the token is valid for GitHub,
              "GitLab" if the token is valid for GitLab,
              "Invalid" if the token is not recognized by either.
     """
+    # Try GitHub Actions token format (Bearer) with repo endpoint if repo is provided
+    if repo:
+        github_repo_url = f'https://api.github.com/repos/{repo}'
+        github_bearer_headers = {'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'}
+        
+        try:
+            github_repo_response = requests.get(github_repo_url, headers=github_bearer_headers, timeout=5)
+            if github_repo_response.status_code == 200:
+                return Platform.GITHUB
+        except requests.RequestException as e:
+            print(f'Error connecting to GitHub API (repo check): {e}')1
+
+    # Try GitHub PAT format (token)
     github_url = 'https://api.github.com/user'
     github_headers = {'Authorization': f'token {token}'}
 
@@ -44,6 +58,7 @@ def identify_token(token: str) -> Platform:
     except requests.RequestException as e:
         print(f'Error connecting to GitHub API: {e}')
 
+    # Try GitLab token
     gitlab_url = 'https://gitlab.com/api/v4/user'
     gitlab_headers = {'Authorization': f'Bearer {token}'}
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Previously, users would encounter a "Token is invalid" error when using the default GITHUB_TOKEN in GitHub Actions workflows, requiring them to set up a Personal Access Token (PAT) instead.  With this fix, the resolver correctly validates GitHub Actions tokens, allowing workflows to run without additional token setup.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
The PR modifies the identify_token function to properly validate GitHub Actions tokens by:

- Adding support for the Bearer authentication format used by GitHub Actions tokens
- Using the repository endpoint instead of the user endpoint for validation, as GitHub Actions tokens have repository-scoped permissions
- Accepting an optional repository parameter to use for validation
- Maintaining backward compatibility with existing PAT validation logic

This approach ensures that both GitHub Actions tokens and Personal Access Tokens can be validated correctly, providing a seamless experience for users in both GitHub Actions workflows and other environments.

---
**Link of any specific issues this addresses.**
I believe the bug was introduced in https://github.com/All-Hands-AI/OpenHands/pull/6458