### PR TITLE
Add error logs to API response from GH Service

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -81,10 +81,11 @@ class GitHubService:
             if e.response.status_code == 401:
                 raise GhAuthenticationError('Invalid Github token')
 
-            logger.warning(f"Error on GH API: {e}")
+            logger.warning(f"Status error on GH API: {e}")
             raise GHUnknownException('Unknown error')
 
-        except httpx.HTTPError:
+        except httpx.HTTPError as e:
+            logger.warning(f"HTTP error on GH API: {e}")
             raise GHUnknownException('Unknown error')
 
     async def get_user(self) -> GitHubUser:
@@ -177,10 +178,11 @@ class GitHubService:
             if e.response.status_code == 401:
                 raise GhAuthenticationError('Invalid Github token')
         
-            logger.warning(f"Error on GH API: {e}")
+            logger.warning(f"Status error on GH API: {e}")
             raise GHUnknownException('Unknown error')
 
-        except httpx.HTTPError:
+        except httpx.HTTPError as e:
+            logger.warning(f"HTTP error on GH API: {e}")
             raise GHUnknownException('Unknown error')
 
     async def get_suggested_tasks(self) -> list[SuggestedTask]:

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -14,7 +14,7 @@ from openhands.integrations.github.github_types import (
     TaskType,
 )
 from openhands.utils.import_utils import get_impl
-
+from openhands.core.logger import openhands_logger as logger
 
 class GitHubService:
     BASE_URL = 'https://api.github.com'
@@ -80,6 +80,8 @@ class GitHubService:
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
                 raise GhAuthenticationError('Invalid Github token')
+
+            logger.warning(f"Error on GH API: {e}")
             raise GHUnknownException('Unknown error')
 
         except httpx.HTTPError:
@@ -174,6 +176,8 @@ class GitHubService:
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
                 raise GhAuthenticationError('Invalid Github token')
+        
+            logger.warning(f"Error on GH API: {e}")
             raise GHUnknownException('Unknown error')
 
         except httpx.HTTPError:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR surfaces logs for failed API responses from GH Service. 401s are caught, but malformed requests are hard to debug without these logs

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:074ebe1-nikolaik   --name openhands-app-074ebe1   docker.all-hands.dev/all-hands-ai/openhands:074ebe1
```