### PR TITLE
Fix stuck detector condition

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -1,4 +1,3 @@
-import json
 import os
 from collections import deque
 
@@ -74,7 +73,7 @@ class CodeActAgent(Agent):
             codeact_enable_llm_editor=self.config.codeact_enable_llm_editor,
         )
         logger.debug(
-            f'TOOLS loaded for CodeActAgent: {json.dumps(self.tools, indent=2, ensure_ascii=False).replace("\\n", "\n")}'
+            f'TOOLS loaded for CodeActAgent: {', '.join([tool.get('function').get('name') for tool in self.tools])}'
         )
         self.prompt_manager = PromptManager(
             microagent_dir=os.path.join(

--- a/openhands/controller/stuck.py
+++ b/openhands/controller/stuck.py
@@ -130,7 +130,7 @@ class StuckDetector:
         # it takes 3 actions and 3 observations to detect a loop
         # check if the last three actions are the same and result in errors
 
-        if len(last_actions) < 4 or len(last_observations) < 4:
+        if len(last_actions) < 3 or len(last_observations) < 3:
             return False
 
         # are the last three actions the "same"?


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes a few small fixes:
- fix stuck detector condition for the (action, error) x3 scenario: in reality, it required 4 if it happened right after the first user message
- tweak log

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fac6af6-nikolaik   --name openhands-app-fac6af6   docker.all-hands.dev/all-hands-ai/openhands:fac6af6
```