### PR TITLE
Fix loading spinner

### DIFF
--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -115,7 +115,7 @@ export function Sidebar() {
                 user.data ? { avatar_url: user.data.avatar_url } : undefined
               }
               onLogout={handleLogout}
-              isLoading={user.isLoading || user.isPending}
+              isLoading={user.isFetching}
             />
           </div>
         </nav>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
If user is not signed in, the loading spinner is in an infinitely loading state.

It also turns out that `user.isLoading` is the same as `user.isFetching && user.isPending`

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Replace `user.isLoading || user.isPending` with `user.isFetching`

---
**Link of any specific issues this addresses.**
