### PR TITLE
[Bug]: Refresh runtime gh token when agent calls gh apis

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -220,7 +220,7 @@ class Runtime(FileEditRuntimeMixin):
         assert event.timeout is not None
         try:
             if isinstance(event, CmdRunAction):
-                if self.user_id and '$GITHUB_TOKEN' in event.command:
+                if self.user_id and 'GITHUB_TOKEN' in event.command:
                     gh_client = GithubServiceImpl(
                         external_auth_id=self.user_id, external_token_manager=True
                     )


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Currently we only refresh the runtime token when we see that the agent is attempting to call a github api using `$GITHUB_TOKEN`. This has caused `401` errors when calling the github api because the token is expired.

The reason the runtime still has an expired token is because the current conditional isn't a catch all as the agent sometimes executes commands with `${GITHUB_tOKEN}`, etc.

This PR tries to check for `GITHUB_TOKEN` in the agent command to ensure that we're catching all possible cases. Worst case we have a false positive, and we've exported the latest github token to the runtime


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1e4303b-nikolaik   --name openhands-app-1e4303b   docker.all-hands.dev/all-hands-ai/openhands:1e4303b
```