### PR TITLE
Add condensation observation to history and detect its loop

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -78,7 +78,6 @@ class AgentController:
         NullObservation,
         ChangeAgentStateAction,
         AgentStateChangedObservation,
-        AgentCondensationObservation,
     )
 
     def __init__(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes to:
- re-add AgentCondensationObservation to the agent history
- add a stuck detector scenario for repeated AgentCondensationObs
- in headless mode, it will stop with an ERROR after 3 repetitions
- in non-headless mode, it will pause with an ERROR after 3, and after a user message, it will continue, disregarding the old observations for stuck detection purpose. (this is in line with how we do for other stuck with the UI, the user can speak to make it reset and continue)

At some point, we have removed an AgentCondensationObservation from history, I believe when we had a report that its truncation message "trimming context to meet context window limitations" message was confusing the LLM sometimes. Unfortunately that also means the stuck detector will not see it, because it works on the agent history.

That lead to a report in [slack](https://openhands-ai.slack.com/archives/C08E1SYKEM9/p1741274578335929?thread_ts=1741274032.140039&channel=C08E1SYKEM9&message_ts=1741274578.335929) that when it happens repeatedly, it will go on until 500 iterations, the default limit.

On a side note, this seems to mean that the summary is also not in history, which might help explain [reports](https://github.com/All-Hands-AI/OpenHands/issues/7023#issuecomment-2702762621) that the agent is redoing old stuff as if it forgot it?

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:592c10b-nikolaik   --name openhands-app-592c10b   docker.all-hands.dev/all-hands-ai/openhands:592c10b
```