### PR TITLE
Make the conversation title a little longer

### DIFF
--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -288,8 +288,8 @@ async def auto_generate_title(conversation_id: str, user_id: str | None) -> str:
 
         if first_user_message:
             first_user_message = first_user_message.strip()
-            title = first_user_message[:20]
-            if len(first_user_message) > 20:
+            title = first_user_message[:30]
+            if len(first_user_message) > 30:
                 title += '...'
             logger.info(f'Generated title: {title}')
             return title

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -288,8 +288,8 @@ async def auto_generate_title(conversation_id: str, user_id: str | None) -> str:
 
         if first_user_message:
             first_user_message = first_user_message.strip()
-            title = first_user_message[:15]
-            if len(first_user_message) > 15:
+            title = first_user_message[:20]
+            if len(first_user_message) > 20:
                 title += '...'
             logger.info(f'Generated title: {title}')
             return title


### PR DESCRIPTION
This PR proposes to make the auto-generated title a little longer (20 chars from 15), maybe it's a bit better for some common use cases?

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ec93cd7-nikolaik   --name openhands-app-ec93cd7   docker.all-hands.dev/all-hands-ai/openhands:ec93cd7
```