### PR TITLE
Fix HTTPException not callable error in action_execution_server middleware

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -546,7 +546,9 @@ if __name__ == '__main__':
             try:
                 verify_api_key(request.headers.get('X-Session-API-Key'))
             except HTTPException as e:
-                return e
+                return JSONResponse(
+                    status_code=e.status_code, content={'detail': e.detail}
+                )
         response = await call_next(request)
         return response
 


### PR DESCRIPTION
## Description
This PR fixes an error in the action execution server where an HTTPException object was being directly returned from a middleware function, causing a `TypeError: HTTPException object is not callable` error.

## Changes
- Modified the `authenticate_requests` middleware to return a proper JSONResponse instead of the HTTPException object
- Added a test script to verify the fix works correctly

## Error Fixed
```
TypeError: HTTPException object is not callable
```

The error occurred because in the middleware function, we were directly returning the exception object instead of converting it to a proper response object.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c7a2ab4-nikolaik   --name openhands-app-c7a2ab4   docker.all-hands.dev/all-hands-ai/openhands:c7a2ab4
```