### PR TITLE
docs: Add development overview and documentation resources

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -126,3 +126,19 @@ cd ./containers/dev
 ```
 
 You do need [Docker](https://docs.docker.com/engine/install/) installed on your host though.
+
+## Key Documentation Resources
+Here's a guide to the important documentation files in the repository:
+
+- `/README.md`: Main project overview, features, and basic setup instructions
+- `/Development.md` (this file): Comprehensive guide for developers working on OpenHands
+- `/CONTRIBUTING.md`: Guidelines for contributing to the project, including code style and PR process
+- `/docs/DOC_STYLE_GUIDE.md`: Standards for writing and maintaining project documentation
+- `/openhands/README.md`: Details about the backend Python implementation
+- `/frontend/README.md`: Frontend React application setup and development guide
+- `/containers/README.md`: Information about Docker containers and deployment
+- `/tests/unit/README.md`: Guide to writing and running unit tests
+- `/evaluation/README.md`: Documentation for the evaluation framework and benchmarks
+- `/microagents/README.md`: Information about the microagents architecture and implementation
+- `/openhands/server/README.md`: Server implementation details and API documentation
+- `/openhands/runtime/README.md`: Documentation for the runtime environment and execution model

--- a/docs/modules/usage/how-to/development-overview.md
+++ b/docs/modules/usage/how-to/development-overview.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 9
+---
+
+# Development Overview
+
+This guide provides an overview of the key documentation resources available in the OpenHands repository. Whether you're looking to contribute, understand the architecture, or work on specific components, these resources will help you navigate the codebase effectively.
+
+## Core Documentation
+
+### Project Fundamentals
+- **Main Project Overview** (`/README.md`)  
+  The primary entry point for understanding OpenHands, including features and basic setup instructions.
+
+- **Development Guide** (`/Development.md`)  
+  Comprehensive guide for developers working on OpenHands, including setup, requirements, and development workflows.
+
+- **Contributing Guidelines** (`/CONTRIBUTING.md`)  
+  Essential information for contributors, covering code style, PR process, and contribution workflows.
+
+### Component Documentation
+
+#### Frontend
+- **Frontend Application** (`/frontend/README.md`)  
+  Complete guide for setting up and developing the React-based frontend application.
+
+#### Backend
+- **Backend Implementation** (`/openhands/README.md`)  
+  Detailed documentation of the Python backend implementation and architecture.
+
+- **Server Documentation** (`/openhands/server/README.md`)  
+  Server implementation details, API documentation, and service architecture.
+
+- **Runtime Environment** (`/openhands/runtime/README.md`)  
+  Documentation covering the runtime environment, execution model, and runtime configurations.
+
+#### Infrastructure
+- **Container Documentation** (`/containers/README.md`)  
+  Comprehensive information about Docker containers, deployment strategies, and container management.
+
+### Testing and Evaluation
+- **Unit Testing Guide** (`/tests/unit/README.md`)  
+  Instructions for writing, running, and maintaining unit tests.
+
+- **Evaluation Framework** (`/evaluation/README.md`)  
+  Documentation for the evaluation framework, benchmarks, and performance testing.
+
+### Advanced Features
+- **Microagents Architecture** (`/microagents/README.md`)  
+  Detailed information about the microagents architecture, implementation, and usage.
+
+### Documentation Standards
+- **Documentation Style Guide** (`/docs/DOC_STYLE_GUIDE.md`)  
+  Standards and guidelines for writing and maintaining project documentation.
+
+## Getting Started with Development
+
+If you're new to developing with OpenHands, we recommend following this sequence:
+
+1. Start with the main `README.md` to understand the project's purpose and features
+2. Review the `CONTRIBUTING.md` guidelines if you plan to contribute
+3. Follow the setup instructions in `Development.md`
+4. Dive into specific component documentation based on your area of interest:
+   - Frontend developers should focus on `/frontend/README.md`
+   - Backend developers should start with `/openhands/README.md`
+   - Infrastructure work should begin with `/containers/README.md`
+
+## Documentation Updates
+
+When making changes to the codebase, please ensure that:
+1. Relevant documentation is updated to reflect your changes
+2. New features are documented in the appropriate README files
+3. Any API changes are reflected in the server documentation
+4. Documentation follows the style guide in `/docs/DOC_STYLE_GUIDE.md`

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -171,6 +171,11 @@ const sidebars: SidebarsConfig = {
       label: 'For OpenHands Developers',
       items: [
         {
+          type: 'doc',
+          label: 'Development Overview',
+          id: 'usage/how-to/development-overview',
+        },
+        {
           type: 'category',
           label: 'Architecture',
           items: [


### PR DESCRIPTION
- [x ] This change is worth documenting at https://docs.all-hands.dev/
- [ x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
This adds a Development Overview Page to the User Guide documentation. Since most of this is documented in the Git Repository and we don't want to maintain a lot of separate documentation, it acts as a guide with Reference Documents to git.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Primary decision was to keep the repo as the Core Developer Documentation, and treat this as a quick reference for Developers to look up specific items. Might be good to add an FAQ at a future date.
http://localhost:50374/modules/usage/how-to/development-overview

---
**Link of any specific issues this addresses.**
![Screenshot 2025-03-12 at 9 38 18 AM](https://github.com/user-attachments/assets/68198fb4-472d-41fd-914f-903d32362ee9)
