### PR TITLE
Fix runtime to call new token refresh

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -51,6 +51,9 @@ class GitHubService:
     async def get_latest_token(self) -> SecretStr:
         return self.token
 
+    async def get_latest_provider_token(self) -> SecretStr:
+        return self.token
+
     async def _fetch_data(
         self, url: str, params: dict | None = None
     ) -> tuple[Any, dict]:

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -222,7 +222,7 @@ class Runtime(FileEditRuntimeMixin):
             if isinstance(event, CmdRunAction):
                 if self.github_user_id and '$GITHUB_TOKEN' in event.command:
                     gh_client = GithubServiceImpl(user_id=self.github_user_id)
-                    token = await gh_client.get_latest_token()
+                    token = await gh_client.get_latest_provider_token()
                     if token:
                         export_cmd = CmdRunAction(
                             f"export GITHUB_TOKEN='{token.get_secret_value()}'"


### PR DESCRIPTION
Fix runtime to use offline refresh token to get refreshed GitHub access token.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5006107-nikolaik   --name openhands-app-5006107   docker.all-hands.dev/all-hands-ai/openhands:5006107
```