### PR TITLE
Add goto-terminal VS Code extension

### DIFF
--- a/openhands/runtime/utils/vscode-extensions/goto-terminal/README.md
+++ b/openhands/runtime/utils/vscode-extensions/goto-terminal/README.md
@@ -1,0 +1,27 @@
+# OpenHands Goto Terminal Extension
+
+This VS Code extension automatically opens a terminal when the URL contains the query parameter `?goto=terminal`.
+
+## Features
+
+- Automatically detects the `goto=terminal` query parameter in the URL
+- Opens a new terminal when the parameter is present
+- Provides a command to manually open a terminal: `openhands-goto-terminal.openTerminal`
+
+## Usage
+
+Simply append `?goto=terminal` to your VS Code URL, and a terminal will automatically open when the editor loads.
+
+Example:
+```
+https://your-vscode-url.example.com?goto=terminal
+```
+
+Or with other parameters:
+```
+https://your-vscode-url.example.com?param1=value1&goto=terminal
+```
+
+## Requirements
+
+- VS Code version 1.94.0 or higher

--- a/openhands/runtime/utils/vscode-extensions/goto-terminal/extension.js
+++ b/openhands/runtime/utils/vscode-extensions/goto-terminal/extension.js
@@ -1,0 +1,44 @@
+const vscode = require('vscode');
+
+/**
+ * Checks if the URL contains the goto=terminal query parameter and opens a terminal if it does
+ */
+function checkUrlAndOpenTerminal() {
+    // Get the current URL from the environment
+    const url = process.env.VSCODE_BROWSER_URL;
+    
+    if (url && url.includes('?goto=terminal') || url && url.includes('&goto=terminal')) {
+        // Open a new terminal
+        vscode.window.createTerminal().show();
+        vscode.window.showInformationMessage('Terminal opened automatically based on URL parameter');
+    }
+}
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+    // Check URL on activation
+    checkUrlAndOpenTerminal();
+    
+    // Register a command that can be called manually if needed
+    let disposable = vscode.commands.registerCommand('openhands-goto-terminal.openTerminal', function () {
+        vscode.window.createTerminal().show();
+    });
+    
+    context.subscriptions.push(disposable);
+    
+    // Also listen for URI changes in case the user navigates within the editor
+    context.subscriptions.push(
+        vscode.window.onDidChangeWindowState(() => {
+            checkUrlAndOpenTerminal();
+        })
+    );
+}
+
+function deactivate() {}
+
+module.exports = {
+    activate,
+    deactivate
+}

--- a/openhands/runtime/utils/vscode-extensions/goto-terminal/package.json
+++ b/openhands/runtime/utils/vscode-extensions/goto-terminal/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "openhands-goto-terminal",
+    "displayName": "OpenHands Goto Terminal",
+    "description": "Automatically opens a terminal when the URL contains ?goto=terminal",
+    "version": "0.0.1",
+    "publisher": "openhands",
+    "engines": {
+        "vscode": "^1.94.0"
+    },
+    "categories": [
+        "Other"
+    ],
+    "activationEvents": [
+        "onStartupFinished"
+    ],
+    "main": "./extension.js",
+    "contributes": {
+        "commands": [{
+            "command": "openhands-goto-terminal.openTerminal",
+            "title": "Open Terminal (OpenHands)"
+        }]
+    }
+}


### PR DESCRIPTION
This PR adds a new VS Code extension that automatically opens a terminal when the URL contains the query parameter `?goto=terminal`.

## Features
- Detects the `goto=terminal` query parameter in the URL
- Automatically opens a terminal when the parameter is present
- Provides a command to manually open a terminal if needed
- Listens for window state changes to handle URL changes

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c479461-nikolaik   --name openhands-app-c479461   docker.all-hands.dev/all-hands-ai/openhands:c479461
```