### PR TITLE
fix: daytona runtime action execution handling

### DIFF
--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -79,7 +79,7 @@ class AppConfig(BaseModel):
     runloop_api_key: SecretStr | None = Field(default=None)
     daytona_api_key: SecretStr | None = Field(default=None)
     daytona_api_url: str = Field(default='https://app.daytona.io/api')
-    daytona_target: str = Field(default='us')
+    daytona_target: str = Field(default='eu')
     cli_multiline_input: bool = Field(default=False)
     conversation_max_age_seconds: int = Field(default=864000)  # 10 days in seconds
     enable_default_condenser: bool = Field(default=True)

--- a/openhands/runtime/impl/daytona/README.md
+++ b/openhands/runtime/impl/daytona/README.md
@@ -67,7 +67,7 @@ docker run -it --rm --pull=always \
     docker.all-hands.dev/all-hands-ai/openhands:${OPENHANDS_VERSION}
 ```
 
-> **Tip:** If you don't want your sandboxes to default to the US region, you can set the `DAYTONA_TARGET` environment variable to `eu`
+> **Tip:** If you don't want your sandboxes to default to the EU region, you can set the `DAYTONA_TARGET` environment variable to `us`
 
 ### Running OpenHands Locally Without Docker
 

--- a/openhands/runtime/impl/daytona/daytona_runtime.py
+++ b/openhands/runtime/impl/daytona/daytona_runtime.py
@@ -111,18 +111,6 @@ class DaytonaRuntime(ActionExecutionClient):
         workspace = self.daytona.create(workspace_params)
         return workspace
 
-    def _get_workspace_status(self) -> str:
-        assert self.workspace is not None, 'Workspace is not initialized'
-        assert (
-            self.workspace.instance.info is not None
-        ), 'Workspace info is not available'
-        assert (
-            self.workspace.instance.info.provider_metadata is not None
-        ), 'Provider metadata is not available'
-
-        provider_metadata = json.loads(self.workspace.instance.info.provider_metadata)
-        return provider_metadata.get('status', 'unknown')
-
     def _construct_api_url(self, port: int) -> str:
         assert self.workspace is not None, 'Workspace is not initialized'
         assert (
@@ -143,10 +131,6 @@ class DaytonaRuntime(ActionExecutionClient):
     def _start_action_execution_server(self) -> None:
         assert self.workspace is not None, 'Workspace is not initialized'
 
-        self.workspace.process.exec(
-            f'mkdir -p {self.config.workspace_mount_path_in_sandbox}'
-        )
-
         start_command: list[str] = get_action_execution_server_startup_command(
             server_port=self._sandbox_port,
             plugins=self.plugins,
@@ -154,7 +138,10 @@ class DaytonaRuntime(ActionExecutionClient):
             override_user_id=1000,
             override_username='openhands',
         )
-        start_command_str: str = ' '.join(start_command)
+        start_command_str: str = (
+            f'mkdir -p {self.config.workspace_mount_path_in_sandbox} && cd /openhands/code && '
+            + ' '.join(start_command)
+        )
 
         self.log(
             'debug',
@@ -163,10 +150,6 @@ class DaytonaRuntime(ActionExecutionClient):
 
         exec_session_id = 'action-execution-server'
         self.workspace.process.create_session(exec_session_id)
-        self.workspace.process.execute_session_command(
-            exec_session_id,
-            SessionExecuteRequest(command='cd /openhands/code', var_async=True),
-        )
 
         exec_command = self.workspace.process.execute_session_command(
             exec_session_id,
@@ -185,24 +168,33 @@ class DaytonaRuntime(ActionExecutionClient):
 
     async def connect(self):
         self.send_status_message('STATUS$STARTING_RUNTIME')
+        should_start_action_execution_server = False
 
         if self.attach_to_existing:
             self.workspace = await call_sync_from_async(self._get_workspace)
+        else:
+            should_start_action_execution_server = True
 
         if self.workspace is None:
             self.send_status_message('STATUS$PREPARING_CONTAINER')
             self.workspace = await call_sync_from_async(self._create_workspace)
             self.log('info', f'Created new workspace with id: {self.workspace_id}')
 
-        if self._get_workspace_status() == 'stopped':
+        self.api_url = self._construct_api_url(self._sandbox_port)
+
+        state = self.workspace.instance.state
+
+        if state == 'stopping':
+            self.log('info', 'Waiting for Daytona workspace to stop...')
+            await call_sync_from_async(self.workspace.wait_for_workspace_stop)
+            state = 'stopped'
+
+        if state == 'stopped':
             self.log('info', 'Starting Daytona workspace...')
             await call_sync_from_async(self.workspace.start)
+            should_start_action_execution_server = True
 
-        self.api_url = await call_sync_from_async(
-            self._construct_api_url, self._sandbox_port
-        )
-
-        if not self.attach_to_existing:
+        if should_start_action_execution_server:
             await call_sync_from_async(self._start_action_execution_server)
             self.log(
                 'info',
@@ -213,7 +205,7 @@ class DaytonaRuntime(ActionExecutionClient):
         self.send_status_message('STATUS$WAITING_FOR_CLIENT')
         await call_sync_from_async(self._wait_until_alive)
 
-        if not self.attach_to_existing:
+        if should_start_action_execution_server:
             await call_sync_from_async(self.setup_initial_env)
 
         self.log(
@@ -221,9 +213,17 @@ class DaytonaRuntime(ActionExecutionClient):
             f'Container initialized with plugins: {[plugin.name for plugin in self.plugins]}',
         )
 
-        if not self.attach_to_existing:
+        if should_start_action_execution_server:
             self.send_status_message(' ')
         self._runtime_initialized = True
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_delay(120) | stop_if_should_exit(),
+        wait=tenacity.wait_fixed(1),
+        reraise=True,
+    )
+    def _send_action_server_request(self, method, url, **kwargs):
+        return super()._send_action_server_request(method, url, **kwargs)
 
     def close(self):
         super().close()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Combines some action execution server setup requests together to save time. Speeds up the initial response time when starting a conversation.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Handles the Daytona sandbox being in "stopping" state by waiting it to complete before starting the sandbox back up.
Handles restarting the action execution server as well when restarting the Daytona sandbox if it times out due to inactivity.
Adds a retry policy for executing actions, allowing time for the action execution server to start up after it had already been "connected" for cases where the Daytona sandbox had been stopped in the meantime.
- Temporarily switches the default Daytona Target to EU instead of US
- Minor code refactors
