### PR TITLE
Fix for broken retry

### DIFF
--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -24,7 +24,7 @@ class RequestHTTPError(requests.HTTPError):
 
 def is_retryable_error(exception):
     return (
-        isinstance(exception, (requests.HTTPError, RequestHTTPError))
+        isinstance(exception, requests.HTTPError)
         and exception.response.status_code == 429
     ) or isinstance(exception, requests.exceptions.ConnectionError)
 

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -24,7 +24,7 @@ class RequestHTTPError(requests.HTTPError):
 
 def is_retryable_error(exception):
     return (
-        isinstance(exception, requests.HTTPError)
+        isinstance(exception, (requests.HTTPError, RequestHTTPError))
         and exception.response.status_code == 429
     )
 

--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -26,7 +26,7 @@ def is_retryable_error(exception):
     return (
         isinstance(exception, (requests.HTTPError, RequestHTTPError))
         and exception.response.status_code == 429
-    )
+    ) or isinstance(exception, requests.exceptions.ConnectionError)
 
 
 @retry(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Fix for issue where function with the sole purpose of retrying http connections does not retry http connections.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
The `send_request` function was refactored to raise a `RequestHTTPError` instance in the event of http errors, but the retry check still checked for the old exception type.

This also fixes the error on local where if the runtime build is taking too long, you get a "Timeout" message in the UI

We also consider connection errors to be retryable.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:678421d-nikolaik   --name openhands-app-678421d   docker.all-hands.dev/all-hands-ai/openhands:678421d
```