### PR TITLE
Improve error detection for `read` and `edit` observations

### DIFF
--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -95,6 +95,7 @@ export function handleObservationMessage(message: ObservationMessage) {
             observation,
             extras: {
               path: String(message.extras.path || ""),
+              impl_source: String(message.extras.impl_source || ""),
             },
           }),
         );
@@ -107,6 +108,7 @@ export function handleObservationMessage(message: ObservationMessage) {
             extras: {
               path: String(message.extras.path || ""),
               diff: String(message.extras.diff || ""),
+              impl_source: String(message.extras.impl_source || ""),
             },
           }),
         );

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -159,9 +159,16 @@ export const chatSlice = createSlice({
           .includes("error:");
       } else if (observationID === "read" || observationID === "edit") {
         // For read/edit operations, we consider it successful if there's content and no error
-        causeMessage.success =
-          observation.payload.content.length > 0 &&
-          !observation.payload.content.toLowerCase().includes("error:");
+
+        if (observation.payload.extras.impl_source === "oh_aci") {
+          causeMessage.success =
+            observation.payload.content.length > 0 &&
+            !observation.payload.content.startsWith("ERROR:\n");
+        } else {
+          causeMessage.success =
+            observation.payload.content.length > 0 &&
+            !observation.payload.content.toLowerCase().includes("error:");
+        }
       }
 
       if (observationID === "run" || observationID === "run_ipython") {

--- a/frontend/src/types/core/observations.ts
+++ b/frontend/src/types/core/observations.ts
@@ -63,6 +63,7 @@ export interface ReadObservation extends OpenHandsObservationEvent<"read"> {
   source: "agent";
   extras: {
     path: string;
+    impl_source: string;
   };
 }
 
@@ -71,6 +72,7 @@ export interface EditObservation extends OpenHandsObservationEvent<"edit"> {
   extras: {
     path: string;
     diff: string;
+    impl_source: string;
   };
 }
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR improves the error detection logic to help reduce false positives on the UI.

Before:
<img width="400" alt="Screenshot 2025-03-04 at 16 11 15" src="https://github.com/user-attachments/assets/9fb77336-fc22-46e1-a09b-e34752261a1a" />

After:
<img width="400" alt="Screenshot 2025-03-04 at 16 43 52" src="https://github.com/user-attachments/assets/53a512b4-cb14-4fd2-8324-f9baf50060d4" />


---
**Link of any specific issues this addresses.**
