### PR TITLE
Always enable GET /settings

### DIFF
--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -43,15 +43,18 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
   const handleFormSubmission = async (formData: FormData) => {
     const newSettings = extractSettings(formData);
 
-    await saveUserSettings(newSettings);
-    onClose();
-    resetOngoingSession();
+    saveUserSettings(newSettings, {
+      onSuccess: () => {
+        onClose();
+        resetOngoingSession();
 
-    posthog.capture("settings_saved", {
-      LLM_MODEL: newSettings.LLM_MODEL,
-      LLM_API_KEY: newSettings.LLM_API_KEY ? "SET" : "UNSET",
-      REMOTE_RUNTIME_RESOURCE_FACTOR:
-        newSettings.REMOTE_RUNTIME_RESOURCE_FACTOR,
+        posthog.capture("settings_saved", {
+          LLM_MODEL: newSettings.LLM_MODEL,
+          LLM_API_KEY: newSettings.LLM_API_KEY ? "SET" : "UNSET",
+          REMOTE_RUNTIME_RESOURCE_FACTOR:
+            newSettings.REMOTE_RUNTIME_RESOURCE_FACTOR,
+        });
+      },
     });
   };
 

--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -43,7 +43,7 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
   const handleFormSubmission = async (formData: FormData) => {
     const newSettings = extractSettings(formData);
 
-    saveUserSettings(newSettings, {
+    await saveUserSettings(newSettings, {
       onSuccess: () => {
         onClose();
         resetOngoingSession();

--- a/frontend/src/context/settings-context.tsx
+++ b/frontend/src/context/settings-context.tsx
@@ -14,7 +14,7 @@ interface SettingsContextType {
   saveUserSettings: (
     newSettings: Partial<PostSettings>,
     config?: SaveUserSettingsConfig,
-  ) => void;
+  ) => Promise<void>;
   settings: Settings | undefined;
 }
 
@@ -28,9 +28,9 @@ interface SettingsProviderProps {
 
 export function SettingsProvider({ children }: SettingsProviderProps) {
   const { data: userSettings } = useSettings();
-  const { mutate: saveSettings } = useSaveSettings();
+  const { mutateAsync: saveSettings } = useSaveSettings();
 
-  const saveUserSettings = (
+  const saveUserSettings = async (
     newSettings: Partial<PostSettings>,
     config?: SaveUserSettingsConfig,
   ) => {
@@ -43,7 +43,7 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
       delete updatedSettings.LLM_API_KEY;
     }
 
-    saveSettings(updatedSettings, {
+    await saveSettings(updatedSettings, {
       onSuccess: config?.onSuccess,
       onError: (error) => {
         const errorMessage = retrieveAxiosErrorMessage(error);

--- a/frontend/src/context/settings-context.tsx
+++ b/frontend/src/context/settings-context.tsx
@@ -14,7 +14,7 @@ interface SettingsContextType {
   saveUserSettings: (
     newSettings: Partial<PostSettings>,
     config?: SaveUserSettingsConfig,
-  ) => Promise<void>;
+  ) => void;
   settings: Settings | undefined;
 }
 
@@ -28,9 +28,9 @@ interface SettingsProviderProps {
 
 export function SettingsProvider({ children }: SettingsProviderProps) {
   const { data: userSettings } = useSettings();
-  const { mutateAsync: saveSettings } = useSaveSettings();
+  const { mutate: saveSettings } = useSaveSettings();
 
-  const saveUserSettings = async (
+  const saveUserSettings = (
     newSettings: Partial<PostSettings>,
     config?: SaveUserSettingsConfig,
   ) => {
@@ -43,7 +43,7 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
       delete updatedSettings.LLM_API_KEY;
     }
 
-    await saveSettings(updatedSettings, {
+    saveSettings(updatedSettings, {
       onSuccess: config?.onSuccess,
       onError: (error) => {
         const errorMessage = retrieveAxiosErrorMessage(error);

--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -3,7 +3,6 @@ import React from "react";
 import posthog from "posthog-js";
 import OpenHands from "#/api/open-hands";
 import { useAuth } from "#/context/auth-context";
-import { useConfig } from "#/hooks/query/use-config";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 
 const getSettingsQueryFn = async () => {
@@ -27,12 +26,10 @@ const getSettingsQueryFn = async () => {
 
 export const useSettings = () => {
   const { setGitHubTokenIsSet, githubTokenIsSet } = useAuth();
-  const { data: config } = useConfig();
 
   const query = useQuery({
     queryKey: ["settings", githubTokenIsSet],
     queryFn: getSettingsQueryFn,
-    enabled: config?.APP_MODE !== "saas" || githubTokenIsSet,
     // Only retry if the error is not a 404 because we
     // would want to show the modal immediately if the
     // settings are not found


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Some users face an issue where the settings modal would pop-up even after saving settings. To reproduce:

1. New user opens saas app
2. Signs in
3. Saves changes from initial settings modal
4. Go to conversations
5. Initial settings shows up again

The problem was the `GET /settings` query was disabled if the GH token was not set. But the only time we set it is after `GET /settings` succeeds.

**This is a hotfix, and I wish to explore alternatives to settings the GH token set state. Perhaps in the oauth intermediate screen. I don't like how we handle this state anyhow and wish to revise it altogether.**

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Always enable `GET /settings` query

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:39c7703-nikolaik   --name openhands-app-39c7703   docker.all-hands.dev/all-hands-ai/openhands:39c7703
```