### PR TITLE
Fix incorrect file position descriptions in script comments

### DIFF
--- a/openhands/agenthub/codeact_agent/tools/llm_based_edit.py
+++ b/openhands/agenthub/codeact_agent/tools/llm_based_edit.py
@@ -9,7 +9,7 @@ _FILE_EDIT_DESCRIPTION = """Edit a file in plain-text format.
 
 **Example 1: general edit for short files**
 For example, given an existing file `/path/to/file.py` that looks like this:
-(this is the end of the file)
+(this is the beginning of the file)
 1|class MyClass:
 2|    def __init__(self):
 3|        self.x = 1
@@ -21,7 +21,7 @@ For example, given an existing file `/path/to/file.py` that looks like this:
 (this is the end of the file)
 
 The assistant wants to edit the file to look like this:
-(this is the end of the file)
+(this is the beginning of the file)
 1|class MyClass:
 2|    def __init__(self):
 3|        self.x = 1
@@ -45,7 +45,7 @@ print(MyClass().y)
 
 **Example 2: append to file for short files**
 For example, given an existing file `/path/to/file.py` that looks like this:
-(this is the end of the file)
+(this is the beginning of the file)
 1|class MyClass:
 2|    def __init__(self):
 3|        self.x = 1


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR fixes incorrect position descriptions in script comments on lines 12, 24, and 48, changing "this is the end of the file" to "this is the beginning of the file" to accurately reflect their actual positions in the file.

---
**Link of any specific issues this addresses.**
