### PR TITLE
Fix failing tests for Memory component integration

### DIFF
--- a/tests/unit/test_agent_session.py
+++ b/tests/unit/test_agent_session.py
@@ -42,6 +42,10 @@ def mock_agent():
     
     # Add prompt_manager attribute
     agent.prompt_manager = MagicMock()
+    
+    # Add memory attribute with on_event method
+    agent.memory = MagicMock()
+    agent.memory.on_event = MagicMock()
 
     return agent
 
@@ -104,10 +108,15 @@ async def test_agent_session_start_with_no_state(mock_agent):
             max_iterations=10,
         )
 
-        # Verify EventStream.subscribe was called with AGENT_CONTROLLER
+        # Verify EventStream.subscribe was called with AGENT_CONTROLLER and MEMORY
         mock_event_stream.subscribe.assert_any_call(
             EventStreamSubscriber.AGENT_CONTROLLER,
             session.controller.on_event,
+            session.controller.id,
+        )
+        mock_event_stream.subscribe.assert_any_call(
+            EventStreamSubscriber.MEMORY,
+            session.controller.agent.memory.on_event,
             session.controller.id,
         )
 
@@ -189,10 +198,15 @@ async def test_agent_session_start_with_restored_state(mock_agent):
         # Verify set_initial_state was called once with the restored state
         assert session.controller.set_initial_state_call_count == 1
 
-        # Verify EventStream.subscribe was called with AGENT_CONTROLLER
+        # Verify EventStream.subscribe was called with AGENT_CONTROLLER and MEMORY
         mock_event_stream.subscribe.assert_any_call(
             EventStreamSubscriber.AGENT_CONTROLLER,
             session.controller.on_event,
+            session.controller.id,
+        )
+        mock_event_stream.subscribe.assert_any_call(
+            EventStreamSubscriber.MEMORY,
+            session.controller.agent.memory.on_event,
             session.controller.id,
         )
         assert session.controller.test_initial_state is mock_restored_state

--- a/tests/unit/test_agent_session.py
+++ b/tests/unit/test_agent_session.py
@@ -35,14 +35,14 @@ def mock_agent():
     agent.llm = llm
     agent.name = 'test-agent'
     agent.sandbox_plugins = []
-    
+
     # Add config attribute with disabled_microagents
     agent.config = MagicMock()
     agent.config.disabled_microagents = []
-    
+
     # Add prompt_manager attribute
     agent.prompt_manager = MagicMock()
-    
+
     # Add memory attribute with on_event method
     agent.memory = MagicMock()
     agent.memory.on_event = MagicMock()

--- a/tests/unit/test_agent_session.py
+++ b/tests/unit/test_agent_session.py
@@ -35,6 +35,13 @@ def mock_agent():
     agent.llm = llm
     agent.name = 'test-agent'
     agent.sandbox_plugins = []
+    
+    # Add config attribute with disabled_microagents
+    agent.config = MagicMock()
+    agent.config.disabled_microagents = []
+    
+    # Add prompt_manager attribute
+    agent.prompt_manager = MagicMock()
 
     return agent
 
@@ -97,8 +104,8 @@ async def test_agent_session_start_with_no_state(mock_agent):
             max_iterations=10,
         )
 
-        # Verify EventStream.subscribe was called with correct parameters
-        mock_event_stream.subscribe.assert_called_with(
+        # Verify EventStream.subscribe was called with AGENT_CONTROLLER
+        mock_event_stream.subscribe.assert_any_call(
             EventStreamSubscriber.AGENT_CONTROLLER,
             session.controller.on_event,
             session.controller.id,
@@ -182,8 +189,8 @@ async def test_agent_session_start_with_restored_state(mock_agent):
         # Verify set_initial_state was called once with the restored state
         assert session.controller.set_initial_state_call_count == 1
 
-        # Verify EventStream.subscribe was called with correct parameters
-        mock_event_stream.subscribe.assert_called_with(
+        # Verify EventStream.subscribe was called with AGENT_CONTROLLER
+        mock_event_stream.subscribe.assert_any_call(
             EventStreamSubscriber.AGENT_CONTROLLER,
             session.controller.on_event,
             session.controller.id,


### PR DESCRIPTION
This PR fixes the failing tests related to PR #6909 which refactors prompt extensions into recalled observations.

Changes made:
- Added mock_agent.prompt_manager = MagicMock() to mock_agent fixture
- Added mock_agent.config = {"disabled_microagents": []} to mock_agent fixture
- Changed assert_called_with to assert_any_call for EventStream.subscribe tests
- Updated comments in test_agent_session.py for clarity