### PR TITLE
Add API key instructions and update documentation links

### DIFF
--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -87,6 +87,53 @@ If the required model does not exist in the list, you can toggle `Advanced` opti
 in the `Custom Model` text box.
 The `Advanced` options also allow you to specify a `Base URL` if required.
 
+### Getting an API Key
+
+OpenHands requires an API key to access language models. Here's how to get an API key from the recommended providers:
+
+#### Anthropic (Claude)
+
+1. **Create an Anthropic account**:
+   - Go to [console.anthropic.com](https://console.anthropic.com/) and sign up for an account if you don't already have one.
+
+2. **Generate an API key**:
+   - Once logged in, navigate to the [API Keys section](https://console.anthropic.com/settings/keys).
+   - Click "Create Key" and provide a name for your key.
+   - Select the appropriate key type (typically "Production" for regular use).
+   - Copy the generated API key immediately, as you won't be able to see it again.
+
+3. **Set up billing**:
+   - Go to [Billing settings](https://console.anthropic.com/settings/billing) to add a payment method.
+   - Consider setting usage limits to control costs.
+
+4. **Use in OpenHands**:
+   - In the OpenHands Settings, select `Anthropic` as the `LLM Provider`.
+   - Select a Claude model (e.g., `claude-3-5-sonnet-20241022`).
+   - Paste your API key in the `API Key` field.
+
+#### OpenAI
+
+1. **Create an OpenAI account**:
+   - Go to [platform.openai.com](https://platform.openai.com/) and sign up for an account if you don't already have one.
+
+2. **Generate an API key**:
+   - Once logged in, navigate to the [API Keys section](https://platform.openai.com/api-keys).
+   - Click "Create new secret key" and provide a name for your key.
+   - Copy the generated API key immediately, as you won't be able to see it again.
+
+3. **Set up billing**:
+   - Go to [Billing settings](https://platform.openai.com/account/billing/overview) to add a payment method.
+   - Consider setting usage limits to control costs.
+
+4. **Use in OpenHands**:
+   - In the OpenHands Settings, select `OpenAI` as the `LLM Provider`.
+   - Select a model (e.g., `gpt-4o`).
+   - Paste your API key in the `API Key` field.
+
+:::warning
+API usage incurs costs based on the models you use. Be sure to monitor your usage and set appropriate spending limits with your provider.
+:::
+
 Now you're ready to [get started with OpenHands](./getting-started).
 
 ## Versions

--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -93,18 +93,11 @@ OpenHands requires an API key to access most language models. Here's how to get 
 
 #### Anthropic (Claude)
 
-1. **Create an Anthropic account**:
-   - Go to [console.anthropic.com](https://console.anthropic.com/) and sign up for an account if you don't already have one.
+1. [Create an Anthropic account](https://console.anthropic.com/)
+2. [Generate an API key](https://console.anthropic.com/settings/keys)
+3. [Set up billing(https://console.anthropic.com/settings/billing)
 
-2. **Generate an API key**:
-   - Once logged in, navigate to the [API Keys section](https://console.anthropic.com/settings/keys).
-   - Click "Create Key" and provide a name for your key.
-   - Select the appropriate key type (typically "Production" for regular use).
-   - Copy the generated API key immediately, as you won't be able to see it again.
-
-3. **Set up billing**:
-   - Go to [Billing settings](https://console.anthropic.com/settings/billing) to add a payment method.
-   - Consider setting usage limits to control costs.
+Consider setting usage limits to control costs.
 
 4. **Use in OpenHands**:
    - In the OpenHands Settings, select `Anthropic` as the `LLM Provider`.

--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -99,11 +99,6 @@ OpenHands requires an API key to access most language models. Here's how to get 
 
 Consider setting usage limits to control costs.
 
-4. **Use in OpenHands**:
-   - In the OpenHands Settings, select `Anthropic` as the `LLM Provider`.
-   - Select a Claude model (e.g., `claude-3-5-sonnet-20241022`).
-   - Paste your API key in the `API Key` field.
-
 #### OpenAI
 
 1. **Create an OpenAI account**:

--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -101,26 +101,9 @@ Consider setting usage limits to control costs.
 
 #### OpenAI
 
-1. **Create an OpenAI account**:
-   - Go to [platform.openai.com](https://platform.openai.com/) and sign up for an account if you don't already have one.
-
-2. **Generate an API key**:
-   - Once logged in, navigate to the [API Keys section](https://platform.openai.com/api-keys).
-   - Click "Create new secret key" and provide a name for your key.
-   - Copy the generated API key immediately, as you won't be able to see it again.
-
-3. **Set up billing**:
-   - Go to [Billing settings](https://platform.openai.com/account/billing/overview) to add a payment method.
-   - Consider setting usage limits to control costs.
-
-4. **Use in OpenHands**:
-   - In the OpenHands Settings, select `OpenAI` as the `LLM Provider`.
-   - Select a model (e.g., `gpt-4o`).
-   - Paste your API key in the `API Key` field.
-
-:::warning
-API usage incurs costs based on the models you use. Be sure to monitor your usage and set appropriate spending limits with your provider.
-:::
+1. [Create an OpenAI account](https://platform.openai.com/)
+2. [Generate an API key](https://platform.openai.com/api-keys)
+3. [Set up billing](https://platform.openai.com/account/billing/overview)
 
 Now you're ready to [get started with OpenHands](./getting-started).
 

--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -89,7 +89,7 @@ The `Advanced` options also allow you to specify a `Base URL` if required.
 
 ### Getting an API Key
 
-OpenHands requires an API key to access language models. Here's how to get an API key from the recommended providers:
+OpenHands requires an API key to access most language models. Here's how to get an API key from the recommended providers:
 
 #### Anthropic (Claude)
 

--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -104,7 +104,7 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
             testId="llm-api-key-help-anchor"
             text="Don't know your API key?"
             linkText="Click here for instructions"
-            href="https://docs.all-hands.dev/modules/usage/llms"
+            href="https://docs.all-hands.dev/modules/usage/installation#getting-an-api-key"
           />
         </div>
 

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -297,7 +297,7 @@ function AccountSettings() {
                   testId="llm-api-key-help-anchor"
                   text="Don't know your API key?"
                   linkText="Click here for instructions"
-                  href="https://docs.all-hands.dev/modules/usage/llms"
+                  href="https://docs.all-hands.dev/modules/usage/installation#getting-an-api-key"
                 />
               )}
 


### PR DESCRIPTION
This PR adds detailed instructions on how to get API keys from Anthropic and OpenAI to the installation documentation. It also updates the "Click here for instructions" links in the UI to point to the new API key instructions section.

Changes:
- Added a new "Getting an API Key" section to the installation documentation with step-by-step instructions for both Anthropic and OpenAI
- Updated links in the UI to point to the new documentation section
- Added a warning about API usage costs

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c0e65e6-nikolaik   --name openhands-app-c0e65e6   docker.all-hands.dev/all-hands-ai/openhands:c0e65e6
```