### PR TITLE
Change API key placeholder from ******** to <hidden>

### DIFF
--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -74,7 +74,7 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
     }
   };
 
-  const isLLMKeySet = settings.LLM_API_KEY === "**********";
+  const isLLMKeySet = settings.LLM_API_KEY === "<hidden>";
 
   return (
     <div>

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -73,7 +73,7 @@ function AccountSettings() {
 
   const hasAppSlug = !!config?.APP_SLUG;
   const isGitHubTokenSet = settings?.GITHUB_TOKEN_IS_SET;
-  const isLLMKeySet = settings?.LLM_API_KEY === "**********";
+  const isLLMKeySet = settings?.LLM_API_KEY === "<hidden>";
   const isAnalyticsEnabled = settings?.USER_CONSENTS_TO_ANALYTICS;
   const isAdvancedSettingsSet = determineWhetherToToggleAdvancedSettings();
 
@@ -288,7 +288,7 @@ function AccountSettings() {
                   startContent={
                     isLLMKeySet && <KeyStatusIcon isSet={isLLMKeySet} />
                   }
-                  placeholder={isLLMKeySet ? "**********" : ""}
+                  placeholder={isLLMKeySet ? "<hidden>" : ""}
                 />
               )}
 
@@ -407,7 +407,7 @@ function AccountSettings() {
                       <KeyStatusIcon isSet={!!isGitHubTokenSet} />
                     )
                   }
-                  placeholder={isGitHubTokenSet ? "**********" : ""}
+                  placeholder={isGitHubTokenSet ? "<hidden>" : ""}
                 />
                 <p data-testId="github-token-help-anchor" className="text-xs">
                   {" "}

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from pydantic import BaseModel, Field, SecretStr, ValidationError
+from pydantic import BaseModel, Field, ValidationError
+from openhands.core.utils.secret_str import SecretStr
 
 from openhands.core.logger import LOG_DIR
 from openhands.core.logger import openhands_logger as logger

--- a/openhands/core/utils/__init__.py
+++ b/openhands/core/utils/__init__.py
@@ -1,0 +1,1 @@
+# Core utilities package

--- a/openhands/core/utils/secret_str.py
+++ b/openhands/core/utils/secret_str.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import SecretStr as PydanticSecretStr
+
+
+class SecretStr(PydanticSecretStr):
+    """Custom SecretStr class that uses <hidden> instead of ******** for display."""
+    
+    def _display(self) -> str:
+        """Override the default display method to use <hidden> instead of ********."""
+        return "<hidden>"

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -7,12 +7,13 @@ from typing import Any, Coroutine, Literal, overload
 from pydantic import (
     BaseModel,
     Field,
-    SecretStr,
     SerializationInfo,
     field_serializer,
     model_validator,
 )
 from pydantic.json import pydantic_encoder
+
+from openhands.core.utils.secret_str import SecretStr
 
 from openhands.events.action.action import Action
 from openhands.events.action.commands import CmdRunAction

--- a/openhands/server/auth.py
+++ b/openhands/server/auth.py
@@ -1,5 +1,5 @@
 from fastapi import Request
-from pydantic import SecretStr
+from openhands.core.utils.secret_str import SecretStr
 
 from openhands.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderType
 

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
-from pydantic import SecretStr
+from openhands.core.utils.secret_str import SecretStr
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.provider import ProviderToken, ProviderType, SecretStore

--- a/openhands/server/settings.py
+++ b/openhands/server/settings.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from pydantic import (
     BaseModel,
     Field,
-    SecretStr,
     SerializationInfo,
     field_serializer,
     model_validator,
 )
 from pydantic.json import pydantic_encoder
+
+from openhands.core.utils.secret_str import SecretStr
 
 from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.utils import load_app_config

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from pydantic import SecretStr
+from openhands.core.utils.secret_str import SecretStr
 
 from openhands.core.config.app_config import AppConfig
 from openhands.core.config.llm_config import LLMConfig
@@ -91,10 +91,10 @@ def test_settings_handles_sensitive_data():
         ),
     )
 
-    assert str(settings.llm_api_key) == '**********'
+    assert str(settings.llm_api_key) == '<hidden>'
     assert (
         str(settings.secrets_store.provider_tokens[ProviderType.GITHUB].token)
-        == '**********'
+        == '<hidden>'
     )
 
     assert settings.llm_api_key.get_secret_value() == 'test-key'


### PR DESCRIPTION
This PR changes the placeholder for API keys from "*******" to `<hidden>` to make it clearer for users.

## Changes

- Created a custom `SecretStr` class that extends Pydantic`s `SecretStr` to display `<hidden>` instead of `**********`
- Updated frontend components to check for `<hidden>` instead of `**********`
- Updated tests to expect the new placeholder format
- Updated imports across the codebase to use the custom `SecretStr` class

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c7ac53e-nikolaik   --name openhands-app-c7ac53e   docker.all-hands.dev/all-hands-ai/openhands:c7ac53e
```