### PR TITLE
adding a basic key feature page that maps to the user interface

### DIFF
--- a/docs/modules/usage/key-features.md
+++ b/docs/modules/usage/key-features.md
@@ -1,0 +1,60 @@
+
+# OpenHands Feature Overview
+
+![overview](https://www.all-hands.dev/assets/product/product-slide-1.webp)
+
+## 1. Workspace
+The Workspace feature provides a comprehensive development environment with the following key capabilities:
+- File Explorer: Browse, view, and manage project files and directories
+- Project Management: Import, create, and navigate between different projects
+- Integrated Development Tools: Seamless integration with various development workflows
+- File Operations:
+  * View file contents
+  * Create new files and folders
+  * Upload and download files
+  * Basic file manipulation
+
+## 2. Jupyter Notebook
+The Jupyter Notebook feature offers an interactive coding and data analysis environment:
+- Interactive Code Cells: Execute Python code in a cell-based interface
+- Input and Output Tracking: Maintain a history of code inputs and their corresponding outputs
+- Persistent Session: Preserve code execution context between cells
+- Supports various Python operations and data analysis tasks
+- Real-time code execution and result visualization
+
+## 3. Browser (Beta)
+The Browser feature provides web interaction capabilities:
+- Web Page Navigation: Open and browse websites within the application
+- Screenshot Capture: Automatically generate screenshots of web pages
+- Interaction Tools:
+  * Click elements
+  * Fill out forms
+  * Scroll pages
+  * Navigate through web content
+- Supports 15 different browser interaction functions
+
+## 4. Terminal
+The Terminal feature offers a command-line interface within the application:
+- Execute Shell Commands: Run bash and system commands
+- Command History: Track and recall previous commands
+- Environment Interaction: Interact directly with the system's command line
+- Support for various programming and system administration tasks
+
+## 5. Chat / AI Conversation
+The Chat interface provides an AI-powered conversational experience:
+- Interactive AI Assistant: Engage in natural language conversations
+- Context-Aware Responses: AI understands and responds to development-related queries
+- Action Suggestions: Provides actionable recommendations for tasks
+- Conversation Management: Create, delete, and manage different conversation threads
+
+## 6. App (Beta)
+The main application interface combines all these features:
+- Integrated Workspace: Seamless integration of workspace, browser, terminal, and AI chat
+- Configurable Layout: Customize the arrangement of different feature panels
+- State Management: Maintain context and state across different features
+- Security and Privacy Controls: Manage application settings and permissions
+
+### Additional Notes
+- The application is currently in beta, with ongoing improvements and feature additions
+- Supports various development workflows and AI-assisted coding
+- Designed to enhance developer productivity through integrated tools and AI assistance

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -14,6 +14,11 @@ const sidebars: SidebarsConfig = {
       id: 'usage/getting-started',
     },
     {
+      type: 'doc',
+      label: 'Key Features',
+      id: 'usage/key-features',
+    },
+    {
       type: 'category',
       label: 'Prompting',
       items: [


### PR DESCRIPTION
- [x ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Adding documentation that maps out key terminology and experience in the web application for new users. 

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Adding documentation that maps out key terminology and experience in the web application for new users. Terms such as Workspace, Juypter, Browser, Terminal and such are not easily findable in documentation and code. This acts as a current status / overview and diving off point. Could also add additional pages for Browsing Best Practices, Working with Notebooks Best Practices. so on.

---
**Link of any specific issues this addresses.**

![Screenshot 2025-03-18 at 3 11 45 PM](https://github.com/user-attachments/assets/7db08893-24fd-4530-a385-468b9a0427cd)
