### PR TITLE
fix timeout to impove stability

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -238,7 +238,7 @@ class ActionExecutor:
 
         await wait_all(
             (self._init_plugin(plugin) for plugin in self.plugins_to_load),
-            timeout=30,
+            timeout=60,
         )
         logger.debug('All plugins initialized')
 


### PR DESCRIPTION
- [ ] This change is worth documenting 
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Extended the timeout period for plugin initialization to prevent setup failures in environments that require more processing time.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR extends the timeout period for plugin initialization from 30 seconds to 60 seconds. Testing in real environments revealed that the 30-second timeout was insufficient in some cases, causing initialization failures.

The error message displayed when a timeout occurs.

```
ERROR: Traceback (most recent call last):
File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/starlette/routing.py", line 693, in lifespan
async with self.lifespan_context(app) as maybe_state:
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/openhands/micromamba/envs/openhands/lib/python3.12/contextlib.py", line 210, in __aenter__
return await anext(self.gen)
^^^^^^^^^^^^^^^^^^^^^
File "/openhands/code/openhands/runtime/action_execution_server.py", line 553, in lifespan
await client.ainit()
File "/openhands/code/openhands/runtime/action_execution_server.py", line 239, in ainit
await wait_all(
File "/openhands/code/openhands/utils/async_utils.py", line 77, in wait_all
raise asyncio.TimeoutError()
TimeoutError
```


---
**Link of any specific issues this addresses.**
