### PR TITLE
[WIP] better code display

### DIFF
--- a/frontend/src/routes/_oh.app._index/route.tsx
+++ b/frontend/src/routes/_oh.app._index/route.tsx
@@ -78,20 +78,18 @@ function FileViewer() {
     <div className="flex h-full bg-base-secondary relative">
       <FileExplorer isOpen={fileExplorerIsOpen} onToggle={toggleFileExplorer} />
       <div className="w-full h-full flex flex-col">
-        {selectedPath && (
-          <div className="flex w-full items-center justify-between self-end p-2">
-            <span className="text-sm text-neutral-500">{selectedPath}</span>
-          </div>
-        )}
         {selectedPath && files[selectedPath] && (
-          <div className="p-4 flex-1 overflow-auto">
+          <div className="h-full w-full overflow-auto">
             <SyntaxHighlighter
               language={getLanguageFromPath(selectedPath)}
               style={vscDarkPlus}
               customStyle={{
                 margin: 0,
+                padding: 0,
+                height: '100%',
                 background: "#171717",
                 fontSize: "0.875rem",
+                borderRadius: 0,
               }}
             >
               {files[selectedPath]}

--- a/frontend/src/routes/_oh.app._index/route.tsx
+++ b/frontend/src/routes/_oh.app._index/route.tsx
@@ -85,8 +85,8 @@ function FileViewer() {
               style={vscDarkPlus}
               customStyle={{
                 margin: 0,
-                padding: 0,
-                height: '100%',
+                padding: "10px",
+                height: "100%",
                 background: "#171717",
                 fontSize: "0.875rem",
                 borderRadius: 0,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below
CHANGELOG: updated styles for file explorer

**End-user friendly description of the problem this fixes or functionality that this introduces.**


Before and after
<img width="557" alt="Screenshot 2025-03-23 at 4 45 55 PM" src="https://github.com/user-attachments/assets/9dfb4c04-a1d9-4431-a8e5-371e980830da" />
<img width="527" alt="Screenshot 2025-03-23 at 4 45 45 PM" src="https://github.com/user-attachments/assets/abccbe9b-cf60-413a-82c7-5c5d01d50440" />

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f2654c3-nikolaik   --name openhands-app-f2654c3   docker.all-hands.dev/all-hands-ai/openhands:f2654c3
```