### PR TITLE
chore: Prevent user from modifying basic LLM settings in saas mode

### DIFF
--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -1033,5 +1033,25 @@ describe("Settings Screen", () => {
         }),
       );
     });
+
+    it("should not submit the unwanted fields when resetting", async () => {
+      const user = userEvent.setup();
+      renderSettingsScreen();
+
+      const resetButton = await screen.findByText("Reset to defaults");
+      await user.click(resetButton);
+
+      const modal = await screen.findByTestId("reset-modal");
+      const confirmButton = within(modal).getByText("Reset");
+      await user.click(confirmButton);
+
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          llm_api_key: undefined,
+          llm_base_url: undefined,
+          llm_model: undefined,
+        }),
+      );
+    });
   });
 });

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -67,6 +67,14 @@ describe("Settings Screen", () => {
   });
 
   describe("Account Settings", () => {
+    beforeEach(() => {
+      getConfigSpy.mockResolvedValue({
+        APP_MODE: "oss",
+        GITHUB_CLIENT_ID: "123",
+        POSTHOG_CLIENT_KEY: "456",
+      });
+    });
+
     it("should render the account settings", async () => {
       renderSettingsScreen();
 
@@ -280,6 +288,14 @@ describe("Settings Screen", () => {
   });
 
   describe("LLM Settings", () => {
+    beforeEach(() => {
+      getConfigSpy.mockResolvedValue({
+        APP_MODE: "oss",
+        GITHUB_CLIENT_ID: "123",
+        POSTHOG_CLIENT_KEY: "456",
+      });
+    });
+
     it("should render the basic LLM settings by default", async () => {
       renderSettingsScreen();
 
@@ -428,7 +444,6 @@ describe("Settings Screen", () => {
       });
 
       it("should render the runtime settings input if SaaS mode", async () => {
-        const user = userEvent.setup();
         getConfigSpy.mockResolvedValue({
           APP_MODE: "saas",
           GITHUB_CLIENT_ID: "123",
@@ -436,9 +451,7 @@ describe("Settings Screen", () => {
         });
 
         renderSettingsScreen();
-
-        await toggleAdvancedSettings(user);
-        screen.getByTestId("runtime-settings-input");
+        await screen.findByTestId("runtime-settings-input");
       });
 
       it("should set the default runtime setting set", async () => {
@@ -455,8 +468,6 @@ describe("Settings Screen", () => {
 
         renderSettingsScreen();
 
-        await toggleAdvancedSettings(userEvent.setup());
-
         const input = await screen.findByTestId("runtime-settings-input");
         expect(input).toHaveValue("1x (2 core, 8G)");
       });
@@ -469,8 +480,6 @@ describe("Settings Screen", () => {
         });
 
         renderSettingsScreen();
-
-        await toggleAdvancedSettings(userEvent.setup());
 
         const input = await screen.findByTestId("runtime-settings-input");
         expect(input).toBeDisabled();
@@ -489,8 +498,6 @@ describe("Settings Screen", () => {
         });
 
         renderSettingsScreen();
-
-        await toggleAdvancedSettings(user);
 
         const input = await screen.findByTestId("runtime-settings-input");
         await user.click(input);
@@ -954,7 +961,7 @@ describe("Settings Screen", () => {
     });
   });
 
-  describe.only("SaaS mode", () => {
+  describe("SaaS mode", () => {
     beforeEach(() => {
       getConfigSpy.mockResolvedValue({
         APP_MODE: "saas",

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -458,7 +458,7 @@ describe("Settings Screen", () => {
         expect(input).not.toBeInTheDocument();
       });
 
-      it("should render the runtime settings input if SaaS mode", async () => {
+      it.skip("should render the runtime settings input if SaaS mode", async () => {
         getConfigSpy.mockResolvedValue({
           APP_MODE: "saas",
           GITHUB_CLIENT_ID: "123",
@@ -469,7 +469,7 @@ describe("Settings Screen", () => {
         await screen.findByTestId("runtime-settings-input");
       });
 
-      it("should set the default runtime setting set", async () => {
+      it.skip("should set the default runtime setting set", async () => {
         getConfigSpy.mockResolvedValue({
           APP_MODE: "saas",
           GITHUB_CLIENT_ID: "123",
@@ -487,7 +487,7 @@ describe("Settings Screen", () => {
         expect(input).toHaveValue("1x (2 core, 8G)");
       });
 
-      it("should always have the runtime input disabled", async () => {
+      it.skip("should always have the runtime input disabled", async () => {
         getConfigSpy.mockResolvedValue({
           APP_MODE: "saas",
           GITHUB_CLIENT_ID: "123",
@@ -976,7 +976,7 @@ describe("Settings Screen", () => {
     });
   });
 
-  describe.only("SaaS mode", () => {
+  describe("SaaS mode", () => {
     beforeEach(() => {
       getConfigSpy.mockResolvedValue({
         APP_MODE: "saas",

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -976,12 +976,23 @@ describe("Settings Screen", () => {
     });
   });
 
-  describe("SaaS mode", () => {
+  describe.only("SaaS mode", () => {
     beforeEach(() => {
       getConfigSpy.mockResolvedValue({
         APP_MODE: "saas",
         GITHUB_CLIENT_ID: "123",
         POSTHOG_CLIENT_KEY: "456",
+      });
+    });
+
+    it("should hide the entire LLM section", async () => {
+      renderSettingsScreen();
+
+      await waitFor(() => {
+        screen.getByTestId("account-settings-form"); // wait for the account settings form to render
+
+        const llmSection = screen.queryByTestId("llm-settings-section");
+        expect(llmSection).not.toBeInTheDocument();
       });
     });
 
@@ -1009,7 +1020,8 @@ describe("Settings Screen", () => {
       });
     });
 
-    it("should render advanced settings by default", async () => {
+    // We might want to bring this back if users wish to set advanced settings
+    it.skip("should render advanced settings by default", async () => {
       renderSettingsScreen();
 
       await waitFor(() => {
@@ -1031,17 +1043,11 @@ describe("Settings Screen", () => {
       const user = userEvent.setup();
       renderSettingsScreen();
 
-      const enableConfirmationModeSwitch = await screen.findByTestId(
-        "enable-confirmation-mode-switch",
-      );
-      await user.click(enableConfirmationModeSwitch);
-
-      const saveButton = screen.getByText("Save Changes");
+      const saveButton = await screen.findByText("Save Changes");
       await user.click(saveButton);
 
       expect(saveSettingsSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          confirmation_mode: true,
           llm_api_key: undefined,
           llm_base_url: undefined,
           llm_model: undefined,

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -1,6 +1,15 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import { createRoutesStub } from "react-router";
-import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  test,
+  vi,
+} from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 import OpenHands from "#/api/open-hands";
@@ -11,6 +20,7 @@ import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { PostApiSettings } from "#/types/settings";
 import * as ConsentHandlers from "#/utils/handle-capture-consent";
 import AccountSettings from "#/routes/account-settings";
+import * as FeatureFlags from "#/utils/feature-flags";
 
 const toggleAdvancedSettings = async (user: UserEvent) => {
   const advancedSwitch = await screen.findByTestId("advanced-settings-switch");
@@ -28,6 +38,11 @@ describe("Settings Screen", () => {
   vi.mock("#/hooks/use-app-logout", () => ({
     useAppLogout: vi.fn().mockReturnValue({ handleLogout: handleLogoutMock }),
   }));
+
+  beforeAll(() => {
+    // TODO: Remove this once we release
+    vi.spyOn(FeatureFlags, "HIDING_LLM_SETTINGS").mockReturnValue(true);
+  });
 
   afterEach(() => {
     vi.clearAllMocks();

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -41,7 +41,7 @@ describe("Settings Screen", () => {
 
   beforeAll(() => {
     // TODO: Remove this once we release
-    vi.spyOn(FeatureFlags, "HIDING_LLM_SETTINGS").mockReturnValue(true);
+    vi.spyOn(FeatureFlags, "HIDE_LLM_SETTINGS").mockReturnValue(true);
   });
 
   afterEach(() => {

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -22,6 +22,7 @@ import { ConversationPanelWrapper } from "../conversation-panel/conversation-pan
 import { useLogout } from "#/hooks/mutation/use-logout";
 import { useConfig } from "#/hooks/query/use-config";
 import { cn } from "#/utils/utils";
+import { HIDE_LLM_SETTINGS } from "#/utils/feature-flags";
 
 export function Sidebar() {
   const location = useLocation();
@@ -42,7 +43,12 @@ export function Sidebar() {
   const [conversationPanelIsOpen, setConversationPanelIsOpen] =
     React.useState(false);
 
+  // TODO: Remove HIDE_LLM_SETTINGS check once released
+  const isSaas = HIDE_LLM_SETTINGS() && config?.APP_MODE === "saas";
+
   React.useEffect(() => {
+    if (isSaas) return;
+
     if (location.pathname === "/settings") {
       setSettingsModalIsOpen(false);
     } else if (

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -30,6 +30,10 @@ const MOCK_USER_PREFERENCES: {
   settings: MOCK_DEFAULT_USER_SETTINGS,
 };
 
+export const resetMockUserPreferences = () => {
+  MOCK_USER_PREFERENCES.settings = MOCK_DEFAULT_USER_SETTINGS;
+};
+
 const conversations: Conversation[] = [
   {
     conversation_id: "1",

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -30,10 +30,6 @@ const MOCK_USER_PREFERENCES: {
   settings: MOCK_DEFAULT_USER_SETTINGS,
 };
 
-export const resetMockUserPreferences = () => {
-  MOCK_USER_PREFERENCES.settings = MOCK_DEFAULT_USER_SETTINGS;
-};
-
 const conversations: Conversation[] = [
   {
     conversation_id: "1",

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -25,6 +25,7 @@ import {
   displayErrorToast,
   displaySuccessToast,
 } from "#/utils/custom-toast-handlers";
+import { PostSettings } from "#/types/settings";
 
 const REMOTE_RUNTIME_OPTIONS = [
   { key: 1, label: "1x (2 core, 8G)" },
@@ -155,19 +156,26 @@ function AccountSettings() {
   };
 
   const handleReset = () => {
-    saveSettings(
-      {
-        ...DEFAULT_SETTINGS,
-        LLM_API_KEY: "", // reset LLM API key
+    const newSettings: Partial<PostSettings> = {
+      ...DEFAULT_SETTINGS,
+      LLM_API_KEY: "", // reset LLM API key
+    };
+
+    // we don't want the user to be able to modify these settings in SaaS
+    // and we should make sure they aren't included in the reset
+    if (isSaas) {
+      delete newSettings.LLM_API_KEY;
+      delete newSettings.LLM_BASE_URL;
+      delete newSettings.LLM_MODEL;
+    }
+
+    saveSettings(newSettings, {
+      onSuccess: () => {
+        displaySuccessToast("Settings reset");
+        setResetSettingsModalIsOpen(false);
+        setLlmConfigMode(isAdvancedSettingsSet ? "advanced" : "basic");
       },
-      {
-        onSuccess: () => {
-          displaySuccessToast("Settings reset");
-          setResetSettingsModalIsOpen(false);
-          setLlmConfigMode(isAdvancedSettingsSet ? "advanced" : "basic");
-        },
-      },
-    );
+    });
   };
 
   React.useEffect(() => {

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -26,7 +26,7 @@ import {
   displaySuccessToast,
 } from "#/utils/custom-toast-handlers";
 import { PostSettings } from "#/types/settings";
-import { HIDING_LLM_SETTINGS } from "#/utils/feature-flags";
+import { HIDE_LLM_SETTINGS } from "#/utils/feature-flags";
 
 const REMOTE_RUNTIME_OPTIONS = [
   { key: 1, label: "1x (2 core, 8G)" },
@@ -53,7 +53,7 @@ function AccountSettings() {
   const isSuccess = isSuccessfulSettings && isSuccessfulResources;
 
   const isSaas = config?.APP_MODE === "saas";
-  const shouldHandleSpecialSaasCase = HIDING_LLM_SETTINGS() && isSaas;
+  const shouldHandleSpecialSaasCase = HIDE_LLM_SETTINGS() && isSaas;
 
   const determineWhetherToToggleAdvancedSettings = () => {
     if (shouldHandleSpecialSaasCase) return true;

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -220,151 +220,156 @@ function AccountSettings() {
         className="flex flex-col grow overflow-auto"
       >
         <div className="flex flex-col gap-12 px-11 py-9">
-          <section className="flex flex-col gap-6">
-            <div className="flex items-center gap-7">
-              <h2 className="text-[28px] leading-8 tracking-[-0.02em] font-bold">
-                LLM Settings
-              </h2>
-              {!shouldHandleSpecialSaasCase && (
-                <SettingsSwitch
-                  testId="advanced-settings-switch"
-                  defaultIsToggled={isAdvancedSettingsSet}
-                  onToggle={onToggleAdvancedMode}
-                >
-                  Advanced
-                </SettingsSwitch>
+          {!shouldHandleSpecialSaasCase && (
+            <section
+              data-testid="llm-settings-section"
+              className="flex flex-col gap-6"
+            >
+              <div className="flex items-center gap-7">
+                <h2 className="text-[28px] leading-8 tracking-[-0.02em] font-bold">
+                  LLM Settings
+                </h2>
+                {!shouldHandleSpecialSaasCase && (
+                  <SettingsSwitch
+                    testId="advanced-settings-switch"
+                    defaultIsToggled={isAdvancedSettingsSet}
+                    onToggle={onToggleAdvancedMode}
+                  >
+                    Advanced
+                  </SettingsSwitch>
+                )}
+              </div>
+
+              {llmConfigMode === "basic" && !shouldHandleSpecialSaasCase && (
+                <ModelSelector
+                  models={modelsAndProviders}
+                  currentModel={settings.LLM_MODEL}
+                />
               )}
-            </div>
 
-            {llmConfigMode === "basic" && !shouldHandleSpecialSaasCase && (
-              <ModelSelector
-                models={modelsAndProviders}
-                currentModel={settings.LLM_MODEL}
-              />
-            )}
+              {llmConfigMode === "advanced" && !shouldHandleSpecialSaasCase && (
+                <SettingsInput
+                  testId="llm-custom-model-input"
+                  name="llm-custom-model-input"
+                  label="Custom Model"
+                  defaultValue={settings.LLM_MODEL}
+                  placeholder="anthropic/claude-3-5-sonnet-20241022"
+                  type="text"
+                  className="w-[680px]"
+                />
+              )}
+              {llmConfigMode === "advanced" && !shouldHandleSpecialSaasCase && (
+                <SettingsInput
+                  testId="base-url-input"
+                  name="base-url-input"
+                  label="Base URL"
+                  defaultValue={settings.LLM_BASE_URL}
+                  placeholder="https://api.openai.com"
+                  type="text"
+                  className="w-[680px]"
+                />
+              )}
 
-            {llmConfigMode === "advanced" && !shouldHandleSpecialSaasCase && (
-              <SettingsInput
-                testId="llm-custom-model-input"
-                name="llm-custom-model-input"
-                label="Custom Model"
-                defaultValue={settings.LLM_MODEL}
-                placeholder="anthropic/claude-3-5-sonnet-20241022"
-                type="text"
-                className="w-[680px]"
-              />
-            )}
-            {llmConfigMode === "advanced" && !shouldHandleSpecialSaasCase && (
-              <SettingsInput
-                testId="base-url-input"
-                name="base-url-input"
-                label="Base URL"
-                defaultValue={settings.LLM_BASE_URL}
-                placeholder="https://api.openai.com"
-                type="text"
-                className="w-[680px]"
-              />
-            )}
+              {!shouldHandleSpecialSaasCase && (
+                <SettingsInput
+                  testId="llm-api-key-input"
+                  name="llm-api-key-input"
+                  label="API Key"
+                  type="password"
+                  className="w-[680px]"
+                  startContent={
+                    isLLMKeySet && <KeyStatusIcon isSet={isLLMKeySet} />
+                  }
+                  placeholder={isLLMKeySet ? "**********" : ""}
+                />
+              )}
 
-            {!shouldHandleSpecialSaasCase && (
-              <SettingsInput
-                testId="llm-api-key-input"
-                name="llm-api-key-input"
-                label="API Key"
-                type="password"
-                className="w-[680px]"
-                startContent={
-                  isLLMKeySet && <KeyStatusIcon isSet={isLLMKeySet} />
-                }
-                placeholder={isLLMKeySet ? "**********" : ""}
-              />
-            )}
+              {!shouldHandleSpecialSaasCase && (
+                <HelpLink
+                  testId="llm-api-key-help-anchor"
+                  text="Don't know your API key?"
+                  linkText="Click here for instructions"
+                  href="https://docs.all-hands.dev/modules/usage/llms"
+                />
+              )}
 
-            {!shouldHandleSpecialSaasCase && (
-              <HelpLink
-                testId="llm-api-key-help-anchor"
-                text="Don't know your API key?"
-                linkText="Click here for instructions"
-                href="https://docs.all-hands.dev/modules/usage/llms"
-              />
-            )}
-
-            {llmConfigMode === "advanced" && (
-              <SettingsDropdownInput
-                testId="agent-input"
-                name="agent-input"
-                label="Agent"
-                items={
-                  resources?.agents.map((agent) => ({
-                    key: agent,
-                    label: agent,
-                  })) || []
-                }
-                defaultSelectedKey={settings.AGENT}
-                isClearable={false}
-              />
-            )}
-
-            {isSaas && llmConfigMode === "advanced" && (
-              <SettingsDropdownInput
-                testId="runtime-settings-input"
-                name="runtime-settings-input"
-                label={
-                  <>
-                    Runtime Settings (
-                    <a href="mailto:contact@all-hands.dev">
-                      get in touch for access
-                    </a>
-                    )
-                  </>
-                }
-                items={REMOTE_RUNTIME_OPTIONS}
-                defaultSelectedKey={settings.REMOTE_RUNTIME_RESOURCE_FACTOR?.toString()}
-                isDisabled
-                isClearable={false}
-              />
-            )}
-
-            {llmConfigMode === "advanced" && (
-              <SettingsSwitch
-                testId="enable-confirmation-mode-switch"
-                onToggle={setConfirmationModeIsEnabled}
-                defaultIsToggled={!!settings.CONFIRMATION_MODE}
-                isBeta
-              >
-                Enable confirmation mode
-              </SettingsSwitch>
-            )}
-
-            {llmConfigMode === "advanced" && (
-              <SettingsSwitch
-                testId="enable-memory-condenser-switch"
-                name="enable-memory-condenser-switch"
-                defaultIsToggled={!!settings.ENABLE_DEFAULT_CONDENSER}
-              >
-                Enable memory condensation
-              </SettingsSwitch>
-            )}
-
-            {llmConfigMode === "advanced" && confirmationModeIsEnabled && (
-              <div>
+              {llmConfigMode === "advanced" && (
                 <SettingsDropdownInput
-                  testId="security-analyzer-input"
-                  name="security-analyzer-input"
-                  label="Security Analyzer"
+                  testId="agent-input"
+                  name="agent-input"
+                  label="Agent"
                   items={
-                    resources?.securityAnalyzers.map((analyzer) => ({
-                      key: analyzer,
-                      label: analyzer,
+                    resources?.agents.map((agent) => ({
+                      key: agent,
+                      label: agent,
                     })) || []
                   }
-                  defaultSelectedKey={settings.SECURITY_ANALYZER}
-                  isClearable
-                  showOptionalTag
+                  defaultSelectedKey={settings.AGENT}
+                  isClearable={false}
                 />
-              </div>
-            )}
-          </section>
+              )}
+
+              {isSaas && llmConfigMode === "advanced" && (
+                <SettingsDropdownInput
+                  testId="runtime-settings-input"
+                  name="runtime-settings-input"
+                  label={
+                    <>
+                      Runtime Settings (
+                      <a href="mailto:contact@all-hands.dev">
+                        get in touch for access
+                      </a>
+                      )
+                    </>
+                  }
+                  items={REMOTE_RUNTIME_OPTIONS}
+                  defaultSelectedKey={settings.REMOTE_RUNTIME_RESOURCE_FACTOR?.toString()}
+                  isDisabled
+                  isClearable={false}
+                />
+              )}
+
+              {llmConfigMode === "advanced" && (
+                <SettingsSwitch
+                  testId="enable-confirmation-mode-switch"
+                  onToggle={setConfirmationModeIsEnabled}
+                  defaultIsToggled={!!settings.CONFIRMATION_MODE}
+                  isBeta
+                >
+                  Enable confirmation mode
+                </SettingsSwitch>
+              )}
+
+              {llmConfigMode === "advanced" && (
+                <SettingsSwitch
+                  testId="enable-memory-condenser-switch"
+                  name="enable-memory-condenser-switch"
+                  defaultIsToggled={!!settings.ENABLE_DEFAULT_CONDENSER}
+                >
+                  Enable memory condensation
+                </SettingsSwitch>
+              )}
+
+              {llmConfigMode === "advanced" && confirmationModeIsEnabled && (
+                <div>
+                  <SettingsDropdownInput
+                    testId="security-analyzer-input"
+                    name="security-analyzer-input"
+                    label="Security Analyzer"
+                    items={
+                      resources?.securityAnalyzers.map((analyzer) => ({
+                        key: analyzer,
+                        label: analyzer,
+                      })) || []
+                    }
+                    defaultSelectedKey={settings.SECURITY_ANALYZER}
+                    isClearable
+                    showOptionalTag
+                  />
+                </div>
+              )}
+            </section>
+          )}
 
           <section className="flex flex-col gap-6">
             <h2 className="text-[28px] leading-8 tracking-[-0.02em] font-bold">

--- a/frontend/src/utils/feature-flags.ts
+++ b/frontend/src/utils/feature-flags.ts
@@ -13,4 +13,4 @@ function loadFeatureFlag(
 }
 
 export const BILLING_SETTINGS = () => loadFeatureFlag("BILLING_SETTINGS");
-export const HIDING_LLM_SETTINGS = () => loadFeatureFlag("HIDING_LLM_SETTINGS");
+export const HIDE_LLM_SETTINGS = () => loadFeatureFlag("HIDE_LLM_SETTINGS");

--- a/frontend/src/utils/feature-flags.ts
+++ b/frontend/src/utils/feature-flags.ts
@@ -13,3 +13,4 @@ function loadFeatureFlag(
 }
 
 export const BILLING_SETTINGS = () => loadFeatureFlag("BILLING_SETTINGS");
+export const HIDING_LLM_SETTINGS = () => loadFeatureFlag("HIDING_LLM_SETTINGS");

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -83,6 +83,12 @@ async def store_settings(
                     existing_settings.user_consents_to_analytics
                 )
 
+            if settings.llm_model is None:
+                settings.llm_model = existing_settings.llm_model
+
+            if settings.llm_base_url is None:
+                settings.llm_base_url = existing_settings.llm_base_url
+
         response = JSONResponse(
             status_code=status.HTTP_200_OK,
             content={'message': 'Settings stored'},


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
The user should not be able to override our default LLM settings in SaaS

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
- Currently locked behind a feature flag (`FEATURE_HIDE_LLM_SETTINGS`)
- Hide entire LLM settings area

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:99a1851-nikolaik   --name openhands-app-99a1851   docker.all-hands.dev/all-hands-ai/openhands:99a1851
```