### PR TITLE
Don't set seed for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ docker pull docker.all-hands.dev/all-hands-ai/runtime:0.29-nikolaik
 docker run -it --rm --pull=always \
     -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.29-nikolaik \
     -e LOG_ALL_EVENTS=true \
-    -e LLM_SEED=42 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.openhands-state:/.openhands-state \
     -p 3000:3000 \


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

I'm not sure this should be set for users. Maybe we could use it for evaluation first, it works with openai and a few other LLMs, to sort of make the outputs more deterministic.

Anthropic fails with it:
```
UnsupportedParamsError: litellm.UnsupportedParamsError: Error code: 400 - {'error': {'message': "litellm.UnsupportedParamsError: anthropic does not support parameters: {'seed': 42}, for model=claude-3-7-sonnet-20250219.
```


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c3dde03-nikolaik   --name openhands-app-c3dde03   docker.all-hands.dev/all-hands-ai/openhands:c3dde03
```