### PR TITLE
chore: daytona runtime windows README.md and docs

### DIFF
--- a/docs/modules/usage/runtimes/daytona.md
+++ b/docs/modules/usage/runtimes/daytona.md
@@ -10,16 +10,30 @@ You can use [Daytona](https://www.daytona.io/) as a runtime provider:
 
 ## Step 2: Set Your API Key as an Environment Variable
 Run the following command in your terminal, replacing `<your-api-key>` with the actual key you copied:
+
+### Mac/Linux:
 ```bash
 export DAYTONA_API_KEY="<your-api-key>"
+```
+
+### Windows PowerShell:
+```powershell
+$env:DAYTONA_API_KEY="<your-api-key>"
 ```
 
 This step ensures that OpenHands can authenticate with the Daytona platform when it runs.
 
 ## Step 3: Run OpenHands Locally Using Docker
 To start the latest version of OpenHands on your machine, execute the following command in your terminal:
+
+### Mac/Linux:
 ```bash
 bash -i <(curl -sL https://get.daytona.io/openhands)
+```
+
+### Windows:
+```powershell
+powershell -Command "irm https://get.daytona.io/openhands-windows | iex"
 ```
 
 ### What This Command Does:

--- a/openhands/runtime/impl/daytona/README.md
+++ b/openhands/runtime/impl/daytona/README.md
@@ -12,16 +12,30 @@
 
 ### Step 2: Set Your API Key as an Environment Variable
 Run the following command in your terminal, replacing `<your-api-key>` with the actual key you copied:
+
+Mac/Linux:
 ```bash
 export DAYTONA_API_KEY="<your-api-key>"
+```
+
+Windows PowerShell:
+```powershell
+$env:DAYTONA_API_KEY="<your-api-key>"
 ```
 
 This step ensures that OpenHands can authenticate with the Daytona platform when it runs.
 
 ### Step 3: Run OpenHands Locally Using Docker
 To start the latest version of OpenHands on your machine, execute the following command in your terminal:
+
+Mac/Linux:
 ```bash
 bash -i <(curl -sL https://get.daytona.io/openhands)
+```
+
+Windows:
+```powershell
+powershell -Command "irm https://get.daytona.io/openhands-windows | iex"
 ```
 
 #### What This Command Does:
@@ -36,8 +50,14 @@ Once executed, OpenHands should be running locally and ready for use.
 ### Step 1: Set the `OPENHANDS_VERSION` Environment Variable
 Run the following command in your terminal, replacing `<openhands-release>` with the latest release's version seen in the [main README.md file](https://github.com/All-Hands-AI/OpenHands?tab=readme-ov-file#-quick-start):
 
+#### Mac/Linux:
 ```bash
 export OPENHANDS_VERSION="<openhands-release>"  # e.g. 0.27
+```
+
+#### Windows PowerShell:
+```powershell
+$env:OPENHANDS_VERSION="<openhands-release>"  # e.g. 0.27
 ```
 
 ### Step 2: Retrieve Your Daytona API Key
@@ -48,13 +68,21 @@ export OPENHANDS_VERSION="<openhands-release>"  # e.g. 0.27
 
 ### Step 3: Set Your API Key as an Environment Variable:
 Run the following command in your terminal, replacing `<your-api-key>` with the actual key you copied:
+
+#### Mac/Linux:
 ```bash
 export DAYTONA_API_KEY="<your-api-key>"
+```
+
+#### Windows PowerShell:
+```powershell
+$env:DAYTONA_API_KEY="<your-api-key>"
 ```
 
 ### Step 4: Run the following `docker` command:
 This command pulls and runs the OpenHands container using Docker. Once executed, OpenHands should be running locally and ready for use.
 
+#### Mac/Linux:
 ```bash
 docker run -it --rm --pull=always \
     -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:${OPENHANDS_VERSION}-nikolaik \
@@ -67,15 +95,35 @@ docker run -it --rm --pull=always \
     docker.all-hands.dev/all-hands-ai/openhands:${OPENHANDS_VERSION}
 ```
 
+#### Windows:
+```powershell
+docker run -it --rm --pull=always `
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:${env:OPENHANDS_VERSION}-nikolaik `
+    -e LOG_ALL_EVENTS=true `
+    -e RUNTIME=daytona `
+    -e DAYTONA_API_KEY=${env:DAYTONA_API_KEY} `
+    -v ~/.openhands-state:/.openhands-state `
+    -p 3000:3000 `
+    --name openhands-app `
+    docker.all-hands.dev/all-hands-ai/openhands:${env:OPENHANDS_VERSION}
+```
+
 > **Tip:** If you don't want your sandboxes to default to the EU region, you can set the `DAYTONA_TARGET` environment variable to `us`
 
 ### Running OpenHands Locally Without Docker
 
 Alternatively, if you want to run the OpenHands app on your local machine using `make run` without Docker, make sure to set the following environment variables first:
 
+#### Mac/Linux:
 ```bash
 export RUNTIME="daytona"
 export DAYTONA_API_KEY="<your-api-key>"
+```
+
+#### Windows PowerShell:
+```powershell
+$env:RUNTIME="daytona"
+$env:DAYTONA_API_KEY="<your-api-key>"
 ```
 
 ## Documentation


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Adds Windows setup steps for Daytona runtime with OpenHands into the runtime README.md and to the docs. Clarifies that the existing commands refer to Mac/Linux