### PR TITLE
Fix GitHub API authorization headers to use Bearer consistently (issue #6032)

### DIFF
--- a/openhands/resolver/interfaces/github.py
+++ b/openhands/resolver/interfaces/github.py
@@ -27,7 +27,7 @@ class GithubIssueHandler(IssueHandlerInterface):
 
     def get_headers(self) -> dict[str, str]:
         return {
-            'Authorization': f'token {self.token}',
+            'Authorization': f'Bearer {self.token}',
             'Accept': 'application/vnd.github.v3+json',
         }
 
@@ -450,7 +450,7 @@ class GithubPRHandler(GithubIssueHandler):
         """Download comments for a specific pull request from Github."""
         url = f'https://api.github.com/repos/{self.owner}/{self.repo}/issues/{pr_number}/comments'
         headers = {
-            'Authorization': f'token {self.token}',
+            'Authorization': f'Bearer {self.token}',
             'Accept': 'application/vnd.github.v3+json',
         }
         params = {'per_page': 100, 'page': 1}

--- a/tests/unit/resolver/github/test_issue_handler.py
+++ b/tests/unit/resolver/github/test_issue_handler.py
@@ -643,3 +643,35 @@ def test_pr_handler_get_converted_issues_with_duplicate_issue_refs():
                 'External context #1.',
                 'External context #2.',
             ]
+
+
+def test_authorization_header_format():
+    """Test that the GitHub API is called with the correct authorization header format."""
+    with patch('requests.get') as mock_get:
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        # Create an instance of GithubIssueHandler
+        handler = GithubIssueHandler('test-owner', 'test-repo', 'test-token')
+        
+        # Call a method that makes an API request
+        handler.download_issues()
+        
+        # Verify that the request was made with the correct authorization header
+        headers = mock_get.call_args[1]['headers']
+        assert headers['Authorization'] == 'Bearer test-token'
+        
+        # Reset the mock
+        mock_get.reset_mock()
+        
+        # Create an instance of GithubPRHandler
+        pr_handler = GithubPRHandler('test-owner', 'test-repo', 'test-token')
+        
+        # Call a method that makes an API request
+        pr_handler.download_issues()
+        
+        # Verify that the request was made with the correct authorization header
+        headers = mock_get.call_args[1]['headers']
+        assert headers['Authorization'] == 'Bearer test-token'


### PR DESCRIPTION
This PR fixes issue #6032 by standardizing the GitHub API authorization headers to use `Bearer` consistently instead of mixing `token` and `Bearer`.

According to the GitHub API documentation, both `Bearer` and `token` are acceptable in most cases, but using `Bearer` is required for JSON web tokens (JWT). This PR standardizes on `Bearer` for all authorization headers for consistency.

Changes:
- Updated all instances of `Authorization: token {self.token}` to use `Authorization: Bearer {self.token}`
- Added a test to verify that the GitHub API is called with the correct authorization header format

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b71ca0c414614ec784b949bf49c81429)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4ea4fb2-nikolaik   --name openhands-app-4ea4fb2   docker.all-hands.dev/all-hands-ai/openhands:4ea4fb2
```