### PR TITLE
Fix agent session tests for Memory component

### DIFF
--- a/tests/unit/test_agent_session.py
+++ b/tests/unit/test_agent_session.py
@@ -9,6 +9,7 @@ from openhands.core.config import AppConfig, LLMConfig
 from openhands.events import EventStream, EventStreamSubscriber
 from openhands.llm import LLM
 from openhands.llm.metrics import Metrics
+from openhands.memory.memory import Memory
 from openhands.runtime.base import Runtime
 from openhands.server.monitoring import MonitoringListener
 from openhands.server.session.agent_session import AgentSession
@@ -23,11 +24,15 @@ def mock_agent():
     llm = MagicMock(spec=LLM)
     metrics = MagicMock(spec=Metrics)
     llm_config = MagicMock(spec=LLMConfig)
+    agent_config = MagicMock()
 
     # Configure the LLM config
     llm_config.model = 'test-model'
     llm_config.base_url = 'http://test'
     llm_config.max_message_chars = 1000
+
+    # Configure the agent config
+    agent_config.disabled_microagents = []
 
     # Set up the chain of mocks
     llm.metrics = metrics
@@ -35,6 +40,8 @@ def mock_agent():
     agent.llm = llm
     agent.name = 'test-agent'
     agent.sandbox_plugins = []
+    agent.config = agent_config
+    agent.prompt_manager = None
 
     return agent
 
@@ -80,7 +87,10 @@ async def test_agent_session_start_with_no_state(mock_agent):
             self.test_initial_state = state
             super().set_initial_state(*args, state=state, **kwargs)
 
-    # Patch AgentController and State.restore_from_session to fail
+    # Create a mock Memory
+    mock_memory = MagicMock(spec=Memory)
+
+    # Patch AgentController, EventStream, State.restore_from_session, and Memory
     with patch(
         'openhands.server.session.agent_session.AgentController', SpyAgentController
     ), patch(
@@ -89,6 +99,9 @@ async def test_agent_session_start_with_no_state(mock_agent):
     ), patch(
         'openhands.controller.state.state.State.restore_from_session',
         side_effect=Exception('No state found'),
+    ), patch(
+        'openhands.server.session.agent_session.Memory',
+        return_value=mock_memory,
     ):
         await session.start(
             runtime_name='test-runtime',
@@ -162,7 +175,10 @@ async def test_agent_session_start_with_restored_state(mock_agent):
             self.test_initial_state = state
             super().set_initial_state(*args, state=state, **kwargs)
 
-    # Patch AgentController and State.restore_from_session to succeed
+    # Create a mock Memory
+    mock_memory = MagicMock(spec=Memory)
+
+    # Patch AgentController, EventStream, State.restore_from_session, and Memory
     with patch(
         'openhands.server.session.agent_session.AgentController', SpyAgentController
     ), patch(
@@ -171,6 +187,9 @@ async def test_agent_session_start_with_restored_state(mock_agent):
     ), patch(
         'openhands.controller.state.state.State.restore_from_session',
         return_value=mock_restored_state,
+    ), patch(
+        'openhands.server.session.agent_session.Memory',
+        return_value=mock_memory,
     ):
         await session.start(
             runtime_name='test-runtime',


### PR DESCRIPTION
This PR fixes the agent session tests to properly mock the Memory component that was added in PR #6909.

Changes:
- Added import for Memory class
- Added mock for Memory in both test cases
- Added agent.config with disabled_microagents to mock_agent fixture
- Added agent.prompt_manager = None to mock_agent fixture

All tests now pass successfully.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bd7c1db-nikolaik   --name openhands-app-bd7c1db   docker.all-hands.dev/all-hands-ai/openhands:bd7c1db
```