### PR TITLE
Remove download workspace and download files buttons

### DIFF
--- a/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -18,7 +18,6 @@ describe("ConversationCard", () => {
   const onClick = vi.fn();
   const onDelete = vi.fn();
   const onChangeTitle = vi.fn();
-  const onDownloadWorkspace = vi.fn();
 
   beforeAll(() => {
     vi.stubGlobal("window", { open: vi.fn() });
@@ -269,30 +268,7 @@ describe("ConversationCard", () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("should call onDownloadWorkspace when the download button is clicked", async () => {
-    const user = userEvent.setup();
-    render(
-      <ConversationCard
-        onClick={onClick}
-        onDelete={onDelete}
-        onChangeTitle={onChangeTitle}
-        onDownloadWorkspace={onDownloadWorkspace}
-        title="Conversation 1"
-        selectedRepository={null}
-        lastUpdatedAt="2021-10-01T12:00:00Z"
-      />,
-    );
 
-    const ellipsisButton = screen.getByTestId("ellipsis-button");
-    await user.click(ellipsisButton);
-
-    const menu = screen.getByTestId("context-menu");
-    const downloadButton = within(menu).getByTestId("download-button");
-
-    await user.click(downloadButton);
-
-    expect(onDownloadWorkspace).toHaveBeenCalled();
-  });
 
   it("should not display the edit or delete options if the handler is not provided", async () => {
     const user = userEvent.setup();
@@ -337,7 +313,6 @@ describe("ConversationCard", () => {
         onClick={onClick}
         onDelete={onDelete}
         onChangeTitle={onChangeTitle}
-        onDownloadWorkspace={onDownloadWorkspace}
         title="Conversation 1"
         selectedRepository={null}
         lastUpdatedAt="2021-10-01T12:00:00Z"
@@ -350,7 +325,6 @@ describe("ConversationCard", () => {
       <ConversationCard
         onClick={onClick}
         onDelete={onDelete}
-        onDownloadWorkspace={onDownloadWorkspace}
         title="Conversation 1"
         selectedRepository={null}
         lastUpdatedAt="2021-10-01T12:00:00Z"
@@ -358,18 +332,6 @@ describe("ConversationCard", () => {
     );
 
     expect(screen.getByTestId("ellipsis-button")).toBeInTheDocument();
-
-    rerender(
-      <ConversationCard
-        onClick={onClick}
-        onDownloadWorkspace={onDownloadWorkspace}
-        title="Conversation 1"
-        selectedRepository={null}
-        lastUpdatedAt="2021-10-01T12:00:00Z"
-      />,
-    );
-
-    expect(screen.queryByTestId("ellipsis-button")).toBeInTheDocument();
 
     rerender(
       <ConversationCard

--- a/frontend/__tests__/components/feedback-actions.test.tsx
+++ b/frontend/__tests__/components/feedback-actions.test.tsx
@@ -8,7 +8,6 @@ describe("TrajectoryActions", () => {
   const user = userEvent.setup();
   const onPositiveFeedback = vi.fn();
   const onNegativeFeedback = vi.fn();
-  const onExportTrajectory = vi.fn();
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -19,14 +18,12 @@ describe("TrajectoryActions", () => {
       <TrajectoryActions
         onPositiveFeedback={onPositiveFeedback}
         onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
       />,
     );
 
     const actions = screen.getByTestId("feedback-actions");
     within(actions).getByTestId("positive-feedback");
     within(actions).getByTestId("negative-feedback");
-    within(actions).getByTestId("export-trajectory");
   });
 
   it("should call onPositiveFeedback when positive feedback is clicked", async () => {
@@ -34,7 +31,6 @@ describe("TrajectoryActions", () => {
       <TrajectoryActions
         onPositiveFeedback={onPositiveFeedback}
         onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
       />,
     );
 
@@ -49,7 +45,6 @@ describe("TrajectoryActions", () => {
       <TrajectoryActions
         onPositiveFeedback={onPositiveFeedback}
         onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
       />,
     );
 
@@ -57,20 +52,5 @@ describe("TrajectoryActions", () => {
     await user.click(negativeFeedback);
 
     expect(onNegativeFeedback).toHaveBeenCalled();
-  });
-
-  it("should call onExportTrajectory when negative feedback is clicked", async () => {
-    renderWithProviders(
-      <TrajectoryActions
-        onPositiveFeedback={onPositiveFeedback}
-        onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
-      />,
-    );
-
-    const exportButton = screen.getByTestId("export-trajectory");
-    await user.click(exportButton);
-
-    expect(onExportTrajectory).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/features/chat/action-suggestions.tsx
+++ b/frontend/src/components/features/chat/action-suggestions.tsx
@@ -2,7 +2,6 @@ import posthog from "posthog-js";
 import React from "react";
 import { useSelector } from "react-redux";
 import { SuggestionItem } from "#/components/features/suggestions/suggestion-item";
-import { DownloadModal } from "#/components/shared/download-modal";
 import type { RootState } from "#/store";
 import { useAuth } from "#/context/auth-context";
 
@@ -18,21 +17,11 @@ export function ActionSuggestions({
     (state: RootState) => state.initialQuery,
   );
 
-  const [isDownloading, setIsDownloading] = React.useState(false);
   const [hasPullRequest, setHasPullRequest] = React.useState(false);
-
-  const handleDownloadClose = () => {
-    setIsDownloading(false);
-  };
 
   return (
     <div className="flex flex-col gap-2 mb-2">
-      <DownloadModal
-        initialPath=""
-        onClose={handleDownloadClose}
-        isOpen={isDownloading}
-      />
-      {githubTokenIsSet && selectedRepository ? (
+      {githubTokenIsSet && selectedRepository && (
         <div className="flex flex-row gap-2 justify-center w-full">
           {!hasPullRequest ? (
             <>
@@ -74,21 +63,6 @@ export function ActionSuggestions({
             />
           )}
         </div>
-      ) : (
-        <SuggestionItem
-          suggestion={{
-            label: !isDownloading
-              ? "Download files"
-              : "Downloading, please wait...",
-            value: "Download files",
-          }}
-          onClick={() => {
-            posthog.capture("download_workspace_button_clicked");
-            if (!isDownloading) {
-              setIsDownloading(true);
-            }
-          }}
-        />
       )}
     </div>
   );

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from "react-redux";
 import React from "react";
 import posthog from "posthog-js";
-import { useParams } from "react-router";
 import { convertImageToBase64 } from "#/utils/convert-image-to-base-64";
 import { TrajectoryActions } from "../trajectory/trajectory-actions";
 import { createChatMessage } from "#/services/chat-service";
@@ -20,9 +19,6 @@ import { ActionSuggestions } from "./action-suggestions";
 import { ContinueButton } from "#/components/shared/buttons/continue-button";
 import { ScrollToBottomButton } from "#/components/shared/buttons/scroll-to-bottom-button";
 import { LoadingSpinner } from "#/components/shared/loading-spinner";
-import { useGetTrajectory } from "#/hooks/mutation/use-get-trajectory";
-import { downloadTrajectory } from "#/utils/download-files";
-import { displayErrorToast } from "#/utils/custom-toast-handlers";
 
 function getEntryPoint(
   hasRepository: boolean | null,
@@ -51,8 +47,6 @@ export function ChatInterface() {
   const { selectedRepository, importedProjectZip } = useSelector(
     (state: RootState) => state.initialQuery,
   );
-  const params = useParams();
-  const { mutate: getTrajectory } = useGetTrajectory();
 
   const handleSendMessage = async (content: string, files: File[]) => {
     if (messages.length === 0) {
@@ -94,25 +88,6 @@ export function ChatInterface() {
   ) => {
     setFeedbackModalIsOpen(true);
     setFeedbackPolarity(polarity);
-  };
-
-  const onClickExportTrajectoryButton = () => {
-    if (!params.conversationId) {
-      displayErrorToast("ConversationId unknown, cannot download trajectory");
-      return;
-    }
-
-    getTrajectory(params.conversationId, {
-      onSuccess: async (data) => {
-        await downloadTrajectory(
-          params.conversationId ?? "unknown",
-          data.trajectory,
-        );
-      },
-      onError: (error) => {
-        displayErrorToast(error.message);
-      },
-    });
   };
 
   const isWaitingForUserInput =
@@ -161,7 +136,6 @@ export function ChatInterface() {
             onNegativeFeedback={() =>
               onClickShareFeedbackActionButton("negative")
             }
-            onExportTrajectory={() => onClickExportTrajectoryButton()}
           />
 
           <div className="absolute left-1/2 transform -translate-x-1/2 bottom-0">

--- a/frontend/src/components/features/controls/controls.tsx
+++ b/frontend/src/components/features/controls/controls.tsx
@@ -1,12 +1,10 @@
 import { useParams } from "react-router";
 import React from "react";
-import posthog from "posthog-js";
 import { AgentControlBar } from "./agent-control-bar";
 import { AgentStatusBar } from "./agent-status-bar";
 import { SecurityLock } from "./security-lock";
 import { useUserConversation } from "#/hooks/query/use-user-conversation";
 import { ConversationCard } from "../conversation-panel/conversation-card";
-import { DownloadModal } from "#/components/shared/download-modal";
 
 interface ControlsProps {
   setSecurityOpen: (isOpen: boolean) => void;
@@ -18,13 +16,6 @@ export function Controls({ setSecurityOpen, showSecurityLock }: ControlsProps) {
   const { data: conversation } = useUserConversation(
     params.conversationId ?? null,
   );
-
-  const [downloading, setDownloading] = React.useState(false);
-
-  const handleDownloadWorkspace = () => {
-    posthog.capture("download_workspace_button_clicked");
-    setDownloading(true);
-  };
 
   return (
     <div className="flex items-center justify-between">
@@ -39,17 +30,10 @@ export function Controls({ setSecurityOpen, showSecurityLock }: ControlsProps) {
 
       <ConversationCard
         variant="compact"
-        onDownloadWorkspace={handleDownloadWorkspace}
         title={conversation?.title ?? ""}
         lastUpdatedAt={conversation?.created_at ?? ""}
         selectedRepository={conversation?.selected_repository ?? null}
         status={conversation?.status}
-      />
-
-      <DownloadModal
-        initialPath=""
-        onClose={() => setDownloading(false)}
-        isOpen={downloading}
       />
     </div>
   );

--- a/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
@@ -7,7 +7,6 @@ interface ConversationCardContextMenuProps {
   onClose: () => void;
   onDelete?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onEdit?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onDownload?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   position?: "top" | "bottom";
 }
 
@@ -15,7 +14,6 @@ export function ConversationCardContextMenu({
   onClose,
   onDelete,
   onEdit,
-  onDownload,
   position = "bottom",
 }: ConversationCardContextMenuProps) {
   const ref = useClickOutsideElement<HTMLUListElement>(onClose);
@@ -38,11 +36,6 @@ export function ConversationCardContextMenu({
       {onEdit && (
         <ContextMenuListItem testId="edit-button" onClick={onEdit}>
           Edit Title
-        </ContextMenuListItem>
-      )}
-      {onDownload && (
-        <ContextMenuListItem testId="download-button" onClick={onDownload}>
-          Download Workspace
         </ContextMenuListItem>
       )}
     </ContextMenu>

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -13,7 +13,6 @@ interface ConversationCardProps {
   onClick?: () => void;
   onDelete?: () => void;
   onChangeTitle?: (title: string) => void;
-  onDownloadWorkspace?: () => void;
   isActive?: boolean;
   title: string;
   selectedRepository: string | null;
@@ -26,7 +25,6 @@ export function ConversationCard({
   onClick,
   onDelete,
   onChangeTitle,
-  onDownloadWorkspace,
   isActive,
   title,
   selectedRepository,
@@ -78,18 +76,13 @@ export function ConversationCard({
     setContextMenuVisible(false);
   };
 
-  const handleDownload = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    onDownloadWorkspace?.();
-  };
-
   React.useEffect(() => {
     if (titleMode === "edit") {
       inputRef.current?.focus();
     }
   }, [titleMode]);
 
-  const hasContextMenu = !!(onDelete || onChangeTitle || onDownloadWorkspace);
+  const hasContextMenu = !!(onDelete || onChangeTitle);
 
   return (
     <div
@@ -145,7 +138,6 @@ export function ConversationCard({
               onClose={() => setContextMenuVisible(false)}
               onDelete={onDelete && handleDelete}
               onEdit={onChangeTitle && handleEdit}
-              onDownload={onDownloadWorkspace && handleDownload}
               position={variant === "compact" ? "top" : "bottom"}
             />
           )}

--- a/frontend/src/components/features/trajectory/trajectory-actions.tsx
+++ b/frontend/src/components/features/trajectory/trajectory-actions.tsx
@@ -1,19 +1,16 @@
 import { useTranslation } from "react-i18next";
 import ThumbsUpIcon from "#/icons/thumbs-up.svg?react";
 import ThumbDownIcon from "#/icons/thumbs-down.svg?react";
-import ExportIcon from "#/icons/export.svg?react";
 import { TrajectoryActionButton } from "#/components/shared/buttons/trajectory-action-button";
 
 interface TrajectoryActionsProps {
   onPositiveFeedback: () => void;
   onNegativeFeedback: () => void;
-  onExportTrajectory: () => void;
 }
 
 export function TrajectoryActions({
   onPositiveFeedback,
   onNegativeFeedback,
-  onExportTrajectory,
 }: TrajectoryActionsProps) {
   const { t } = useTranslation();
 
@@ -30,12 +27,6 @@ export function TrajectoryActions({
         onClick={onNegativeFeedback}
         icon={<ThumbDownIcon width={15} height={15} />}
         tooltip={t("BUTTON$MARK_NOT_HELPFUL")}
-      />
-      <TrajectoryActionButton
-        testId="export-trajectory"
-        onClick={onExportTrajectory}
-        icon={<ExportIcon width={15} height={15} />}
-        tooltip={t("BUTTON$EXPORT_CONVERSATION")}
       />
     </div>
   );


### PR DESCRIPTION
This PR removes the download workspace button from the conversation card and the download files button from the action suggestions. These features are no longer working properly and have been removed as requested.