### PR TITLE
Fix for too much reaction in logs

### DIFF
--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -240,7 +240,7 @@ class SensitiveDataFilter(logging.Filter):
             if (
                 len(value) > 2
                 and value != 'default'
-                and any(s in key_upper for s in ('SECRET', 'KEY', 'CODE', 'TOKEN'))
+                and any(s in key_upper for s in ('SECRET', '_KEY', '_CODE', '_TOKEN'))
             ):
                 sensitive_values.append(value)
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Fields like `KEYCLOAK_SERVER_URL` or `VSCODE_INJECTION` should not be redacted. By adding an underscore before the token, we remove these false positives.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bab0aba-nikolaik   --name openhands-app-bab0aba   docker.all-hands.dev/all-hands-ai/openhands:bab0aba
```