### PR TITLE
feat(client-authn): Add client authentication function in openhands server using JWT

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -87,6 +87,9 @@
 # JWT secret for authentication
 #jwt_secret = ""
 
+# jwt secret for authentication
+#jwt_secret_client_auth = jwt-secret-for-client-auth
+
 # Restrict file types for file uploads
 #file_uploads_restrict_file_types = false
 

--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -6,3 +6,4 @@ VITE_USE_TLS="false" # Use HTTPS/WSS for backend connections (true or false)
 VITE_FRONTEND_PORT="3001" # Port to run the frontend application
 VITE_INSECURE_SKIP_VERIFY="false" # Skip TLS certificate verification (true or false)
 # VITE_GITHUB_TOKEN="" # GitHub token for repository access (used in some tests)
+# VITE_CLIENT_JWT="" # jwt secret for authentication

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -91,6 +91,7 @@ The frontend application uses the following environment variables:
 | `VITE_FRONTEND_PORT`        | Port to run the frontend application                                   | `3001`           |
 | `VITE_INSECURE_SKIP_VERIFY` | Skip TLS certificate verification                                      | `false`          |
 | `VITE_GITHUB_TOKEN`         | GitHub token for repository access (used in some tests)                | -                |
+| `VITE_CLIENT_JWT`           | JWT secret for client authentication (Specify JWT_SECRET_CLIENT_AUTH in server) <br> Example of JWT <br> `import jwt` <br> `payload = {'user_id': 'some-user-id(any string)'}` <br> `secret = 'secret-key-for-client-auth'` <br> `token = jwt.encode(payload, secret, algorithm='HS256')`   | -  |
 
 You can create a `.env` file in the frontend directory with these variables based on the `.env.sample` file.
 

--- a/frontend/src/api/open-hands-axios.ts
+++ b/frontend/src/api/open-hands-axios.ts
@@ -22,3 +22,8 @@ export const removeGitHubTokenHeader = () => {
     delete openHands.defaults.headers.common["X-GitHub-Token"];
   }
 };
