### PR TITLE
[Refactor]: Create dedicated reset settings route

### DIFF
--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -832,7 +832,9 @@ describe("Settings Screen", () => {
       await user.click(confirmButton);
 
       expect(resetSettingsSpy).toHaveBeenCalled();
-      expect(screen.queryByTestId("reset-modal")).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId("reset-modal")).not.toBeInTheDocument();
+      });
     });
 
     it("should cancel the reset when the 'Cancel' button is clicked", async () => {

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -821,7 +821,6 @@ describe("Settings Screen", () => {
         ...MOCK_DEFAULT_USER_SETTINGS,
       };
       delete mockCopy.github_token_is_set;
-      delete mockCopy.unset_github_token;
       delete mockCopy.user_consents_to_analytics;
 
       expect(saveSettingsSpy).toHaveBeenCalledWith({

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -8,7 +8,6 @@ import { AuthProvider } from "#/context/auth-context";
 import SettingsScreen from "#/routes/settings";
 import * as AdvancedSettingsUtlls from "#/utils/has-advanced-settings-set";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
-import { PostApiSettings } from "#/types/settings";
 import * as ConsentHandlers from "#/utils/handle-capture-consent";
 import AccountSettings from "#/routes/account-settings";
 
@@ -584,6 +583,11 @@ describe("Settings Screen", () => {
 
       test("resetting settings with no changes but having advanced enabled should hide the advanced items", async () => {
         const user = userEvent.setup();
+
+        getSettingsSpy.mockResolvedValueOnce({
+          ...MOCK_DEFAULT_USER_SETTINGS,
+        });
+
         renderSettingsScreen();
 
         await toggleAdvancedSettings(user);
@@ -594,6 +598,15 @@ describe("Settings Screen", () => {
         // show modal
         const modal = await screen.findByTestId("reset-modal");
         expect(modal).toBeInTheDocument();
+
+        // Mock the settings that will be returned after reset
+        // This should be the default settings with no advanced settings enabled
+        getSettingsSpy.mockResolvedValueOnce({
+          ...MOCK_DEFAULT_USER_SETTINGS,
+          llm_base_url: "",
+          confirmation_mode: false,
+          security_analyzer: "",
+        });
 
         // confirm reset
         const confirmButton = within(modal).getByText("Reset");
@@ -818,9 +831,7 @@ describe("Settings Screen", () => {
       const confirmButton = within(modal).getByText("Reset");
       await user.click(confirmButton);
 
-      expect(saveSettingsSpy).not.toHaveBeenCalled();
       expect(resetSettingsSpy).toHaveBeenCalled();
-
       expect(screen.queryByTestId("reset-modal")).not.toBeInTheDocument();
     });
 
@@ -1061,7 +1072,7 @@ describe("Settings Screen", () => {
       const confirmButton = within(modal).getByText("Reset");
       await user.click(confirmButton);
       expect(saveSettingsSpy).not.toHaveBeenCalled();
-      expect(resetSettingsSpy).toHaveBeenCalledWith([[]]);
+      expect(resetSettingsSpy).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -831,9 +831,26 @@ describe("Settings Screen", () => {
       const confirmButton = within(modal).getByText("Reset");
       await user.click(confirmButton);
 
-      expect(resetSettingsSpy).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(resetSettingsSpy).toHaveBeenCalled();
+      });
+
+      // Mock the settings response after reset
+      getSettingsSpy.mockResolvedValueOnce({
+        ...MOCK_DEFAULT_USER_SETTINGS,
+        llm_base_url: "",
+        confirmation_mode: false,
+        security_analyzer: "",
+      });
+
+      // Wait for the mutation to complete and the modal to be removed
       await waitFor(() => {
         expect(screen.queryByTestId("reset-modal")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("llm-custom-model-input")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("base-url-input")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("agent-input")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("security-analyzer-input")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("enable-confirmation-mode-switch")).not.toBeInTheDocument();
       });
     });
 

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -352,7 +352,8 @@ class OpenHands {
   }
 
   static async logout(appMode: GetConfigResponse["APP_MODE"]): Promise<void> {
-    const endpoint = appMode === "saas" ? "/api/logout" : "/api/unset-settings-tokens";
+    const endpoint =
+      appMode === "saas" ? "/api/logout" : "/api/unset-settings-tokens";
     await openHands.post(endpoint);
   }
 }

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -352,8 +352,11 @@ class OpenHands {
   }
 
   static async logout(appMode: GetConfigResponse["APP_MODE"]): Promise<void> {
-    const endpoint = appMode === "saas" ? "/api/logout" : "/api/unset-settings-tokens";
-    await openHands.post(endpoint);
+    if (appMode === "saas") {
+      await openHands.post("/api/logout");
+    } else {
+      await openHands.post("/api/settings", { provider_tokens: {} });
+    }
   }
 }
 

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -271,6 +271,14 @@ class OpenHands {
     return data.status === 200;
   }
 
+  /**
+   * Reset user settings in server
+   */
+  static async resetSettings(): Promise<boolean> {
+    const { data } = await openHands.post("/api/reset-settings");
+    return data.status === 200;
+  }
+
   static async createCheckoutSession(amount: number): Promise<string> {
     const { data } = await openHands.post(
       "/api/billing/create-checkout-session",

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -351,8 +351,9 @@ class OpenHands {
     return data;
   }
 
-  static async logout(): Promise<void> {
-    await openHands.post("/api/logout");
+  static async logout(appMode: GetConfigResponse["APP_MODE"]): Promise<void> {
+    const endpoint = appMode === "saas" ? "/api/logout" : "/api/unset-settings-tokens";
+    await openHands.post(endpoint);
   }
 }
 

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -275,8 +275,8 @@ class OpenHands {
    * Reset user settings in server
    */
   static async resetSettings(): Promise<boolean> {
-    const { data } = await openHands.post("/api/reset-settings");
-    return data.status === 200;
+    const response = await openHands.post("/api/reset-settings");
+    return response.status === 200;
   }
 
   static async createCheckoutSession(amount: number): Promise<string> {

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -352,11 +352,8 @@ class OpenHands {
   }
 
   static async logout(appMode: GetConfigResponse["APP_MODE"]): Promise<void> {
-    if (appMode === "saas") {
-      await openHands.post("/api/logout");
-    } else {
-      await openHands.post("/api/settings", { provider_tokens: {} });
-    }
+    const endpoint = appMode === "saas" ? "/api/logout" : "/api/unset-settings-tokens";
+    await openHands.post(endpoint);
   }
 }
 

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -36,7 +36,7 @@ export function Sidebar() {
     isFetching: isFetchingSettings,
   } = useSettings();
   const { mutateAsync: logout } = useLogout();
-  const { mutate: saveUserSettings } = useSaveSettings();
+
 
   const [settingsModalIsOpen, setSettingsModalIsOpen] = React.useState(false);
 

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -21,7 +21,7 @@ import { useLogout } from "#/hooks/mutation/use-logout";
 import { useConfig } from "#/hooks/query/use-config";
 import { cn } from "#/utils/utils";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
-import { useSaveSettings } from "#/hooks/mutation/use-save-settings";
+
 
 export function Sidebar() {
   const location = useLocation();
@@ -78,8 +78,7 @@ export function Sidebar() {
   };
 
   const handleLogout = async () => {
-    if (config?.APP_MODE === "saas") await logout();
-    else saveUserSettings({ unset_github_token: true });
+    await logout();
     posthog.reset();
   };
 

--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -22,7 +22,6 @@ import { useConfig } from "#/hooks/query/use-config";
 import { cn } from "#/utils/utils";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 
-
 export function Sidebar() {
   const location = useLocation();
   const dispatch = useDispatch();
@@ -36,7 +35,6 @@ export function Sidebar() {
     isFetching: isFetchingSettings,
   } = useSettings();
   const { mutateAsync: logout } = useLogout();
-
 
   const [settingsModalIsOpen, setSettingsModalIsOpen] = React.useState(false);
 

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -9,10 +9,18 @@ export const useLogout = () => {
   const { data: config } = useConfig();
 
   return useMutation({
-    mutationFn: () => OpenHands.logout(config?.APP_MODE ?? "oss"),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries();
+    mutationFn: async () => {
+      // Pause all queries that depend on githubTokenIsSet
+      queryClient.setQueryData(["user"], null);
+      
+      // Call logout endpoint
+      await OpenHands.logout(config?.APP_MODE ?? "oss");
+      
+      // Update token state
       setGitHubTokenIsSet(false);
+      
+      // Refetch settings to get updated token state
+      await queryClient.invalidateQueries({ queryKey: ["settings"] });
     },
   });
 };

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -9,10 +9,10 @@ export const useLogout = () => {
   const { data: config } = useConfig();
 
   return useMutation({
-    mutationFn: async () => {
-      setGitHubTokenIsSet(false);
+    mutationFn: () => OpenHands.logout(config?.APP_MODE ?? "oss"),
+    onSuccess: async () => {
       await queryClient.invalidateQueries();
-      await OpenHands.logout(config?.APP_MODE ?? "oss");
+      setGitHubTokenIsSet(false);
     },
   });
 };

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -1,13 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import OpenHands from "#/api/open-hands";
 import { useAuth } from "#/context/auth-context";
+import { useConfig } from "../query/use-config";
 
 export const useLogout = () => {
   const { setGitHubTokenIsSet } = useAuth();
   const queryClient = useQueryClient();
+  const { data: config } = useConfig();
 
   return useMutation({
-    mutationFn: OpenHands.logout,
+    mutationFn: () => OpenHands.logout(config?.APP_MODE ?? "oss"),
     onSuccess: async () => {
       setGitHubTokenIsSet(false);
       await queryClient.invalidateQueries();

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -9,10 +9,10 @@ export const useLogout = () => {
   const { data: config } = useConfig();
 
   return useMutation({
-    mutationFn: () => OpenHands.logout(config?.APP_MODE ?? "oss"),
-    onSuccess: async () => {
+    mutationFn: async () => {
       setGitHubTokenIsSet(false);
       await queryClient.invalidateQueries();
+      await OpenHands.logout(config?.APP_MODE ?? "oss");
     },
   });
 };

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -16,11 +16,11 @@ export const useLogout = () => {
       // Call logout endpoint
       await OpenHands.logout(config?.APP_MODE ?? "oss");
       
-      // Update token state
-      setGitHubTokenIsSet(false);
+      // Remove settings from cache so it will be refetched with new token state
+      queryClient.removeQueries({ queryKey: ["settings"] });
       
-      // Refetch settings to get updated token state
-      await queryClient.invalidateQueries({ queryKey: ["settings"] });
+      // Update token state - this will trigger a settings refetch since it's part of the query key
+      setGitHubTokenIsSet(false);
     },
   });
 };

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -12,13 +12,13 @@ export const useLogout = () => {
     mutationFn: async () => {
       // Pause all queries that depend on githubTokenIsSet
       queryClient.setQueryData(["user"], null);
-      
+
       // Call logout endpoint
       await OpenHands.logout(config?.APP_MODE ?? "oss");
-      
+
       // Remove settings from cache so it will be refetched with new token state
       queryClient.removeQueries({ queryKey: ["settings"] });
-      
+
       // Update token state - this will trigger a settings refetch since it's part of the query key
       setGitHubTokenIsSet(false);
     },

--- a/frontend/src/hooks/mutation/use-save-settings.ts
+++ b/frontend/src/hooks/mutation/use-save-settings.ts
@@ -23,7 +23,6 @@ const saveSettingsMutationFn = async (
     llm_api_key: settings.LLM_API_KEY?.trim() || undefined,
     remote_runtime_resource_factor: settings.REMOTE_RUNTIME_RESOURCE_FACTOR,
     provider_tokens: settings.provider_tokens,
-    unset_github_token: settings.unset_github_token,
     enable_default_condenser: settings.ENABLE_DEFAULT_CONDENSER,
     enable_sound_notifications: settings.ENABLE_SOUND_NOTIFICATIONS,
     user_consents_to_analytics: settings.user_consents_to_analytics,

--- a/frontend/src/hooks/mutation/use-save-settings.ts
+++ b/frontend/src/hooks/mutation/use-save-settings.ts
@@ -20,7 +20,10 @@ const saveSettingsMutationFn = async (
     language: settings.LANGUAGE || DEFAULT_SETTINGS.LANGUAGE,
     confirmation_mode: settings.CONFIRMATION_MODE,
     security_analyzer: settings.SECURITY_ANALYZER,
-    llm_api_key: settings.LLM_API_KEY?.trim() || undefined,
+    llm_api_key:
+      settings.LLM_API_KEY === ""
+        ? ""
+        : settings.LLM_API_KEY?.trim() || undefined,
     remote_runtime_resource_factor: settings.REMOTE_RUNTIME_RESOURCE_FACTOR,
     provider_tokens: settings.provider_tokens,
     enable_default_condenser: settings.ENABLE_DEFAULT_CONDENSER,

--- a/frontend/src/hooks/mutation/use-save-settings.ts
+++ b/frontend/src/hooks/mutation/use-save-settings.ts
@@ -4,14 +4,14 @@ import OpenHands from "#/api/open-hands";
 import { PostSettings, PostApiSettings } from "#/types/settings";
 import { useSettings } from "../query/use-settings";
 
-const saveSettingsMutationFn = async (settings: Partial<PostSettings> | null) => {
+const saveSettingsMutationFn = async (
+  settings: Partial<PostSettings> | null,
+) => {
   // If settings is null, we're resetting
   if (settings === null) {
     await OpenHands.resetSettings();
     return;
   }
-
-  const resetLlmApiKey = settings.LLM_API_KEY === "";
 
   const apiSettings: Partial<PostApiSettings> = {
     llm_model: settings.LLM_MODEL,
@@ -20,9 +20,7 @@ const saveSettingsMutationFn = async (settings: Partial<PostSettings> | null) =>
     language: settings.LANGUAGE || DEFAULT_SETTINGS.LANGUAGE,
     confirmation_mode: settings.CONFIRMATION_MODE,
     security_analyzer: settings.SECURITY_ANALYZER,
-    llm_api_key: resetLlmApiKey
-      ? ""
-      : settings.LLM_API_KEY?.trim() || undefined,
+    llm_api_key: settings.LLM_API_KEY?.trim() || undefined,
     remote_runtime_resource_factor: settings.REMOTE_RUNTIME_RESOURCE_FACTOR,
     provider_tokens: settings.provider_tokens,
     unset_github_token: settings.unset_github_token,
@@ -46,18 +44,6 @@ export const useSaveSettings = () => {
       }
 
       const newSettings = { ...currentSettings, ...settings };
-
-      // Temp hack for reset logic
-      if (
-        settings.LLM_API_KEY === undefined &&
-        settings.LLM_BASE_URL === undefined &&
-        settings.LLM_MODEL === undefined
-      ) {
-        delete newSettings.LLM_API_KEY;
-        delete newSettings.LLM_BASE_URL;
-        delete newSettings.LLM_MODEL;
-      }
-
       await saveSettingsMutationFn(newSettings);
     },
     onSuccess: async () => {

--- a/frontend/src/hooks/mutation/use-save-settings.ts
+++ b/frontend/src/hooks/mutation/use-save-settings.ts
@@ -4,7 +4,13 @@ import OpenHands from "#/api/open-hands";
 import { PostSettings, PostApiSettings } from "#/types/settings";
 import { useSettings } from "../query/use-settings";
 
-const saveSettingsMutationFn = async (settings: Partial<PostSettings>) => {
+const saveSettingsMutationFn = async (settings: Partial<PostSettings> | null) => {
+  // If settings is null, we're resetting
+  if (settings === null) {
+    await OpenHands.resetSettings();
+    return;
+  }
+
   const resetLlmApiKey = settings.LLM_API_KEY === "";
 
   const apiSettings: Partial<PostApiSettings> = {
@@ -33,7 +39,12 @@ export const useSaveSettings = () => {
   const { data: currentSettings } = useSettings();
 
   return useMutation({
-    mutationFn: async (settings: Partial<PostSettings>) => {
+    mutationFn: async (settings: Partial<PostSettings> | null) => {
+      if (settings === null) {
+        await saveSettingsMutationFn(null);
+        return;
+      }
+
       const newSettings = { ...currentSettings, ...settings };
 
       // Temp hack for reset logic

--- a/frontend/src/hooks/query/use-github-user.ts
+++ b/frontend/src/hooks/query/use-github-user.ts
@@ -37,7 +37,6 @@ export const useGitHubUser = () => {
 
   const handleLogout = async () => {
     await logout();
-    setGitHubTokenIsSet(false);
     posthog.reset();
   };
 

--- a/frontend/src/hooks/query/use-github-user.ts
+++ b/frontend/src/hooks/query/use-github-user.ts
@@ -11,7 +11,7 @@ export const useGitHubUser = () => {
   const { githubTokenIsSet } = useAuth();
   const { setGitHubTokenIsSet } = useAuth();
   const { mutateAsync: logout } = useLogout();
-  const { mutate: saveUserSettings } = useSaveSettings();
+
   const { data: config } = useConfig();
 
   const user = useQuery({

--- a/frontend/src/hooks/query/use-github-user.ts
+++ b/frontend/src/hooks/query/use-github-user.ts
@@ -6,10 +6,8 @@ import OpenHands from "#/api/open-hands";
 import { useAuth } from "#/context/auth-context";
 import { useLogout } from "../mutation/use-logout";
 
-
 export const useGitHubUser = () => {
   const { githubTokenIsSet } = useAuth();
-  const { setGitHubTokenIsSet } = useAuth();
   const { mutateAsync: logout } = useLogout();
 
   const { data: config } = useConfig();

--- a/frontend/src/hooks/query/use-github-user.ts
+++ b/frontend/src/hooks/query/use-github-user.ts
@@ -5,7 +5,7 @@ import { useConfig } from "./use-config";
 import OpenHands from "#/api/open-hands";
 import { useAuth } from "#/context/auth-context";
 import { useLogout } from "../mutation/use-logout";
-import { useSaveSettings } from "../mutation/use-save-settings";
+
 
 export const useGitHubUser = () => {
   const { githubTokenIsSet } = useAuth();
@@ -36,11 +36,8 @@ export const useGitHubUser = () => {
   }, [user.data]);
 
   const handleLogout = async () => {
-    if (config?.APP_MODE === "saas") await logout();
-    else {
-      saveUserSettings({ unset_github_token: true });
-      setGitHubTokenIsSet(false);
-    }
+    await logout();
+    setGitHubTokenIsSet(false);
     posthog.reset();
   };
 

--- a/frontend/src/hooks/use-app-logout.ts
+++ b/frontend/src/hooks/use-app-logout.ts
@@ -1,15 +1,10 @@
 import { useLogout } from "./mutation/use-logout";
-import { useSaveSettings } from "./mutation/use-save-settings";
-import { useConfig } from "./query/use-config";
 
 export const useAppLogout = () => {
-  const { data: config } = useConfig();
   const { mutateAsync: logout } = useLogout();
-  const { mutate: saveUserSettings } = useSaveSettings();
 
   const handleLogout = async () => {
-    if (config?.APP_MODE === "saas") await logout();
-    else saveUserSettings({ unset_github_token: true });
+    await logout();
   };
 
   return { handleLogout };

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -206,11 +206,6 @@ export const handlers = [
       let newSettings: Partial<PostApiSettings> = {};
       if (typeof body === "object") {
         newSettings = { ...body };
-        if (newSettings.unset_github_token) {
-          newSettings.provider_tokens = { github: "", gitlab: "" };
-          newSettings.github_token_is_set = false;
-          delete newSettings.unset_github_token;
-        }
       }
 
       const fullSettings = {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -301,4 +301,10 @@ export const handlers = [
   }),
 
   http.post("/api/logout", () => HttpResponse.json(null, { status: 200 })),
+
+  http.post("/api/reset-settings", async () => {
+    await delay();
+    MOCK_USER_PREFERENCES.settings = { ...MOCK_DEFAULT_USER_SETTINGS };
+    return HttpResponse.json(null, { status: 200 });
+  }),
 ];

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -173,7 +173,7 @@ function AccountSettings() {
       onSuccess: () => {
         displaySuccessToast("Settings reset");
         setResetSettingsModalIsOpen(false);
-        setLlmConfigMode(isAdvancedSettingsSet ? "advanced" : "basic");
+        setLlmConfigMode("basic");
       },
     });
   };

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -25,7 +25,6 @@ import {
   displayErrorToast,
   displaySuccessToast,
 } from "#/utils/custom-toast-handlers";
-import { PostSettings } from "#/types/settings";
 
 const REMOTE_RUNTIME_OPTIONS = [
   { key: 1, label: "1x (2 core, 8G)" },

--- a/frontend/src/routes/account-settings.tsx
+++ b/frontend/src/routes/account-settings.tsx
@@ -170,20 +170,7 @@ function AccountSettings() {
   };
 
   const handleReset = () => {
-    const newSettings: Partial<PostSettings> = {
-      ...DEFAULT_SETTINGS,
-      LLM_API_KEY: "", // reset LLM API key
-    };
-
-    // we don't want the user to be able to modify these settings in SaaS
-    // and we should make sure they aren't included in the reset
-    if (shouldHandleSpecialSaasCase) {
-      delete newSettings.LLM_API_KEY;
-      delete newSettings.LLM_BASE_URL;
-      delete newSettings.LLM_MODEL;
-    }
-
-    saveSettings(newSettings, {
+    saveSettings(null, {
       onSuccess: () => {
         displaySuccessToast("Settings reset");
         setResetSettingsModalIsOpen(false);

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -35,12 +35,10 @@ export type ApiSettings = {
 
 export type PostSettings = Settings & {
   provider_tokens: Record<Provider, string>;
-  unset_github_token: boolean;
   user_consents_to_analytics: boolean | null;
 };
 
 export type PostApiSettings = ApiSettings & {
   provider_tokens: Record<Provider, string>;
-  unset_github_token: boolean;
   user_consents_to_analytics: boolean | null;
 };

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -64,7 +64,19 @@ async def reset_settings(
         )
 
         existing_settings = await settings_store.load()
-        settings = Settings(llm_api_key="")
+        settings = Settings(language="en",
+                             agent="CodeActAgent",
+                             security_analyzer="",
+                             confirmation_mode=False,
+                             llm_model="anthropic/claude-3-5-sonnet-20241022",
+                             llm_api_key="",
+                             llm_base_url="",
+                             remote_runtime_resource_factor=1,
+                             enable_default_condenser=True,
+                             enable_sound_notifications=False,
+                             user_consents_to_analytics=False
+                    )
+        
         server_config_values = server_config.get_config()
         is_hide_llm_settings_enabled = server_config_values.get("FEATURE_FLAGS", {}).get("HIDE_LLM_SETTINGS", False)
         # We don't want the user to be able to modify these settings in SaaS

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -47,16 +47,7 @@ async def reset_settings(
     request: Request
 ) -> JSONResponse:
     """
-    Resets user settings. 
-
-    Sensitive info removed 
-
-        1. Personal access tokens
-        2. LLM API key
-
-    Defaults set
-        1. LLM Settings
-
+    Resets user settings.
     """
     try:
         settings_store = await SettingsStoreImpl.get_instance(

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -88,7 +88,7 @@ async def reset_settings(
                              remote_runtime_resource_factor=1,
                              enable_default_condenser=True,
                              enable_sound_notifications=False,
-                             user_consents_to_analytics=False
+                             user_consents_to_analytics=existing_settings.user_consents_to_analytics
                     )
         
         server_config_values = server_config.get_config()

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -42,8 +42,8 @@ async def load_settings(request: Request) -> GETSettingsModel | JSONResponse:
 
 
 @app.post('/unset-settings-tokens', response_model=dict[str, str])
-async def reset_settings(
-    request
+async def unset_settings_tokens(
+    request: Request
 ) -> JSONResponse:
     try:
         settings_store = await SettingsStoreImpl.get_instance(

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -51,9 +51,10 @@ async def unset_settings_tokens(
         )
 
         existing_settings = await settings_store.load()
-        settings = existing_settings.model_copy(update={'secrets_store': SecretStore()})
-
-        await settings_store.store(settings)
+        if existing_settings:
+            settings = existing_settings.model_copy(update={'secrets_store': SecretStore()})
+            await settings_store.store(settings)
+            
         return JSONResponse(
             status_code=status.HTTP_200_OK,
             content={'message': 'Settings stored'},
@@ -88,7 +89,7 @@ async def reset_settings(
                              remote_runtime_resource_factor=1,
                              enable_default_condenser=True,
                              enable_sound_notifications=False,
-                             user_consents_to_analytics=existing_settings.user_consents_to_analytics
+                             user_consents_to_analytics=existing_settings.user_consents_to_analytics if existing_settings else False
                     )
         
         server_config_values = server_config.get_config()

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -42,7 +42,7 @@ async def load_settings(request: Request) -> GETSettingsModel | JSONResponse:
         )
 
 
-@app.post('reset-settings')
+@app.post('/reset-settings', response_model=dict[str, str])
 async def reset_settings(
     request: Request
 ) -> JSONResponse:
@@ -64,11 +64,11 @@ async def reset_settings(
         )
 
         existing_settings = await settings_store.load()
-        settings = Settings()
+        settings = Settings(llm_api_key="")
         server_config_values = server_config.get_config()
         is_hide_llm_settings_enabled = server_config_values.get("FEATURE_FLAGS", {}).get("HIDE_LLM_SETTINGS", False)
         # We don't want the user to be able to modify these settings in SaaS
-        if (server_config.APP_MODE == AppMode.SAAS and is_hide_llm_settings_enabled):
+        if (server_config.app_mode == AppMode.SAAS and is_hide_llm_settings_enabled):
             if existing_settings:
                 settings.llm_api_key = existing_settings.llm_api_key
                 settings.llm_base_url = existing_settings.llm_base_url

--- a/openhands/server/settings.py
+++ b/openhands/server/settings.py
@@ -107,7 +107,6 @@ class POSTSettingsModel(Settings):
     Settings for POST requests
     """
 
-    unset_github_token: bool | None = None
     # Override provider_tokens to accept string tokens from frontend
     provider_tokens: dict[str, str] = {}
 

--- a/tests/unit/test_settings_api.py
+++ b/tests/unit/test_settings_api.py
@@ -209,53 +209,6 @@ async def test_settings_api_set_github_token(
     assert data['token_is_set'] is True
 
 
-@pytest.mark.skip(
-    reason='Mock middleware does not seem to properly set the github_token'
-)
-async def test_settings_unset_github_token(
-    mock_github_service,
-    test_client,
-    mock_settings_store,
-    mock_get_user_id,
-    mock_validate_provider_token,
-):
-    # Test data with unset_token set to True
-    settings_data = {
-        'language': 'en',
-        'agent': 'test-agent',
-        'max_iterations': 100,
-        'security_analyzer': 'default',
-        'confirmation_mode': True,
-        'llm_model': 'test-model',
-        'llm_api_key': 'test-key',
-        'llm_base_url': 'https://test.com',
-        'provider_tokens': {'github': 'test-token'},
-    }
-
-    # Mock settings store to return our settings for the GET request
-    mock_settings_store.load.return_value = Settings(**settings_data)
-
-    response = test_client.get('/api/settings')
-    assert response.status_code == 200
-    assert response.json()['token_is_set'] is True
-
-    settings_data['unset_token'] = True
-
-    # Make the POST request to store settings
-    response = test_client.post('/api/settings', json=settings_data)
-    assert response.status_code == 200
-
-    # Verify the settings were stored with the provider token unset
-    stored_settings = mock_settings_store.store.call_args[0][0]
-    assert not stored_settings.secrets_store.provider_tokens
-    mock_settings_store.load.return_value = Settings(**stored_settings.dict())
-
-    # Make a GET request to retrieve settings
-    response = test_client.get('/api/settings')
-    assert response.status_code == 200
-    assert response.json()['token_is_set'] is False
-
-
 @pytest.mark.asyncio
 async def test_settings_preserve_llm_fields_when_none(test_client, mock_settings_store):
     # Setup initial settings with LLM fields populated


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**





In this PR we 

1. Implement a dedicated `/reset-settings` route to reset user settings to the defaults
2. We implement a dedicated `/logout` route for wiping provider tokens from the user settings


This serves as only one part of bullet proofing the settings route. 

Currently, all settings changes go through one route `/settings`. We, however, make many assumptions about which values should/shouldn't change when the route is triggered. 

With this PR, we can remove all the temp hacks in the FE when resetting settings, and solely have the backend fill in default values. We also isolate the logic for wiping the provider tokens, so we don't accidentally overlap logic with other parts of the user settings. 

Note that ideally the `Settings` basemodel in the BE should be hold the default values (instead of `None`) but that will likely happen in a different PR as its more involved of a process to migrate. 


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2481637-nikolaik   --name openhands-app-2481637   docker.all-hands.dev/all-hands-ai/openhands:2481637
```