### PR TITLE
Create LLM outside agent controller and pass it in directly

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -601,9 +601,10 @@ class AgentController:
         """
         agent_cls: Type[Agent] = Agent.get_cls(action.agent)
         agent_config = self.agent_configs.get(action.agent, self.agent.config)
-        
-        # Use the existing LLM directly instead of creating a new one
-        delegate_agent = agent_cls(llm=self.agent.llm, config=agent_config)
+        llm_config = self.agent_to_llm_config.get(action.agent, self.agent.llm.config)
+        # Create a new LLM instance for the delegate with its own config
+        llm = LLM(config=llm_config, retry_listener=self._notify_on_llm_retry)
+        delegate_agent = agent_cls(llm=llm, config=agent_config)
         state = State(
             inputs=action.inputs or {},
             local_iteration=0,
@@ -617,7 +618,7 @@ class AgentController:
         )
         self.log(
             'debug',
-            f'start delegate, creating agent {delegate_agent.name} using existing LLM {self.agent.llm}',
+            f'start delegate, creating agent {delegate_agent.name} using LLM {llm}',
         )
 
         # Create the delegate with is_delegate=True so it does NOT subscribe directly

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -114,7 +114,7 @@ class AgentController:
         """Initializes a new instance of the AgentController class.
 
         Args:
-            agent: The agent instance to control.
+            agent: The agent instance to control. The agent should already have an initialized LLM.
             event_stream: The event stream to publish events to.
             max_iterations: The maximum number of iterations the agent can run.
             max_budget_per_task: The maximum budget (in USD) allowed per task, beyond which the agent will stop.
@@ -601,9 +601,9 @@ class AgentController:
         """
         agent_cls: Type[Agent] = Agent.get_cls(action.agent)
         agent_config = self.agent_configs.get(action.agent, self.agent.config)
-        llm_config = self.agent_to_llm_config.get(action.agent, self.agent.llm.config)
-        llm = LLM(config=llm_config, retry_listener=self._notify_on_llm_retry)
-        delegate_agent = agent_cls(llm=llm, config=agent_config)
+        
+        # Use the existing LLM directly instead of creating a new one
+        delegate_agent = agent_cls(llm=self.agent.llm, config=agent_config)
         state = State(
             inputs=action.inputs or {},
             local_iteration=0,
@@ -617,7 +617,7 @@ class AgentController:
         )
         self.log(
             'debug',
-            f'start delegate, creating agent {delegate_agent.name} using LLM {llm}',
+            f'start delegate, creating agent {delegate_agent.name} using existing LLM {self.agent.llm}',
         )
 
         # Create the delegate with is_delegate=True so it does NOT subscribe directly

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -166,12 +166,17 @@ def create_memory(
     return memory
 
 
-def create_agent(config: AppConfig) -> Agent:
+def create_agent(config: AppConfig, llm: LLM | None = None) -> Agent:
     agent_cls: Type[Agent] = Agent.get_cls(config.default_agent)
     agent_config = config.get_agent_config(config.default_agent)
-    llm_config = config.get_llm_config_from_agent(config.default_agent)
+
+    # Create LLM if not provided
+    if llm is None:
+        llm_config = config.get_llm_config_from_agent(config.default_agent)
+        llm = LLM(config=llm_config)
+
     agent = agent_cls(
-        llm=LLM(config=llm_config),
+        llm=llm,
         config=agent_config,
     )
 
@@ -197,6 +202,7 @@ def create_controller(
     except Exception as e:
         logger.debug(f'Cannot restore agent state: {e}')
 
+    # The agent already has an initialized LLM
     controller = AgentController(
         agent=agent,
         max_iterations=config.max_iterations,

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -139,9 +139,7 @@ class AgentSession:
 
             if git_provider_tokens:
                 provider_handler = ProviderHandler(provider_tokens=git_provider_tokens)
-                await provider_handler.set_event_stream_secrets(
-                    self.event_stream
-                )
+                await provider_handler.set_event_stream_secrets(self.event_stream)
 
             if not self._closed:
                 if initial_message:
@@ -243,12 +241,15 @@ class AgentSession:
                 headless_mode=False,
                 attach_to_existing=False,
                 git_provider_tokens=git_provider_tokens,
-                user_id=self.user_id
+                user_id=self.user_id,
             )
         else:
-            provider_handler = ProviderHandler(provider_tokens=git_provider_tokens or cast(PROVIDER_TOKEN_TYPE, MappingProxyType({})))
+            provider_handler = ProviderHandler(
+                provider_tokens=git_provider_tokens
+                or cast(PROVIDER_TOKEN_TYPE, MappingProxyType({}))
+            )
             env_vars = await provider_handler.get_env_vars(expose_secrets=True)
-        
+
             self.runtime = runtime_cls(
                 config=config,
                 event_stream=self.event_stream,
@@ -257,7 +258,7 @@ class AgentSession:
                 status_callback=self._status_callback,
                 headless_mode=False,
                 attach_to_existing=False,
-                env_vars=env_vars
+                env_vars=env_vars,
             )
 
         # FIXME: this sleep is a terrible hack.
@@ -329,6 +330,7 @@ class AgentSession:
         )
         self.logger.debug(msg)
 
+        # The agent already has an initialized LLM
         controller = AgentController(
             sid=self.sid,
             event_stream=self.event_stream,


### PR DESCRIPTION
This PR modifies the code to create the LLM outside the agent controller and pass it to the controller.

Changes:
1. Modified the `create_agent` function in `openhands/core/setup.py` to accept an optional LLM parameter
2. Updated the documentation in the `AgentController.__init__` method to clarify that the agent should already have an initialized LLM
3. Added comments in the code to indicate that the agent already has an initialized LLM

The delegate agent still creates its own LLM with its own configuration, as different agents may need different LLM configurations.