### PR TITLE
Fix missing 'fi' statement in GAIA benchmark scripts/run_infer.sh

### DIFF
--- a/evaluation/benchmarks/gaia/scripts/run_infer.sh
+++ b/evaluation/benchmarks/gaia/scripts/run_infer.sh
@@ -53,6 +53,7 @@ fi
 if [ -n "$AGENT_CONFIG" ]; then
   echo "AGENT_CONFIG: $AGENT_CONFIG"
   COMMAND="$COMMAND --agent-config $AGENT_CONFIG"
+fi
 
 # Run the command
 eval $COMMAND


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Fixed a missing fi statement in the GAIA benchmark scripts/run_infer.sh script. This syntax error would cause the script to fail execution. Adding the missing fi statement ensures proper conditional logic execution.

---
**Link of any specific issues this addresses.**
