### PR TITLE
[Feat]: Trigger microagents on agent keywords

### DIFF
--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -97,11 +97,14 @@ class Memory:
                     return
 
                 # Handle knowledge recall (triggered microagents)
+                # Allow triggering from both user and agent messages
                 elif (
                     event.source == EventSource.USER
-                    and event.recall_type == RecallType.KNOWLEDGE
-                ):
-                    logger.debug('Microagent knowledge recall')
+                    or event.source == EventSource.AGENT
+                ) and event.recall_type == RecallType.KNOWLEDGE:
+                    logger.debug(
+                        f'Microagent knowledge recall from {event.source} message'
+                    )
                     microagent_obs: RecallObservation | NullObservation | None = None
                     microagent_obs = self._on_microagent_recall(event)
                     if microagent_obs is None:

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -261,3 +261,62 @@ REPOSITORY INSTRUCTIONS: This is a test repository.
 
     # Clean up
     os.remove(os.path.join(prompt_dir, 'micro', f'{repo_microagent_name}.md'))
+
+
+@pytest.mark.asyncio
+async def test_memory_with_agent_microagents():
+    """
+    Test that Memory processes microagent based on trigger words from agent messages.
+    """
+    # Create a mock event stream
+    event_stream = MagicMock(spec=EventStream)
+
+    # Initialize Memory to use the global microagents dir
+    memory = Memory(
+        event_stream=event_stream,
+        sid='test-session',
+    )
+
+    # Verify microagents were loaded - at least one microagent should be loaded
+    # from the global directory that's in the repo
+    assert len(memory.knowledge_microagents) > 0
+
+    # We know 'flarglebargle' exists in the global directory
+    assert 'flarglebargle' in memory.knowledge_microagents
+
+    # Create a microagent action with the trigger word
+    microagent_action = RecallAction(
+        query='Hello, flarglebargle!', recall_type=RecallType.KNOWLEDGE
+    )
+
+    # Set the source to AGENT
+    microagent_action._source = EventSource.AGENT  # type: ignore[attr-defined]
+
+    # Mock the event_stream.add_event method
+    added_events = []
+
+    def original_add_event(event, source):
+        added_events.append((event, source))
+
+    event_stream.add_event = original_add_event
+
+    # Add the microagent action to the event stream
+    event_stream.add_event(microagent_action, EventSource.AGENT)
+
+    # Clear the events list to only capture new events
+    added_events.clear()
+
+    # Process the microagent action
+    await memory._on_event(microagent_action)
+
+    # Verify a RecallObservation was added to the event stream
+    assert len(added_events) == 1
+    observation, source = added_events[0]
+    assert isinstance(observation, RecallObservation)
+    assert source == EventSource.ENVIRONMENT
+    assert observation.recall_type == RecallType.KNOWLEDGE
+    assert len(observation.microagent_knowledge) == 1
+    assert observation.microagent_knowledge[0].name == 'flarglebargle'
+    assert observation.microagent_knowledge[0].trigger == 'flarglebargle'
+    assert 'magic word' in observation.microagent_knowledge[0].content
+

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -319,4 +319,3 @@ async def test_memory_with_agent_microagents():
     assert observation.microagent_knowledge[0].name == 'flarglebargle'
     assert observation.microagent_knowledge[0].trigger == 'flarglebargle'
     assert 'magic word' in observation.microagent_knowledge[0].content
-


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
- Trigger microagents on agent keywords

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR 

1. adds a `RecallAction` for agent message actions as well 
2. pulls microagent knowledge when specific keyword triggers exist in the agent's message

---
**Link of any specific issues this addresses.**
#7505

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ef8821f-nikolaik   --name openhands-app-ef8821f   docker.all-hands.dev/all-hands-ai/openhands:ef8821f
```