### PR TITLE
Refactor on_first_message_action in the controller

### DIFF
--- a/openhands/events/__init__.py
+++ b/openhands/events/__init__.py
@@ -1,4 +1,4 @@
-from openhands.events.event import Event, EventSource
+from openhands.events.event import Event, EventSource, RecallType
 from openhands.events.stream import EventStream, EventStreamSubscriber
 
 __all__ = [
@@ -6,4 +6,5 @@ __all__ = [
     'EventSource',
     'EventStream',
     'EventStreamSubscriber',
+    'RecallType',
 ]

--- a/openhands/events/action/agent.py
+++ b/openhands/events/action/agent.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from openhands.core.schema import ActionType
 from openhands.events.action.action import Action
+from openhands.events.event import RecallType
 
 
 @dataclass
@@ -114,6 +115,7 @@ class AgentRecallAction(Action):
     query: str = ''
     thought: str = ''
     action: str = ActionType.RECALL
+    recall_type: RecallType = RecallType.DEFAULT
 
     @property
     def message(self) -> str:

--- a/openhands/events/event.py
+++ b/openhands/events/event.py
@@ -22,6 +22,19 @@ class FileReadSource(str, Enum):
     DEFAULT = 'default'
 
 
+class RecallType(str, Enum):
+    """The type of information that can be recalled."""
+
+    ENVIRONMENT_INFO = 'environment_info'
+    """environment information (repo instructions, runtime, etc.)"""
+
+    KNOWLEDGE_MICROAGENT = 'knowledge_microagent'
+    """A knowledge microagent."""
+
+    DEFAULT = 'default'
+    """Anything else that doesn't fit into the other categories."""
+
+
 @dataclass
 class Event:
     INVALID_ID = -1

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -1,9 +1,9 @@
+from openhands.events.event import RecallType
 from openhands.events.observation.agent import (
     AgentCondensationObservation,
     AgentStateChangedObservation,
     AgentThinkObservation,
     RecallObservation,
-    RecallType,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (

--- a/openhands/events/observation/agent.py
+++ b/openhands/events/observation/agent.py
@@ -1,21 +1,8 @@
 from dataclasses import dataclass, field
-from enum import Enum
 
 from openhands.core.schema import ObservationType
+from openhands.events.event import RecallType
 from openhands.events.observation.observation import Observation
-
-
-class RecallType(Enum):
-    """The type of information that can be recalled."""
-
-    ENVIRONMENT_INFO = 'environment_info'
-    """environment information (repo instructions, runtime, etc.)"""
-
-    KNOWLEDGE_MICROAGENT = 'knowledge_microagent'
-    """A knowledge microagent."""
-
-    DEFAULT = 'default'
-    """Anything else that doesn't fit into the other categories."""
 
 
 @dataclass
@@ -70,26 +57,29 @@ class RecallObservation(Observation):
     runtime_hosts: dict[str, int] = field(default_factory=dict)
     additional_agent_instructions: str = ''
 
-    # knowledge_microagent
-    # A list of dictionaries, where each dictionary contains information about a triggered microagent.
-    # Each dictionary has the following keys:
-    # - agent_name: str - The name of the microagent that was triggered
-    # - trigger_word: str - The word that triggered this microagent
-    # - content: str - The actual content/knowledge from the microagent
-    # Example:
-    # [
-    #     {
-    #         "agent_name": "python_best_practices",
-    #         "trigger_word": "python",
-    #         "content": "Always use virtual environments for Python projects."
-    #     },
-    #     {
-    #         "agent_name": "git_workflow",
-    #         "trigger_word": "git",
-    #         "content": "Create a new branch for each feature or bugfix."
-    #     }
-    # ]
+    # microagent
     microagent_knowledge: list[dict[str, str]] = field(default_factory=list)
+    """
+    A list of dictionaries, each containing information about a triggered microagent.
+    Each dictionary has the following keys:
+        - agent_name: str - The name of the microagent that was triggered
+        - trigger_word: str - The word that triggered this microagent
+        - content: str - The actual content/knowledge from the microagent
+
+    Example:
+    [
+        {
+            "agent_name": "python_best_practices",
+            "trigger_word": "python",
+            "content": "Always use virtual environments for Python projects."
+        },
+        {
+            "agent_name": "git_workflow",
+            "trigger_word": "git",
+            "content": "Create a new branch for each feature or bugfix."
+        }
+    ]
+    """
 
     @property
     def message(self) -> str:

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -1,11 +1,11 @@
 import copy
 
+from openhands.events.event import RecallType
 from openhands.events.observation.agent import (
     AgentCondensationObservation,
     AgentStateChangedObservation,
     AgentThinkObservation,
     RecallObservation,
-    RecallType,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -17,7 +17,7 @@ from openhands.events.action import (
     IPythonRunCellAction,
     MessageAction,
 )
-from openhands.events.event import Event
+from openhands.events.event import Event, RecallType
 from openhands.events.observation import (
     AgentCondensationObservation,
     AgentDelegateObservation,
@@ -29,7 +29,7 @@ from openhands.events.observation import (
     IPythonRunCellObservation,
     UserRejectObservation,
 )
-from openhands.events.observation.agent import RecallObservation, RecallType
+from openhands.events.observation.agent import RecallObservation
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.observation.observation import Observation
 from openhands.events.serialization.event import truncate_content

--- a/tests/unit/test_action_serialization.py
+++ b/tests/unit/test_action_serialization.py
@@ -363,6 +363,7 @@ def test_agent_recall_action_serialization_deserialization():
         'args': {
             'query': 'What is the capital of France?',
             'thought': 'I need to recall information about France',
+            'recall_type': 'default',
         },
     }
     serialization_deserialization(original_action_dict, AgentRecallAction)

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -15,10 +15,11 @@ from openhands.core.schema import AgentState
 from openhands.events import Event, EventSource, EventStream, EventStreamSubscriber
 from openhands.events.action import ChangeAgentStateAction, CmdRunAction, MessageAction
 from openhands.events.action.agent import AgentRecallAction
+from openhands.events.event import RecallType
 from openhands.events.observation import (
     ErrorObservation,
 )
-from openhands.events.observation.agent import RecallObservation, RecallType
+from openhands.events.observation.agent import RecallObservation
 from openhands.events.serialization import event_to_dict
 from openhands.llm import LLM
 from openhands.llm.metrics import Metrics

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -189,7 +189,6 @@ only respond with a message telling them how smart they are
 
     # Verify microagents were loaded
     assert len(memory.repo_microagents) == 0
-    assert len(memory.knowledge_microagents) == 6
     assert 'flarglebargle' in memory.knowledge_microagents
 
     # Create a recall action with the trigger word
@@ -270,7 +269,9 @@ REPOSITORY INSTRUCTIONS: This is a test repository.
     event_stream.add_event(user_message, EventSource.USER)
 
     # Create and add the recall action
-    recall_action = AgentRecallAction(query='First user message')
+    recall_action = AgentRecallAction(
+        query='First user message', recall_type=RecallType.ENVIRONMENT_INFO
+    )
     recall_action._source = EventSource.USER  # type: ignore[attr-defined]
     event_stream.add_event(recall_action, EventSource.USER)
 
@@ -343,7 +344,11 @@ It may or may not be relevant to the user's request.
 
     # Process the observation
     messages = conversation_memory._process_observation(
-        obs=recall_observation, tool_call_id_to_message={}, max_message_chars=None
+        obs=recall_observation,
+        tool_call_id_to_message={},
+        max_message_chars=None,
+        current_index=0,
+        events=[],
     )
 
     # Verify the message was created correctly
@@ -424,7 +429,11 @@ each of which has a corresponding port:
 
     # Process the observation
     messages = conversation_memory._process_observation(
-        obs=recall_observation, tool_call_id_to_message={}, max_message_chars=None
+        obs=recall_observation,
+        tool_call_id_to_message={},
+        max_message_chars=None,
+        current_index=0,
+        events=[],
     )
 
     # Verify the message was created correctly

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -192,7 +192,9 @@ only respond with a message telling them how smart they are
     assert 'flarglebargle' in memory.knowledge_microagents
 
     # Create a recall action with the trigger word
-    recall_action = AgentRecallAction(query='Hello, flarglebargle!')
+    recall_action = AgentRecallAction(
+        query='Hello, flarglebargle!', recall_type=RecallType.DEFAULT
+    )
 
     # Mock the event_stream.add_event method
     added_events = []

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -9,8 +9,8 @@ from openhands.core.config.agent_config import AgentConfig
 from openhands.core.message import TextContent
 from openhands.events.action.agent import AgentRecallAction
 from openhands.events.action.message import MessageAction
-from openhands.events.event import EventSource
-from openhands.events.observation.agent import RecallObservation, RecallType
+from openhands.events.event import EventSource, RecallType
+from openhands.events.observation.agent import RecallObservation
 from openhands.events.stream import EventStream
 from openhands.memory.conversation_memory import ConversationMemory
 from openhands.memory.memory import Memory


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes an alternative on where the decision on recalling `ENVIRONMENT_INFO` is taken:
- refactor the `on first user message` trigger to be in the controller, not in memory, so that it can account for delegate agents.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:825e1b1-nikolaik   --name openhands-app-825e1b1   docker.all-hands.dev/all-hands-ai/openhands:825e1b1
```