### PR TITLE
[Feat]: Tell the agent the current date

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/additional_info.j2
+++ b/openhands/agenthub/codeact_agent/prompts/additional_info.j2
@@ -24,8 +24,8 @@ For example, if you are using vite.config.js, you should set server.host and ser
 {% if runtime_info.additional_agent_instructions %}
 {{ runtime_info.additional_agent_instructions }}
 {% endif %}
-{% if runtime_info.date or runtime_info.utc_time %}
-Today's datetime is {{ runtime_info.date }} at {{ runtime_info.utc_time }} (UTC).
+{% if runtime_info.date %}
+Today's date is {{ runtime_info.date }} (UTC).
 {% endif %}
 </RUNTIME_INFORMATION>
 {% endif %}

--- a/openhands/agenthub/codeact_agent/prompts/additional_info.j2
+++ b/openhands/agenthub/codeact_agent/prompts/additional_info.j2
@@ -24,5 +24,8 @@ For example, if you are using vite.config.js, you should set server.host and ser
 {% if runtime_info.additional_agent_instructions %}
 {{ runtime_info.additional_agent_instructions }}
 {% endif %}
+{% if runtime_info.date or runtime_info.utc_time %}
+Today's datetime is {{ runtime_info.date }} at {{ runtime_info.utc_time }} (UTC).
+{% endif %}
 </RUNTIME_INFORMATION>
 {% endif %}

--- a/openhands/events/observation/agent.py
+++ b/openhands/events/observation/agent.py
@@ -73,7 +73,6 @@ class RecallObservation(Observation):
     runtime_hosts: dict[str, int] = field(default_factory=dict)
     additional_agent_instructions: str = ''
     date: str = ''
-    utc_time: str = ''
 
     # knowledge
     microagent_knowledge: list[MicroagentKnowledge] = field(default_factory=list)
@@ -115,7 +114,6 @@ class RecallObservation(Observation):
                     f'runtime_hosts={self.runtime_hosts}',
                     f'additional_agent_instructions={self.additional_agent_instructions[:20]}...',
                     f'date={self.date}'
-                    f'utc_time={self.utc_time}'
                 ]
             )
         else:

--- a/openhands/events/observation/agent.py
+++ b/openhands/events/observation/agent.py
@@ -72,6 +72,8 @@ class RecallObservation(Observation):
     repo_instructions: str = ''
     runtime_hosts: dict[str, int] = field(default_factory=dict)
     additional_agent_instructions: str = ''
+    date: str = ''
+    utc_time: str = ''
 
     # knowledge
     microagent_knowledge: list[MicroagentKnowledge] = field(default_factory=list)
@@ -112,6 +114,8 @@ class RecallObservation(Observation):
                     f'repo_instructions={self.repo_instructions[:20]}...',
                     f'runtime_hosts={self.runtime_hosts}',
                     f'additional_agent_instructions={self.additional_agent_instructions[:20]}...',
+                    f'date={self.date}'
+                    f'utc_time={self.utc_time}'
                 ]
             )
         else:

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -399,13 +399,18 @@ class ConversationMemory:
                 else:
                     repo_info = None
 
+                date = obs.date
+                utc_time = obs.utc_time
+
                 if obs.runtime_hosts or obs.additional_agent_instructions:
                     runtime_info = RuntimeInfo(
                         available_hosts=obs.runtime_hosts,
                         additional_agent_instructions=obs.additional_agent_instructions,
+                        date=date,
+                        utc_time=utc_time,
                     )
                 else:
-                    runtime_info = None
+                    runtime_info = RuntimeInfo(date=date, utc_time=utc_time)
 
                 repo_instructions = (
                     obs.repo_instructions if obs.repo_instructions else ''

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -400,17 +400,15 @@ class ConversationMemory:
                     repo_info = None
 
                 date = obs.date
-                utc_time = obs.utc_time
 
                 if obs.runtime_hosts or obs.additional_agent_instructions:
                     runtime_info = RuntimeInfo(
                         available_hosts=obs.runtime_hosts,
                         additional_agent_instructions=obs.additional_agent_instructions,
                         date=date,
-                        utc_time=utc_time,
                     )
                 else:
-                    runtime_info = RuntimeInfo(date=date, utc_time=utc_time)
+                    runtime_info = RuntimeInfo(date=date)
 
                 repo_instructions = (
                     obs.repo_instructions if obs.repo_instructions else ''

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import uuid
+from datetime import datetime, timezone
 from typing import Callable
 
 import openhands
@@ -170,6 +171,10 @@ class Memory:
                 else '',
                 microagent_knowledge=microagent_knowledge,
                 content='Added workspace context',
+                date=self.runtime_info.date if self.runtime_info is not None else '',
+                utc_time=self.runtime_info.utc_time
+                if self.runtime_info is not None
+                else '',
             )
             return obs
         return None
@@ -263,13 +268,20 @@ class Memory:
     def set_runtime_info(self, runtime: Runtime) -> None:
         """Store runtime info (web hosts, ports, etc.)."""
         # e.g. { '127.0.0.1': 8080 }
+        utc_now = datetime.now(timezone.utc)
+
+        date = str(utc_now.date())
+        utc_time = str(utc_now.time())
+
         if runtime.web_hosts or runtime.additional_agent_instructions:
             self.runtime_info = RuntimeInfo(
                 available_hosts=runtime.web_hosts,
                 additional_agent_instructions=runtime.additional_agent_instructions,
+                date=date,
+                utc_time=utc_time,
             )
         else:
-            self.runtime_info = None
+            self.runtime_info = RuntimeInfo(date=date, utc_time=utc_time)
 
     def send_error_message(self, message_id: str, message: str):
         """Sends an error message if the callback function was provided."""

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -172,9 +172,6 @@ class Memory:
                 microagent_knowledge=microagent_knowledge,
                 content='Added workspace context',
                 date=self.runtime_info.date if self.runtime_info is not None else '',
-                utc_time=self.runtime_info.utc_time
-                if self.runtime_info is not None
-                else '',
             )
             return obs
         return None
