### PR TITLE
RecallObservations 

### DIFF
--- a/openhands/core/schema/observation.py
+++ b/openhands/core/schema/observation.py
@@ -49,8 +49,8 @@ class ObservationTypeSchema(BaseModel):
     CONDENSE: str = Field(default='condense')
     """Result of a condensation operation."""
 
-    MICROAGENT: str = Field(default='microagent')
-    """Result of a microagent retrieval operation."""
+    RECALL: str = Field(default='recall')
+    """Result of a recall operation. This can be the workspace context, a microagent, or other types of information."""
 
 
 ObservationType = ObservationTypeSchema()

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -3,7 +3,7 @@ from openhands.events.observation.agent import (
     AgentCondensationObservation,
     AgentStateChangedObservation,
     AgentThinkObservation,
-    MicroagentObservation,
+    RecallObservation,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (
@@ -42,6 +42,6 @@ __all__ = [
     'SuccessObservation',
     'UserRejectObservation',
     'AgentCondensationObservation',
-    'MicroagentObservation',
+    'RecallObservation',
     'RecallType',
 ]

--- a/openhands/events/observation/agent.py
+++ b/openhands/events/observation/agent.py
@@ -60,13 +60,13 @@ class MicroagentKnowledge:
 
 
 @dataclass
-class MicroagentObservation(Observation):
+class RecallObservation(Observation):
     """The retrieval of content from a microagent or more microagents."""
 
     recall_type: RecallType
-    observation: str = ObservationType.MICROAGENT
+    observation: str = ObservationType.RECALL
 
-    # environment
+    # workspace context
     repo_name: str = ''
     repo_directory: str = ''
     repo_instructions: str = ''
@@ -95,22 +95,36 @@ class MicroagentObservation(Observation):
 
     @property
     def message(self) -> str:
-        return self.__str__()
+        return (
+            'Added workspace context'
+            if self.recall_type == RecallType.WORKSPACE_CONTEXT
+            else 'Added microagent knowledge'
+        )
 
     def __str__(self) -> str:
-        # Build a string representation of all fields
-        fields = [
-            f'recall_type={self.recall_type}',
-            f'repo_name={self.repo_name}',
-            f'repo_instructions={self.repo_instructions[:20]}...',
-            f'runtime_hosts={self.runtime_hosts}',
-            f'additional_agent_instructions={self.additional_agent_instructions[:20]}...',
-        ]
-
-        # Only include microagent_knowledge if it's not empty
+        # Build a string representation
+        fields = []
+        if self.recall_type == RecallType.WORKSPACE_CONTEXT:
+            fields.extend(
+                [
+                    f'recall_type={self.recall_type}',
+                    f'repo_name={self.repo_name}',
+                    f'repo_instructions={self.repo_instructions[:20]}...',
+                    f'runtime_hosts={self.runtime_hosts}',
+                    f'additional_agent_instructions={self.additional_agent_instructions[:20]}...',
+                ]
+            )
+        else:
+            fields.extend(
+                [
+                    f'recall_type={self.recall_type}',
+                ]
+            )
         if self.microagent_knowledge:
-            fields.append(
-                f'microagent_knowledge={", ".join([m.name for m in self.microagent_knowledge])}'
+            fields.extend(
+                [
+                    f'microagent_knowledge={", ".join([m.name for m in self.microagent_knowledge])}',
+                ]
             )
 
-        return f'**MicroagentObservation**\n{", ".join(fields)}'
+        return f'**RecallObservation**\n{", ".join(fields)}'

--- a/openhands/events/serialization/event.py
+++ b/openhands/events/serialization/event.py
@@ -122,7 +122,7 @@ def event_to_dict(event: 'Event') -> dict:
         # props is a dict whose values can include a complex object like an instance of a BaseModel subclass
         # such as CmdOutputMetadata
         # we serialize it along with the rest
-        # we also handle the Enum conversion for MicroagentObservation
+        # we also handle the Enum conversion for RecallObservation
         d['extras'] = {
             k: (v.value if isinstance(v, Enum) else _convert_pydantic_to_dict(v))
             for k, v in props.items()

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -114,10 +114,6 @@ def observation_from_dict(observation: dict) -> Observation:
         else:
             extras['metadata'] = CmdOutputMetadata()
 
-    # compatibility
-    if observation_class.__name__ == 'MicroagentObservation':
-        observation_class = RecallObservation
-
     if observation_class is RecallObservation:
         # handle the Enum conversion
         if 'recall_type' in extras:

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -6,7 +6,7 @@ from openhands.events.observation.agent import (
     AgentStateChangedObservation,
     AgentThinkObservation,
     MicroagentKnowledge,
-    MicroagentObservation,
+    RecallObservation,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (
@@ -43,7 +43,7 @@ observations = (
     UserRejectObservation,
     AgentCondensationObservation,
     AgentThinkObservation,
-    MicroagentObservation,
+    RecallObservation,
 )
 
 OBSERVATION_TYPE_TO_CLASS = {
@@ -114,7 +114,11 @@ def observation_from_dict(observation: dict) -> Observation:
         else:
             extras['metadata'] = CmdOutputMetadata()
 
-    if observation_class is MicroagentObservation:
+    # compatibility
+    if observation_class.__name__ == 'MicroagentObservation':
+        observation_class = RecallObservation
+
+    if observation_class is RecallObservation:
         # handle the Enum conversion
         if 'recall_type' in extras:
             extras['recall_type'] = RecallType(extras['recall_type'])

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -83,7 +83,7 @@ class Memory:
                     event.source == EventSource.USER
                     and event.recall_type == RecallType.WORKSPACE_CONTEXT
                 ):
-                    logger.info('Workspace context recall')
+                    logger.debug('Workspace context recall')
                     workspace_obs: RecallObservation | NullObservation | None = None
 
                     workspace_obs = self._on_workspace_context_recall(event)
@@ -101,7 +101,7 @@ class Memory:
                     event.source == EventSource.USER
                     and event.recall_type == RecallType.KNOWLEDGE
                 ):
-                    logger.info('Microagent knowledge recall')
+                    logger.debug('Microagent knowledge recall')
                     microagent_obs: RecallObservation | NullObservation | None = None
                     microagent_obs = self._on_microagent_recall(event)
                     if microagent_obs is None:

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -76,7 +76,7 @@ class PromptManager:
         if example_message:
             message.content.insert(0, TextContent(text=example_message))
 
-    def build_additional_info(
+    def build_workspace_context(
         self,
         repository_info: RepositoryInfo | None,
         runtime_info: RuntimeInfo | None,

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -863,12 +863,12 @@ async def test_run_controller_with_memory_error(test_event_stream):
     # Create a real Memory instance
     memory = Memory(event_stream=event_stream, sid='test-memory')
 
-    # Patch the _on_microagent_recall method to raise our test exception
-    def mock_on_microagent_recall(*args, **kwargs):
+    # Patch the _find_microagent_knowledge method to raise our test exception
+    def mock_find_microagent_knowledge(*args, **kwargs):
         raise RuntimeError('Test memory error')
 
     with patch.object(
-        memory, '_on_microagent_recall', side_effect=mock_on_microagent_recall
+        memory, '_find_microagent_knowledge', side_effect=mock_find_microagent_knowledge
     ):
         state = await run_controller(
             config=config,

--- a/tests/unit/test_agent_delegation.py
+++ b/tests/unit/test_agent_delegation.py
@@ -19,7 +19,7 @@ from openhands.events.action import (
 )
 from openhands.events.action.agent import RecallAction
 from openhands.events.event import Event, RecallType
-from openhands.events.observation.agent import MicroagentObservation
+from openhands.events.observation.agent import RecallObservation
 from openhands.events.stream import EventStreamSubscriber
 from openhands.llm.llm import LLM
 from openhands.llm.metrics import Metrics
@@ -86,10 +86,10 @@ async def test_delegation_flow(mock_parent_agent, mock_child_agent, mock_event_s
 
     def on_event(event: Event):
         if isinstance(event, RecallAction):
-            # create a MicroagentObservation
-            microagent_observation = MicroagentObservation(
+            # create a RecallObservation
+            microagent_observation = RecallObservation(
                 recall_type=RecallType.KNOWLEDGE,
-                content='microagent',
+                content='Found info',
             )
             microagent_observation._cause = event.id  # ignore attr-defined warning
             mock_event_stream.add_event(microagent_observation, EventSource.ENVIRONMENT)
@@ -111,14 +111,14 @@ async def test_delegation_flow(mock_parent_agent, mock_child_agent, mock_event_s
     # Give time for the async step() to execute
     await asyncio.sleep(1)
 
-    # Verify that a MicroagentObservation was added to the event stream
+    # Verify that a RecallObservation was added to the event stream
     events = list(mock_event_stream.get_events())
     assert (
         mock_event_stream.get_latest_event_id() == 3
     )  # Microagents and AgentChangeState
 
-    # a MicroagentObservation and an AgentDelegateAction should be in the list
-    assert any(isinstance(event, MicroagentObservation) for event in events)
+    # a RecallObservation and an AgentDelegateAction should be in the list
+    assert any(isinstance(event, RecallObservation) for event in events)
     assert any(isinstance(event, AgentDelegateAction) for event in events)
 
     # Verify that a delegate agent controller is created

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -177,7 +177,7 @@ async def test_memory_with_microagents():
     added_events.clear()
 
     # Process the microagent action
-    await memory.on_event(microagent_action)
+    await memory._on_event(microagent_action)
 
     # Verify a RecallObservation was added to the event stream
     assert len(added_events) == 1

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -14,7 +14,7 @@ from openhands.events.action.agent import RecallAction
 from openhands.events.action.message import MessageAction
 from openhands.events.event import EventSource
 from openhands.events.observation.agent import (
-    MicroagentObservation,
+    RecallObservation,
     RecallType,
 )
 from openhands.events.stream import EventStream
@@ -74,7 +74,7 @@ async def test_memory_on_event_exception_handling(memory, event_stream):
 
     # Mock Memory method to raise an exception
     with patch.object(
-        memory, '_on_first_microagent_action', side_effect=Exception('Test error')
+        memory, '_on_workspace_context_recall', side_effect=Exception('Test error')
     ):
         state = await run_controller(
             config=AppConfig(),
@@ -93,10 +93,10 @@ async def test_memory_on_event_exception_handling(memory, event_stream):
 
 
 @pytest.mark.asyncio
-async def test_memory_on_first_microagent_action_exception_handling(
+async def test_memory_on_workspace_context_recall_exception_handling(
     memory, event_stream
 ):
-    """Test that exceptions in Memory._on_first_microagent_action are properly handled via status callback."""
+    """Test that exceptions in Memory._on_workspace_context_recall are properly handled via status callback."""
 
     # Create a dummy agent for the controller
     agent = MagicMock(spec=Agent)
@@ -108,11 +108,11 @@ async def test_memory_on_first_microagent_action_exception_handling(
     runtime = MagicMock(spec=Runtime)
     runtime.event_stream = event_stream
 
-    # Mock Memory._on_first_microagent_action to raise an exception
+    # Mock Memory._on_workspace_context_recall to raise an exception
     with patch.object(
         memory,
-        '_on_first_microagent_action',
-        side_effect=Exception('Test error from _on_first_microagent_action'),
+        '_find_microagent_knowledge',
+        side_effect=Exception('Test error from _find_microagent_knowledge'),
     ):
         state = await run_controller(
             config=AppConfig(),
@@ -130,12 +130,13 @@ async def test_memory_on_first_microagent_action_exception_handling(
         assert state.last_error == 'Error: Exception'
 
 
-def test_memory_with_microagents():
+@pytest.mark.asyncio
+async def test_memory_with_microagents():
     """Test that Memory loads microagents from the global directory and processes microagent actions.
 
     This test verifies that:
     1. Memory loads microagents from the global GLOBAL_MICROAGENTS_DIR
-    2. When a microagent action with a trigger word is processed, a MicroagentObservation is created
+    2. When a microagent action with a trigger word is processed, a RecallObservation is created
     """
     # Create a mock event stream
     event_stream = MagicMock(spec=EventStream)
@@ -158,6 +159,9 @@ def test_memory_with_microagents():
         query='Hello, flarglebargle!', recall_type=RecallType.KNOWLEDGE
     )
 
+    # Set the source to USER
+    microagent_action._source = EventSource.USER  # type: ignore[attr-defined]
+
     # Mock the event_stream.add_event method
     added_events = []
 
@@ -173,12 +177,12 @@ def test_memory_with_microagents():
     added_events.clear()
 
     # Process the microagent action
-    memory.on_event(microagent_action)
+    await memory.on_event(microagent_action)
 
-    # Verify a MicroagentObservation was added to the event stream
+    # Verify a RecallObservation was added to the event stream
     assert len(added_events) == 1
     observation, source = added_events[0]
-    assert isinstance(observation, MicroagentObservation)
+    assert isinstance(observation, RecallObservation)
     assert source == EventSource.ENVIRONMENT
     assert observation.recall_type == RecallType.KNOWLEDGE
     assert len(observation.microagent_knowledge) == 1
@@ -188,7 +192,7 @@ def test_memory_with_microagents():
 
 
 def test_memory_repository_info(prompt_dir):
-    """Test that Memory adds repository info to MicroagentObservations."""
+    """Test that Memory adds repository info to RecallObservations."""
     # Create an in-memory file store and real event stream
     file_store = InMemoryFileStore()
     event_stream = EventStream(sid='test-session', file_store=file_store)
@@ -241,15 +245,15 @@ REPOSITORY INSTRUCTIONS: This is a test repository.
         # Get all events from the stream
         events = list(event_stream.get_events())
 
-        # Find the MicroagentObservation event
+        # Find the RecallObservation event
         microagent_obs_events = [
-            event for event in events if isinstance(event, MicroagentObservation)
+            event for event in events if isinstance(event, RecallObservation)
         ]
 
-        # We should have at least one MicroagentObservation
+        # We should have at least one RecallObservation
         assert len(microagent_obs_events) > 0
 
-        # Get the first MicroagentObservation
+        # Get the first RecallObservation
         observation = microagent_obs_events[0]
         assert observation.recall_type == RecallType.WORKSPACE_CONTEXT
         assert observation.repo_name == 'owner/repo'

--- a/tests/unit/test_observation_serialization.py
+++ b/tests/unit/test_observation_serialization.py
@@ -5,8 +5,8 @@ from openhands.events.observation import (
     CmdOutputMetadata,
     CmdOutputObservation,
     FileEditObservation,
-    MicroagentObservation,
     Observation,
+    RecallObservation,
 )
 from openhands.events.observation.agent import MicroagentKnowledge
 from openhands.events.serialization import (
@@ -245,9 +245,9 @@ def test_file_edit_observation_legacy_serialization():
 
 def test_microagent_observation_serialization():
     original_observation_dict = {
-        'observation': 'microagent',
+        'observation': 'recall',
         'content': '',
-        'message': "**MicroagentObservation**\nrecall_type=RecallType.WORKSPACE_CONTEXT, repo_name=some_repo_name, repo_instructions=complex_repo_instruc..., runtime_hosts={'host1': 8080, 'host2': 8081}, additional_agent_instructions=You know it all abou...",
+        'message': "**RecallObservation**\nrecall_type=RecallType.WORKSPACE_CONTEXT, repo_name=some_repo_name, repo_instructions=complex_repo_instruc..., runtime_hosts={'host1': 8080, 'host2': 8081}, additional_agent_instructions=You know it all abou...",
         'extras': {
             'recall_type': 'workspace_context',
             'repo_name': 'some_repo_name',
@@ -258,14 +258,14 @@ def test_microagent_observation_serialization():
             'microagent_knowledge': [],
         },
     }
-    serialization_deserialization(original_observation_dict, MicroagentObservation)
+    serialization_deserialization(original_observation_dict, RecallObservation)
 
 
 def test_microagent_observation_microagent_knowledge_serialization():
     original_observation_dict = {
-        'observation': 'microagent',
+        'observation': 'recall',
         'content': '',
-        'message': '**MicroagentObservation**\nrecall_type=RecallType.KNOWLEDGE, repo_name=, repo_instructions=..., runtime_hosts={}, additional_agent_instructions=..., microagent_knowledge=microagent1, microagent2',
+        'message': '**RecallObservation**\nrecall_type=RecallType.KNOWLEDGE, repo_name=, repo_instructions=..., runtime_hosts={}, additional_agent_instructions=..., microagent_knowledge=microagent1, microagent2',
         'extras': {
             'recall_type': 'knowledge',
             'repo_name': '',
@@ -287,13 +287,13 @@ def test_microagent_observation_microagent_knowledge_serialization():
             ],
         },
     }
-    serialization_deserialization(original_observation_dict, MicroagentObservation)
+    serialization_deserialization(original_observation_dict, RecallObservation)
 
 
 def test_microagent_observation_knowledge_microagent_serialization():
-    """Test serialization of a MicroagentObservation with KNOWLEDGE_MICROAGENT type."""
-    # Create a MicroagentObservation with microagent knowledge content
-    original = MicroagentObservation(
+    """Test serialization of a RecallObservation with KNOWLEDGE_MICROAGENT type."""
+    # Create a RecallObservation with microagent knowledge content
+    original = RecallObservation(
         content='Knowledge microagent information',
         recall_type=RecallType.KNOWLEDGE,
         microagent_knowledge=[
@@ -314,13 +314,13 @@ def test_microagent_observation_knowledge_microagent_serialization():
     serialized = event_to_dict(original)
 
     # Verify serialized data structure
-    assert serialized['observation'] == ObservationType.MICROAGENT
+    assert serialized['observation'] == ObservationType.RECALL
     assert serialized['content'] == 'Knowledge microagent information'
     assert serialized['extras']['recall_type'] == RecallType.KNOWLEDGE.value
     assert len(serialized['extras']['microagent_knowledge']) == 2
     assert serialized['extras']['microagent_knowledge'][0]['trigger'] == 'python'
 
-    # Deserialize back to MicroagentObservation
+    # Deserialize back to RecallObservation
     deserialized = observation_from_dict(serialized)
 
     # Verify properties are preserved
@@ -336,9 +336,9 @@ def test_microagent_observation_knowledge_microagent_serialization():
 
 
 def test_microagent_observation_environment_serialization():
-    """Test serialization of a MicroagentObservation with ENVIRONMENT type."""
-    # Create a MicroagentObservation with environment info
-    original = MicroagentObservation(
+    """Test serialization of a RecallObservation with ENVIRONMENT type."""
+    # Create a RecallObservation with environment info
+    original = RecallObservation(
         content='Environment information',
         recall_type=RecallType.WORKSPACE_CONTEXT,
         repo_name='OpenHands',
@@ -352,7 +352,7 @@ def test_microagent_observation_environment_serialization():
     serialized = event_to_dict(original)
 
     # Verify serialized data structure
-    assert serialized['observation'] == ObservationType.MICROAGENT
+    assert serialized['observation'] == ObservationType.RECALL
     assert serialized['content'] == 'Environment information'
     assert serialized['extras']['recall_type'] == RecallType.WORKSPACE_CONTEXT.value
     assert serialized['extras']['repo_name'] == 'OpenHands'
@@ -364,7 +364,7 @@ def test_microagent_observation_environment_serialization():
         serialized['extras']['additional_agent_instructions']
         == 'You know it all about this runtime'
     )
-    # Deserialize back to MicroagentObservation
+    # Deserialize back to RecallObservation
     deserialized = observation_from_dict(serialized)
 
     # Verify properties are preserved
@@ -382,11 +382,11 @@ def test_microagent_observation_environment_serialization():
 
 
 def test_microagent_observation_combined_serialization():
-    """Test serialization of a MicroagentObservation with both types of information."""
-    # Create a MicroagentObservation with both environment and microagent info
+    """Test serialization of a RecallObservation with both types of information."""
+    # Create a RecallObservation with both environment and microagent info
     # Note: In practice, recall_type would still be one specific type,
     # but the object could contain both types of fields
-    original = MicroagentObservation(
+    original = RecallObservation(
         content='Combined information',
         recall_type=RecallType.WORKSPACE_CONTEXT,
         # Environment info
@@ -419,7 +419,7 @@ def test_microagent_observation_combined_serialization():
         serialized['extras']['additional_agent_instructions']
         == 'You know it all about this runtime'
     )
-    # Deserialize back to MicroagentObservation
+    # Deserialize back to RecallObservation
     deserialized = observation_from_dict(serialized)
 
     # Verify all properties are preserved

--- a/tests/unit/test_observation_serialization.py
+++ b/tests/unit/test_observation_serialization.py
@@ -247,7 +247,7 @@ def test_microagent_observation_serialization():
     original_observation_dict = {
         'observation': 'recall',
         'content': '',
-        'message': "**RecallObservation**\nrecall_type=RecallType.WORKSPACE_CONTEXT, repo_name=some_repo_name, repo_instructions=complex_repo_instruc..., runtime_hosts={'host1': 8080, 'host2': 8081}, additional_agent_instructions=You know it all abou...",
+        'message': 'Added workspace context',
         'extras': {
             'recall_type': 'workspace_context',
             'repo_name': 'some_repo_name',
@@ -265,7 +265,7 @@ def test_microagent_observation_microagent_knowledge_serialization():
     original_observation_dict = {
         'observation': 'recall',
         'content': '',
-        'message': '**RecallObservation**\nrecall_type=RecallType.KNOWLEDGE, repo_name=, repo_instructions=..., runtime_hosts={}, additional_agent_instructions=..., microagent_knowledge=microagent1, microagent2',
+        'message': 'Added microagent knowledge',
         'extras': {
             'recall_type': 'knowledge',
             'repo_name': '',

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -51,7 +51,7 @@ At the user's request, repository {{ repository_info.repo_name }} has been clone
     assert 'System prompt: bar' in system_msg
 
     # Test building additional info
-    additional_info = manager.build_additional_info(
+    additional_info = manager.build_workspace_context(
         repository_info=repo_info, runtime_info=None, repo_instructions=''
     )
     assert '<REPOSITORY_INFO>' in additional_info
@@ -199,7 +199,7 @@ def test_add_turns_left_reminder(prompt_dir):
     )
 
 
-def test_build_additional_info_with_repo_and_runtime(prompt_dir):
+def test_build_workspace_context_with_repo_and_runtime(prompt_dir):
     """Test building additional info with repository and runtime information."""
     # Create an additional_info.j2 template file
     with open(os.path.join(prompt_dir, 'additional_info.j2'), 'w') as f:
@@ -245,7 +245,7 @@ each of which has a corresponding port:
     repo_instructions = 'This repository contains important code.'
 
     # Build additional info
-    result = manager.build_additional_info(
+    result = manager.build_workspace_context(
         repository_info=repo_info,
         runtime_info=runtime_info,
         repo_instructions=repo_instructions,

--- a/tests/unit/test_truncation.py
+++ b/tests/unit/test_truncation.py
@@ -23,7 +23,13 @@ def mock_event_stream():
 def mock_agent():
     agent = MagicMock()
     agent.llm = MagicMock()
-    agent.llm.config = MagicMock()
+
+    # Create a step function that returns an action without an ID
+    def agent_step_fn(state):
+        return MessageAction(content='Agent returned a message')
+
+    agent.step = agent_step_fn
+
     return agent
 
 


### PR DESCRIPTION
Follow-up on #6909 

@xingyaoww This PR proposes to bring back a generic name for the recall obs:
- `RecallObservations`
- with type `WORKSPACE_CONTEXT`
- or type `KNOWLEDGE` [1]

And we can also maybe look into adding:
- https://github.com/All-Hands-AI/OpenHands/issues/7290

---

I tried an alternative here, if you think just adding a new Observation type for the workspace/environment case would work better for us:
- https://github.com/All-Hands-AI/OpenHands/pull/7275

I think you're right that we need to do something about the first message, it doesn't look great.

---

Curious detail: apparently Claude Code has in its prompt:
```
# Memory
If the current working directory contains a file called CLAUDE.md, it will be automatically added to your context. 
This file serves multiple purposes:
1. Storing frequently used bash commands (build, test, lint, etc.) so you can use them without searching each time
2. Recording the user's code style preferences (naming conventions, preferred libraries, etc.)
3. Maintaining useful information about the codebase structure...
```

That's... `repo.md` maintained and recalled by the agent. (this may answer Robert's concern 😄)

Just for fun, I asked Claude in architect mode what it thinks, FWIW here's what it made of it:
[RecallObservations vs PromptExtensionObservations](https://gist.github.com/enyst/654cc71e4e2860cd2e732671072a1114)

---
[1] Maybe when we consider migrating Events to BaseModel, we can look into subclasses / type union for these subtypes. Meanwhile, the design in this PR is similar with we did with `FileEdit` events (different attributes for different conceptual subtypes). It keeps the event stream flat -ish.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3538875-nikolaik   --name openhands-app-3538875   docker.all-hands.dev/all-hands-ai/openhands:3538875
```