### PR TITLE
Add WorkspaceContext observation for the initial user message

### DIFF
--- a/openhands/core/schema/observation.py
+++ b/openhands/core/schema/observation.py
@@ -52,5 +52,8 @@ class ObservationTypeSchema(BaseModel):
     MICROAGENT: str = Field(default='microagent')
     """Result of a microagent retrieval operation."""
 
+    WORKSPACE_CONTEXT: str = Field(default='workspace_context')
+    """Workspace context information such as repository details and runtime information."""
+
 
 ObservationType = ObservationTypeSchema()

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -4,6 +4,7 @@ from openhands.events.observation.agent import (
     AgentStateChangedObservation,
     AgentThinkObservation,
     MicroagentObservation,
+    WorkspaceContextObservation,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (
@@ -43,5 +44,6 @@ __all__ = [
     'UserRejectObservation',
     'AgentCondensationObservation',
     'MicroagentObservation',
+    'WorkspaceContextObservation',
     'RecallType',
 ]

--- a/openhands/events/observation/agent.py
+++ b/openhands/events/observation/agent.py
@@ -60,11 +60,11 @@ class MicroagentKnowledge:
 
 
 @dataclass
-class MicroagentObservation(Observation):
-    """The retrieval of content from a microagent or more microagents."""
+class WorkspaceContextObservation(Observation):
+    """Workspace context information such as repository details and runtime information."""
 
-    recall_type: RecallType
-    observation: str = ObservationType.MICROAGENT
+    recall_type: RecallType = RecallType.WORKSPACE_CONTEXT
+    observation: str = ObservationType.WORKSPACE_CONTEXT
 
     # environment
     repo_name: str = ''
@@ -72,6 +72,37 @@ class MicroagentObservation(Observation):
     repo_instructions: str = ''
     runtime_hosts: dict[str, int] = field(default_factory=dict)
     additional_agent_instructions: str = ''
+
+    # Include a microagent_knowledge list
+    microagent_knowledge: list[MicroagentKnowledge] = field(default_factory=list)
+
+    @property
+    def message(self) -> str:
+        return 'Added workspace context'
+
+    def __str__(self) -> str:
+        fields = [
+            f'recall_type={self.recall_type}',
+            f'repo_name={self.repo_name}',
+            f'repo_instructions={self.repo_instructions[:20]}...',
+            f'runtime_hosts={self.runtime_hosts}',
+            f'additional_agent_instructions={self.additional_agent_instructions[:20]}...',
+        ]
+
+        if self.microagent_knowledge:
+            fields.append(
+                f'microagent_knowledge={", ".join([m.name for m in self.microagent_knowledge])}'
+            )
+
+        return f'**WorkspaceContextObservation**\n{", ".join(fields)}'
+
+
+@dataclass
+class MicroagentObservation(Observation):
+    """The retrieval of content from a microagent or more microagents."""
+
+    recall_type: RecallType = RecallType.KNOWLEDGE
+    observation: str = ObservationType.MICROAGENT
 
     # knowledge
     microagent_knowledge: list[MicroagentKnowledge] = field(default_factory=list)
@@ -98,14 +129,7 @@ class MicroagentObservation(Observation):
         return self.__str__()
 
     def __str__(self) -> str:
-        # Build a string representation of all fields
-        fields = [
-            f'recall_type={self.recall_type}',
-            f'repo_name={self.repo_name}',
-            f'repo_instructions={self.repo_instructions[:20]}...',
-            f'runtime_hosts={self.runtime_hosts}',
-            f'additional_agent_instructions={self.additional_agent_instructions[:20]}...',
-        ]
+        fields = [f'recall_type={self.recall_type}']
 
         # Only include microagent_knowledge if it's not empty
         if self.microagent_knowledge:

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -131,4 +131,19 @@ def observation_from_dict(observation: dict) -> Observation:
                 for item in extras['microagent_knowledge']
             ]
 
+    # Compatibility: If we're trying to deserialize a WorkspaceContextObservation as a MicroagentObservation
+    if observation_class is MicroagentObservation and any(
+        key in extras
+        for key in [
+            'repo_name',
+            'repo_directory',
+            'repo_instructions',
+            'runtime_hosts',
+            'additional_agent_instructions',
+        ]
+    ):
+        # Switch to WorkspaceContextObservation
+        observation_class = WorkspaceContextObservation
+        extras['recall_type'] = RecallType.WORKSPACE_CONTEXT
+
     return observation_class(content=content, **extras)

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -7,6 +7,7 @@ from openhands.events.observation.agent import (
     AgentThinkObservation,
     MicroagentKnowledge,
     MicroagentObservation,
+    WorkspaceContextObservation,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (
@@ -44,6 +45,7 @@ observations = (
     AgentCondensationObservation,
     AgentThinkObservation,
     MicroagentObservation,
+    WorkspaceContextObservation,
 )
 
 OBSERVATION_TYPE_TO_CLASS = {
@@ -114,7 +116,8 @@ def observation_from_dict(observation: dict) -> Observation:
         else:
             extras['metadata'] = CmdOutputMetadata()
 
-    if observation_class is MicroagentObservation:
+    # Handle recall_type and microagent_knowledge
+    if observation_class in (MicroagentObservation, WorkspaceContextObservation):
         # handle the Enum conversion
         if 'recall_type' in extras:
             extras['recall_type'] = RecallType(extras['recall_type'])

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -86,7 +86,7 @@ class Memory:
                     workspace_obs: (
                         WorkspaceContextObservation | NullObservation | None
                     ) = None
-                    workspace_obs = self._on_first_microagent_action(event)
+                    workspace_obs = self._on_workspace_context_action(event)
                     if workspace_obs is None:
                         workspace_obs = NullObservation(content='')
 
@@ -150,7 +150,7 @@ class Memory:
 
         return recalled_content
 
-    def _on_first_microagent_action(
+    def _on_workspace_context_action(
         self, event: RecallAction
     ) -> WorkspaceContextObservation | None:
         """Add repository and runtime information to the stream as a WorkspaceContextObservation."""

--- a/tests/unit/test_conversation_memory.py
+++ b/tests/unit/test_conversation_memory.py
@@ -23,6 +23,7 @@ from openhands.events.observation import CmdOutputObservation
 from openhands.events.observation.agent import (
     MicroagentKnowledge,
     MicroagentObservation,
+    WorkspaceContextObservation,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (
@@ -631,15 +632,15 @@ def test_process_events_with_knowledge_microagent_microagent_observation(
     assert 'disabled_agent' not in agent_names
 
 
-def test_process_events_with_microagent_observation_extensions_disabled(
+def test_process_events_with_microagent_observations_extensions_disabled(
     agent_config, conversation_memory
 ):
-    """Test processing a MicroagentObservation when prompt extensions are disabled."""
+    """Test processing MicroagentObservation and WorkspaceContextObservation when prompt extensions are disabled."""
     # Modify the agent config to disable prompt extensions
     agent_config.enable_prompt_extensions = False
 
-    obs = MicroagentObservation(
-        recall_type=RecallType.WORKSPACE_CONTEXT,
+    # Test with WorkspaceContextObservation
+    workspace_obs = WorkspaceContextObservation(
         repo_name='test-repo',
         repo_directory='/path/to/repo',
         content='Retrieved environment info',
@@ -649,14 +650,15 @@ def test_process_events_with_microagent_observation_extensions_disabled(
         Message(role='system', content=[TextContent(text='System message')])
     ]
 
+    # Test WorkspaceContextObservation
     messages = conversation_memory.process_events(
-        condensed_history=[obs],
-        initial_messages=initial_messages,
+        condensed_history=[workspace_obs],
+        initial_messages=initial_messages.copy(),
         max_message_chars=None,
         vision_is_active=False,
     )
 
-    # When prompt extensions are disabled, the MicroagentObservation should be ignored
+    # When prompt extensions are disabled, the WorkspaceContextObservation should be ignored
     assert len(messages) == 1  # Only the initial system message
     assert messages[0].role == 'system'
 

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -125,8 +125,12 @@ async def test_memory_on_workspace_context_action_exception_handling(
         status_callback_mock.assert_called_once()
         call_args = status_callback_mock.call_args[0]
         assert call_args[0] == 'error'  # First arg should be message type 'error'
-        assert call_args[1] == 'STATUS$ERROR_MEMORY'  # Second arg should be the message ID
-        assert 'Error: Exception' in call_args[2]  # Third arg should contain the error message
+        assert (
+            call_args[1] == 'STATUS$ERROR_MEMORY'
+        )  # Second arg should be the message ID
+        assert (
+            'Error: Exception' in call_args[2]
+        )  # Third arg should contain the error message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_truncation.py
+++ b/tests/unit/test_truncation.py
@@ -23,7 +23,12 @@ def mock_event_stream():
 def mock_agent():
     agent = MagicMock()
     agent.llm = MagicMock()
-    agent.llm.config = MagicMock()
+
+    # Create a step function that returns an action without an ID
+    def step_fn(state):
+        return MessageAction(content='Agent returned a message')
+
+    agent.step = step_fn
     return agent
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Follow-up on #6909 

The current proposal:
- conceptually, it still seems to me these are information retrieval events
- the action is the same (`RecallAction`)
- the results are different though. So what if we do make them different, do we like this?

This PR proposes to add a `WorkspaceContext` type of observation on initial user message, instead of trying to squeeze its context (runtime info, repo info. etc) into a `MicroagentObservation`. It can also have microagents, since the first user message is a user message, but it has plenty of other things as well.

So in this PR, the execution flow becomes:
- on first user message
    - look up workspace info, microagents => WorkspaceContextObservation
- on any other user message
    - look up microagents => MicroagentObservation

Alternative to just use a generic name:
- https://github.com/All-Hands-AI/OpenHands/pull/7292 

(please ignore the log spam, I'll clean it up)

---
@xingyaoww You're absolutely right it didn't really work to make the workspace context a MicroagentInfoType.ENVIRONMENT when it's... not a microagent. They're different observations, so maybe we could just model them differently.
I tried to prepare the ground for this in the other PR.

There are multiple alternatives, and tradeoffs, idk, please tell if this one doesn't seem right.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:33057e5-nikolaik   --name openhands-app-33057e5   docker.all-hands.dev/all-hands-ai/openhands:33057e5
```