@@ -271,17 +268,15 @@ class Memory:
         utc_now = datetime.now(timezone.utc)
 
         date = str(utc_now.date())
-        utc_time = str(utc_now.time())
 
         if runtime.web_hosts or runtime.additional_agent_instructions:
             self.runtime_info = RuntimeInfo(
                 available_hosts=runtime.web_hosts,
                 additional_agent_instructions=runtime.additional_agent_instructions,
                 date=date,
-                utc_time=utc_time,
             )
         else:
-            self.runtime_info = RuntimeInfo(date=date, utc_time=utc_time)
+            self.runtime_info = RuntimeInfo(date=date)
 
     def send_error_message(self, message_id: str, message: str):
         """Sends an error message if the callback function was provided."""

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -266,7 +266,6 @@ class Memory:
         """Store runtime info (web hosts, ports, etc.)."""
         # e.g. { '127.0.0.1': 8080 }
         utc_now = datetime.now(timezone.utc)
-
         date = str(utc_now.date())
 
         if runtime.web_hosts or runtime.additional_agent_instructions:

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -12,7 +12,6 @@ from openhands.events.observation.agent import MicroagentKnowledge
 @dataclass
 class RuntimeInfo:
     date: str
-    utc_time: str
     available_hosts: dict[str, int] = field(default_factory=dict)
     additional_agent_instructions: str = ''
 

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -11,6 +11,8 @@ from openhands.events.observation.agent import MicroagentKnowledge
 
 @dataclass
 class RuntimeInfo:
+    date: str
+    utc_time: str
     available_hosts: dict[str, int] = field(default_factory=dict)
     additional_agent_instructions: str = ''
 

--- a/tests/unit/test_observation_serialization.py
+++ b/tests/unit/test_observation_serialization.py
@@ -245,6 +245,7 @@ def test_microagent_observation_serialization():
             'runtime_hosts': {'host1': 8080, 'host2': 8081},
             'repo_instructions': 'complex_repo_instructions',
             'additional_agent_instructions': 'You know it all about this runtime',
+            'date': '04/12/1023',
             'microagent_knowledge': [],
         },
     }
@@ -263,6 +264,7 @@ def test_microagent_observation_microagent_knowledge_serialization():
             'repo_instructions': '',
             'runtime_hosts': {},
             'additional_agent_instructions': '',
+            'date': '',
             'microagent_knowledge': [
                 {
                     'name': 'microagent1',

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -239,6 +239,7 @@ each of which has a corresponding port:
     # Create repository and runtime information
     repo_info = RepositoryInfo(repo_name='owner/repo', repo_directory='/workspace/repo')
     runtime_info = RuntimeInfo(
+        date='02/12/1232',
         available_hosts={'example.com': 8080},
         additional_agent_instructions='You know everything about this runtime.',
     )
@@ -260,6 +261,7 @@ each of which has a corresponding port:
     assert '<RUNTIME_INFORMATION>' in result
     assert 'example.com (port 8080)' in result
     assert 'You know everything about this runtime.' in result
+    assert "Today's datetime is 02/12/1232 (UTC)."
 
     # Clean up
     os.remove(os.path.join(prompt_dir, 'additional_info.j2'))

--- a/tests/unit/test_prompt_manager.py
+++ b/tests/unit/test_prompt_manager.py
@@ -261,7 +261,7 @@ each of which has a corresponding port:
     assert '<RUNTIME_INFORMATION>' in result
     assert 'example.com (port 8080)' in result
     assert 'You know everything about this runtime.' in result
-    assert "Today's datetime is 02/12/1232 (UTC)."
+    assert "Today's date is 02/12/1232 (UTC)."
 
     # Clean up
     os.remove(os.path.join(prompt_dir, 'additional_info.j2'))


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

Agent is created with knowledge of current date 

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR attaches the current date and time to the `RuntimeInfo` object. We may want to, in the future, update the date and time as the conversation ages. As per the issue, however, we're looking to only tell the agent the time/date at the start of the agent trajectory for now. 

![image](https://github.com/user-attachments/assets/da8a0699-de79-40bd-83d9-4374a8767ff5)


---
**Link of any specific issues this addresses.**
#7436

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6aa5732-nikolaik   --name openhands-app-6aa5732   docker.all-hands.dev/all-hands-ai/openhands:6aa5732
```