### PR TITLE
feat(Session): add sandbox base, runtime container image to session settings

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -105,7 +105,8 @@ class Session:
         )
         self.config.sandbox.runtime_container_image = (
             settings.sandbox_runtime_container_image
-            if settings.sandbox_base_container_image 
+            if settings.sandbox_base_container_image
+            or settings.sandbox_runtime_container_image
             else self.config.sandbox.runtime_container_image
         )
         max_iterations = settings.max_iterations or self.config.max_iterations

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -105,7 +105,8 @@ class Session:
         )
         self.config.sandbox.runtime_container_image = (
             settings.sandbox_runtime_container_image
-            or self.config.sandbox.runtime_container_image
+            if settings.sandbox_base_container_image 
+            else self.config.sandbox.runtime_container_image
         )
         max_iterations = settings.max_iterations or self.config.max_iterations
 

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -99,6 +99,14 @@ class Session:
         self.config.security.security_analyzer = (
             settings.security_analyzer or self.config.security.security_analyzer
         )
+        self.config.sandbox.base_container_image = (
+            settings.sandbox_base_container_image
+            or self.config.sandbox.base_container_image
+        )
+        self.config.sandbox.runtime_container_image = (
+            settings.sandbox_runtime_container_image
+            or self.config.sandbox.runtime_container_image
+        )
         max_iterations = settings.max_iterations or self.config.max_iterations
 
         # This is a shallow copy of the default LLM config, so changes here will

--- a/openhands/server/settings.py
+++ b/openhands/server/settings.py
@@ -33,6 +33,8 @@ class Settings(BaseModel):
     enable_default_condenser: bool = False
     enable_sound_notifications: bool = False
     user_consents_to_analytics: bool | None = None
+    sandbox_base_container_image: str | None = None
+    sandbox_runtime_container_image: str | None = None
 
     model_config = {
         'validate_assignment': True,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Allows users to specify a custom base or runtime sandbox image in the POST request to /api/settings

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Add `sandbox_base_container_image` and `sandbox_runtime_container_image` to `openhands.server.settings.Settings` and update `Session.initialize_agent()` to use these custom base or runtime sandbox images.

---
**Link of any specific issues this addresses.**
