### PR TITLE
Add tests for ConversationInitData class variables

### DIFF
--- a/tests/unit/test_conversation_init_data.py
+++ b/tests/unit/test_conversation_init_data.py
@@ -1,7 +1,5 @@
-import pytest
-
+from openhands.integrations.provider import ProviderToken, ProviderType
 from openhands.server.session.conversation_init_data import ConversationInitData
-from openhands.integrations.provider import ProviderType, ProviderToken
 
 
 def test_provider_tokens_not_shared_between_instances():
@@ -15,12 +13,12 @@ def test_provider_tokens_not_shared_between_instances():
     assert instance2.provider_tokens == {}
 
     # Modify the first instance
-    provider_token = ProviderToken(token=None, user_id="test_user")
+    provider_token = ProviderToken(token=None, user_id='test_user')
     instance1.provider_tokens[ProviderType.GITHUB] = provider_token
 
     # Verify the second instance is not affected
     assert ProviderType.GITHUB in instance1.provider_tokens
-    assert instance1.provider_tokens[ProviderType.GITHUB].user_id == "test_user"
+    assert instance1.provider_tokens[ProviderType.GITHUB].user_id == 'test_user'
     assert instance2.provider_tokens == {}
 
 
@@ -35,10 +33,10 @@ def test_selected_repository_not_shared_between_instances():
     assert instance2.selected_repository is None
 
     # Modify the first instance
-    instance1.selected_repository = "test_repo"
+    instance1.selected_repository = 'test_repo'
 
     # Verify the second instance is not affected
-    assert instance1.selected_repository == "test_repo"
+    assert instance1.selected_repository == 'test_repo'
     assert instance2.selected_repository is None
 
 
@@ -53,8 +51,8 @@ def test_selected_branch_not_shared_between_instances():
     assert instance2.selected_branch is None
 
     # Modify the first instance
-    instance1.selected_branch = "test_branch"
+    instance1.selected_branch = 'test_branch'
 
     # Verify the second instance is not affected
-    assert instance1.selected_branch == "test_branch"
+    assert instance1.selected_branch == 'test_branch'
     assert instance2.selected_branch is None

--- a/tests/unit/test_conversation_init_data.py
+++ b/tests/unit/test_conversation_init_data.py
@@ -1,6 +1,7 @@
 import pytest
 
 from openhands.server.session.conversation_init_data import ConversationInitData
+from openhands.integrations.provider import ProviderType, ProviderToken
 
 
 def test_provider_tokens_not_shared_between_instances():
@@ -14,10 +15,12 @@ def test_provider_tokens_not_shared_between_instances():
     assert instance2.provider_tokens == {}
 
     # Modify the first instance
-    instance1.provider_tokens["test_provider"] = "test_token"
+    provider_token = ProviderToken(token=None, user_id="test_user")
+    instance1.provider_tokens[ProviderType.GITHUB] = provider_token
 
     # Verify the second instance is not affected
-    assert instance1.provider_tokens == {"test_provider": "test_token"}
+    assert ProviderType.GITHUB in instance1.provider_tokens
+    assert instance1.provider_tokens[ProviderType.GITHUB].user_id == "test_user"
     assert instance2.provider_tokens == {}
 
 

