### PR TITLE
fix retry on the right exception & set retry on remote runtime by default

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -15,6 +15,7 @@ class SandboxConfig(BaseModel):
         timeout: The timeout for the default sandbox action execution.
         remote_runtime_init_timeout: The timeout for the remote runtime to start.
         remote_runtime_api_timeout: The timeout for the remote runtime API requests.
+        remote_runtime_enable_retries: Whether to enable retries (on recoverable errors like requests.ConnectionError) for the remote runtime API requests.
         enable_auto_lint: Whether to enable auto-lint.
         use_host_network: Whether to use the host network.
         runtime_binding_address: The binding address for the runtime ports.  It specifies which network interface on the host machine Docker should bind the runtime ports to.
@@ -53,7 +54,7 @@ class SandboxConfig(BaseModel):
     timeout: int = Field(default=120)
     remote_runtime_init_timeout: int = Field(default=180)
     remote_runtime_api_timeout: int = Field(default=10)
-    remote_runtime_enable_retries: bool = Field(default=False)
+    remote_runtime_enable_retries: bool = Field(default=True)
     remote_runtime_class: str | None = Field(
         default=None
     )  # can be "None" (default to gvisor) or "sysbox" (support docker inside runtime + more stable)

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Callable
 from urllib.parse import urlparse
@@ -425,10 +426,11 @@ class RemoteRuntime(ActionExecutionClient):
             return self._send_action_server_request_impl(method, url, **kwargs)
 
         retry_decorator = tenacity.retry(
-            retry=tenacity.retry_if_exception_type(ConnectionError),
+            retry=tenacity.retry_if_exception_type(requests.ConnectionError),
             stop=tenacity.stop_after_attempt(3)
             | stop_if_should_exit()
             | self._stop_if_closed,
+            before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
             wait=tenacity.wait_exponential(multiplier=1, min=4, max=60),
         )
         return retry_decorator(self._send_action_server_request_impl)(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Improve the stability of OpenHands application and evaluation harness by retry on ConnectionError

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

😓 We've been retrying on the WRONG exception.. We should do `requests.ConnectionError` rather than `ConnectionError`. I've tested on an evaluation run and it indeed stabilize things a bit more.

Also, this PR set retry on ConnectionError by default -- hopefully making our app itself more stable.

---
**Link of any specific issues this addresses.**
