### PR TITLE
Add logo color (#CFB755) for tab icons

### DIFF
--- a/frontend/src/components/layout/nav-tab.tsx
+++ b/frontend/src/components/layout/nav-tab.tsx
@@ -23,7 +23,7 @@ export function NavTab({ to, label, icon, isBeta }: NavTabProps) {
     >
       {({ isActive }) => (
         <>
-          <div className={cn(isActive && "text-primary")}>{icon}</div>
+          <div className={cn(isActive && "text-tab-highlight")}>{icon}</div>
           {label}
           {isBeta && <BetaBadge />}
         </>

--- a/frontend/src/components/layout/nav-tab.tsx
+++ b/frontend/src/components/layout/nav-tab.tsx
@@ -23,7 +23,7 @@ export function NavTab({ to, label, icon, isBeta }: NavTabProps) {
     >
       {({ isActive }) => (
         <>
-          <div className={cn(isActive && "text-tab-highlight")}>{icon}</div>
+          <div className={cn(isActive && "text-logo")}>{icon}</div>
           {label}
           {isBeta && <BetaBadge />}
         </>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,7 +10,7 @@ export default {
     extend: {
       colors: {
         primary: "#C9B974", // nice yellow
-        "tab-highlight": "#CFB755", // highlight color for tabs
+        logo: "#CFB755", // color for logos and icons
         base: "#0D0F11", // dark background also used for tooltips
         "base-secondary": "#24272E", // lighter background
         danger: "#E76A5E",
@@ -36,7 +36,7 @@ export default {
         dark: {
           colors: {
             primary: "#4465DB",
-            "tab-highlight": "#CFB755",
+            logo: "#CFB755",
           },
         },
       },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,7 +9,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: "#C9B974", // nice yellow
+        primary: "#CFB755", // nice yellow
         base: "#0D0F11", // dark background also used for tooltips
         "base-secondary": "#24272E", // lighter background
         danger: "#E76A5E",
@@ -34,7 +34,7 @@ export default {
       themes: {
         dark: {
           colors: {
-            primary: "#4465DB",
+            primary: "#CFB755",
           },
         },
       },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,7 +9,8 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: "#CFB755", // nice yellow
+        primary: "#C9B974", // nice yellow
+        "tab-highlight": "#CFB755", // highlight color for tabs
         base: "#0D0F11", // dark background also used for tooltips
         "base-secondary": "#24272E", // lighter background
         danger: "#E76A5E",
@@ -34,7 +35,8 @@ export default {
       themes: {
         dark: {
           colors: {
-            primary: "#CFB755",
+            primary: "#4465DB",
+            "tab-highlight": "#CFB755",
           },
         },
       },


### PR DESCRIPTION
This PR adds a new color specifically for logos and icons in the UI. The changes include:

1. Added a new `logo` color (#CFB755) in the tailwind configuration for both default and dark themes
2. Updated the NavTab component to use the new color instead of the primary color

This approach keeps the existing primary color intact while allowing the logo/icon color to be customized separately.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c1bd2e0-nikolaik   --name openhands-app-c1bd2e0   docker.all-hands.dev/all-hands-ai/openhands:c1bd2e0
```