### PR TITLE
Fix official SWE-Bench docker image prefix

### DIFF
--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -121,24 +121,26 @@ You SHOULD NEVER attempt to browse the web.
 
 
 # TODO: migrate all swe-bench docker to ghcr.io/openhands
-DOCKER_IMAGE_PREFIX = os.environ.get('EVAL_DOCKER_IMAGE_PREFIX', 'docker.io/xingyaoww/')
-logger.info(f'Using docker image prefix: {DOCKER_IMAGE_PREFIX}')
+DEFAULT_DOCKER_IMAGE_PREFIX = os.environ.get('EVAL_DOCKER_IMAGE_PREFIX', 'docker.io/xingyaoww/')
+logger.info(f'Default docker image prefix: {DEFAULT_DOCKER_IMAGE_PREFIX}')
 
 
 def get_instance_docker_image(instance_id: str, official_image: bool = False) -> str:
     if official_image:
         # Official SWE-Bench image
         # swebench/sweb.eval.x86_64.django_1776_django-11333:v1
+        docker_image_prefix = 'docker.io/swebench/'
         repo, name = instance_id.split('__')
         image_name = f'sweb.eval.x86_64.{repo}_1776_{name}:latest'
         logger.warning(f'Using official SWE-Bench image: {image_name}')
     else:
         # OpenHands version of the image
+        docker_image_prefix = DEFAULT_DOCKER_IMAGE_PREFIX
         image_name = 'sweb.eval.x86_64.' + instance_id
         image_name = image_name.replace(
             '__', '_s_'
         )  # to comply with docker image naming convention
-    return (DOCKER_IMAGE_PREFIX.rstrip('/') + '/' + image_name).lower()
+    return (docker_image_prefix.rstrip('/') + '/' + image_name).lower()
 
 
 def get_config(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

The correct Docker image prefix is applied when building official images. Previously, the system attempted to load non-existent `xingyaoww/sweb.eval.*` images instead of `swebench/sweb.eval.*`.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

- Overrides the default prefix with the official repository prefix when building official SWE-Bench images.

---
**Link of any specific issues this addresses.**

Fix https://github.com/All-Hands-AI/OpenHands/issues/7168 
Fix https://github.com/All-Hands-AI/OpenHands/issues/7143

