### PR TITLE
[Debug]: Add logs to runtime to assess root cause of expired github token

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -226,6 +226,7 @@ class Runtime(FileEditRuntimeMixin):
                     gh_client = GithubServiceImpl(
                         external_auth_id=self.user_id, external_token_manager=True
                     )
+                    logger.info(f"Fetching latest github token for runtime: {self.sid}")
                     token = await gh_client.get_latest_token()
                     if not token:
                         logger.info(

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -226,7 +226,7 @@ class Runtime(FileEditRuntimeMixin):
                     gh_client = GithubServiceImpl(
                         external_auth_id=self.user_id, external_token_manager=True
                     )
-                    logger.info(f"Fetching latest github token for runtime: {self.sid}")
+                    logger.info(f'Fetching latest github token for runtime: {self.sid}')
                     token = await gh_client.get_latest_token()
                     if not token:
                         logger.info(

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -132,6 +132,7 @@ class Runtime(FileEditRuntimeMixin):
 
         self.user_id = user_id
 
+        # TODO: remove once done debugging expired github token
         self.prev_token: SecretStr | None = None
 
     def setup_initial_env(self) -> None:
@@ -229,7 +230,7 @@ class Runtime(FileEditRuntimeMixin):
                     logger.info(f'Fetching latest github token for runtime: {self.sid}')
                     token = await gh_client.get_latest_token()
                     if not token:
-                        logger.info(
+                        logger.error(
                             f'Failed to refresh github token for runtime: {self.sid}'
                         )
 
@@ -243,7 +244,7 @@ class Runtime(FileEditRuntimeMixin):
 
                         elif self.prev_token.get_secret_value() != raw_token:
                             logger.info(
-                                f'Setting [NEW] github token in runtime {self.sid}\nToken value: {raw_token[0:5]}; length: {len(raw_token)}'
+                                f'Setting new github token in runtime {self.sid}\nToken value: {raw_token[0:5]}; length: {len(raw_token)}'
                             )
 
                         self.prev_token = token

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -246,15 +246,23 @@ class Runtime(FileEditRuntimeMixin):
                             )
 
                         self.prev_token = token
-                        export_cmd = CmdRunAction(f"export GITHUB_TOKEN='{raw_token}'")
+
+                        env_vars = {
+                            'GITHUB_TOKEN': raw_token,
+                        }
+
+                        try:
+                            self.add_env_vars(env_vars)
+                        except Exception as e:
+                            logger.warning(
+                                f'Failed export latest github token to runtime: {self.sid}, {e}'
+                            )
 
                         self.event_stream.update_secrets(
                             {
                                 'github_token': raw_token,
                             }
                         )
-
-                        await call_sync_from_async(self.run, export_cmd)
 
             observation: Observation = await call_sync_from_async(
                 self.run_action, event


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR adds logging to check whether the github tokens are being refreshed and exported as expected in the runtime (for Openhands SAAS)

This PR checks 
1. Checks if the the latest token exist when agent calls github api 
2. Checks if the new token is different from the existing one in the runtime
3. Uses `self.add_env_vars to see if the export command fails


NOTE: we should remove these logs once we have figured out the root cause

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:809de89-nikolaik   --name openhands-app-809de89   docker.all-hands.dev/all-hands-ai/openhands:809de89
```