### PR TITLE
Fix flaky test

### DIFF
--- a/frontend/__tests__/routes/home.test.tsx
+++ b/frontend/__tests__/routes/home.test.tsx
@@ -51,6 +51,8 @@ afterEach(() => {
 });
 
 describe("Home Screen", () => {
+  const getConfigSpy = vi.spyOn(OpenHands, "getConfig");
+
   it("should render the home screen", () => {
     renderWithProviders(<RouterStub initialEntries={["/"]} />);
   });
@@ -67,6 +69,14 @@ describe("Home Screen", () => {
   });
 
   it("should navigate to the settings when pressing 'Connect to GitHub' if the user isn't authenticated", async () => {
+    // @ts-expect-error - we only need APP_MODE for this test
+    getConfigSpy.mockResolvedValue({
+      APP_MODE: "oss",
+      FEATURE_FLAGS: {
+        ENABLE_BILLING: false,
+        HIDE_LLM_SETTINGS: false,
+      },
+    });
     const user = userEvent.setup();
     renderWithProviders(<RouterStub initialEntries={["/"]} />);
 
@@ -119,7 +129,13 @@ describe("Settings 404", () => {
 
   it("should not open the settings modal if GET /settings fails but is SaaS mode", async () => {
     // @ts-expect-error - we only need APP_MODE for this test
-    getConfigSpy.mockResolvedValue({ APP_MODE: "saas" });
+    getConfigSpy.mockResolvedValue({
+      APP_MODE: "saas",
+      FEATURE_FLAGS: {
+        ENABLE_BILLING: false,
+        HIDE_LLM_SETTINGS: false,
+      },
+    });
     const error = createAxiosNotFoundErrorObject();
     getSettingsSpy.mockRejectedValue(error);
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Tests would sometimes fail unpredictably. This is possibly due to the `APP_MODE` returning "saas" instead of "oss" when the test requires it

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:dfa6379-nikolaik   --name openhands-app-dfa6379   docker.all-hands.dev/all-hands-ai/openhands:dfa6379
```