### PR TITLE
Fix visual browsing

### DIFF
--- a/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
+++ b/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
@@ -219,7 +219,6 @@ Note:
                 return AgentFinishAction(outputs={'content': event.content})
             elif isinstance(event, Observation):
                 # Only process BrowserOutputObservation and skip other observation types
-                # This handles MicroagentObservation added in PR #6909
                 if not isinstance(event, BrowserOutputObservation):
                     continue
                 last_obs = event

--- a/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
+++ b/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
@@ -218,6 +218,10 @@ Note:
                 # agent has responded, task finished.
                 return AgentFinishAction(outputs={'content': event.content})
             elif isinstance(event, Observation):
+                # Only process BrowserOutputObservation and skip other observation types
+                # This handles MicroagentObservation added in PR #6909
+                if not isinstance(event, BrowserOutputObservation):
+                    continue
                 last_obs = event
 
         if len(prev_actions) >= 1:  # ignore noop()

--- a/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
+++ b/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
@@ -202,6 +202,7 @@ Note:
         tabs = ''
         last_obs = None
         last_action = None
+        set_of_marks = None  # Initialize set_of_marks to None
 
         if len(state.history) == 1:
             # for visualwebarena, webarena and miniwob++ eval, we need to retrieve the initial observation already in browser env

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -52,7 +52,6 @@ class ConversationMemory:
         initial_messages: list[Message],
         max_message_chars: int | None = None,
         vision_is_active: bool = False,
-        enable_som_visual_browsing: bool = False,
     ) -> list[Message]:
         """Process state history into a list of messages for the LLM.
 
@@ -64,7 +63,6 @@ class ConversationMemory:
             max_message_chars: The maximum number of characters in the content of an event included
                 in the prompt to the LLM. Larger observations are truncated.
             vision_is_active: Whether vision is active in the LLM. If True, image URLs will be included.
-            enable_som_visual_browsing: Whether to enable visual browsing for the SOM model.
         """
 
         events = condensed_history

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -68,7 +68,7 @@ class ConversationMemory:
         events = condensed_history
 
         # log visual browsing status
-        logger.info(f'Visual browsing: {self.agent_config.enable_som_visual_browsing}')
+        logger.debug(f'Visual browsing: {self.agent_config.enable_som_visual_browsing}')
 
         # Process special events first (system prompts, etc.)
         messages = initial_messages

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -67,6 +67,9 @@ class ConversationMemory:
 
         events = condensed_history
 
+        # log visual browsing status
+        logger.info(f'Visual browsing: {self.agent_config.enable_som_visual_browsing}')
+
         # Process special events first (system prompts, etc.)
         messages = initial_messages
 


### PR DESCRIPTION
Just debugging the failure of an integration test overnight

_Edited to add:_

This PR proposes a fix for VisualBrowsingAgent UnboundLocal error: it was due to the new MicroagentObservation in its history. It doesn't know how to handle it, so this PR enforces a check for only BrowsingOutputObs.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:11409ea-nikolaik   --name openhands-app-11409ea   docker.all-hands.dev/all-hands-ai/openhands:11409ea
```