### PR TITLE
Update translation updater to use claude-3-7-sonnet-20250219

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,4 +57,4 @@ $ poetry run python docs/translation_updater.py
 # ...
 ```
 
-This process uses `claude-3-opus-20240229` as base model and each language consumes at least ~30k input tokens and ~35k output tokens.
+This process uses `claude-3-7-sonnet-20250219` as base model and each language consumes at least ~30k input tokens and ~35k output tokens.

--- a/docs/translation_updater.py
+++ b/docs/translation_updater.py
@@ -56,7 +56,7 @@ def translate_content(content, target_lang):
     system_prompt = f'You are a professional translator. Translate the following content into {target_lang}. Preserve all Markdown formatting, code blocks, and front matter. Keep any {{% jsx %}} tags and similar intact. Do not translate code examples, URLs, or technical terms.'
 
     message = client.messages.create(
-        model='claude-3-opus-20240229',
+        model='claude-3-7-sonnet-20250219',
         max_tokens=4096,
         temperature=0,
         system=system_prompt,


### PR DESCRIPTION
Fixes #7499

Updated the translation updater to use `claude-3-7-sonnet-20250219` instead of `claude-3-opus-20240229` as it is better and cheaper.

Changes made:
1. Updated model name in `docs/translation_updater.py`
2. Updated model name in `docs/README.md`

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d5ff20b2fdea40fdacf10da4a4e3bf77)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8d8d9e2-nikolaik   --name openhands-app-8d8d9e2   docker.all-hands.dev/all-hands-ai/openhands:8d8d9e2
```