### PR TITLE
Remove mention of non-existent config micro_agent_name

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -218,9 +218,6 @@ codeact_enable_llm_editor = false
 # whether the IPython tool is enabled
 codeact_enable_jupyter = true
 
-# Name of the micro agent to use for this agent
-#micro_agent_name = ""
-
 # Memory enabled
 #memory_enabled = false
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -333,12 +333,6 @@ Pour les configurations de développement, vous pouvez également définir des c
 
 Les options de configuration de l'agent sont définies dans les sections `[agent]` et `[agent.<agent_name>]` du fichier `config.toml`.
 
-**Configuration du micro-agent**
-- `micro_agent_name`
-  - Type : `str`
-  - Valeur par défaut : `""`
-  - Description : Nom du micro-agent à utiliser pour cet agent
-
 **Configuration de la mémoire**
 - `memory_enabled`
   - Type : `bool`

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -328,12 +328,6 @@ LLM(大语言模型)配置选项在 `config.toml` 文件的 `[llm]` 部分中定
 
 Agent 配置选项在 `config.toml` 文件的 `[agent]` 和 `[agent.<agent_name>]` 部分中定义。
 
-**Microagent 配置**
-- `micro_agent_name`
-  - 类型: `str`
-  - 默认值: `""`
-  - 描述: 用于此 agent 的 micro agent 名称
-
 **内存配置**
 - `memory_enabled`
   - 类型: `bool`

--- a/docs/modules/usage/configuration-options.md
+++ b/docs/modules/usage/configuration-options.md
@@ -281,13 +281,6 @@ For development setups, you can also define custom named LLM configurations. See
 
 The agent configuration options are defined in the `[agent]` and `[agent.<agent_name>]` sections of the `config.toml` file.
 
-### Microagent Configuration
-- `micro_agent_name`
-  - Type: `str`
-  - Default: `""`
-  - Description: Name of the micro agent to use for this agent
-
-
 ### LLM Configuration
 - `llm_config`
   - Type: `str`


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

micro_agent_name config has been deprecated and removed from the codebase, yet our docs still mention it. This PR fixes docs.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

I guess we may have similar issues in documentation. Seems this could be a very low-hanging fruit for new contributors? This PR can be an example.

One might even implement a workflow that detects any outdated config in doc.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:209dd3a-nikolaik   --name openhands-app-209dd3a   docker.all-hands.dev/all-hands-ai/openhands:209dd3a
```