### PR TITLE
Save agent state

### DIFF
--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -111,12 +111,13 @@ class State:
                 get_conversation_agent_state_filename(sid, user_id), encoded
             )
 
-            # see if state is in old directory. If yes, delete it.
-            filename = get_conversation_agent_state_filename(sid)
-            try:
-                file_store.delete(filename)
-            except Exception:
-                pass
+            # see if state is in the old directory on saas use case and delete it.
+            if user_id:
+                filename = get_conversation_agent_state_filename(sid)
+                try:
+                    file_store.delete(filename)
+                except Exception:
+                    pass
         except Exception as e:
             logger.error(f'Failed to save state to session: {e}')
             raise e

--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -138,7 +138,7 @@ class State:
             pickled = base64.b64decode(encoded)
             state = pickle.loads(pickled)
         except FileNotFoundError:
-            # if user_id is not provided, we are in a saas/remote use case
+            # if user_id is provided, we are in a saas/remote use case
             # and we need to check if the state is in the old directory.
             if user_id:
                 filename = get_conversation_agent_state_filename(sid)

--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -111,7 +111,7 @@ class State:
                 get_conversation_agent_state_filename(sid, user_id), encoded
             )
 
-            # see if state is in the old directory on saas use case and delete it.
+            # see if state is in the old directory on saas/remote use cases and delete it.
             if user_id:
                 filename = get_conversation_agent_state_filename(sid)
                 try:

--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -126,6 +126,11 @@ class State:
     def restore_from_session(
         sid: str, file_store: FileStore, user_id: str | None = None
     ) -> 'State':
+        """
+        Restores the state from the previously saved session.
+        """
+
+        state: State
         try:
             encoded = file_store.read(
                 get_conversation_agent_state_filename(sid, user_id)
@@ -133,12 +138,17 @@ class State:
             pickled = base64.b64decode(encoded)
             state = pickle.loads(pickled)
         except FileNotFoundError:
+            # if user_id is not provided, we are in a saas/remote use case
+            # and we need to check if the state is in the old directory.
             if user_id:
-                # see if state is in old directory. If yes, load it.
                 filename = get_conversation_agent_state_filename(sid)
                 encoded = file_store.read(filename)
                 pickled = base64.b64decode(encoded)
                 state = pickle.loads(pickled)
+            else:
+                raise FileNotFoundError(
+                    f'Could not restore state from session file for sid: {sid}'
+                )
         except Exception as e:
             logger.debug(f'Could not restore state from session: {e}')
             raise e


### PR DESCRIPTION
---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This is a quick fix to save the local agent state pickle. Currently on `main`, I see:
```
01:41:58 - openhands:DEBUG: state.py:107 - Saving state to session acd72a11dd5340ac971230b26a80dea9:stopped
01:41:58 - openhands:DEBUG: local.py:46 - Removed local file: /Users/enyst/repos/odie/cache/sessions/acd72a11dd5340ac971230b26a80dea9/agent_state.pkl
```

I think we want something like this little bit in https://github.com/All-Hands-AI/OpenHands/pull/7340 😅 

_Updated to add:_ also this bit
```
01:57:44 - openhands:WARNING: agent_session.py:382 - State could not be restored: cannot access local variable 'state' where it is not associated with a value
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b3b78f0-nikolaik   --name openhands-app-b3b78f0   docker.all-hands.dev/all-hands-ai/openhands:b3b78f0
```