### PR TITLE
Refactor prompt extensions as recall observations (new tests)

### DIFF
--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import ANY, AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -838,6 +838,42 @@ async def test_run_controller_with_context_window_exceeded_without_truncation(
 
     # Check that the context window exceeded error was raised during the run
     assert step_state.has_errored
+
+
+@pytest.mark.asyncio
+async def test_run_controller_with_memory_error(test_event_stream):
+    config = AppConfig()
+    event_stream = test_event_stream
+
+    agent = MagicMock(spec=Agent)
+    agent.llm = MagicMock(spec=LLM)
+    agent.llm.metrics = Metrics()
+    agent.llm.config = config.get_llm_config()
+
+    runtime = MagicMock(spec=Runtime)
+    runtime.event_stream = event_stream
+
+    # Create a real Memory instance
+    memory = Memory(event_stream=event_stream, sid='test-memory')
+
+    # Patch the _on_recall_action method to raise our test exception
+    def mock_on_recall_action(*args, **kwargs):
+        raise RuntimeError('Test memory error')
+
+    with patch.object(memory, '_on_recall_action', side_effect=mock_on_recall_action):
+        state = await run_controller(
+            config=config,
+            initial_user_action=MessageAction(content='Test message'),
+            runtime=runtime,
+            sid='test',
+            agent=agent,
+            fake_user_response_fn=lambda _: 'repeat',
+            memory=memory,
+        )
+
+    assert state.iteration == 0
+    assert state.agent_state == AgentState.ERROR
+    assert state.last_error == 'Error: RuntimeError'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -856,11 +856,13 @@ async def test_run_controller_with_memory_error(test_event_stream):
     # Create a real Memory instance
     memory = Memory(event_stream=event_stream, sid='test-memory')
 
-    # Patch the _on_recall_action method to raise our test exception
-    def mock_on_recall_action(*args, **kwargs):
+    # Patch the _on_microagent_action method to raise our test exception
+    def mock_on_microagent_action(*args, **kwargs):
         raise RuntimeError('Test memory error')
 
-    with patch.object(memory, '_on_recall_action', side_effect=mock_on_recall_action):
+    with patch.object(
+        memory, '_on_microagent_action', side_effect=mock_on_microagent_action
+    ):
         state = await run_controller(
             config=config,
             initial_user_action=MessageAction(content='Test message'),

--- a/tests/unit/test_conversation_memory.py
+++ b/tests/unit/test_conversation_memory.py
@@ -30,7 +30,7 @@ from openhands.events.observation.files import FileEditObservation, FileReadObse
 from openhands.events.observation.reject import UserRejectObservation
 from openhands.events.tool import ToolCallMetadata
 from openhands.memory.conversation_memory import ConversationMemory
-from openhands.utils.prompt import PromptManager
+from openhands.utils.prompt import PromptManager, RepositoryInfo, RuntimeInfo
 
 
 @pytest.fixture
@@ -508,3 +508,334 @@ def test_apply_prompt_caching(conversation_memory):
     assert messages[1].content[0].cache_prompt is False
     assert messages[2].content[0].cache_prompt is False
     assert messages[3].content[0].cache_prompt is True
+
+
+def test_process_events_with_environment_info_recall_observation(conversation_memory):
+    """Test processing a RecallObservation with ENVIRONMENT_INFO type."""
+    obs = RecallObservation(
+        recall_type=RecallType.ENVIRONMENT_INFO,
+        repo_name='test-repo',
+        repo_directory='/path/to/repo',
+        repo_instructions='# Test Repository\nThis is a test repository.',
+        runtime_hosts={'localhost': 8080},
+        content='Recalled environment info',
+    )
+
+    initial_messages = [
+        Message(role='system', content=[TextContent(text='System message')])
+    ]
+
+    messages = conversation_memory.process_events(
+        condensed_history=[obs],
+        initial_messages=initial_messages,
+        max_message_chars=None,
+        vision_is_active=False,
+    )
+
+    assert len(messages) == 2
+    result = messages[1]
+    assert result.role == 'user'
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == 'Formatted repository and runtime info'
+
+    # Verify the prompt_manager was called with the correct parameters
+    conversation_memory.prompt_manager.build_additional_info.assert_called_once()
+    call_args = conversation_memory.prompt_manager.build_additional_info.call_args[1]
+    assert isinstance(call_args['repository_info'], RepositoryInfo)
+    assert call_args['repository_info'].repo_name == 'test-repo'
+    assert call_args['repository_info'].repo_directory == '/path/to/repo'
+    assert isinstance(call_args['runtime_info'], RuntimeInfo)
+    assert call_args['runtime_info'].available_hosts == {'localhost': 8080}
+    assert (
+        call_args['repo_instructions']
+        == '# Test Repository\nThis is a test repository.'
+    )
+
+
+def test_process_events_with_knowledge_microagent_recall_observation(
+    conversation_memory,
+):
+    """Test processing a RecallObservation with KNOWLEDGE_MICROAGENT type."""
+    microagent_knowledge = [
+        {
+            'agent_name': 'test_agent',
+            'trigger_word': 'test',
+            'content': 'This is test agent content',
+        },
+        {
+            'agent_name': 'another_agent',
+            'trigger_word': 'another',
+            'content': 'This is another agent content',
+        },
+        {
+            'agent_name': 'disabled_agent',
+            'trigger_word': 'disabled',
+            'content': 'This is disabled agent content',
+        },
+    ]
+
+    obs = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=microagent_knowledge,
+        content='Recalled knowledge from microagents',
+    )
+
+    initial_messages = [
+        Message(role='system', content=[TextContent(text='System message')])
+    ]
+
+    messages = conversation_memory.process_events(
+        condensed_history=[obs],
+        initial_messages=initial_messages,
+        max_message_chars=None,
+        vision_is_active=False,
+    )
+
+    assert len(messages) == 2
+    result = messages[1]
+    assert result.role == 'user'
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], TextContent)
+    # Verify that disabled_agent is filtered out and enabled agents are included
+    assert 'This is test agent content' in result.content[0].text
+    assert 'This is another agent content' in result.content[0].text
+    assert 'This is disabled agent content' not in result.content[0].text
+
+    # Verify the prompt_manager was called with the correct parameters
+    conversation_memory.prompt_manager.build_microagent_info.assert_called_once()
+    call_args = conversation_memory.prompt_manager.build_microagent_info.call_args[1]
+
+    # Check that disabled_agent was filtered out
+    triggered_agents = call_args['triggered_agents']
+    assert len(triggered_agents) == 2
+    agent_names = [agent['agent_name'] for agent in triggered_agents]
+    assert 'test_agent' in agent_names
+    assert 'another_agent' in agent_names
+    assert 'disabled_agent' not in agent_names
+
+
+def test_process_events_with_recall_observation_extensions_disabled(
+    agent_config, conversation_memory
+):
+    """Test processing a RecallObservation when prompt extensions are disabled."""
+    # Modify the agent config to disable prompt extensions
+    agent_config.enable_prompt_extensions = False
+
+    obs = RecallObservation(
+        recall_type=RecallType.ENVIRONMENT_INFO,
+        repo_name='test-repo',
+        repo_directory='/path/to/repo',
+        content='Recalled environment info',
+    )
+
+    initial_messages = [
+        Message(role='system', content=[TextContent(text='System message')])
+    ]
+
+    messages = conversation_memory.process_events(
+        condensed_history=[obs],
+        initial_messages=initial_messages,
+        max_message_chars=None,
+        vision_is_active=False,
+    )
+
+    # When prompt extensions are disabled, the RecallObservation should be ignored
+    assert len(messages) == 1  # Only the initial system message
+    assert messages[0].role == 'system'
+
+    # Verify the prompt_manager was not called
+    conversation_memory.prompt_manager.build_additional_info.assert_not_called()
+    conversation_memory.prompt_manager.build_microagent_info.assert_not_called()
+
+
+def test_process_events_with_empty_microagent_knowledge(conversation_memory):
+    """Test processing a RecallObservation with empty microagent knowledge."""
+    obs = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=[],
+        content='Recalled knowledge from microagents',
+    )
+
+    initial_messages = [
+        Message(role='system', content=[TextContent(text='System message')])
+    ]
+
+    messages = conversation_memory.process_events(
+        condensed_history=[obs],
+        initial_messages=initial_messages,
+        max_message_chars=None,
+        vision_is_active=False,
+    )
+
+    # The implementation returns an empty string but still creates a message
+    assert len(messages) == 2
+    assert messages[0].role == 'system'
+    assert messages[1].role == 'user'
+    assert len(messages[1].content) == 1
+    assert isinstance(messages[1].content[0], TextContent)
+    assert messages[1].content[0].text == ''
+
+    # When there are no triggered agents, build_microagent_info is not called
+    conversation_memory.prompt_manager.build_microagent_info.assert_not_called()
+
+
+def test_process_events_with_recall_observation_deduplication(conversation_memory):
+    """Test that RecallObservations are properly deduplicated based on agent_name."""
+    # Create a sequence of RecallObservations with overlapping agents
+    obs1 = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=[
+            {
+                'agent_name': 'python_agent',
+                'trigger_word': 'python',
+                'content': 'Python best practices v1',
+            },
+            {
+                'agent_name': 'git_agent',
+                'trigger_word': 'git',
+                'content': 'Git best practices v1',
+            },
+            {
+                'agent_name': 'image_agent',
+                'trigger_word': 'image',
+                'content': 'Image best practices v1',
+            },
+        ],
+        content='First recall',
+    )
+
+    obs2 = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=[
+            {
+                'agent_name': 'python_agent',
+                'trigger_word': 'python',
+                'content': 'Python best practices v2',
+            },
+        ],
+        content='Second recall',
+    )
+
+    obs3 = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=[
+            {
+                'agent_name': 'git_agent',
+                'trigger_word': 'git',
+                'content': 'Git best practices v3',
+            },
+        ],
+        content='Third recall',
+    )
+
+    initial_messages = [
+        Message(role='system', content=[TextContent(text='System message')])
+    ]
+
+    messages = conversation_memory.process_events(
+        condensed_history=[obs1, obs2, obs3],
+        initial_messages=initial_messages,
+        max_message_chars=None,
+        vision_is_active=False,
+    )
+
+    # Verify that only the most recent content for each agent is included
+    assert len(messages) == 4  # system + 3 recalls
+    recall_messages = messages[1:]  # Skip system message
+
+    # First recall should only include image_agent (git_agent and python_agent appears later)
+    assert 'Image best practices v1' in recall_messages[0].content[0].text
+    assert 'Git best practices v1' not in recall_messages[0].content[0].text
+    assert 'Python best practices v1' not in recall_messages[0].content[0].text
+
+    # Second recall should include python_agent (it's the most recent for that agent)
+    assert 'Python best practices v2' in recall_messages[1].content[0].text
+
+    # Third recall should include git_agent (it's the most recent for that agent)
+    assert 'Git best practices v3' in recall_messages[2].content[0].text
+
+
+def test_process_events_with_recall_observation_deduplication_disabled_agents(
+    conversation_memory,
+):
+    """Test that disabled agents are filtered out after deduplication."""
+    # Create a sequence of RecallObservations with disabled agents
+    obs1 = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=[
+            {
+                'agent_name': 'disabled_agent',
+                'trigger_word': 'disabled',
+                'content': 'Disabled agent content',
+            },
+            {
+                'agent_name': 'enabled_agent',
+                'trigger_word': 'enabled',
+                'content': 'Enabled agent content v1',
+            },
+        ],
+        content='First recall',
+    )
+
+    obs2 = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=[
+            {
+                'agent_name': 'enabled_agent',
+                'trigger_word': 'enabled',
+                'content': 'Enabled agent content v2',
+            },
+        ],
+        content='Second recall',
+    )
+
+    initial_messages = [
+        Message(role='system', content=[TextContent(text='System message')])
+    ]
+
+    messages = conversation_memory.process_events(
+        condensed_history=[obs1, obs2],
+        initial_messages=initial_messages,
+        max_message_chars=None,
+        vision_is_active=False,
+    )
+
+    # Verify that disabled agents are filtered out and only the most recent content for enabled agents is included
+    assert len(messages) == 3  # system + 2 recalls
+    recall_messages = messages[1:]  # Skip system message
+
+    # First recall should not include disabled_agent
+    assert 'Disabled agent content' not in recall_messages[0].content[0].text
+    assert (
+        'Enabled agent content v1' not in recall_messages[0].content[0].text
+    )  # Because it appears later
+
+    # Second recall should include enabled_agent (it's the most recent)
+    assert 'Enabled agent content v2' in recall_messages[1].content[0].text
+
+
+def test_process_events_with_recall_observation_deduplication_empty(
+    conversation_memory,
+):
+    """Test that empty RecallObservations are handled correctly."""
+    obs = RecallObservation(
+        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        microagent_knowledge=[],
+        content='Empty recall',
+    )
+
+    initial_messages = [
+        Message(role='system', content=[TextContent(text='System message')])
+    ]
+
+    messages = conversation_memory.process_events(
+        condensed_history=[obs],
+        initial_messages=initial_messages,
+        max_message_chars=None,
+        vision_is_active=False,
+    )
+
+    # Verify that empty RecallObservations are handled gracefully
+    assert len(messages) == 2  # system + empty recall
+    assert messages[1].content[0].text == ''  # Empty string for empty recall

