### PR TITLE
Optimize file_editor pattern with prefix check

### DIFF
--- a/openhands/events/serialization/action.py
+++ b/openhands/events/serialization/action.py
@@ -1,5 +1,3 @@
-import re
-
 from openhands.core.exceptions import LLMMalformedActionError
 from openhands.events.action.action import Action
 from openhands.events.action.agent import (
@@ -53,14 +51,20 @@ def handle_action_deprecated_args(args: dict) -> dict:
     if 'translated_ipython_code' in args:
         code = args.pop('translated_ipython_code')
 
-        # Check if it's a file_editor call
-        file_editor_pattern = r'print\(file_editor\(\*\*(.*?)\)\)'
-        if code is not None and (match := re.match(file_editor_pattern, code)):
+        # Check if it's a file_editor call using a prefix check for efficiency
+        file_editor_prefix = 'print(file_editor(**'
+        if (
+            code is not None
+            and code.startswith(file_editor_prefix)
+            and code.endswith('))')
+        ):
             try:
                 # Extract and evaluate the dictionary string
                 import ast
 
-                file_args = ast.literal_eval(match.group(1))
+                # Extract the dictionary string between the prefix and the closing parentheses
+                dict_str = code[len(file_editor_prefix) : -2]  # Remove prefix and '))'
+                file_args = ast.literal_eval(dict_str)
 
                 # Update args with the extracted file editor arguments
                 args.update(file_args)


### PR DESCRIPTION
This PR replaces the regex pattern for file_editor with a more efficient prefix check. Instead of using a regex pattern with a non-greedy capture group, we now use `startswith()` and `endswith()` string methods which are more efficient for this simple pattern matching case.

Changes:
- Replace `re.match(file_editor_pattern, code)` with `code.startswith(file_editor_prefix) and code.endswith(`))`)`
- Extract the dictionary string using string slicing instead of regex capture groups

All tests are passing.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:710cf19-nikolaik   --name openhands-app-710cf19   docker.all-hands.dev/all-hands-ai/openhands:710cf19
```