### PR TITLE
Fixes for keycloak in localhost

### DIFF
--- a/frontend/src/utils/generate-github-auth-url.ts
+++ b/frontend/src/utils/generate-github-auth-url.ts
@@ -6,12 +6,11 @@
  */
 export const generateGitHubAuthUrl = (clientId: string, requestUrl: URL) => {
   const redirectUri = `${requestUrl.origin}/oauth/keycloak/callback`;
-  const baseUrl = `${requestUrl.origin}`
-    .replace("https://", "")
-    .replace("http://", "");
-  const authUrl = baseUrl
+  const authUrl = requestUrl.hostname
     .replace(/(^|\.)staging\.all-hands\.dev$/, "$1auth.staging.all-hands.dev")
-    .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev");
+    .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev")
+    .replace(/(^|\.)localhost$/, "auth.staging.all-hands.dev");
+  console.log("TRACE", authUrl);
   const scope = "openid email profile";
   return `https://${authUrl}/realms/allhands/protocol/openid-connect/auth?client_id=github&response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}`;
 };

--- a/frontend/src/utils/generate-github-auth-url.ts
+++ b/frontend/src/utils/generate-github-auth-url.ts
@@ -10,7 +10,6 @@ export const generateGitHubAuthUrl = (clientId: string, requestUrl: URL) => {
     .replace(/(^|\.)staging\.all-hands\.dev$/, "$1auth.staging.all-hands.dev")
     .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev")
     .replace(/(^|\.)localhost$/, "auth.staging.all-hands.dev");
-  console.log("TRACE", authUrl);
   const scope = "openid email profile";
   return `https://${authUrl}/realms/allhands/protocol/openid-connect/auth?client_id=github&response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}`;
 };


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Specifically allowing localhost domains in the generate github url function - if localhost, this defaults to `auth.staging.all-hands.dev`

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:adcd9d0-nikolaik   --name openhands-app-adcd9d0   docker.all-hands.dev/all-hands-ai/openhands:adcd9d0
```