### PR TITLE
(frontend): only show "download via vscode" in conversation card

### DIFF
--- a/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/frontend/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -273,7 +273,7 @@ describe("ConversationCard", () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("should show display cost button only when showDisplayCostOption is true", async () => {
+  it("should show display cost button only when showOptions is true", async () => {
     const user = userEvent.setup();
     const { rerender } = renderWithProviders(
       <ConversationCard
@@ -302,7 +302,7 @@ describe("ConversationCard", () => {
       <ConversationCard
         onDelete={onDelete}
         onChangeTitle={onChangeTitle}
-        showDisplayCostOption
+        showOptions
         isActive
         title="Conversation 1"
         selectedRepository={null}
@@ -328,7 +328,7 @@ describe("ConversationCard", () => {
         title="Conversation 1"
         selectedRepository={null}
         lastUpdatedAt="2021-10-01T12:00:00Z"
-        showDisplayCostOption
+        showOptions
       />,
     );
 

--- a/frontend/src/components/features/controls/controls.tsx
+++ b/frontend/src/components/features/controls/controls.tsx
@@ -32,7 +32,7 @@ export function Controls({ setSecurityOpen, showSecurityLock }: ControlsProps) {
 
       <ConversationCard
         variant="compact"
-        showDisplayCostOption
+        showOptions
         title={conversation?.title ?? ""}
         lastUpdatedAt={conversation?.created_at ?? ""}
         selectedRepository={conversation?.selected_repository ?? null}

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -199,7 +199,9 @@ export function ConversationCard({
                   onDelete={onDelete && handleDelete}
                   onEdit={onChangeTitle && handleEdit}
                   onDownloadViaVSCode={
-                    conversationId ? handleDownloadViaVSCode : undefined
+                    conversationId && showOptions
+                      ? handleDownloadViaVSCode
+                      : undefined
                   }
                   onDisplayCost={
                     showOptions ? handleDisplayCost : undefined

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -203,9 +203,7 @@ export function ConversationCard({
                       ? handleDownloadViaVSCode
                       : undefined
                   }
-                  onDisplayCost={
-                    showOptions ? handleDisplayCost : undefined
-                  }
+                  onDisplayCost={showOptions ? handleDisplayCost : undefined}
                   position={variant === "compact" ? "top" : "bottom"}
                 />
               )}

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -17,7 +17,7 @@ interface ConversationCardProps {
   onClick?: () => void;
   onDelete?: () => void;
   onChangeTitle?: (title: string) => void;
-  showDisplayCostOption?: boolean;
+  showOptions?: boolean;
   isActive?: boolean;
   title: string;
   selectedRepository: string | null;
@@ -34,7 +34,7 @@ export function ConversationCard({
   onClick,
   onDelete,
   onChangeTitle,
-  showDisplayCostOption,
+  showOptions,
   isActive,
   title,
   selectedRepository,
@@ -132,7 +132,7 @@ export function ConversationCard({
     }
   }, [titleMode]);
 
-  const hasContextMenu = !!(onDelete || onChangeTitle || showDisplayCostOption);
+  const hasContextMenu = !!(onDelete || onChangeTitle || showOptions);
   const timeBetweenUpdateAndCreation = createdAt
     ? new Date(lastUpdatedAt).getTime() - new Date(createdAt).getTime()
     : 0;
@@ -202,7 +202,7 @@ export function ConversationCard({
                     conversationId ? handleDownloadViaVSCode : undefined
                   }
                   onDisplayCost={
-                    showDisplayCostOption ? handleDisplayCost : undefined
+                    showOptions ? handleDisplayCost : undefined
                   }
                   position={variant === "compact" ? "top" : "bottom"}
                 />


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

As point out by @mamoodi here - https://openhands-ai.slack.com/archives/C08E1SYKEM9/p1742838823683489

it doesn't make sense to show "download via vscode" in conversation selector.

This PR:
- rename `showDisplayCostOption` to `showOptions`
- stop showing download via vscode when `showOptions` is not true

![image](https://github.com/user-attachments/assets/632b17cf-6c92-4a5a-a3eb-a058ba68a596)
![image](https://github.com/user-attachments/assets/6d178cce-9f7b-47a7-9faa-74cf5acc441f)

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:82746e7-nikolaik   --name openhands-app-82746e7   docker.all-hands.dev/all-hands-ai/openhands:82746e7
```