### PR TITLE
Reduce max iterations by default

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -24,7 +24,7 @@
 #daytona_target = ""
 
 # Base path for the workspace
-workspace_base = "./workspace"
+#workspace_base = "./workspace"
 
 # Cache directory path
 #cache_dir = "/tmp/cache"
@@ -64,7 +64,7 @@ workspace_base = "./workspace"
 #max_budget_per_task = 0.0
 
 # Maximum number of iterations
-#max_iterations = 100
+#max_iterations = 250
 
 # Path to mount the workspace in the sandbox
 #workspace_mount_path_in_sandbox = "/workspace"

--- a/openhands/core/config/config_utils.py
+++ b/openhands/core/config/config_utils.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
 OH_DEFAULT_AGENT = 'CodeActAgent'
-OH_MAX_ITERATIONS = 500
+OH_MAX_ITERATIONS = 250
 
 
 def get_field_info(field: FieldInfo) -> dict[str, Any]:


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Set max iterations to 250 by default.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes to reduce max iterations to 250.

With Sonnet 3.7's energy, this does seem to go off quite a lot. We also had a fix meanwhile, where if the user speaks, the max iterations are added again on top of existing value, which gives more breathing room than 250 anyway.

With UI, hitting this only means that the user tells it to continue.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:60c1111-nikolaik   --name openhands-app-60c1111   docker.all-hands.dev/all-hands-ai/openhands:60c1111
```