--- a/tests/unit/test_conversation_init_data.py
+++ b/tests/unit/test_conversation_init_data.py
@@ -1,0 +1,62 @@
+import unittest
+
+from openhands.server.session.conversation_init_data import ConversationInitData
+
+
+class TestConversationInitData(unittest.TestCase):
+    """Tests for the ConversationInitData class."""
+
+    def test_provider_tokens_not_shared_between_instances(self):
+        """Test that provider_tokens is not shared between instances."""
+        # Create two instances
+        instance1 = ConversationInitData()
+        instance2 = ConversationInitData()
+
+        # Verify they start with empty dictionaries
+        self.assertEqual(instance1.provider_tokens, {})
+        self.assertEqual(instance2.provider_tokens, {})
+
+        # Modify the first instance
+        instance1.provider_tokens["test_provider"] = "test_token"
+
+        # Verify the second instance is not affected
+        self.assertEqual(instance1.provider_tokens, {"test_provider": "test_token"})
+        self.assertEqual(instance2.provider_tokens, {})
+
+    def test_selected_repository_not_shared_between_instances(self):
+        """Test that selected_repository is not shared between instances."""
+        # Create two instances
+        instance1 = ConversationInitData()
+        instance2 = ConversationInitData()
+
+        # Verify they start with None
+        self.assertIsNone(instance1.selected_repository)
+        self.assertIsNone(instance2.selected_repository)
+
+        # Modify the first instance
+        instance1.selected_repository = "test_repo"
+
+        # Verify the second instance is not affected
+        self.assertEqual(instance1.selected_repository, "test_repo")
+        self.assertIsNone(instance2.selected_repository)
+
+    def test_selected_branch_not_shared_between_instances(self):
+        """Test that selected_branch is not shared between instances."""
+        # Create two instances
+        instance1 = ConversationInitData()
+        instance2 = ConversationInitData()
+
+        # Verify they start with None
+        self.assertIsNone(instance1.selected_branch)
+        self.assertIsNone(instance2.selected_branch)
+
+        # Modify the first instance
+        instance1.selected_branch = "test_branch"
+
+        # Verify the second instance is not affected
+        self.assertEqual(instance1.selected_branch, "test_branch")
+        self.assertIsNone(instance2.selected_branch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_conversation_init_data.py
+++ b/tests/unit/test_conversation_init_data.py
@@ -1,62 +1,57 @@
-import unittest
+import pytest
 
 from openhands.server.session.conversation_init_data import ConversationInitData
 
 
-class TestConversationInitData(unittest.TestCase):
-    """Tests for the ConversationInitData class."""
+def test_provider_tokens_not_shared_between_instances():
+    """Test that provider_tokens is not shared between instances."""
+    # Create two instances
+    instance1 = ConversationInitData()
+    instance2 = ConversationInitData()
 
-    def test_provider_tokens_not_shared_between_instances(self):
-        """Test that provider_tokens is not shared between instances."""
-        # Create two instances
-        instance1 = ConversationInitData()
-        instance2 = ConversationInitData()
+    # Verify they start with empty dictionaries
+    assert instance1.provider_tokens == {}
+    assert instance2.provider_tokens == {}
 
-        # Verify they start with empty dictionaries
-        self.assertEqual(instance1.provider_tokens, {})
-        self.assertEqual(instance2.provider_tokens, {})
+    # Modify the first instance
+    instance1.provider_tokens["test_provider"] = "test_token"
 
-        # Modify the first instance
-        instance1.provider_tokens["test_provider"] = "test_token"
-
-        # Verify the second instance is not affected
-        self.assertEqual(instance1.provider_tokens, {"test_provider": "test_token"})
-        self.assertEqual(instance2.provider_tokens, {})
-
-    def test_selected_repository_not_shared_between_instances(self):
-        """Test that selected_repository is not shared between instances."""
-        # Create two instances
-        instance1 = ConversationInitData()
-        instance2 = ConversationInitData()
-
-        # Verify they start with None
-        self.assertIsNone(instance1.selected_repository)
-        self.assertIsNone(instance2.selected_repository)
-
-        # Modify the first instance
-        instance1.selected_repository = "test_repo"
-
-        # Verify the second instance is not affected
-        self.assertEqual(instance1.selected_repository, "test_repo")
-        self.assertIsNone(instance2.selected_repository)
-
-    def test_selected_branch_not_shared_between_instances(self):
-        """Test that selected_branch is not shared between instances."""
-        # Create two instances
-        instance1 = ConversationInitData()
-        instance2 = ConversationInitData()
-
-        # Verify they start with None
-        self.assertIsNone(instance1.selected_branch)
-        self.assertIsNone(instance2.selected_branch)
-
-        # Modify the first instance
-        instance1.selected_branch = "test_branch"
-
-        # Verify the second instance is not affected
-        self.assertEqual(instance1.selected_branch, "test_branch")
-        self.assertIsNone(instance2.selected_branch)
+    # Verify the second instance is not affected
+    assert instance1.provider_tokens == {"test_provider": "test_token"}
+    assert instance2.provider_tokens == {}
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_selected_repository_not_shared_between_instances():
+    """Test that selected_repository is not shared between instances."""
+    # Create two instances
+    instance1 = ConversationInitData()
+    instance2 = ConversationInitData()
+
+    # Verify they start with None
+    assert instance1.selected_repository is None
+    assert instance2.selected_repository is None
+
+    # Modify the first instance
+    instance1.selected_repository = "test_repo"
+
+    # Verify the second instance is not affected
+    assert instance1.selected_repository == "test_repo"
+    assert instance2.selected_repository is None
+
+
+def test_selected_branch_not_shared_between_instances():
+    """Test that selected_branch is not shared between instances."""
+    # Create two instances
+    instance1 = ConversationInitData()
+    instance2 = ConversationInitData()
+
+    # Verify they start with None
+    assert instance1.selected_branch is None
+    assert instance2.selected_branch is None
+
+    # Modify the first instance
+    instance1.selected_branch = "test_branch"
+
+    # Verify the second instance is not affected
+    assert instance1.selected_branch == "test_branch"
+    assert instance2.selected_branch is None


### PR DESCRIPTION
This PR proposes a few unit tests for ConversationInitData.

---
(openhands-ai)

This PR adds unit tests for the ConversationInitData class to verify that mutable default values are not shared between instances.

## Test Results
All tests pass, confirming that the current implementation is safe and working as expected.

## Changes
- Added tests for provider_tokens, selected_repository, and selected_branch class variables
- Updated tests to use proper ProviderType and ProviderToken objects
- Fixed lint issues in test file

## Analysis of Mutable Default Values

Regarding the use of mutable default values like `provider_tokens: PROVIDER_TOKEN_TYPE = Field(default={})` in the ConversationInitData class:

In regular Python classes, using mutable objects (like dictionaries or lists) as default values is generally considered a bad practice because these objects are created once when the class is defined, not when instances are created. This means all instances would share the same mutable object, leading to unexpected behavior.

However, Pydantic models (which ConversationInitData inherits from) handle this differently:

1. **Pydantic's Safety Mechanism**: Pydantic creates a deep copy of mutable default values for each instance. This means each instance gets its own independent copy of the dictionary, avoiding the shared state problem.

2. **Validation and Type Safety**: Pydantic also provides validation and type checking, ensuring the values conform to the expected types.

3. **Clear Intent**: The syntax `provider_tokens: dict = {}` clearly communicates that this field defaults to an empty dictionary.

The tests we've written confirm that Pydantic is handling this correctly - modifying one instance's dictionary doesn't affect other instances.

While this approach is safe with Pydantic, for better clarity and to avoid confusion for developers who might not be familiar with Pydantic's behavior, two alternative approaches could be considered:

1. **Use Field with default_factory**:
   ```python
   from pydantic import Field
   provider_tokens: dict = Field(default_factory=dict)
   ```

2. **Use model_config and populate_by_name**:
   ```python
   class ConversationInitData(Settings):
       provider_tokens: dict = None
       
       model_config = {
           "populate_by_name": True,
       }
       
       def __init__(self, **data):
           super().__init__(**data)
           if self.provider_tokens is None:
               self.provider_tokens = {}
   ```

These approaches make the intent clearer and follow more widely accepted Python practices, but the current implementation is technically correct and safe due to Pydantic's handling of mutable defaults.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e75c9a5-nikolaik   --name openhands-app-e75c9a5   docker.all-hands.dev/all-hands-ai/openhands:e75c9a5
```