### PR TITLE
Checkout HEAD instead of Merge Commit for builds

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.4.0
         with:
@@ -90,6 +92,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.4.0
         with:
@@ -154,6 +158,8 @@ jobs:
         base_image: ['nikolaik']
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Cache Poetry dependencies
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Checkout HEAD instead of Merge Commit for builds

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Reason for this is when we build the images, we don't want to checkout the merge commit, we want to checkout the exact PR commit. 

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9756d3f-nikolaik   --name openhands-app-9756d3f   docker.all-hands.dev/all-hands-ai/openhands:9756d3f
```