### PR TITLE
Adds unit test for the interaction between agent controller truncation and condenser

### DIFF
--- a/tests/unit/test_condenser.py
+++ b/tests/unit/test_condenser.py
@@ -378,6 +378,48 @@ def test_llm_summarizing_condenser_llm_call(mock_llm, mock_state):
     assert mock_state.extra_data['condenser_meta'][0]['metrics'] == {'test_metric': 1.0}
 
 
+def test_llm_summarizing_condenser_resets_when_given_truncated_history(
+    mock_llm, mock_state
+):
+    """Test that the condenser, when it sees a shorter history than it has in the past (due to truncation), will reset its tracking."""
+    max_size = 4
+    keep_first = 1
+    condenser = LLMSummarizingCondenser(
+        max_size=max_size, keep_first=keep_first, llm=mock_llm
+    )
+
+    # Add initial event
+    first_event = create_test_event('Event 0')
+    mock_state.history.append(first_event)
+
+    # Set up mock LLM response
+    mock_llm.set_mock_response_content('Summary of forgotten events')
+
+    # Add enough events to trigger forgetting
+    for i in range(max_size + 3):  # +3 to ensure we're well past max_size
+        event = create_test_event(f'Event {i+1}')
+        mock_state.history.append(event)
+
+    # Get the condensed history
+    results = condenser.condensed_history(mock_state)
+
+    # We should have exactly 3 events:
+    # 1. First event (keep_first = 1)
+    # 2. Summary event
+    # 3. Most recent event
+    assert len(results) == 3, f'Expected 3 events, got {len(results)}: {results}'
+
+    # Now, call condensation on a small history that contains only two events.
+    alternate_history = [
+        create_test_event('Alt. Event 0'),
+        create_test_event('Alt. Event 1'),
+    ]
+    mock_state.history = alternate_history
+
+    results = condenser.condensed_history(mock_state)
+    assert results == alternate_history
+
+
 def test_amortized_forgetting_condenser_from_config():
     """Test that AmortizedForgettingCondenser objects can be made from config."""
     max_size = 50

--- a/tests/unit/test_condenser.py
+++ b/tests/unit/test_condenser.py
@@ -416,6 +416,9 @@ def test_llm_summarizing_condenser_resets_when_given_truncated_history(
     ]
     mock_state.history = alternate_history
 
+    # When we do this, the condenser should start tracking the alternative history
+    # as the de-facto history. That means we lose the summarization event and any
+    # other events that were in the previous history.
     results = condenser.condensed_history(mock_state)
     assert results == alternate_history
 


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces.**

Adds a simple test to confirm that, when the LLM summarizing condenser sees a smaller history than it's been tracking (likely due to the agent controller truncating the history upon seeing a context window error) that it resets its tracking.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**
