### PR TITLE
Implement condenser interface

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -165,7 +165,13 @@ class CodeActAgent(Agent):
             with_caching=self.llm.is_caching_prompt_active()
         )
 
-        # Condense the events from the state.
+        # Check if we need to condense the history and add a condensation action
+        condensation_action = self.condenser.get_condensation_action(state)
+        if condensation_action:
+            # Add the condensation action to the state history
+            state.add_event(condensation_action)
+            
+        # Get the condensed history for processing
         events = self.condenser.condensed_history(state)
 
         logger.debug(

--- a/openhands/memory/condenser/condenser.py
+++ b/openhands/memory/condenser/condenser.py
@@ -270,6 +270,7 @@ class RollingCondenser(Condenser, ABC):
             
             # Reconstruct the condensation result based on the condenser's structure
             # For LLMSummarizingCondenser, this would be head + condensation_action
+            # We need to use the keep_first attribute if it exists, otherwise just use the condensation action
             head = state.history[:min(self.keep_first, len(state.history))] if hasattr(self, 'keep_first') else []
             self._condensation = head + [condensation_action]
             self._last_history_length = last_processed_index
@@ -365,6 +366,7 @@ class RollingCondenser(Condenser, ABC):
         
         # Reconstruct the condensation result based on the condenser's structure
         # For LLMSummarizingCondenser, this would be head + condensation_action
+        # We need to use the keep_first attribute if it exists, otherwise just use the condensation action
         head = state.history[:min(self.keep_first, len(state.history))] if hasattr(self, 'keep_first') else []
         condensation = head + [condensation_action]
         

--- a/openhands/memory/condenser/impl/llm_summarizing_condenser.py
+++ b/openhands/memory/condenser/impl/llm_summarizing_condenser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from openhands.core.config.condenser_config import LLMSummarizingCondenserConfig
 from openhands.core.message import Message, TextContent
+from openhands.controller.state.state import State
 from openhands.events.action.agent import AgentCondensationAction
 from openhands.events.event import Event
 from openhands.llm import LLM


### PR DESCRIPTION
(openhands-ai)

This PR adds the necessary changes to the CodeActAgent to properly persist condensation actions in the event stream.

- Added call to condenser.get_condensation_action(state)
- Added logic to add condensation_action to state if one is returned
- Preserved existing call to condenser.condensed_history(state)

This PR is intended to be merged into PR #7311 (condenser-visibility branch).