### PR TITLE
Fix CWD for FileEditor constructor in action_execution_server.py

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -158,7 +158,7 @@ class ActionExecutor:
         self.bash_session: BashSession | None = None
         self.lock = asyncio.Lock()
         self.plugins: dict[str, Plugin] = {}
-        self.file_editor = OHEditor()
+        self.file_editor = OHEditor(cwd=self._initial_cwd)
         self.browser = BrowserEnv(browsergym_eval_env)
         self.start_time = time.time()
         self.last_execution_time = self.start_time

--- a/tests/unit/test_file_editor_cwd.py
+++ b/tests/unit/test_file_editor_cwd.py
@@ -1,0 +1,55 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from openhands_aci.editor.editor import OHEditor
+from openhands_aci.editor.exceptions import EditorToolParameterInvalidError
+
+
+def test_file_editor_cwd_initialization():
+    """Test that the OHEditor correctly initializes with a custom cwd."""
+    test_cwd = "/tmp/test_cwd"
+    editor = OHEditor(cwd=test_cwd)
+    assert editor._cwd == test_cwd
+
+
+def test_file_editor_cwd_default():
+    """Test that the OHEditor uses os.getcwd() as the default cwd."""
+    with mock.patch("os.getcwd", return_value="/mock/cwd"):
+        editor = OHEditor()
+        assert editor._cwd == "/mock/cwd"
+
+
+def test_file_editor_validate_path_with_cwd():
+    """Test that validate_path uses the custom cwd for path suggestions."""
+    test_cwd = "/custom/cwd"
+    editor = OHEditor(cwd=test_cwd)
+    
+    # Test with a relative path
+    with pytest.raises(EditorToolParameterInvalidError) as excinfo:
+        editor.validate_path("view", Path("relative/path"))
+    
+    # Check that the error message contains the correct suggested path
+    assert f"{test_cwd}/relative/path" in str(excinfo.value)
+
+
+def test_file_editor_in_action_execution_server():
+    """Test that the OHEditor is initialized with the correct cwd in ActionExecutor."""
+    from openhands.runtime.action_execution_server import ActionExecutor
+    
+    # Create a temporary directory to use as the working directory
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Initialize ActionExecutor with the temporary directory as the working directory
+        executor = ActionExecutor(
+            plugins_to_load=[],
+            work_dir=temp_dir,
+            username="test_user",
+            user_id=1000,
+            browsergym_eval_env=None,
+        )
+        
+        # Check that the file_editor was initialized with the correct cwd
+        assert executor.file_editor._cwd == temp_dir


### PR DESCRIPTION
This PR fixes issue #7174 by passing the current working directory to the OHEditor constructor in action_execution_server.py.

The issue was that the CWD was not properly set for the FileEditor constructor, which led to errors when constructing file creation paths. This PR adds a test to verify that the CWD is correctly passed to the OHEditor constructor.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b100ae00586747f3a178cd92635e0ee0)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:62bc9ef-nikolaik   --name openhands-app-62bc9ef   docker.all-hands.dev/all-hands-ai/openhands:62bc9ef
```