### PR TITLE
Fix for error where credits is accessed even when billing is disabled

### DIFF
--- a/frontend/__tests__/components/features/payment/payment-form.test.tsx
+++ b/frontend/__tests__/components/features/payment/payment-form.test.tsx
@@ -4,8 +4,10 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import OpenHands from "#/api/open-hands";
 import { PaymentForm } from "#/components/features/payment/payment-form";
+import * as featureFlags from "#/utils/feature-flags";
 
 describe("PaymentForm", () => {
+  const billingSettingsSpy = vi.spyOn(featureFlags, "BILLING_SETTINGS");
   const getBalanceSpy = vi.spyOn(OpenHands, "getBalance");
   const createCheckoutSessionSpy = vi.spyOn(OpenHands, "createCheckoutSession");
   const getConfigSpy = vi.spyOn(OpenHands, "getConfig");
@@ -26,6 +28,7 @@ describe("PaymentForm", () => {
       GITHUB_CLIENT_ID: "123",
       POSTHOG_CLIENT_KEY: "456",
     });
+    billingSettingsSpy.mockReturnValue(true);
   });
 
   afterEach(() => {

--- a/frontend/src/hooks/query/use-balance.ts
+++ b/frontend/src/hooks/query/use-balance.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useConfig } from "./use-config";
 import OpenHands from "#/api/open-hands";
+import { BILLING_SETTINGS } from "#/utils/feature-flags";
 
 export const useBalance = () => {
   const { data: config } = useConfig();
@@ -8,6 +9,6 @@ export const useBalance = () => {
   return useQuery({
     queryKey: ["user", "balance"],
     queryFn: OpenHands.getBalance,
-    enabled: config?.APP_MODE === "saas",
+    enabled: config?.APP_MODE === "saas" && BILLING_SETTINGS(),
   });
 };


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Fix for issue where we are getting credits in the background even when it is inappropriate to do so.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This is a fix for a regression introduced yesterday. It only affects SAAS

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5111fda-nikolaik   --name openhands-app-5111fda   docker.all-hands.dev/all-hands-ai/openhands:5111fda
```