### PR TITLE
Feat user settings

### DIFF
--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -12,7 +12,7 @@ from starlette.requests import Request as StarletteRequest
 from starlette.types import ASGIApp
 
 from openhands.server import shared
-from openhands.server.auth import get_github_user_id
+from openhands.server.auth import get_user_id
 from openhands.server.types import SessionMiddlewareInterface
 
 
@@ -189,7 +189,7 @@ class GitHubTokenMiddleware(SessionMiddlewareInterface):
 
     async def __call__(self, request: Request, call_next: Callable):
         settings_store = await shared.SettingsStoreImpl.get_instance(
-            shared.config, get_github_user_id(request)
+            shared.config, get_user_id(request)
         )
         settings = await settings_store.load()
 

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -4,7 +4,7 @@ from pydantic import SecretStr
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.github.github_service import GithubServiceImpl
-from openhands.server.auth import get_github_token, get_github_user_id
+from openhands.server.auth import get_github_token, get_user_id
 from openhands.server.settings import GETSettingsModel, POSTSettingsModel, Settings
 from openhands.server.shared import SettingsStoreImpl, config
 
@@ -14,7 +14,7 @@ app = APIRouter(prefix='/api')
 @app.get('/settings', response_model=GETSettingsModel)
 async def load_settings(request: Request) -> GETSettingsModel | JSONResponse:
     try:
-        user_id = get_github_user_id(request)
+        user_id = get_user_id(request)
         settings_store = await SettingsStoreImpl.get_instance(config, user_id)
         settings = await settings_store.load()
         if not settings:
@@ -68,7 +68,7 @@ async def store_settings(
 
     try:
         settings_store = await SettingsStoreImpl.get_instance(
-            config, get_github_user_id(request)
+            config, get_user_id(request)
         )
         existing_settings = await settings_store.load()
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
This should have no visible effect in the OSS repo - we swap over from using github_user_id to user_id (Keycloak) when creating settings stores. (The OSS repo does not use the user_id - it is always None)

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fbc9b50-nikolaik   --name openhands-app-fbc9b50   docker.all-hands.dev/all-hands-ai/openhands:fbc9b50
```