### PR TITLE
Add message-level feedback with thumbs up/down buttons

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -6,15 +6,20 @@ import { cn } from "#/utils/utils";
 import { ul, ol } from "../markdown/list";
 import { CopyToClipboardButton } from "#/components/shared/buttons/copy-to-clipboard-button";
 import { anchor } from "../markdown/anchor";
+import { MessageFeedback } from "./message-feedback";
 
 interface ChatMessageProps {
   type: "user" | "assistant";
   message: string;
+  messageId?: number;
+  feedback?: "positive" | "negative" | null;
 }
 
 export function ChatMessage({
   type,
   message,
+  messageId,
+  feedback,
   children,
 }: React.PropsWithChildren<ChatMessageProps>) {
   const [isHovering, setIsHovering] = React.useState(false);
@@ -70,6 +75,12 @@ export function ChatMessage({
           {message}
         </Markdown>
       </div>
+      
+      {/* Add feedback buttons only for assistant messages */}
+      {type === "assistant" && messageId && (
+        <MessageFeedback messageId={messageId} feedback={feedback} />
+      )}
+      
       {children}
     </article>
   );

--- a/frontend/src/components/features/chat/message-feedback.tsx
+++ b/frontend/src/components/features/chat/message-feedback.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useDispatch } from "react-redux";
+import { useWsClient } from "#/context/ws-client-provider";
+import ThumbsUpIcon from "#/icons/thumbs-up.svg?react";
+import ThumbDownIcon from "#/icons/thumbs-down.svg?react";
+import { TrajectoryActionButton } from "#/components/shared/buttons/trajectory-action-button";
+import { createUserFeedback } from "#/services/chat-service";
+import { setMessageFeedback } from "#/state/chat-slice";
+import { useTranslation } from "react-i18next";
+
+interface MessageFeedbackProps {
+  messageId: number;
+  feedback?: "positive" | "negative" | null;
+}
+
+export function MessageFeedback({ messageId, feedback }: MessageFeedbackProps) {
+  const { t } = useTranslation();
+  const { send } = useWsClient();
+  const dispatch = useDispatch();
+
+  const handleFeedback = (feedbackType: "positive" | "negative") => {
+    // Don't send if already selected
+    if (feedback === feedbackType) return;
+    
+    // Update local state
+    dispatch(setMessageFeedback({ messageId, feedbackType }));
+    
+    // Send to backend
+    send(createUserFeedback(feedbackType, "message", messageId));
+  };
+
+  return (
+    <div className="flex gap-1 mt-2">
+      <TrajectoryActionButton
+        testId={`positive-${messageId}`}
+        onClick={() => handleFeedback("positive")}
+        icon={<ThumbsUpIcon width={15} height={15} />}
+        tooltip={t("BUTTON$MARK_HELPFUL")}
+        className={feedback === "positive" ? "bg-neutral-700" : ""}
+      />
+      <TrajectoryActionButton
+        testId={`negative-${messageId}`}
+        onClick={() => handleFeedback("negative")}
+        icon={<ThumbDownIcon width={15} height={15} />}
+        tooltip={t("BUTTON$MARK_NOT_HELPFUL")}
+        className={feedback === "negative" ? "bg-neutral-700" : ""}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/features/chat/messages.tsx
+++ b/frontend/src/components/features/chat/messages.tsx
@@ -37,6 +37,8 @@ export const Messages: React.FC<MessagesProps> = React.memo(
           key={index}
           type={message.sender}
           message={message.content}
+          messageId={message.eventID}
+          feedback={message.feedback}
         >
           {message.imageUrls && message.imageUrls.length > 0 && (
             <ImageCarousel size="small" images={message.imageUrls} />

--- a/frontend/src/message.d.ts
+++ b/frontend/src/message.d.ts
@@ -8,4 +8,5 @@ export type Message = {
   pending?: boolean;
   translationID?: string;
   eventID?: number;
+  feedback?: "positive" | "negative" | null;
 };

--- a/frontend/src/services/chat-service.ts
+++ b/frontend/src/services/chat-service.ts
@@ -11,3 +11,21 @@ export function createChatMessage(
   };
   return event;
 }
+
+export function createUserFeedback(
+  feedbackType: "positive" | "negative",
+  targetType: "message" | "trajectory",
+  targetId?: number,
+  content?: string
+) {
+  const event = {
+    action: ActionType.USER_FEEDBACK,
+    args: { 
+      feedback_type: feedbackType,
+      target_type: targetType,
+      target_id: targetId,
+      content
+    },
+  };
+  return event;
+}

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -223,6 +223,22 @@ export const chatSlice = createSlice({
     clearMessages(state: SliceState) {
       state.messages = [];
     },
+
+    setMessageFeedback(
+      state: SliceState,
+      action: PayloadAction<{
+        messageId: number;
+        feedbackType: "positive" | "negative";
+      }>
+    ) {
+      const { messageId, feedbackType } = action.payload;
+      const messageIndex = state.messages.findIndex(
+        (message) => message.eventID === messageId
+      );
+      if (messageIndex !== -1) {
+        state.messages[messageIndex].feedback = feedbackType;
+      }
+    },
   },
 });
 
@@ -233,5 +249,6 @@ export const {
   addAssistantObservation,
   addErrorMessage,
   clearMessages,
+  setMessageFeedback,
 } = chatSlice.actions;
 export default chatSlice.reducer;

--- a/frontend/src/types/action-type.tsx
+++ b/frontend/src/types/action-type.tsx
@@ -38,6 +38,9 @@ enum ActionType {
 
   // Changes the state of the agent, e.g. to paused or running
   CHANGE_AGENT_STATE = "change_agent_state",
+  
+  // User feedback on messages or the entire trajectory
+  USER_FEEDBACK = "user_feedback",
 }
 
 export default ActionType;

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -133,6 +133,16 @@ export interface RejectAction extends OpenHandsActionEvent<"reject"> {
   };
 }
 
+export interface UserFeedbackAction extends OpenHandsActionEvent<"user_feedback"> {
+  source: "user";
+  args: {
+    feedback_type: "positive" | "negative";
+    target_type: "message" | "trajectory";
+    target_id?: number; // Event ID for message feedback, null for trajectory feedback
+    content?: string; // Optional additional feedback
+  };
+}
+
 export type OpenHandsAction =
   | UserMessageAction
   | AssistantMessageAction
@@ -146,4 +156,5 @@ export type OpenHandsAction =
   | FileReadAction
   | FileEditAction
   | FileWriteAction
-  | RejectAction;
+  | RejectAction
+  | UserFeedbackAction;


### PR DESCRIPTION
This PR adds thumbs up and thumbs down buttons to each assistant message in the chat interface.

### Changes:

- Added a new `UserFeedbackAction` type for sending feedback events
- Updated the `Message` type to include a feedback property
- Created a new `MessageFeedback` component to display thumbs up/down buttons
- Modified the trajectory-level feedback to use the same mechanism
- Removed the old feedback modal in favor of direct WebSocket events
- Added toast notifications for feedback confirmation

Feedback can now be provided at both the message level and trajectory level, with consistent handling for both.