+
+const CLIENT_JWT = import.meta.env.VITE_CLIENT_JWT;
+if (CLIENT_JWT) {
+  setAuthTokenHeader(CLIENT_JWT);
+}

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -173,9 +173,16 @@ export function WsClientProvider({
     const baseUrl =
       import.meta.env.VITE_BACKEND_BASE_URL || window?.location.host;
 
+    let auth = {};
+    const CLIENT_JWT = import.meta.env.VITE_CLIENT_JWT;
+    if (CLIENT_JWT) {
+      auth = { token: `Bearer ${CLIENT_JWT}` };
+    }
+
     sio = io(baseUrl, {
       transports: ["websocket"],
       query,
+      auth,
     });
     sio.on("connect", handleConnect);
     sio.on("oh_event", handleMessage);

--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -74,6 +74,7 @@ class AppConfig(BaseModel):
     modal_api_token_secret: SecretStr | None = Field(default=None)
     disable_color: bool = Field(default=False)
     jwt_secret: SecretStr | None = Field(default=None)
+    jwt_secret_client_auth: SecretStr | None = Field(default=None)
     debug: bool = Field(default=False)
     file_uploads_max_file_size_mb: int = Field(default=0)
     file_uploads_restrict_file_types: bool = Field(default=False)

--- a/openhands/server/README.md
+++ b/openhands/server/README.md
@@ -43,6 +43,7 @@ websocat ws://127.0.0.1:3000/ws
 LLM_API_KEY=sk-... # Your Anthropic API Key
 LLM_MODEL=claude-3-5-sonnet-20241022 # Default model for the agent to use
 WORKSPACE_BASE=/path/to/your/workspace # Default absolute path to workspace
+JWT_SECRET_CLIENT_AUTH=jwt-secret-for-client-auth # JWT secret for client authentication
 ```
 
 ## API Schema

--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -5,11 +5,13 @@ with warnings.catch_warnings():
     warnings.simplefilter('ignore')
 
 from fastapi import (
+    Depends,
     FastAPI,
 )
 
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands import __version__
+from openhands.server.auth import verify_token_api
 from openhands.server.routes.conversation import app as conversation_api_router
 from openhands.server.routes.feedback import app as feedback_api_router
 from openhands.server.routes.files import app as files_api_router
@@ -21,7 +23,7 @@ from openhands.server.routes.public import app as public_api_router
 from openhands.server.routes.security import app as security_api_router
 from openhands.server.routes.settings import app as settings_router
 from openhands.server.routes.trajectory import app as trajectory_router
-from openhands.server.shared import conversation_manager
+from openhands.server.shared import config, conversation_manager
 
 
 @asynccontextmanager
@@ -30,11 +32,16 @@ async def _lifespan(app: FastAPI):
         yield
 
 
+dependencies = []
+if config.jwt_secret_client_auth:
+    dependencies.append(Depends(verify_token_api))
+
 app = FastAPI(
     title='OpenHands',
     description='OpenHands: Code Less, Make More',
     version=__version__,
     lifespan=_lifespan,
+    dependencies=dependencies,
 )
 
 

--- a/openhands/server/auth.py
+++ b/openhands/server/auth.py
@@ -1,7 +1,11 @@
-from fastapi import Request
+import jwt
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import APIKeyHeader
 from pydantic import SecretStr
 
+from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderType
+from openhands.server.shared import config
 
 
 def get_provider_tokens(request: Request) -> PROVIDER_TOKEN_TYPE | None:
@@ -32,3 +36,39 @@ def get_github_user_id(request: Request) -> str | None:
         return provider_tokens[ProviderType.GITHUB].user_id
 
     return None
+
+
+api_key_header = APIKeyHeader(name='Authorization', auto_error=True)
+
+
+def verify_token_api(auth_header: str = Depends(api_key_header)):
+    try:
+        verify_token(auth_header)
+    except (
+        jwt.ExpiredSignatureError,
+        jwt.MissingRequiredClaimError,
+        jwt.InvalidTokenError,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail='Invalid authentication token',
+        )
+
+
+def verify_token(auth_header: str):
+    logger.debug('verify_token start')
+    if not config.jwt_secret_client_auth:
+        raise RuntimeError('JWT secret not found')
+    jwt_secret_client_auth = (
+        config.jwt_secret_client_auth.get_secret_value()
+        if isinstance(config.jwt_secret_client_auth, SecretStr)
+        else config.jwt_secret_client_auth
+    )
+    decoded = jwt.decode(
+        auth_header[7:],
+        jwt_secret_client_auth,
+        options={'require': ['user_id']},
+        algorithms=['HS256'],
+    )
+    logger.debug(f'token with user_id: {decoded['user_id']} verified')
+    return decoded['user_id'], None

--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -1,12 +1,26 @@
 import os
 
+import jwt
+from socketio.exceptions import ConnectionRefusedError
+
+from openhands.server.auth import verify_token
+from openhands.server.shared import config
 from openhands.utils.import_utils import get_impl
 
 
 class ConversationValidator:
     """Storage for conversation metadata. May or may not support multiple users depending on the environment."""
 
-    async def validate(self, conversation_id: str, cookies_str: str):
+    async def validate(self, conversation_id: str, auth_info_str: str):
+        if config.jwt_secret_client_auth:
+            try:
+                return verify_token(auth_info_str)
+            except (
+                jwt.ExpiredSignatureError,
+                jwt.MissingRequiredClaimError,
+                jwt.InvalidTokenError,
+            ):
+                raise ConnectionRefusedError('Invalid authentication token')
         return None, None
 
 

--- a/tests/unit/test_client_auth.py
+++ b/tests/unit/test_client_auth.py
@@ -1,0 +1,51 @@
+import asyncio
+
+import pytest
+import socketio
+from fastapi.testclient import TestClient
+from uvicorn import Config, Server
+
+test_jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGVzdF91c2VyIn0.gM08EEDdgYsezEBG2tPFBJrWdNDwhbETb44TonKQntI'
+
+
+@pytest.fixture
+def set_app(monkeypatch):
+    monkeypatch.setenv('JWT_SECRET_CLIENT_AUTH', 'secret-key-for-client-auth')
+    # import here to load env
+    from openhands.server.listen import app
+
+    return app
+
+
+@pytest.fixture
+def test_client(set_app):
+    headers = {
+        'Authorization': f'Bearer {test_jwt}',
+        'Content-Type': 'application/json',
+    }
+    return TestClient(set_app, headers=headers)
+
+
+def test_socket_connect(set_app, test_client):
+    def start_socket_server(set_app):
+        config = Config(set_app, host='127.0.0.1', port=3000)
+        server = Server(config=config)
+        server_task = server.serve()
+        asyncio.ensure_future(server_task)
+        return server_task
+
+    async def run_socket_client():
+        response = test_client.post('/api/conversations', json={})
+        assert response.status_code == 200
+        conversation_id = response.json()['conversation_id']
+        sio = socketio.AsyncClient()
+        await sio.connect(
+            f'http://localhost:3000?conversation_id={conversation_id}',
+            auth={'token': f'Bearer {test_jwt}'},
+        )
+        response = test_client.delete(f'/api/conversations/{conversation_id}')
+        assert response.status_code == 200
+
+    start_socket_server(set_app)
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run_socket_client())


### PR DESCRIPTION
- [X] This change is worth documenting at https://docs.all-hands.dev/

**End-user friendly description of the problem this fixes or functionality that this introduces.**
This change add a token-based authentication function to OpenHands server.
It will be possible to open OpenHands server to the public, not just locally(frontend).

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
- The implementation is based on JWT with the intention of expanding to OAuth and OIDC.
- This is an optional feature and the default is JWT_SECRET_CLIENT_AUTH=None. This will enable multiple OpenHands instances to collaborate on multiple hosts in the near future. 
  - https://github.com/All-Hands-AI/OpenHands/pull/6492
  - https://github.com/All-Hands-AI/OpenHands/pull/6815
- The frontend currently provides the JWT via an environment variable, but in the future we would like to add a login function to the frontend so that it can be provided dynamically.
- The JWT must be encoded with the secret phrase specified in JWT_SECRET_CLIENT_AUTH.
  - JWT example:
    ```
     import jwt
     payload = {'user_id': 'some-user-id(any string)'}
     secret = 'secret-key-for-client-auth'
     token = jwt.encode(payload, secret, algorithm='HS256')
    ```