### PR TITLE
Change back the runtime binding address to 0.0.0.0

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -61,7 +61,7 @@ class SandboxConfig(BaseModel):
         default=False
     )  # once enabled, OpenHands would lint files after editing
     use_host_network: bool = Field(default=False)
-    runtime_binding_address: str = Field(default='127.0.0.1')
+    runtime_binding_address: str = Field(default='0.0.0.0')
     runtime_extra_build_args: list[str] | None = Field(default=None)
     initialize_plugins: bool = Field(default=True)
     force_rebuild_runtime: bool = Field(default=False)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Change back the runtime binding address to 0.0.0.0

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Lots of users are running into issues with 0.28 as the runtime doesn't seem to start.
This was the original PR that changed this: https://github.com/All-Hands-AI/OpenHands/pull/6992/files

---
**Link of any specific issues this addresses.**
https://github.com/All-Hands-AI/OpenHands/issues/7152

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:14117bc-nikolaik   --name openhands-app-14117bc   docker.all-hands.dev/all-hands-ai/openhands:14117bc
```