### PR TITLE
Fix GitHub authentication headers to use Bearer token consistently

### DIFF
--- a/openhands/resolver/interfaces/github.py
+++ b/openhands/resolver/interfaces/github.py
@@ -27,7 +27,7 @@ class GithubIssueHandler(IssueHandlerInterface):
 
     def get_headers(self) -> dict[str, str]:
         return {
-            'Authorization': f'token {self.token}',
+            'Authorization': f'Bearer {self.token}',
             'Accept': 'application/vnd.github.v3+json',
         }
 
@@ -450,7 +450,7 @@ class GithubPRHandler(GithubIssueHandler):
         """Download comments for a specific pull request from Github."""
         url = f'https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pr_number}/comments'
         headers = {
-            'Authorization': f'token {self.token}',
+            'Authorization': f'Bearer {self.token}',
             'Accept': 'application/vnd.github.v3+json',
         }
         params = {'per_page': 100, 'page': 1}

--- a/tests/unit/test_github_auth_headers.py
+++ b/tests/unit/test_github_auth_headers.py
@@ -1,0 +1,66 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from openhands.resolver.interfaces.github import GithubIssueHandler, GithubPRHandler
+
+
+@pytest.mark.asyncio
+async def test_github_issue_handler_auth_headers():
+    """Test that GithubIssueHandler uses Bearer token in authorization headers."""
+    # Create a GithubIssueHandler instance
+    handler = GithubIssueHandler(
+        owner="test-owner",
+        repo="test-repo",
+        token="test-token",
+        username="test-username"
+    )
+    
+    # Check that the headers use Bearer token
+    headers = handler.get_headers()
+    assert headers["Authorization"] == "Bearer test-token"
+    
+    # Mock requests.get to check headers in API calls
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+        
+        # Call a method that uses requests.get
+        handler.download_issues()
+        
+        # Check that the call to requests.get used Bearer token
+        call_args = mock_get.call_args
+        headers_used = call_args[1]["headers"]
+        assert headers_used["Authorization"] == "Bearer test-token"
+
+
+@pytest.mark.asyncio
+async def test_github_pr_handler_auth_headers():
+    """Test that GithubPRHandler uses Bearer token in authorization headers."""
+    # Create a GithubPRHandler instance
+    handler = GithubPRHandler(
+        owner="test-owner",
+        repo="test-repo",
+        token="test-token",
+        username="test-username"
+    )
+    
+    # Check that the headers use Bearer token
+    headers = handler.get_headers()
+    assert headers["Authorization"] == "Bearer test-token"
+    
+    # Mock requests.post to check headers in GraphQL API calls
+    with patch("requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": {"repository": {"pullRequest": {}}}}
+        mock_post.return_value = mock_response
+        
+        # Call a method that uses requests.post with GraphQL
+        handler.download_pr_metadata(1)
+        
+        # Check that the call to requests.post used Bearer token
+        call_args = mock_post.call_args
+        headers_used = call_args[1]["headers"]
+        assert headers_used["Authorization"] == "Bearer test-token"


### PR DESCRIPTION
This PR fixes issue #6661 by updating all GitHub API authorization headers to consistently use `Bearer` token format instead of mixing `token` and `Bearer` formats.

The GitHub API documentation states that `Bearer` is the preferred format, especially for JWT tokens. This change ensures consistency across all GitHub API calls in the codebase.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d82ef66663fb4ec5bda62f93746f44fe)