### PR TITLE
(Chore): Use OH logger instead of prints for resolver

### DIFF
--- a/openhands/resolver/interfaces/github.py
+++ b/openhands/resolver/interfaces/github.py
@@ -178,12 +178,12 @@ class GithubIssueHandler(IssueHandlerInterface):
         return all_comments if all_comments else None
 
     def branch_exists(self, branch_name: str) -> bool:
-        print(f'Checking if branch {branch_name} exists...')
+        logger.info(f'Checking if branch {branch_name} exists...')
         response = requests.get(
             f'{self.base_url}/branches/{branch_name}', headers=self.headers
         )
         exists = response.status_code == 200
-        print(f'Branch {branch_name} exists: {exists}')
+        logger.info(f'Branch {branch_name} exists: {exists}')
         return exists
 
     def get_branch_name(self, base_branch_name: str) -> str:
@@ -253,8 +253,8 @@ class GithubIssueHandler(IssueHandlerInterface):
             json=review_data,
         )
         if review_response.status_code != 201:
-            print(
-                f'Warning: Failed to request review from {reviewer}: {review_response.text}'
+            logger.warning(
+                f'Failed to request review from {reviewer}: {review_response.text}'
             )
 
     def send_comment_msg(self, issue_number: int, msg: str) -> None:
@@ -271,11 +271,11 @@ class GithubIssueHandler(IssueHandlerInterface):
             comment_url, headers=self.headers, json=comment_data
         )
         if comment_response.status_code != 201:
