### PR TITLE
[Optimize]: Add compression support to GitHubService

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -20,6 +20,7 @@ class GitHubService:
     BASE_URL = 'https://api.github.com'
     token: SecretStr = SecretStr('')
     refresh = False
+    compress = False
 
     def __init__(
         self,
@@ -27,9 +28,11 @@ class GitHubService:
         idp_token: SecretStr | None = None,
         token: SecretStr | None = None,
         external_token_manager: bool = False,
+        compress: bool = False,
     ):
         self.user_id = user_id
         self.external_token_manager = external_token_manager
+        self.compress = compress
 
         if token:
             self.token = token
@@ -42,10 +45,15 @@ class GitHubService:
         if self.user_id and not self.token:
             self.token = await self.get_latest_token()
 
-        return {
+        headers = {
             'Authorization': f'Bearer {self.token.get_secret_value()}',
             'Accept': 'application/vnd.github.v3+json',
         }
+        
+        if self.compress:
+            headers['Accept-Encoding'] = 'gzip'
+            
+        return headers
 
     def _has_token_expired(self, status_code: int) -> bool:
         return status_code == 401

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -20,19 +20,16 @@ class GitHubService:
     BASE_URL = 'https://api.github.com'
     token: SecretStr = SecretStr('')
     refresh = False
-    compress = False
 
     def __init__(
         self,
         user_id: str | None = None,
         idp_token: SecretStr | None = None,
         token: SecretStr | None = None,
-        external_token_manager: bool = False,
-        compress: bool = False,
+        external_token_manager: bool = False
     ):
         self.user_id = user_id
         self.external_token_manager = external_token_manager
-        self.compress = compress
 
         if token:
             self.token = token
@@ -48,10 +45,8 @@ class GitHubService:
         headers = {
             'Authorization': f'Bearer {self.token.get_secret_value()}',
             'Accept': 'application/vnd.github.v3+json',
+            'Accept-Encoding': 'gzip'
         }
-        
-        if self.compress:
-            headers['Accept-Encoding'] = 'gzip'
             
         return headers
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR enables gzip compression by default for Github API requests.

Github API sends back compressed data, which gets decompressed automatically at `response.json()` step (because GitHub ensure the response header contains gzip) 

Manual tests indicate that this works as expected (logging into app to see user profile, repositories, etc)

---
**Link of any specific issues this addresses.**
