### PR TITLE
(Hotfix): Github token fails to refresh on cloud openhands

### DIFF
--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -298,9 +298,11 @@ class ProviderHandler:
         # for the user when the socket event for connect is sent
         if ProviderType.GITHUB not in env_vars and get_latest:
             logger.info('Force refresh runtime token')
-            env_vars[ProviderType.GITHUB] = await self._get_latest_provider_token(
-                ProviderType.GITHUB
+            service = GithubServiceImpl(
+                external_auth_id=self.external_auth_id,
+                external_token_manager=self.external_token_manager,
             )
+            env_vars[ProviderType.GITHUB] = await service.get_latest_token()
 
         if not expose_secrets:
             return env_vars

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -289,6 +289,15 @@ class ProviderHandler:
                 if token:
                     env_vars[provider] = token
 
+        # TODO: we have an error where reinitializing the runtime doesn't happen with
+        # the provider tokens; thus the code above believes that github isn't a provider
+        # when it really is. We need to share information about current providers set
+        # for the user when the socket event for connect is sent
+        if ProviderType.GITHUB not in env_vars and get_latest:
+            env_vars[ProviderType.GITHUB] = await self._get_latest_provider_token(
+                provider
+            )
+
         if not expose_secrets:
             return env_vars
 

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -14,6 +14,7 @@ from pydantic import (
 )
 from pydantic.json import pydantic_encoder
 
+from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.action import Action
 from openhands.events.action.commands import CmdRunAction
 from openhands.events.stream import EventStream
@@ -294,8 +295,9 @@ class ProviderHandler:
         # when it really is. We need to share information about current providers set
         # for the user when the socket event for connect is sent
         if ProviderType.GITHUB not in env_vars and get_latest:
+            logger.info('Force refresh runtime token')
             env_vars[ProviderType.GITHUB] = await self._get_latest_provider_token(
-                provider
+                ProviderType.GITHUB
             )
 
         if not expose_secrets:

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -269,7 +269,9 @@ class ProviderHandler:
             get_latest: Get the latest working token for the providers if True, otherwise get the existing ones
         """
 
-        if not self.provider_tokens:
+        # TODO: We should remove `not get_latest` in the future. More
+        # details about the error this fixes is in the next comment below
+        if not self.provider_tokens and not get_latest:
             return {}
 
         env_vars: dict[ProviderType, SecretStr] = {}

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -297,7 +297,9 @@ class ProviderHandler:
         # when it really is. We need to share information about current providers set
         # for the user when the socket event for connect is sent
         if ProviderType.GITHUB not in env_vars and get_latest:
-            logger.info('Force refresh runtime token')
+            logger.info(
+                f'Force refresh runtime token for user: {self.external_auth_id}'
+            )
             service = GithubServiceImpl(
                 external_auth_id=self.external_auth_id,
                 external_token_manager=self.external_token_manager,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This bug was introduced in #7247

#### Error path 

1. When coming back to a conversation after a long time, the GitHub token doesn't exist anymore
2. We get logs `fetching latest token` and `failed to refresh` immediately after
3. We see there was no GitHub token present when attempting to fetch the latest working tokens for providers
 
#### Explanation

1. When restarting a conversation after a long, a new runtime object is initialized via the `connect` socket event; however this new runtime object doesn't contain the `provider_tokens` object anymore (or any information about which providers are currently set for the user)
2. Upon initialization, the `env_vars` are empty so the GITHUB_TOKEN env is never set
3. For the refresh path, we see that GitHub isn't a provider so we never attempt to fetch its latest token

#### Why did it work before - 
Before we assumed that GitHub provider was guaranteed to be set, so we always fetched its latest token. Now, however, we first check which providers are set and only set the latest token for the set providers. The state for which providers are set, however, is lost when restarting a runtme.


#### Fix explanation
Inside `provider.py`, we've made a change so that we always fetch the latest token for Github (a temporary fix). Long term we need to share which providers are currently set to the `connect` event in `listen_socket.py` (and this should be done before we support multiple providers on cloud).


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6ee24b4-nikolaik   --name openhands-app-6ee24b4   docker.all-hands.dev/all-hands-ai/openhands:6ee24b4
```