### PR TITLE
Add troubleshooting note for GitHub token in microagent

### DIFF
--- a/microagents/knowledge/github.md
+++ b/microagents/knowledge/github.md
@@ -14,6 +14,8 @@ the GitHub API.
 You can use `curl` with the `GITHUB_TOKEN` to interact with GitHub's API.
 ALWAYS use the GitHub API for operations instead of a web browser.
 
+If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the token may have expired or become invalid. In such cases, update the remote URL to include the token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`
+
 Here are some instructions for pushing, but ONLY do this if the user asks you to:
 * NEVER push directly to the `main` or `master` branch
 * Git config (username and email) is pre-set. Do not modify.

--- a/microagents/knowledge/github.md
+++ b/microagents/knowledge/github.md
@@ -14,7 +14,7 @@ the GitHub API.
 You can use `curl` with the `GITHUB_TOKEN` to interact with GitHub's API.
 ALWAYS use the GitHub API for operations instead of a web browser.
 
-If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the token may have expired or become invalid. In such cases, update the remote URL to include the token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`
+If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`
 
 Here are some instructions for pushing, but ONLY do this if the user asks you to:
 * NEVER push directly to the `main` or `master` branch


### PR DESCRIPTION
This PR addresses issue #7199 by adding a troubleshooting note to the GitHub microagent to help users resolve issues with expired or invalid GitHub tokens.

The note provides clear instructions on how to update the remote URL to include the token when encountering authentication issues during push operations.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3d10096728a64a2289a1f5a47fffad6d)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:78c5ec6-nikolaik   --name openhands-app-78c5ec6   docker.all-hands.dev/all-hands-ai/openhands:78c5ec6
```