### PR TITLE
Feat/cost logging

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -669,7 +669,9 @@ class LLM(RetryMixin, DebugMixin):
                     f'Using fallback model name {_model_name} to get cost: {cost}'
                 )
             self.metrics.add_cost(cost)
-            logger.info(f'LLM query cost: ${cost:.6f}')
+            logger.info(
+                f'LLM query cost: ${cost:.6f}, accumulated cost: ${self.metrics.accumulated_cost:.6f}'
+            )
             return cost
         except Exception:
             self.cost_metric_supported = False

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -669,6 +669,7 @@ class LLM(RetryMixin, DebugMixin):
                     f'Using fallback model name {_model_name} to get cost: {cost}'
                 )
             self.metrics.add_cost(cost)
+            logger.info(f'LLM query cost: ${cost:.6f}')
             return cost
         except Exception:
             self.cost_metric_supported = False

--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -83,6 +83,12 @@ class Metrics:
         self._accumulated_cost += value
         self._costs.append(Cost(cost=value, model=self.model_name))
 
+    def get_last_cost(self) -> float | None:
+        """Return the cost of the last query, or None if no queries have been made."""
+        if not self._costs:
+            return None
+        return self._costs[-1].cost
+
     def add_response_latency(self, value: float, response_id: str) -> None:
         self._response_latencies.append(
             ResponseLatency(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
logs the cost after each LLM query as well as the total accumulated cost, i.e.

```
13:51:17 - openhands:INFO: llm.py:672 - LLM query cost: $0.013310, accumulated cost: $0.130695
```

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Often openhands gets rate limiting issues just because the context window is too large. Seeing the cost of queries can help the user decide when its time to start a new session due to overgrown context. Maybe just a bandaid on the issue but a useful metric.

Perhaps in the future the cost can even be fed as input to the agent to optimize for its own lifespan.

---
**Link of any specific issues this addresses.**