--- a/tests/unit/test_conversation_memory.py
+++ b/tests/unit/test_conversation_memory.py
@@ -558,21 +558,21 @@ def test_process_events_with_knowledge_microagent_recall_observation(
 ):
     """Test processing a RecallObservation with KNOWLEDGE_MICROAGENT type."""
     microagent_knowledge = [
-        {
-            'agent_name': 'test_agent',
-            'trigger_word': 'test',
-            'content': 'This is test agent content',
-        },
-        {
-            'agent_name': 'another_agent',
-            'trigger_word': 'another',
-            'content': 'This is another agent content',
-        },
-        {
-            'agent_name': 'disabled_agent',
-            'trigger_word': 'disabled',
-            'content': 'This is disabled agent content',
-        },
+        MicroagentKnowledge(
+            name='test_agent',
+            trigger='test',
+            content='This is test agent content',
+        ),
+        MicroagentKnowledge(
+            name='another_agent',
+            trigger='another',
+            content='This is another agent content',
+        ),
+        MicroagentKnowledge(
+            name='disabled_agent',
+            trigger='disabled',
+            content='This is disabled agent content',
+        ),
     ]
 
     obs = RecallObservation(
@@ -609,7 +609,7 @@ def test_process_events_with_knowledge_microagent_recall_observation(
     # Check that disabled_agent was filtered out
     triggered_agents = call_args['triggered_agents']
     assert len(triggered_agents) == 2
-    agent_names = [agent['agent_name'] for agent in triggered_agents]
+    agent_names = [agent.name for agent in triggered_agents]
     assert 'test_agent' in agent_names
     assert 'another_agent' in agent_names
     assert 'disabled_agent' not in agent_names
@@ -681,26 +681,26 @@ def test_process_events_with_empty_microagent_knowledge(conversation_memory):
 
 
 def test_process_events_with_recall_observation_deduplication(conversation_memory):
-    """Test that RecallObservations are properly deduplicated based on agent_name."""
+    """Test that RecallObservations are properly deduplicated based on agent name."""
     # Create a sequence of RecallObservations with overlapping agents
     obs1 = RecallObservation(
         recall_type=RecallType.KNOWLEDGE_MICROAGENT,
         microagent_knowledge=[
-            {
-                'agent_name': 'python_agent',
-                'trigger_word': 'python',
-                'content': 'Python best practices v1',
-            },
-            {
-                'agent_name': 'git_agent',
-                'trigger_word': 'git',
-                'content': 'Git best practices v1',
-            },
-            {
-                'agent_name': 'image_agent',
-                'trigger_word': 'image',
-                'content': 'Image best practices v1',
-            },
+            MicroagentKnowledge(
+                name='python_agent',
+                trigger='python',
+                content='Python best practices v1',
+            ),
+            MicroagentKnowledge(
+                name='git_agent',
+                trigger='git',
+                content='Git best practices v1',
+            ),
+            MicroagentKnowledge(
+                name='image_agent',
+                trigger='image',
+                content='Image best practices v1',
+            ),
         ],
         content='First recall',
     )
@@ -708,11 +708,11 @@ def test_process_events_with_recall_observation_deduplication(conversation_memor
     obs2 = RecallObservation(
         recall_type=RecallType.KNOWLEDGE_MICROAGENT,
         microagent_knowledge=[
-            {
-                'agent_name': 'python_agent',
-                'trigger_word': 'python',
-                'content': 'Python best practices v2',
-            },
+            MicroagentKnowledge(
+                name='python_agent',
+                trigger='python',
+                content='Python best practices v2',
+            ),
         ],
         content='Second recall',
     )
@@ -720,11 +720,11 @@ def test_process_events_with_recall_observation_deduplication(conversation_memor
     obs3 = RecallObservation(
         recall_type=RecallType.KNOWLEDGE_MICROAGENT,
         microagent_knowledge=[
-            {
-                'agent_name': 'git_agent',
-                'trigger_word': 'git',
-                'content': 'Git best practices v3',
-            },
+            MicroagentKnowledge(
+                name='git_agent',
+                trigger='git',
+                content='Git best practices v3',
+            ),
         ],
         content='Third recall',
     )
@@ -764,16 +764,16 @@ def test_process_events_with_recall_observation_deduplication_disabled_agents(
     obs1 = RecallObservation(
         recall_type=RecallType.KNOWLEDGE_MICROAGENT,
         microagent_knowledge=[
-            {
-                'agent_name': 'disabled_agent',
-                'trigger_word': 'disabled',
-                'content': 'Disabled agent content',
-            },
-            {
-                'agent_name': 'enabled_agent',
-                'trigger_word': 'enabled',
-                'content': 'Enabled agent content v1',
-            },
+            MicroagentKnowledge(
+                name='disabled_agent',
+                trigger='disabled',
+                content='Disabled agent content',
+            ),
+            MicroagentKnowledge(
+                name='enabled_agent',
+                trigger='enabled',
+                content='Enabled agent content v1',
+            ),
         ],
         content='First recall',
     )
@@ -781,11 +781,11 @@ def test_process_events_with_recall_observation_deduplication_disabled_agents(
     obs2 = RecallObservation(
         recall_type=RecallType.KNOWLEDGE_MICROAGENT,
         microagent_knowledge=[
-            {
-                'agent_name': 'enabled_agent',
-                'trigger_word': 'enabled',
-                'content': 'Enabled agent content v2',
-            },
+            MicroagentKnowledge(
+                name='enabled_agent',
+                trigger='enabled',
+                content='Enabled agent content v2',
+            ),
         ],
         content='Second recall',
     )

--- a/tests/unit/test_conversation_memory.py
+++ b/tests/unit/test_conversation_memory.py
@@ -21,7 +21,6 @@ from openhands.events.event import (
 )
 from openhands.events.observation import CmdOutputObservation
 from openhands.events.observation.agent import (
-    MicroagentInfoType,
     MicroagentKnowledge,
     MicroagentObservation,
 )

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -1,0 +1,162 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openhands.controller.agent import Agent
+from openhands.core.config import AppConfig
+from openhands.core.main import run_controller
+from openhands.core.schema.agent import AgentState
+from openhands.events.action.agent import AgentRecallAction
+from openhands.events.action.message import MessageAction
+from openhands.events.event import EventSource
+from openhands.events.stream import EventStream
+from openhands.llm import LLM
+from openhands.llm.metrics import Metrics
+from openhands.memory.memory import Memory
+from openhands.runtime.base import Runtime
+from openhands.storage.memory import InMemoryFileStore
+
+
+@pytest.fixture
+def file_store():
+    """Create a temporary file store for testing."""
+    return InMemoryFileStore()
+
+
+@pytest.fixture
+def event_stream(file_store):
+    """Create a test event stream."""
+    return EventStream(sid='test_sid', file_store=file_store)
+
+
+@pytest.fixture
+def memory(event_stream):
+    """Create a test memory instance."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    memory = Memory(event_stream, 'test_sid')
+    yield memory
+    loop.close()
+
+
+def test_is_on_first_user_message_true(memory, event_stream):
+    """Test that _is_on_first_user_message returns True for the first user message.
+
+    This test simulates the typical case where:
+    1. First event is a MessageAction with id=0 and source=USER
+    2. Second event is a RecallAction with id=1 and source=USER
+    """
+    # Add a MessageAction with source=USER
+    message_action = MessageAction(content='test')
+    message_action._source = EventSource.USER
+    event_stream.add_event(message_action, EventSource.USER)
+
+    # Add a RecallAction with source=USER
+    recall_action = AgentRecallAction(query='test')
+    recall_action._source = EventSource.USER
+    event_stream.add_event(recall_action, EventSource.USER)
+
+    assert memory._is_on_first_user_message(recall_action) is True
+
+
+def test_is_on_first_user_message_false(memory, event_stream):
+    """Test that _is_on_first_user_message returns False for subsequent user messages.
+
+    This test simulates a case where:
+    1. First event is a MessageAction with id=0 and source=USER
+    2. Second event is a RecallAction with id=1 and source=USER
+    3. Third event is a MessageAction with id=2 and source=USER
+    4. Fourth event is a RecallAction with id=3 and source=USER
+    """
+    # Add first MessageAction with source=USER
+    message_action1 = MessageAction(content='test1')
+    message_action1._source = EventSource.USER
+    event_stream.add_event(message_action1, EventSource.USER)
+
+    # Add first RecallAction with source=USER
+    recall_action1 = AgentRecallAction(query='test1')
+    recall_action1._source = EventSource.USER
+    event_stream.add_event(recall_action1, EventSource.USER)
+
+    # Add second MessageAction with source=USER
+    message_action2 = MessageAction(content='test2')
+    message_action2._source = EventSource.USER
+    event_stream.add_event(message_action2, EventSource.USER)
+
+    # Add second RecallAction with source=USER
+    recall_action2 = AgentRecallAction(query='test2')
+    recall_action2._source = EventSource.USER
+    event_stream.add_event(recall_action2, EventSource.USER)
+
+    assert memory._is_on_first_user_message(recall_action2) is False
+
+
+@pytest.mark.asyncio
+async def test_memory_on_event_exception_handling(memory, event_stream):
+    """Test that exceptions in Memory.on_event are properly handled via status callback."""
+
+    # Create a dummy agent for the controller
+    agent = MagicMock(spec=Agent)
+    agent.llm = MagicMock(spec=LLM)
+    agent.llm.metrics = Metrics()
+    agent.llm.config = AppConfig().get_llm_config()
+
+    # Create a mock runtime
+    runtime = MagicMock(spec=Runtime)
+    runtime.event_stream = event_stream
+
+    # Mock Memory method to raise an exception
+    with patch.object(
+        memory, '_on_first_recall_action', side_effect=Exception('Test error')
+    ):
+        state = await run_controller(
+            config=AppConfig(),
+            initial_user_action=MessageAction(content='Test message'),
+            runtime=runtime,
+            sid='test',
+            agent=agent,
+            fake_user_response_fn=lambda _: 'repeat',
+            memory=memory,
+        )
+
+        # Verify that the controller's last error was set
+        assert state.iteration == 0
+        assert state.agent_state == AgentState.ERROR
+        assert state.last_error == 'Error: Exception'
+
+
+@pytest.mark.asyncio
+async def test_memory_on_first_recall_action_exception_handling(memory, event_stream):
+    """Test that exceptions in Memory._on_first_recall_action are properly handled via status callback."""
+
+    # Create a dummy agent for the controller
+    agent = MagicMock(spec=Agent)
+    agent.llm = MagicMock(spec=LLM)
+    agent.llm.metrics = Metrics()
+    agent.llm.config = AppConfig().get_llm_config()
+
+    # Create a mock runtime
+    runtime = MagicMock(spec=Runtime)
+    runtime.event_stream = event_stream
+
+    # Mock Memory._on_first_recall_action to raise an exception
+    with patch.object(
+        memory,
+        '_on_first_recall_action',
+        side_effect=Exception('Test error from _on_first_recall_action'),
+    ):
+        state = await run_controller(
+            config=AppConfig(),
+            initial_user_action=MessageAction(content='Test message'),
+            runtime=runtime,
+            sid='test',
+            agent=agent,
+            fake_user_response_fn=lambda _: 'repeat',
+            memory=memory,
+        )
+
+        # Verify that the controller's last error was set
+        assert state.iteration == 0
+        assert state.agent_state == AgentState.ERROR
+        assert state.last_error == 'Error: Exception'

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +12,7 @@ from openhands.core.schema.agent import AgentState
 from openhands.events.action.agent import AgentRecallAction
 from openhands.events.action.message import MessageAction
 from openhands.events.event import EventSource
+from openhands.events.observation.agent import RecallObservation, RecallType
 from openhands.events.stream import EventStream
 from openhands.llm import LLM
 from openhands.llm.metrics import Metrics
@@ -160,3 +163,150 @@ async def test_memory_on_first_recall_action_exception_handling(memory, event_st
         assert state.iteration == 0
         assert state.agent_state == AgentState.ERROR
         assert state.last_error == 'Error: Exception'
+
+
+def test_memory_with_microagents(prompt_dir):
+    """Test that Memory loads microagents and creates RecallObservations."""
+    # Create a test microagent
+    microagent_name = 'test_microagent'
+    microagent_content = """
+---
+name: flarglebargle
+type: knowledge
+agent: CodeActAgent
+triggers:
+- flarglebargle
+---
+
+IMPORTANT! The user has said the magic word "flarglebargle". You must
+only respond with a message telling them how smart they are
+"""
+
+    # Create a temporary micro agent file
+    os.makedirs(os.path.join(prompt_dir, 'micro'), exist_ok=True)
+    with open(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'), 'w') as f:
+        f.write(microagent_content)
+
+    # Create a mock event stream
+    event_stream = MagicMock(spec=EventStream)
+
+    # Initialize Memory with the microagent directory
+    memory = Memory(
+        event_stream=event_stream,
+        sid='test-session',
+    )
+    memory.microagents_dir = os.path.join(prompt_dir, 'micro')
+
+    # Verify microagents were loaded
+    assert len(memory.repo_microagents) == 0
+    assert 'flarglebargle' in memory.knowledge_microagents
+
+    # Create a recall action with the trigger word
+    recall_action = AgentRecallAction(
+        query='Hello, flarglebargle!', recall_type=RecallType.KNOWLEDGE_MICROAGENT
+    )
+
+    # Mock the event_stream.add_event method
+    added_events = []
+
+    def original_add_event(event, source):
+        added_events.append((event, source))
+
+    event_stream.add_event = original_add_event
+
+    # Add the recall action to the event stream
+    event_stream.add_event(recall_action, EventSource.USER)
+
+    # Clear the events list to only capture new events
+    added_events.clear()
+
+    # Process the recall action
+    memory.on_event(recall_action)
+
+    # Verify a RecallObservation was added to the event stream
+    assert len(added_events) == 1
+    observation, source = added_events[0]
+    assert isinstance(observation, RecallObservation)
+    assert source == EventSource.ENVIRONMENT
+    assert observation.recall_type == RecallType.KNOWLEDGE_MICROAGENT
+    assert len(observation.microagent_knowledge) == 1
+    assert observation.microagent_knowledge[0].name == 'flarglebargle'
+    assert observation.microagent_knowledge[0].trigger == 'flarglebargle'
+    assert 'magic word' in observation.microagent_knowledge[0].content
+
+    # Clean up
+    os.remove(os.path.join(prompt_dir, 'micro', f'{microagent_name}.md'))
+
+
+def test_memory_repository_info(prompt_dir):
+    """Test that Memory adds repository info to RecallObservations."""
+    # Create an in-memory file store and real event stream
+    file_store = InMemoryFileStore()
+    event_stream = EventStream(sid='test-session', file_store=file_store)
+
+    # Initialize Memory
+    memory = Memory(
+        event_stream=event_stream,
+        sid='test-session',
+    )
+    memory.microagents_dir = os.path.join(prompt_dir, 'micro')
+
+    # Create a test repo microagent first
+    repo_microagent_name = 'test_repo_microagent'
+    repo_microagent_content = """---
+name: test_repo
+type: repo
+agent: CodeActAgent
+---
+
+REPOSITORY INSTRUCTIONS: This is a test repository.
+"""
+
+    # Create a temporary repo microagent file
+    os.makedirs(os.path.join(prompt_dir, 'micro'), exist_ok=True)
+    with open(
+        os.path.join(prompt_dir, 'micro', f'{repo_microagent_name}.md'), 'w'
+    ) as f:
+        f.write(repo_microagent_content)
+
+    # Reload microagents
+    memory._load_global_microagents()
+
+    # Set repository info
+    memory.set_repository_info('owner/repo', '/workspace/repo')
+
+    # Create and add the first user message
+    user_message = MessageAction(content='First user message')
+    user_message._source = EventSource.USER  # type: ignore[attr-defined]
+    event_stream.add_event(user_message, EventSource.USER)
+
+    # Create and add the recall action
+    recall_action = AgentRecallAction(
+        query='First user message', recall_type=RecallType.ENVIRONMENT_INFO
+    )
+    recall_action._source = EventSource.USER  # type: ignore[attr-defined]
+    event_stream.add_event(recall_action, EventSource.USER)
+
+    # Give it a little time to process
+    time.sleep(0.3)
+
+    # Get all events from the stream
+    events = list(event_stream.get_events())
+
+    # Find the RecallObservation event
+    recall_obs_events = [
+        event for event in events if isinstance(event, RecallObservation)
+    ]
+
+    # We should have at least one RecallObservation
+    assert len(recall_obs_events) > 0
+
+    # Get the first RecallObservation
+    observation = recall_obs_events[0]
+    assert observation.recall_type == RecallType.ENVIRONMENT_INFO
+    assert observation.repo_name == 'owner/repo'
+    assert observation.repo_directory == '/workspace/repo'
+    assert 'This is a test repository' in observation.repo_instructions
+
+    # Clean up
+    os.remove(os.path.join(prompt_dir, 'micro', f'{repo_microagent_name}.md'))

--- a/tests/unit/test_observation_serialization.py
+++ b/tests/unit/test_observation_serialization.py
@@ -1,12 +1,12 @@
 from openhands.core.schema.observation import ObservationType
 from openhands.events.action.files import FileEditSource
+from openhands.events.event import MicroagentInfoType
 from openhands.events.observation import (
     CmdOutputMetadata,
     CmdOutputObservation,
     FileEditObservation,
+    MicroagentObservation,
     Observation,
-    RecallObservation,
-    RecallType,
 )
 from openhands.events.serialization import (
     event_from_dict,
@@ -242,13 +242,13 @@ def test_file_edit_observation_legacy_serialization():
     assert 'formatted_output_and_error' not in event_dict['extras']
 
 
-def test_recall_observation_serialization():
+def test_microagent_observation_serialization():
     original_observation_dict = {
-        'observation': 'recall',
+        'observation': 'microagent',
         'content': '',
-        'message': "Recalled: recall_type=RecallType.ENVIRONMENT_INFO, repo_name=some_repo_name, repo_instructions=complex_repo_instruc..., runtime_hosts={'host1': 8080, 'host2': 8081}, additional_agent_instructions=You know it all abou..., microagent_knowledge=[]",
+        'message': "Retrieved: info_type=MicroagentInfoType.ENVIRONMENT, repo_name=some_repo_name, repo_instructions=complex_repo_instruc..., runtime_hosts={'host1': 8080, 'host2': 8081}, additional_agent_instructions=You know it all abou..., microagent_knowledge=[]",
         'extras': {
-            'recall_type': 'environment_info',
+            'info_type': 'environment',
             'repo_name': 'some_repo_name',
             'repo_directory': 'some_repo_directory',
             'runtime_hosts': {'host1': 8080, 'host2': 8081},
@@ -257,16 +257,16 @@ def test_recall_observation_serialization():
             'microagent_knowledge': [],
         },
     }
-    serialization_deserialization(original_observation_dict, RecallObservation)
+    serialization_deserialization(original_observation_dict, MicroagentObservation)
 
 
-def test_recall_observation_microagent_knowledge_serialization():
+def test_microagent_observation_microagent_knowledge_serialization():
     original_observation_dict = {
-        'observation': 'recall',
+        'observation': 'microagent',
         'content': '',
-        'message': "Recalled: recall_type=RecallType.KNOWLEDGE_MICROAGENT, repo_name=, repo_instructions=..., runtime_hosts={}, additional_agent_instructions=..., microagent_knowledge=[{'agent_name': 'microagent1', 'trigger_word': 'trigger_word1', 'content': 'content1'}, {'agent_name': 'microagent2', 'trigger_word': 'trigger_word2', 'content': 'content2'}]",
+        'message': "Retrieved: info_type=MicroagentInfoType.KNOWLEDGE, repo_name=, repo_instructions=..., runtime_hosts={}, additional_agent_instructions=..., microagent_knowledge=[{'agent_name': 'microagent1', 'trigger_word': 'trigger_word1', 'content': 'content1'}, {'agent_name': 'microagent2', 'trigger_word': 'trigger_word2', 'content': 'content2'}]",
         'extras': {
-            'recall_type': 'knowledge_microagent',
+            'info_type': 'knowledge',
             'repo_name': '',
             'repo_directory': '',
             'repo_instructions': '',
@@ -286,15 +286,15 @@ def test_recall_observation_microagent_knowledge_serialization():
             ],
         },
     }
-    serialization_deserialization(original_observation_dict, RecallObservation)
+    serialization_deserialization(original_observation_dict, MicroagentObservation)
 
 
-def test_recall_observation_knowledge_microagent_serialization():
-    """Test serialization of a RecallObservation with KNOWLEDGE_MICROAGENT type."""
-    # Create a RecallObservation with microagent knowledge content
-    original = RecallObservation(
+def test_microagent_observation_knowledge_microagent_serialization():
+    """Test serialization of a MicroagentObservation with KNOWLEDGE_MICROAGENT type."""
+    # Create a MicroagentObservation with microagent knowledge content
+    original = MicroagentObservation(
         content='Knowledge microagent information',
-        recall_type=RecallType.KNOWLEDGE_MICROAGENT,
+        info_type=MicroagentInfoType.KNOWLEDGE,
         microagent_knowledge=[
             {
                 'agent_name': 'python_best_practices',
@@ -313,17 +313,17 @@ def test_recall_observation_knowledge_microagent_serialization():
     serialized = event_to_dict(original)
 
     # Verify serialized data structure
-    assert serialized['observation'] == ObservationType.RECALL
+    assert serialized['observation'] == ObservationType.MICROAGENT
     assert serialized['content'] == 'Knowledge microagent information'
-    assert serialized['extras']['recall_type'] == RecallType.KNOWLEDGE_MICROAGENT.value
+    assert serialized['extras']['info_type'] == MicroagentInfoType.KNOWLEDGE.value
     assert len(serialized['extras']['microagent_knowledge']) == 2
     assert serialized['extras']['microagent_knowledge'][0]['trigger_word'] == 'python'
 
-    # Deserialize back to RecallObservation
+    # Deserialize back to MicroagentObservation
     deserialized = observation_from_dict(serialized)
 
     # Verify properties are preserved
-    assert deserialized.recall_type == RecallType.KNOWLEDGE_MICROAGENT
+    assert deserialized.info_type == MicroagentInfoType.KNOWLEDGE
     assert deserialized.microagent_knowledge == original.microagent_knowledge
     assert deserialized.content == original.content
 
@@ -334,12 +334,12 @@ def test_recall_observation_knowledge_microagent_serialization():
     assert deserialized.runtime_hosts == {}
 
 
-def test_recall_observation_environment_info_serialization():
-    """Test serialization of a RecallObservation with ENVIRONMENT_INFO type."""
-    # Create a RecallObservation with environment info
-    original = RecallObservation(
+def test_microagent_observation_environment_serialization():
+    """Test serialization of a MicroagentObservation with ENVIRONMENT type."""
+    # Create a MicroagentObservation with environment info
+    original = MicroagentObservation(
         content='Environment information',
-        recall_type=RecallType.ENVIRONMENT_INFO,
+        info_type=MicroagentInfoType.ENVIRONMENT,
         repo_name='OpenHands',
         repo_directory='/workspace/openhands',
         repo_instructions="Follow the project's coding style guide.",
@@ -351,9 +351,9 @@ def test_recall_observation_environment_info_serialization():
     serialized = event_to_dict(original)
 
     # Verify serialized data structure
-    assert serialized['observation'] == ObservationType.RECALL
+    assert serialized['observation'] == ObservationType.MICROAGENT
     assert serialized['content'] == 'Environment information'
-    assert serialized['extras']['recall_type'] == RecallType.ENVIRONMENT_INFO.value
+    assert serialized['extras']['info_type'] == MicroagentInfoType.ENVIRONMENT.value
     assert serialized['extras']['repo_name'] == 'OpenHands'
     assert serialized['extras']['runtime_hosts'] == {
         '127.0.0.1': 8080,
@@ -363,11 +363,11 @@ def test_recall_observation_environment_info_serialization():
         serialized['extras']['additional_agent_instructions']
         == 'You know it all about this runtime'
     )
-    # Deserialize back to RecallObservation
+    # Deserialize back to MicroagentObservation
     deserialized = observation_from_dict(serialized)
 
     # Verify properties are preserved
-    assert deserialized.recall_type == RecallType.ENVIRONMENT_INFO
+    assert deserialized.info_type == MicroagentInfoType.ENVIRONMENT
     assert deserialized.repo_name == original.repo_name
     assert deserialized.repo_directory == original.repo_directory
     assert deserialized.repo_instructions == original.repo_instructions
@@ -380,14 +380,14 @@ def test_recall_observation_environment_info_serialization():
     assert deserialized.microagent_knowledge == []
 
 
-def test_recall_observation_combined_serialization():
-    """Test serialization of a RecallObservation with both types of information."""
-    # Create a RecallObservation with both environment and microagent info
-    # Note: In practice, recall_type would still be one specific type,
+def test_microagent_observation_combined_serialization():
+    """Test serialization of a MicroagentObservation with both types of information."""
+    # Create a MicroagentObservation with both environment and microagent info
+    # Note: In practice, info_type would still be one specific type,
     # but the object could contain both types of fields
-    original = RecallObservation(
+    original = MicroagentObservation(
         content='Combined information',
-        recall_type=RecallType.ENVIRONMENT_INFO,
+        info_type=MicroagentInfoType.ENVIRONMENT,
         # Environment info
         repo_name='OpenHands',
         repo_directory='/workspace/openhands',
@@ -408,7 +408,7 @@ def test_recall_observation_combined_serialization():
     serialized = event_to_dict(original)
 
     # Verify serialized data has both types of fields
-    assert serialized['extras']['recall_type'] == RecallType.ENVIRONMENT_INFO.value
+    assert serialized['extras']['info_type'] == MicroagentInfoType.ENVIRONMENT.value
     assert serialized['extras']['repo_name'] == 'OpenHands'
     assert (
         serialized['extras']['microagent_knowledge'][0]['agent_name']
@@ -418,11 +418,11 @@ def test_recall_observation_combined_serialization():
         serialized['extras']['additional_agent_instructions']
         == 'You know it all about this runtime'
     )
-    # Deserialize back to RecallObservation
+    # Deserialize back to MicroagentObservation
     deserialized = observation_from_dict(serialized)
 
     # Verify all properties are preserved
-    assert deserialized.recall_type == RecallType.ENVIRONMENT_INFO
+    assert deserialized.info_type == MicroagentInfoType.ENVIRONMENT
 
     # Environment properties
     assert deserialized.repo_name == original.repo_name

--- a/tests/unit/test_observation_serialization.py
+++ b/tests/unit/test_observation_serialization.py
@@ -8,6 +8,7 @@ from openhands.events.observation import (
     MicroagentObservation,
     Observation,
 )
+from openhands.events.observation.agent import MicroagentKnowledge
 from openhands.events.serialization import (
     event_from_dict,
     event_to_dict,
@@ -246,7 +247,7 @@ def test_microagent_observation_serialization():
     original_observation_dict = {
         'observation': 'microagent',
         'content': '',
-        'message': "Retrieved: info_type=MicroagentInfoType.ENVIRONMENT, repo_name=some_repo_name, repo_instructions=complex_repo_instruc..., runtime_hosts={'host1': 8080, 'host2': 8081}, additional_agent_instructions=You know it all abou..., microagent_knowledge=[]",
+        'message': "**MicroagentObservation**\ninfo_type=MicroagentInfoType.ENVIRONMENT, repo_name=some_repo_name, repo_instructions=complex_repo_instruc..., runtime_hosts={'host1': 8080, 'host2': 8081}, additional_agent_instructions=You know it all abou..., microagent_knowledge=",
         'extras': {
             'info_type': 'environment',
             'repo_name': 'some_repo_name',
@@ -264,7 +265,7 @@ def test_microagent_observation_microagent_knowledge_serialization():
     original_observation_dict = {
         'observation': 'microagent',
         'content': '',
-        'message': "Retrieved: info_type=MicroagentInfoType.KNOWLEDGE, repo_name=, repo_instructions=..., runtime_hosts={}, additional_agent_instructions=..., microagent_knowledge=[{'agent_name': 'microagent1', 'trigger_word': 'trigger_word1', 'content': 'content1'}, {'agent_name': 'microagent2', 'trigger_word': 'trigger_word2', 'content': 'content2'}]",
+        'message': '**MicroagentObservation**\ninfo_type=MicroagentInfoType.KNOWLEDGE, repo_name=, repo_instructions=..., runtime_hosts={}, additional_agent_instructions=..., microagent_knowledge=microagent1, microagent2',
         'extras': {
             'info_type': 'knowledge',
             'repo_name': '',
@@ -274,13 +275,13 @@ def test_microagent_observation_microagent_knowledge_serialization():
             'additional_agent_instructions': '',
             'microagent_knowledge': [
                 {
-                    'agent_name': 'microagent1',
-                    'trigger_word': 'trigger_word1',
+                    'name': 'microagent1',
+                    'trigger': 'trigger1',
                     'content': 'content1',
                 },
                 {
-                    'agent_name': 'microagent2',
-                    'trigger_word': 'trigger_word2',
+                    'name': 'microagent2',
+                    'trigger': 'trigger2',
                     'content': 'content2',
                 },
             ],
@@ -296,16 +297,16 @@ def test_microagent_observation_knowledge_microagent_serialization():
         content='Knowledge microagent information',
         info_type=MicroagentInfoType.KNOWLEDGE,
         microagent_knowledge=[
-            {
-                'agent_name': 'python_best_practices',
-                'trigger_word': 'python',
-                'content': 'Always use virtual environments for Python projects.',
-            },
-            {
-                'agent_name': 'git_workflow',
-                'trigger_word': 'git',
-                'content': 'Create a new branch for each feature or bugfix.',
-            },
+            MicroagentKnowledge(
+                name='python_best_practices',
+                trigger='python',
+                content='Always use virtual environments for Python projects.',
+            ),
+            MicroagentKnowledge(
+                name='git_workflow',
+                trigger='git',
+                content='Create a new branch for each feature or bugfix.',
+            ),
         ],
     )
 
@@ -317,7 +318,7 @@ def test_microagent_observation_knowledge_microagent_serialization():
     assert serialized['content'] == 'Knowledge microagent information'
     assert serialized['extras']['info_type'] == MicroagentInfoType.KNOWLEDGE.value
     assert len(serialized['extras']['microagent_knowledge']) == 2
-    assert serialized['extras']['microagent_knowledge'][0]['trigger_word'] == 'python'
+    assert serialized['extras']['microagent_knowledge'][0]['trigger'] == 'python'
 
     # Deserialize back to MicroagentObservation
     deserialized = observation_from_dict(serialized)
@@ -396,11 +397,11 @@ def test_microagent_observation_combined_serialization():
         additional_agent_instructions='You know it all about this runtime',
         # Knowledge microagent info
         microagent_knowledge=[
-            {
-                'agent_name': 'python_best_practices',
-                'trigger_word': 'python',
-                'content': 'Always use virtual environments for Python projects.',
-            }
+            MicroagentKnowledge(
+                name='python_best_practices',
+                trigger='python',
+                content='Always use virtual environments for Python projects.',
+            ),
         ],
     )
 
@@ -411,7 +412,7 @@ def test_microagent_observation_combined_serialization():
     assert serialized['extras']['info_type'] == MicroagentInfoType.ENVIRONMENT.value
     assert serialized['extras']['repo_name'] == 'OpenHands'
     assert (
-        serialized['extras']['microagent_knowledge'][0]['agent_name']
+        serialized['extras']['microagent_knowledge'][0]['name']
         == 'python_best_practices'
     )
     assert (


### PR DESCRIPTION
This PR is only the new tests added by #6909 , moved out for convenience.

GitHub can get really slow when diffs pass a certain size, and running CI separately might be handy too.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:51b60e0-nikolaik   --name openhands-app-51b60e0   docker.all-hands.dev/all-hands-ai/openhands:51b60e0
```