### PR TITLE
Fix for issue where initial command fails

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -293,7 +293,7 @@ class Runtime(FileEditRuntimeMixin):
         )
 
         action = CmdRunAction(
-            command=f'{clone_command} ; cd {dir_name} ; {checkout_command} ; cd ..',
+            command=f'{clone_command} ; cd {dir_name} ; {checkout_command}',
         )
         self.log('info', f'Cloning repo: {selected_repository}')
         self.run_action(action)

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -293,7 +293,7 @@ class Runtime(FileEditRuntimeMixin):
         )
 
         action = CmdRunAction(
-            command=f'{clone_command} ; cd {dir_name} ; {checkout_command}',
+            command=f'{clone_command} ; cd {dir_name} ; {checkout_command} ; cd ..',
         )
         self.log('info', f'Cloning repo: {selected_repository}')
         self.run_action(action)

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -117,7 +117,7 @@ def test_prompt_manager_template_rendering(prompt_dir):
     msg_content: str = initial_msg.content[0].text
     assert '<REPOSITORY_INFO>' in msg_content
     assert (
-        "At the user's request, repository owner/repo has been cloned to directory /workspace/repo."
+        "At the user's request, repository owner/repo has been cloned to the current working directory /workspace/repo."
         in msg_content
     )
     assert '</REPOSITORY_INFO>' in msg_content


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
We now explicitly tell the agent that they the current working directory is the directory for the checked out repository.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

The checkout command changes the current working directory to that of the workspace, causing the initial command to fail for some repositories. e.g.: 
<img width="575" alt="image" src="https://github.com/user-attachments/assets/7c002fbe-ef77-4b10-a506-e874ea6468ec" />

Although the agent rapidly recovers from this, it means we start with an error. This PR should resolve this issue

**More explicitly, I have found the following:**
![image](https://github.com/user-attachments/assets/591fae6a-ade2-4040-a298-de634341b1a0)
The agent only knows that the OpenHands project has a home directory of OpenHands based upon the instructions in the OpenHands repository.

**Other repositories do not have these instructions! (I have found the same results on multiple repositories)**
![image](https://github.com/user-attachments/assets/8ee0b7e6-5194-4d09-a7ce-0a95307fc300)

This is due to the command here: https://github.com/All-Hands-AI/OpenHands/blob/ec763f81051c65dea17ddd53556ceab8e73c6f6a/openhands/runtime/base.py#L295 - we change to the directory of the checked out repo

In many places, we prompt the agent to use absolute paths - the cd violates this:
* https://github.com/All-Hands-AI/OpenHands/blob/ec763f81051c65dea17ddd53556ceab8e73c6f6a/openhands/core/config/app_config.py#L33
* https://github.com/All-Hands-AI/OpenHands/blob/ec763f81051c65dea17ddd53556ceab8e73c6f6a/openhands/agenthub/codeact_agent/tools/str_replace_editor.py#L48
* https://github.com/All-Hands-AI/OpenHands/blob/ec763f81051c65dea17ddd53556ceab8e73c6f6a/openhands/runtime/plugins/agent_skills/file_ops/file_ops.py#L187

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:03c700d-nikolaik   --name openhands-app-03c700d   docker.all-hands.dev/all-hands-ai/openhands:03c700d
```