-            print(
+            logger.error(
                 f'Failed to post comment: {comment_response.status_code} {comment_response.text}'
             )
         else:
-            print(f'Comment added to the PR: {msg}')
+            logger.info(f'Comment added to the PR: {msg}')
 
     def get_context_from_external_issues_references(
         self,

--- a/openhands/resolver/interfaces/gitlab.py
+++ b/openhands/resolver/interfaces/gitlab.py
@@ -181,12 +181,12 @@ class GitlabIssueHandler(IssueHandlerInterface):
         return all_comments if all_comments else None
 
     def branch_exists(self, branch_name: str) -> bool:
-        print(f'Checking if branch {branch_name} exists...')
+        logger.info(f'Checking if branch {branch_name} exists...')
         response = requests.get(
             f'{self.base_url}/repository/branches/{branch_name}', headers=self.headers
         )
         exists = response.status_code == 200
-        print(f'Branch {branch_name} exists: {exists}')
+        logger.info(f'Branch {branch_name} exists: {exists}')
         return exists
 
     def get_branch_name(self, base_branch_name: str) -> str:
@@ -263,8 +263,8 @@ class GitlabIssueHandler(IssueHandlerInterface):
                 json=review_data,
             )
             if review_response.status_code != 200:
-                print(
-                    f'Warning: Failed to request review from {reviewer}: {review_response.text}'
+                logger.warning(
+                    f'Failed to request review from {reviewer}: {review_response.text}'
                 )
 
     def send_comment_msg(self, issue_number: int, msg: str) -> None:
@@ -281,11 +281,11 @@ class GitlabIssueHandler(IssueHandlerInterface):
             comment_url, headers=self.headers, json=comment_data
         )
         if comment_response.status_code != 201:
-            print(
+            logger.error(
                 f'Failed to post comment: {comment_response.status_code} {comment_response.text}'
             )
         else:
-            print(f'Comment added to the PR: {msg}')
+            logger.info(f'Comment added to the PR: {msg}')
 
     def get_context_from_external_issues_references(
         self,

--- a/openhands/resolver/resolve_all_issues.py
+++ b/openhands/resolver/resolve_all_issues.py
@@ -27,9 +27,9 @@ from openhands.resolver.utils import (
 
 
 def cleanup() -> None:
-    print('Cleaning up child processes...')
+    logger.info('Cleaning up child processes...')
     for process in mp.active_children():
-        print(f'Terminating child process: {process.name}')
+        logger.info(f'Terminating child process: {process.name}')
         process.terminate()
         process.join()
 
@@ -222,7 +222,7 @@ async def resolve_issues(
         await asyncio.gather(*[run_with_semaphore(task) for task in tasks])
 
     except KeyboardInterrupt:
-        print('KeyboardInterrupt received. Cleaning up...')
+        logger.info('KeyboardInterrupt received. Cleaning up...')
         cleanup()
 
     output_fp.close()

--- a/openhands/resolver/send_pull_request.py
+++ b/openhands/resolver/send_pull_request.py
@@ -205,7 +205,9 @@ def make_commit(repo_dir: str, issue: Issue, issue_type: str) -> None:
 
     # If there are no changes, raise an error
     if not status_result.stdout.strip():
-        logger.error(f'No changes to commit for issue #{issue.number}. Skipping commit.')
+        logger.error(
+            f'No changes to commit for issue #{issue.number}. Skipping commit.'
+        )
         raise RuntimeError('ERROR: Openhands failed to make code changes.')
 
     # Prepare the commit message

--- a/openhands/resolver/send_pull_request.py
+++ b/openhands/resolver/send_pull_request.py
@@ -36,7 +36,7 @@ def apply_patch(repo_dir: str, patch: str) -> None:
     diffs = parse_patch(patch)
     for diff in diffs:
         if not diff.header.new_path:
-            print('Warning: Could not determine file to patch')
+            logger.warning('Could not determine file to patch')
             continue
 
         # Remove both "a/" and "b/" prefixes from paths
@@ -56,7 +56,7 @@ def apply_patch(repo_dir: str, patch: str) -> None:
             assert old_path is not None
             if os.path.exists(old_path):
                 os.remove(old_path)
-                print(f'Deleted file: {old_path}')
+                logger.info(f'Deleted file: {old_path}')
             continue
 
         # Handle file rename
@@ -106,7 +106,7 @@ def apply_patch(repo_dir: str, patch: str) -> None:
             split_content = []
 
         if diff.changes is None:
-            print(f'Warning: No changes to apply for {old_path}')
+            logger.warning(f'No changes to apply for {old_path}')
             continue
 
         new_content = apply_diff(diff, split_content)
@@ -119,7 +119,7 @@ def apply_patch(repo_dir: str, patch: str) -> None:
             for line in new_content:
                 print(line, file=f)
 
-    print('Patch applied successfully')
+    logger.info('Patch applied successfully')
 
 
 def initialize_repo(
@@ -143,7 +143,7 @@ def initialize_repo(
         shutil.rmtree(dest_dir)
 
     shutil.copytree(src_dir, dest_dir)
-    print(f'Copied repository to {dest_dir}')
+    logger.info(f'Copied repository to {dest_dir}')
 
     # Checkout the base commit if provided
     if base_commit:
@@ -154,7 +154,7 @@ def initialize_repo(
             text=True,
         )
         if result.returncode != 0:
-            print(f'Error checking out commit: {result.stderr}')
+            logger.info(f'Error checking out commit: {result.stderr}')
             raise RuntimeError('Failed to check out commit')
 
     return dest_dir
@@ -185,14 +185,14 @@ def make_commit(repo_dir: str, issue: Issue, issue_type: str) -> None:
             shell=True,
             check=True,
         )
-        print('Git user configured as openhands')
+        logger.info('Git user configured as openhands')
 
     # Add all changes to the git index
     result = subprocess.run(
         f'git -C {repo_dir} add .', shell=True, capture_output=True, text=True
     )
     if result.returncode != 0:
-        print(f'Error adding files: {result.stderr}')
+        logger.error(f'Error adding files: {result.stderr}')
         raise RuntimeError('Failed to add files to git')
 
     # Check the status of the git index
@@ -205,7 +205,7 @@ def make_commit(repo_dir: str, issue: Issue, issue_type: str) -> None:
 
     # If there are no changes, raise an error
     if not status_result.stdout.strip():
-        print(f'No changes to commit for issue #{issue.number}. Skipping commit.')
+        logger.error(f'No changes to commit for issue #{issue.number}. Skipping commit.')
         raise RuntimeError('ERROR: Openhands failed to make code changes.')
 
     # Prepare the commit message
@@ -269,7 +269,7 @@ def send_pull_request(
     )
 
     # Get the default branch or use specified target branch
-    print('Getting base branch...')
+    logger.info('Getting base branch...')
     if target_branch:
         base_branch = target_branch
         exists = handler.branch_exists(branch_name=target_branch)
@@ -277,17 +277,17 @@ def send_pull_request(
             raise ValueError(f'Target branch {target_branch} does not exist')
     else:
         base_branch = handler.get_default_branch_name()
-    print(f'Base branch: {base_branch}')
+    logger.info(f'Base branch: {base_branch}')
 
     # Create and checkout the new branch
-    print('Creating new branch...')
+    logger.info('Creating new branch...')
     result = subprocess.run(
         ['git', '-C', patch_dir, 'checkout', '-b', branch_name],
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
-        print(f'Error creating new branch: {result.stderr}')
+        logger.error(f'Error creating new branch: {result.stderr}')
         raise RuntimeError(
             f'Failed to create a new branch {branch_name} in {patch_dir}:'
         )
@@ -297,7 +297,7 @@ def send_pull_request(
 
     handler._strategy.set_owner(push_owner)
 
-    print('Pushing changes...')
+    logger.info('Pushing changes...')
     push_url = handler.get_clone_url()
     result = subprocess.run(
         ['git', '-C', patch_dir, 'push', push_url, branch_name],
@@ -305,7 +305,7 @@ def send_pull_request(
         text=True,
     )
     if result.returncode != 0:
-        print(f'Error pushing changes: {result.stderr}')
+        logger.error(f'Error pushing changes: {result.stderr}')
         raise RuntimeError('Failed to push changes to the remote repository')
 
     # Prepare the PR data: title and body
@@ -334,13 +334,12 @@ def send_pull_request(
         pr_data = handler.create_pull_request(data)
         url = pr_data['html_url']
 
-        print(pr_data)
         # Request review if a reviewer was specified
         if reviewer and pr_type != 'branch':
             number = pr_data['number']
             handler.request_reviewers(reviewer, number)
 
-    print(
+    logger.info(
         f'{pr_type} created: {url}\n\n--- Title: {final_pr_title}\n\n--- Body:\n{pr_body}'
     )
 
@@ -393,11 +392,11 @@ def update_existing_pull_request(
     # Push the changes to the existing branch
     result = subprocess.run(push_command, shell=True, capture_output=True, text=True)
     if result.returncode != 0:
-        print(f'Error pushing changes: {result.stderr}')
+        logger.error(f'Error pushing changes: {result.stderr}')
         raise RuntimeError('Failed to push changes to the remote repository')
 
     pr_url = handler.get_pull_url(issue.number)
-    print(f'Updated pull request {pr_url} with new patches.')
+    logger.info(f'Updated pull request {pr_url} with new patches.')
 
     # Generate a summary of all comment success indicators for PR message
     if not comment_message and additional_message:
@@ -463,7 +462,7 @@ def process_single_issue(
     pr_title: str | None = None,
 ) -> None:
     if not resolver_output.success and not send_on_failure:
-        print(
+        logger.info(
             f'Issue {resolver_output.issue.number} was not successfully resolved. Skipping PR creation.'
         )
         return
@@ -529,7 +528,7 @@ def process_all_successful_issues(
     output_path = os.path.join(output_dir, 'output.jsonl')
     for resolver_output in load_all_resolver_outputs(output_path):
         if resolver_output.success:
-            print(f'Processing issue {resolver_output.issue.number}')
+            logger.info(f'Processing issue {resolver_output.issue.number}')
             process_single_issue(
                 output_dir,
                 resolver_output,

--- a/openhands/resolver/utils.py
+++ b/openhands/resolver/utils.py
@@ -50,7 +50,7 @@ def identify_token(token: str, selected_repo: str | None = None) -> Platform:
             if github_repo_response.status_code == 200:
                 return Platform.GITHUB
         except requests.RequestException as e:
-            print(f'Error connecting to GitHub API (selected_repo check): {e}')
+            logger.error(f'Error connecting to GitHub API (selected_repo check): {e}')
 
     # Try GitHub PAT format (token)
     github_url = 'https://api.github.com/user'
@@ -61,7 +61,7 @@ def identify_token(token: str, selected_repo: str | None = None) -> Platform:
         if github_response.status_code == 200:
             return Platform.GITHUB
     except requests.RequestException as e:
-        print(f'Error connecting to GitHub API: {e}')
+        logger.error(f'Error connecting to GitHub API: {e}')
 
     # Try GitLab token
     gitlab_url = 'https://gitlab.com/api/v4/user'
@@ -72,7 +72,7 @@ def identify_token(token: str, selected_repo: str | None = None) -> Platform:
         if gitlab_response.status_code == 200:
             return Platform.GITLAB
     except requests.RequestException as e:
-        print(f'Error connecting to GitLab API: {e}')
+        logger.error(f'Error connecting to GitLab API: {e}')
 
     return Platform.INVALID
 
@@ -128,9 +128,9 @@ def codeact_user_response(
 
 
 def cleanup() -> None:
-    print('Cleaning up child processes...')
+    logger.info('Cleaning up child processes...')
     for process in mp.active_children():
-        print(f'Terminating child process: {process.name}')
+        logger.info(f'Terminating child process: {process.name}')
         process.terminate()
         process.join()
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Noticed we had a log of print statements checked in, we should update these to use the logger

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:16dee19-nikolaik   --name openhands-app-16dee19   docker.all-hands.dev/all-hands-ai/openhands:16dee19
```