### PR TITLE
Fix for broken vscode url

### DIFF
--- a/frontend/src/hooks/query/use-vscode-url.ts
+++ b/frontend/src/hooks/query/use-vscode-url.ts
@@ -12,9 +12,7 @@ export const useVSCodeUrl = (config: { enabled: boolean }) => {
       return OpenHands.getVSCodeUrl(conversationId);
     },
     enabled: !!conversationId && config.enabled,
-    refetchOnMount: false,
-    staleTime: 1000 * 60 * 5, // 5 minutes
-    gcTime: 1000 * 60 * 15, // 15 minutes
+    refetchOnMount: true,
   });
 
   return data;

--- a/openhands/runtime/plugins/vscode/__init__.py
+++ b/openhands/runtime/plugins/vscode/__init__.py
@@ -17,6 +17,8 @@ class VSCodeRequirement(PluginRequirement):
 
 class VSCodePlugin(Plugin):
     name: str = 'vscode'
+    vscode_port: int | None = None
+    vscode_connection_token: str | None = None
 
     async def initialize(self, username: str):
         if username not in ['root', 'openhands']:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Fix for broken VSCode Plugin when accessing restarted runtime due to caching.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
When a runtime restarts, the VSCode token changes. We were caching the old token in the frontend, so that if you stopped a conversation and then restarted it, you would get a `Forbidden` message when clicking on the VSCode button.

e.g.:
Go to the home screen to stop a conversation...
![image](https://github.com/user-attachments/assets/2f2484d6-6445-4a83-8e78-d78882aad2f5)

Click back into the conversation...
![image](https://github.com/user-attachments/assets/509a2f10-fcfd-4949-89a9-3e76a1db2b6d)

Before this change, you get a forbidden URL...
![image](https://github.com/user-attachments/assets/92929308-4853-449e-b425-1070ef83db1e)

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e63374b-nikolaik   --name openhands-app-e63374b   docker.all-hands.dev/all-hands-ai/openhands:e63374b
```