### PR TITLE
feat(frontend): Add agent icons to the chat UI

### DIFF
--- a/frontend/__tests__/components/chat/expandable-message.test.tsx
+++ b/frontend/__tests__/components/chat/expandable-message.test.tsx
@@ -95,6 +95,96 @@ describe("ExpandableMessage", () => {
     expect(screen.queryByTestId("status-icon")).not.toBeInTheDocument();
   });
 
+  const testTimestamp = "2025-03-21T10:00:00Z";
+
+  it(`should display LocalFormat if timestamp is UtcFormat for`, async () => {
+    const testTimestampLocalFormat = "2025-03-21T10:00:00";
+    renderWithProviders(
+      <ExpandableMessage
+        message="Agent Message"
+        type="thought"
+        timestamp={testTimestampLocalFormat}
+        sender="assistant"
+      />,
+    );
+
+    const agent = "Agent";
+    const date = new Date(`${testTimestampLocalFormat}Z`);
+    const pad = (num: number): string => num.toString().padStart(2, "0");
+    const month = pad(date.getMonth() + 1);
+    const day = pad(date.getDate());
+    const hour = pad(date.getHours());
+    const minute = pad(date.getMinutes());
+    const agentNameElement = await screen.findByText(agent);
+
+    expect(agentNameElement.textContent?.trim()).toBe(agent);
+    expect(
+      await screen.findByText((content) =>
+        content.includes(`${month}/${day} ${hour}:${minute}`),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it(`should display Agent if sender is assistant and agentName is undefind`, async () => {
+    renderWithProviders(
+      <ExpandableMessage
+        message="Agent Message"
+        type="thought"
+        timestamp={testTimestamp}
+        sender="assistant"
+      />,
+    );
+
+    const agent = "Agent";
+    const agentNameElement = await screen.findByText(agent);
+
+    const date = new Date(testTimestamp);
+    const pad = (num: number): string => num.toString().padStart(2, "0");
+    const month = pad(date.getMonth() + 1);
+    const day = pad(date.getDate());
+    const hour = pad(date.getHours());
+    const minute = pad(date.getMinutes());
+
+    expect(agentNameElement.textContent?.trim()).toBe(agent);
+    expect(
+      await screen.findByText((content) =>
+        content.includes(`${month}/${day} ${hour}:${minute}`),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it(`should display Agent if sender is assistant and timestamp is undefind`, async () => {
+    renderWithProviders(
+      <ExpandableMessage
+        message="Agent Message"
+        type="thought"
+        sender="assistant"
+      />,
+    );
+
+    const agent = "Agent";
+    const agentNameElement = await screen.findByText(agent);
+
+    expect(agentNameElement.textContent?.trim()).toBe(agent);
+    expect(
+      await screen.findByText((content) => content.includes("N/A")),
+    ).toBeInTheDocument();
+  });
+
+  it("should display N/A if sender is assistant and timestamp is undefind", async () => {
+    renderWithProviders(
+      <ExpandableMessage
+        message="Assistant Message"
+        type="thought"
+        sender="assistant"
+      />,
+    );
+    expect(await screen.findByText("Agent")).toBeInTheDocument();
+    expect(
+      await screen.findByText((content) => content.trim() === "N/A"),
+    ).toBeInTheDocument();
+  });
+
   it("should render the out of credits message when the user is out of credits", async () => {
     const getConfigSpy = vi.spyOn(OpenHands, "getConfig");
     // @ts-expect-error - We only care about the APP_MODE and FEATURE_FLAGS fields

--- a/frontend/__tests__/components/chat/messages.test.tsx
+++ b/frontend/__tests__/components/chat/messages.test.tsx
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "test-utils";
+import { Messages } from "#/components/features/chat/messages";
+import { Message } from "#/message";
+
+const testTimestamp = "2025-03-24T15:30:00Z";
+const testTimestampNoZ = "2025-03-24T15:30:00";
+
+describe("Messages Component", () => {
+  it("should correctly format timestamp with Z in UTC Time Zone", async () => {
+    const messages: Message[] = [
+      {
+        content: "Message with Z",
+        sender: "assistant",
+        timestamp: testTimestamp,
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(await screen.findByText("03/24 15:30")).toBeInTheDocument();
+  });
+
+  it("should correctly format timestamp without Z in UTC Time Zone", async () => {
+    const messages: Message[] = [
+      {
+        content: "Message without Z",
+        sender: "assistant",
+        timestamp: testTimestampNoZ,
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(await screen.findByText("03/24 15:30")).toBeInTheDocument();
+  });
+
+  it("should correctly format timestamp with invalid timestamp", async () => {
+    const messages: Message[] = [
+      {
+        content: "Message with invalid timestamp",
+        sender: "assistant",
+        timestamp: "",
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+
+  it("should correctly format timestamp without timestamp", async () => {
+    const messages: Message[] = [
+      {
+        content: "Message without timestamp",
+        sender: "assistant",
+        timestamp: "",
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+
+  it("should return null when message content is null or empty", async () => {
+    const messages: Message[] = [
+      {
+        content: "",
+        sender: "assistant",
+        timestamp: testTimestamp,
+        type: "thought",
+      },
+      {
+        content: null as unknown as string,
+        sender: "assistant",
+        timestamp: testTimestamp,
+        type: "thought",
+      },
+      {
+        content: undefined as unknown as string,
+        sender: "assistant",
+        timestamp: testTimestamp,
+        type: "thought",
+      },
+    ];
+
+    const { container } = renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should display 'N/A' when timestamp is missing", async () => {
+    const messages: Message[] = [
+      {
+        content: "No timestamp",
+        sender: "assistant",
+        timestamp: "",
+        type: "thought",
+      },
+      {
+        content: "Null timestamp",
+        sender: "assistant",
+        timestamp: null as unknown as string,
+        type: "thought",
+      },
+      {
+        content: "Undefined timestamp",
+        sender: "assistant",
+        timestamp: undefined as unknown as string,
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(await screen.findAllByText("N/A")).toHaveLength(3);
+  });
+
+  it("should correctly format timestamp when sender is user and timestamp is missing", async () => {
+    const messages: Message[] = [
+      {
+        content: "User timestamp missing",
+        sender: "user",
+        timestamp: "",
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(
+      await screen.findByText("User timestamp missing"),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+
+  it("should render agent info when agentname is provided", async () => {
+    const messages: Message[] = [
+      {
+        content: "Agent message",
+        sender: "assistant",
+        timestamp: testTimestampNoZ,
+        agentName: "TestAgent@host",
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(await screen.findByText(/TestAgent@host/i)).toBeInTheDocument();
+  });
+
+  it("should render agent info when agentname is provided (timestamp endsWith('Z') === false)", async () => {
+    const messages: Message[] = [
+      {
+        content: "Agent message without Z",
+        sender: "assistant",
+        timestamp: testTimestampNoZ,
+        agentName: "TestAgent@host",
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+
+    const agentInfo = screen
+      .getByText(/TestAgent@host/i)
+      .closest(".agent-info");
+    expect(agentInfo).toBeInTheDocument();
+    expect(await screen.findByText(/TestAgent@host/i)).toBeInTheDocument();
+  });
+
+  it("should correctly format timestamp when sender is assistant and timestamp is missing", async () => {
+    const messages: Message[] = [
+      {
+        content: "Assistant timestamp missing",
+        sender: "assistant",
+        timestamp: "",
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(
+      await screen.findByText("Assistant timestamp missing"),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+
+  it("should render image carousel when imageUrls are present", async () => {
+    const messages: Message[] = [
+      {
+        content: "Message with images",
+        sender: "assistant",
+        timestamp: testTimestamp,
+        imageUrls: ["image1.jpg", "image2.jpg"],
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+
+    const images = await screen.findAllByRole("img");
+    expect(images.length).toBe(2);
+  });
+
+  it("should render ConfirmationButtons when awaiting user confirmation", async () => {
+    const messages: Message[] = [
+      {
+        content: "Needs confirmation",
+        sender: "assistant",
+        timestamp: testTimestamp,
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation />,
+    );
+    expect(
+      await screen.findByRole("button", { name: /confirm/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should correctly format timestamp when sender is user and timestamp is missing", async () => {
+    const messages: Message[] = [
+      {
+        content: "User timestamp missing",
+        sender: "user",
+        timestamp: "",
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(
+      await screen.findByText("User timestamp missing"),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+
+  it("should render user-time div when sender is user", async () => {
+    const messages: Message[] = [
+      {
+        content: "User message",
+        sender: "user",
+        timestamp: testTimestamp,
+        type: "thought",
+      },
+    ];
+
+    renderWithProviders(
+      <Messages messages={messages} isAwaitingUserConfirmation={false} />,
+    );
+    expect(await screen.findByText("User message")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/services/actions.test.ts
+++ b/frontend/__tests__/services/actions.test.ts
@@ -80,8 +80,8 @@ describe("Actions Service", () => {
       let capturedPartialMessage = "";
       (store.dispatch as any).mockImplementation((action: any) => {
         if (action.type === "chat/addAssistantMessage" &&
-            action.payload.includes("believe that the task was **completed partially**")) {
-          capturedPartialMessage = action.payload;
+            action.payload.content.includes("believe that the task was **completed partially**")) {
+          capturedPartialMessage = action.payload.content;
         }
       });
 
@@ -107,8 +107,8 @@ describe("Actions Service", () => {
       let capturedNotCompletedMessage = "";
       (store.dispatch as any).mockImplementation((action: any) => {
         if (action.type === "chat/addAssistantMessage" &&
-            action.payload.includes("believe that the task was **not completed**")) {
-          capturedNotCompletedMessage = action.payload;
+            action.payload.content.includes("believe that the task was **not completed**")) {
+          capturedNotCompletedMessage = action.payload.content;
         }
       });
 
@@ -134,8 +134,8 @@ describe("Actions Service", () => {
       let capturedCompletedMessage = "";
       (store.dispatch as any).mockImplementation((action: any) => {
         if (action.type === "chat/addAssistantMessage" &&
-            action.payload.includes("believe that the task was **completed successfully**")) {
-          capturedCompletedMessage = action.payload;
+            action.payload.content.includes("believe that the task was **completed successfully**")) {
+          capturedCompletedMessage = action.payload.content;
         }
       });
 

--- a/frontend/__tests__/state/chat-slice.test.tsx
+++ b/frontend/__tests__/state/chat-slice.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import chatReducer, {
+  addAssistantMessage,
+} from "#/state/chat-slice";
+
+describe("chatSlice - addAssistantMessage", () => {
+  it("adds an assistant message with correct content, agent name, and timestamp", () => {
+    const store = configureStore({ reducer: { chat: chatReducer } });
+
+    const content = "Test message";
+    const agentName = "OpenHands";
+    const timestamp = "2025-03-24T15:30:00Z";
+
+    store.dispatch(
+      addAssistantMessage({
+        content: content,
+        agentName: agentName,
+        timestamp: timestamp
+      }),
+    );
+
+    const state = store.getState().chat;
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]).toEqual(
+      expect.objectContaining({
+        type: "thought",
+        sender: "assistant",
+        content,
+        agentName,
+        timestamp,
+        imageUrls: [],
+        pending: false,
+      }),
+    );
+  });
+
+  it("adds an assistant message with default timestamp when not provided", () => {
+    const store = configureStore({ reducer: { chat: chatReducer } });
+
+    const content = "Message without timestamp";
+    const agentName = "AssistantAgent";
+
+    store.dispatch(
+      addAssistantMessage({
+        content: content,
+        agentName: agentName,
+        timestamp: "",
+      }),
+    );
+
+    const state = store.getState().chat;
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]).toEqual(
+      expect.objectContaining({
+        type: "thought",
+        sender: "assistant",
+        content,
+        agentName,
+        timestamp: expect.any(String),
+        imageUrls: [],
+        pending: false,
+      }),
+    );
+  });
+
+  it("handles empty content and agent name correctly", () => {
+    const store = configureStore({ reducer: { chat: chatReducer } });
+
+    store.dispatch(
+      addAssistantMessage({
+        content: "",
+        agentName: "",
+        timestamp: "",
+      }),
+    );
+
+    const state = store.getState().chat;
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]).toEqual(
+      expect.objectContaining({
+        type: "thought",
+        sender: "assistant",
+        content: "",
+        agentName: "",
+        timestamp: expect.any(String),
+        imageUrls: [],
+        pending: false,
+      }),
+    );
+  });
+});

--- a/frontend/src/components/features/chat/expandable-message.tsx
+++ b/frontend/src/components/features/chat/expandable-message.tsx
@@ -17,6 +17,10 @@ interface ExpandableMessageProps {
   message: string;
   type: string;
   success?: boolean;
+  timestamp?: string;
+  sender?: string;
+  agentName?: string;
+  agentBgColor?: string;
 }
 
 export function ExpandableMessage({
@@ -24,13 +28,16 @@ export function ExpandableMessage({
   message,
   type,
   success,
+  timestamp,
+  sender,
+  agentName,
+  agentBgColor,
 }: ExpandableMessageProps) {
   const { data: config } = useConfig();
   const { t, i18n } = useTranslation();
   const [showDetails, setShowDetails] = useState(true);
   const [headline, setHeadline] = useState("");
   const [details, setDetails] = useState(message);
-
   useEffect(() => {
     if (id && i18n.exists(id)) {
       setHeadline(t(id));
@@ -66,66 +73,97 @@ export function ExpandableMessage({
     );
   }
 
+  const agentDisplayName = agentName || "Agent";
+  const agentInitial = agentDisplayName.charAt(0).toUpperCase();
+
+  let timestampDisplay = "N/A";
+  if (timestamp) {
+    const date = new Date(
+      timestamp.endsWith("Z") ? timestamp : `${timestamp}Z`,
+    );
+
+    const pad = (num: number): string => num.toString().padStart(2, "0");
+    const month = pad(date.getMonth() + 1);
+    const day = pad(date.getDate());
+    const hour = pad(date.getHours());
+    const minute = pad(date.getMinutes());
+    timestampDisplay = `${month}/${day} ${hour}:${minute}`;
+  }
+
+  const renderAgentInfo = () => {
+    if (sender === "assistant") {
+      return (
+        <div className="agent-info-expandable">
+          <div className={`common-icon ${agentBgColor}`}>{agentInitial}</div>
+          <div className="agent-name">{agentDisplayName}</div>
+          <div className="agent-time">{timestampDisplay}</div>
+        </div>
+      );
+    }
+    return null;
+  };
+
   return (
-    <div
-      className={cn(
-        "flex gap-2 items-center justify-start border-l-2 pl-2 my-2 py-2",
-        type === "error" ? "border-danger" : "border-neutral-300",
-      )}
-    >
-      <div className="text-sm w-full">
-        <div className="flex flex-row justify-between items-center w-full">
-          <span
-            className={cn(
-              headline ? "font-bold" : "",
-              type === "error" ? "text-danger" : "text-neutral-300",
-            )}
-          >
-            {headline && (
-              <>
-                {headline}
-                <button
-                  type="button"
-                  onClick={() => setShowDetails(!showDetails)}
-                  className="cursor-pointer text-left"
-                >
-                  {showDetails ? (
-                    <ArrowUp
-                      className={cn(
-                        "h-4 w-4 ml-2 inline",
-                        type === "error" ? "fill-danger" : "fill-neutral-300",
-                      )}
-                    />
-                  ) : (
-                    <ArrowDown
-                      className={cn(
-                        "h-4 w-4 ml-2 inline",
-                        type === "error" ? "fill-danger" : "fill-neutral-300",
-                      )}
-                    />
-                  )}
-                </button>
-              </>
-            )}
-          </span>
-          {type === "action" && success !== undefined && (
-            <span className="flex-shrink-0">
-              {success ? (
-                <CheckCircle
-                  data-testid="status-icon"
-                  className={cn(statusIconClasses, "fill-success")}
-                />
-              ) : (
-                <XCircle
-                  data-testid="status-icon"
-                  className={cn(statusIconClasses, "fill-danger")}
-                />
+    <div>
+      {renderAgentInfo()}
+      <div
+        className={cn(
+          "flex gap-2 items-center justify-start border-l-2 pl-2 my-2 py-2",
+          type === "error" ? "border-danger" : "border-neutral-300",
+        )}
+      >
+        <div className="text-sm w-full">
+          <div className="flex flex-row justify-between items-center w-full">
+            <span
+              className={cn(
+                headline ? "font-bold" : "",
+                type === "error" ? "text-danger" : "text-neutral-300",
+              )}
+            >
+              {headline && (
+                <>
+                  {headline}
+                  <button
+                    type="button"
+                    onClick={() => setShowDetails(!showDetails)}
+                    className="cursor-pointer text-left"
+                  >
+                    {showDetails ? (
+                      <ArrowUp
+                        className={cn(
+                          "h-4 w-4 ml-2 inline",
+                          type === "error" ? "fill-danger" : "fill-neutral-300",
+                        )}
+                      />
+                    ) : (
+                      <ArrowDown
+                        className={cn(
+                          "h-4 w-4 ml-2 inline",
+                          type === "error" ? "fill-danger" : "fill-neutral-300",
+                        )}
+                      />
+                    )}
+                  </button>
+                </>
               )}
             </span>
-          )}
-        </div>
-        {(!headline || showDetails) && (
-          <div className="text-sm overflow-auto">
+            {type === "action" && success !== undefined && (
+              <span className="flex-shrink-0">
+                {success ? (
+                  <CheckCircle
+                    data-testid="status-icon"
+                    className={cn(statusIconClasses, "fill-success")}
+                  />
+                ) : (
+                  <XCircle
+                    data-testid="status-icon"
+                    className={cn(statusIconClasses, "fill-danger")}
+                  />
+                )}
+              </span>
+            )}
+          </div>
+          {(!headline || showDetails) && (
             <Markdown
               components={{
                 code,
@@ -136,8 +174,8 @@ export function ExpandableMessage({
             >
               {details}
             </Markdown>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/features/chat/messages.tsx
+++ b/frontend/src/components/features/chat/messages.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import type { Message } from "#/message";
 import { ChatMessage } from "#/components/features/chat/chat-message";
 import { ConfirmationButtons } from "#/components/shared/buttons/confirmation-buttons";
@@ -10,13 +10,59 @@ interface MessagesProps {
   isAwaitingUserConfirmation: boolean;
 }
 
+enum IconBackgroundColor {
+  RED = "bg-red-600",
+  BLUE = "bg-blue-600",
+  GREEN = "bg-green-600",
+  ORANGE = "bg-orange-600",
+  SKY = "bg-sky-600",
+  YELLOW = "bg-yellow-600",
+  PINK = "bg-pink-600",
+  CYAN = "bg-cyan-600",
+  PURPLE = "bg-purple-600",
+}
+
 export const Messages: React.FC<MessagesProps> = React.memo(
-  ({ messages, isAwaitingUserConfirmation }) =>
-    messages.map((message, index) => {
+  ({ messages, isAwaitingUserConfirmation }) => {
+    const [receivedAgentNames, setAgentNames] = useState<string[]>([]);
+    const iconColors = Object.values(IconBackgroundColor);
+
+    useEffect(() => {
+      const newAgentNames = messages
+        .map((message) => message.agentName)
+        .filter(
+          (name): name is string =>
+            !!name && !receivedAgentNames.includes(name),
+        );
+      if (newAgentNames.length > 0) {
+        setAgentNames((prev) => [...prev, ...newAgentNames]);
+      }
+    }, [messages]);
+
+    return messages.map((message, index) => {
+      if (!message.content) {
+        return null;
+      }
       const shouldShowConfirmationButtons =
         messages.length - 1 === index &&
         message.sender === "assistant" &&
         isAwaitingUserConfirmation;
+
+      let agentDisplayName = "";
+      let agentInitial = "";
+      let agentBgColor = iconColors[0];
+      if (message.agentName) {
+        const agentIndex = Math.max(
+          receivedAgentNames.indexOf(message.agentName),
+          0,
+        );
+        const colorIndex = agentIndex % iconColors.length;
+        agentBgColor = iconColors[colorIndex];
+        agentDisplayName = message.agentName;
+      } else {
+        agentDisplayName = "Agent";
+      }
+      agentInitial = agentDisplayName.charAt(0).toUpperCase();
 
       if (message.type === "error" || message.type === "action") {
         return (
@@ -26,25 +72,68 @@ export const Messages: React.FC<MessagesProps> = React.memo(
               id={message.translationID}
               message={message.content}
               success={message.success}
+              timestamp={message.timestamp}
+              sender={message.sender}
+              agentName={message.agentName}
+              agentBgColor={agentBgColor}
             />
             {shouldShowConfirmationButtons && <ConfirmationButtons />}
           </div>
         );
       }
 
+      let timestampDisplay = "N/A";
+      if (message.timestamp) {
+        const date = new Date(
+          message.timestamp.endsWith("Z")
+            ? message.timestamp
+            : `${message.timestamp}Z`,
+        );
+
+        const pad = (num: number): string => num.toString().padStart(2, "0");
+        const month = pad(date.getMonth() + 1);
+        const day = pad(date.getDate());
+        const hour = pad(date.getHours());
+        const minute = pad(date.getMinutes());
+        timestampDisplay = `${month}/${day} ${hour}:${minute}`;
+      }
+
       return (
-        <ChatMessage
+        <div
           key={index}
-          type={message.sender}
-          message={message.content}
+          className={message.sender === "assistant" ? "assistant" : "user"}
         >
-          {message.imageUrls && message.imageUrls.length > 0 && (
-            <ImageCarousel size="small" images={message.imageUrls} />
-          )}
-          {shouldShowConfirmationButtons && <ConfirmationButtons />}
-        </ChatMessage>
+          {(() => {
+            if (message.sender === "assistant") {
+              return (
+                <div className="agent-info">
+                  <div className={`common-icon ${agentBgColor}`}>
+                    {agentInitial}
+                  </div>
+                  <div className="agent-name">{agentDisplayName}</div>
+                  <div className="agent-time">{timestampDisplay}</div>
+                </div>
+              );
+            }
+            if (message.sender === "user") {
+              return (
+                <div>
+                  <div className="user-time">{timestampDisplay}</div>
+                </div>
+              );
+            }
+            return null;
+          })()}
+          <ChatMessage type={message.sender} message={message.content}>
+            {message.imageUrls && message.imageUrls.length > 0 && (
+              <ImageCarousel size="small" images={message.imageUrls} />
+            )}
+            {shouldShowConfirmationButtons && <ConfirmationButtons />}
+          </ChatMessage>
+        </div>
       );
-    }),
+    });
+  },
 );
 
 Messages.displayName = "Messages";

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -57,3 +57,87 @@ code {
 .markdown-body td {
   padding: 0.1rem 1rem;
 }
+
+.border-neutral-300{
+  font-size: 15px;
+  margin-left: 50px;
+  margin-top: -15px;
+}
+
+.border-danger{
+  font-size: 15px;
+  margin-left: 50px;
+  margin-top: -15px;
+}
+
+.max-w-full {
+  max-width:90%;
+  margin-left: 50px;
+  margin-top: -26px;
+}
+
+.flex gap-2 items-center justify-start border-l-2 pl-2 my-2 py-2{
+  font-size: 15px;
+  margin-top: -30px;
+}
+
+.user {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+}
+
+.assistant {
+  margin-bottom: 10px;
+}
+
+.agent-info {
+  align-items: center;
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.agent-info-expandable {
+  align-items: center;
+  width: auto;
+  display: flex;
+}
+
+.common-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 20px;
+  margin-right: 10px;
+  display: flex;
+}
+
+.agent-name {
+  margin-right: 0px;
+  font-size: 15px;
+  margin-top: -21px;
+  float: right;
+  position:relative;
+}
+
+.user-time {
+  margin-right: 5px;
+  font-size: 15px;
+  margin-top: -15px;
+  float: right;
+  position:relative;
+  opacity:50% ;
+}
+
+.agent-time {
+  font-size: 15px;
+  margin-left: 10px;
+  margin-right: -50px;
+  margin-top: -20px;
+  float: right;
+  position:relative;
+  opacity:50% ;
+}

--- a/frontend/src/message.d.ts
+++ b/frontend/src/message.d.ts
@@ -1,5 +1,6 @@
 export type Message = {
   sender: "user" | "assistant";
+  agentName?: string;
   content: string;
   timestamp: string;
   imageUrls?: string[];

--- a/frontend/src/routes/_oh.app/hooks/use-handle-ws-events.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-handle-ws-events.ts
@@ -58,6 +58,7 @@ export const useHandleWSEvents = () => {
         addErrorMessage({
           id: event.extras?.error_id,
           message: event.message,
+          timestamp: event.timestamp,
         }),
       );
     }

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -23,12 +23,24 @@ import { appendInput } from "#/state/command-slice";
 const messageActions = {
   [ActionType.BROWSE]: (message: ActionMessage) => {
     if (!message.args.thought && message.message) {
-      store.dispatch(addAssistantMessage(message.message));
+      store.dispatch(
+        addAssistantMessage({
+          content: message.message,
+          agentName: message.agent_name,
+          timestamp: message.timestamp,
+        }),
+      );
     }
   },
   [ActionType.BROWSE_INTERACTIVE]: (message: ActionMessage) => {
     if (!message.args.thought && message.message) {
-      store.dispatch(addAssistantMessage(message.message));
+      store.dispatch(
+        addAssistantMessage({
+          content: message.message,
+          agentName: message.agent_name,
+          timestamp: message.timestamp,
+        }),
+      );
     }
   },
   [ActionType.WRITE]: (message: ActionMessage) => {
@@ -50,7 +62,13 @@ const messageActions = {
         }),
       );
     } else {
-      store.dispatch(addAssistantMessage(message.args.content));
+      store.dispatch(
+        addAssistantMessage({
+          content: message.args.content,
+          agentName: message.agent_name,
+          timestamp: message.timestamp,
+        }),
+      );
     }
   },
   [ActionType.RUN_IPYTHON]: (message: ActionMessage) => {
@@ -59,7 +77,13 @@ const messageActions = {
     }
   },
   [ActionType.FINISH]: (message: ActionMessage) => {
-    store.dispatch(addAssistantMessage(message.args.final_thought));
+    store.dispatch(
+      addAssistantMessage({
+        content: message.args.final_thought,
+        agentName: message.agent_name,
+        timestamp: message.timestamp,
+      }),
+    );
     let successPrediction = "";
     if (message.args.task_completed === "partial") {
       successPrediction =
@@ -73,9 +97,21 @@ const messageActions = {
     if (successPrediction) {
       // if final_thought is not empty, add a new line before the success prediction
       if (message.args.final_thought) {
-        store.dispatch(addAssistantMessage(`\n${successPrediction}`));
+        store.dispatch(
+          addAssistantMessage({
+            content: `\n${successPrediction}`,
+            agentName: message.agent_name,
+            timestamp: message.timestamp,
+          }),
+        );
       } else {
-        store.dispatch(addAssistantMessage(successPrediction));
+        store.dispatch(
+          addAssistantMessage({
+            content: successPrediction,
+            agentName: message.agent_name,
+            timestamp: message.timestamp,
+          }),
+        );
       }
     }
   },
@@ -105,7 +141,13 @@ export function handleActionMessage(message: ActionMessage) {
 
   if (message.source === "agent") {
     if (message.args && message.args.thought) {
-      store.dispatch(addAssistantMessage(message.args.thought));
+      store.dispatch(
+        addAssistantMessage({
+          content: message.args.thought,
+          agentName: message.agent_name,
+          timestamp: message.timestamp,
+        }),
+      );
     }
     // Need to convert ActionMessage to RejectAction
     // @ts-expect-error TODO: fix

--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -44,7 +44,13 @@ export function handleObservationMessage(message: ObservationMessage) {
     case ObservationType.DELEGATE:
       // TODO: better UI for delegation result (#2309)
       if (message.content) {
-        store.dispatch(addAssistantMessage(message.content));
+        store.dispatch(
+          addAssistantMessage({
+            content: message.content,
+            agentName: message.agent_name,
+            timestamp: message.timestamp,
+          }),
+        );
       }
       break;
     case ObservationType.READ:
@@ -53,7 +59,13 @@ export function handleObservationMessage(message: ObservationMessage) {
     case ObservationType.NULL:
       break; // We don't display the default message for these observations
     default:
-      store.dispatch(addAssistantMessage(message.message));
+      store.dispatch(
+        addAssistantMessage({
+          content: message.message,
+          agentName: message.agent_name,
+          timestamp: message.timestamp,
+        }),
+      );
       break;
   }
   if (!message.extras?.hidden) {
@@ -70,6 +82,7 @@ export function handleObservationMessage(message: ObservationMessage) {
           addAssistantObservation({
             ...baseObservation,
             observation: "agent_state_changed" as const,
+            agent_name: message.agent_name,
             extras: {
               agent_state: (message.extras.agent_state as AgentState) || "idle",
             },
@@ -81,6 +94,7 @@ export function handleObservationMessage(message: ObservationMessage) {
           addAssistantObservation({
             ...baseObservation,
             observation: "run" as const,
+            agent_name: message.agent_name,
             extras: {
               command: String(message.extras.command || ""),
               metadata: message.extras.metadata,
@@ -223,6 +237,7 @@ export function handleObservationMessage(message: ObservationMessage) {
         store.dispatch(
           addAssistantObservation({
             ...baseObservation,
+            agent_name: message.agent_name,
             observation: "error" as const,
             source: "user" as const,
             extras: {

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -75,13 +75,21 @@ export const chatSlice = createSlice({
       state.messages.push(message);
     },
 
-    addAssistantMessage(state: SliceState, action: PayloadAction<string>) {
+    addAssistantMessage(
+      state: SliceState,
+      action: PayloadAction<{
+        content: string;
+        agentName?: string;
+        timestamp?: string;
+      }>,
+    ) {
       const message: Message = {
         type: "thought",
         sender: "assistant",
-        content: action.payload,
+        content: action.payload.content,
+        agentName: action.payload.agentName || "",
         imageUrls: [],
-        timestamp: new Date().toISOString(),
+        timestamp: action.payload.timestamp || new Date().toISOString(),
         pending: false,
       };
       state.messages.push(message);
@@ -129,7 +137,8 @@ export const chatSlice = createSlice({
         eventID: action.payload.id,
         content: text,
         imageUrls: [],
-        timestamp: new Date().toISOString(),
+        agentName: action.payload.agent_name || "",
+        timestamp: action.payload.timestamp || new Date().toISOString(),
       };
 
       state.messages.push(message);
@@ -156,6 +165,7 @@ export const chatSlice = createSlice({
       if (observationID === "run") {
         const commandObs = observation.payload as CommandObservation;
         causeMessage.success = commandObs.extras.metadata.exit_code === 0;
+        causeMessage.agentName = observation.payload.agent_name || "";
       } else if (observationID === "run_ipython") {
         // For IPython, we consider it successful if there's no error message
         const ipythonObs = observation.payload as IPythonObservation;
@@ -208,15 +218,19 @@ export const chatSlice = createSlice({
 
     addErrorMessage(
       state: SliceState,
-      action: PayloadAction<{ id?: string; message: string }>,
+      action: PayloadAction<{
+        id?: string;
+        message: string;
+        timestamp?: string;
+      }>,
     ) {
-      const { id, message } = action.payload;
+      const { id, message, timestamp } = action.payload;
       state.messages.push({
         translationID: id,
         content: message,
         type: "error",
         sender: "assistant",
-        timestamp: new Date().toISOString(),
+        timestamp: timestamp || new Date().toISOString(),
       });
     },
 

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -3,6 +3,7 @@ import { ActionSecurityRisk } from "#/state/security-analyzer-slice";
 
 export interface UserMessageAction extends OpenHandsActionEvent<"message"> {
   source: "user";
+  agent_name?: string;
   args: {
     content: string;
     image_urls: string[];
@@ -11,6 +12,7 @@ export interface UserMessageAction extends OpenHandsActionEvent<"message"> {
 
 export interface CommandAction extends OpenHandsActionEvent<"run"> {
   source: "agent";
+  agent_name?: string;
   args: {
     command: string;
     security_risk: ActionSecurityRisk;
@@ -23,6 +25,7 @@ export interface CommandAction extends OpenHandsActionEvent<"run"> {
 export interface AssistantMessageAction
   extends OpenHandsActionEvent<"message"> {
   source: "agent";
+  agent_name?: string;
   args: {
     thought: string;
     image_urls: string[] | null;
@@ -32,6 +35,7 @@ export interface AssistantMessageAction
 
 export interface IPythonAction extends OpenHandsActionEvent<"run_ipython"> {
   source: "agent";
+  agent_name?: string;
   args: {
     code: string;
     security_risk: ActionSecurityRisk;
@@ -43,6 +47,7 @@ export interface IPythonAction extends OpenHandsActionEvent<"run_ipython"> {
 
 export interface ThinkAction extends OpenHandsActionEvent<"think"> {
   source: "agent";
+  agent_name?: string;
   args: {
     thought: string;
   };
@@ -50,6 +55,7 @@ export interface ThinkAction extends OpenHandsActionEvent<"think"> {
 
 export interface FinishAction extends OpenHandsActionEvent<"finish"> {
   source: "agent";
+  agent_name?: string;
   args: {
     final_thought: string;
     task_completed: "success" | "failure" | "partial";
@@ -60,6 +66,7 @@ export interface FinishAction extends OpenHandsActionEvent<"finish"> {
 
 export interface DelegateAction extends OpenHandsActionEvent<"delegate"> {
   source: "agent";
+  agent_name?: string;
   timeout: number;
   args: {
     agent: "BrowsingAgent";
@@ -70,6 +77,7 @@ export interface DelegateAction extends OpenHandsActionEvent<"delegate"> {
 
 export interface BrowseAction extends OpenHandsActionEvent<"browse"> {
   source: "agent";
+  agent_name?: string;
   args: {
     url: string;
     thought: string;
@@ -80,6 +88,7 @@ export interface BrowseInteractiveAction
   extends OpenHandsActionEvent<"browse_interactive"> {
   source: "agent";
   timeout: number;
+  agent_name?: string;
   args: {
     browser_actions: string;
     thought: string | null;
@@ -89,6 +98,7 @@ export interface BrowseInteractiveAction
 
 export interface FileReadAction extends OpenHandsActionEvent<"read"> {
   source: "agent";
+  agent_name?: string;
   args: {
     path: string;
     thought: string;
@@ -100,6 +110,7 @@ export interface FileReadAction extends OpenHandsActionEvent<"read"> {
 
 export interface FileWriteAction extends OpenHandsActionEvent<"write"> {
   source: "agent";
+  agent_name?: string;
   args: {
     path: string;
     content: string;
@@ -109,6 +120,7 @@ export interface FileWriteAction extends OpenHandsActionEvent<"write"> {
 
 export interface FileEditAction extends OpenHandsActionEvent<"edit"> {
   source: "agent";
+  agent_name?: string;
   args: {
     path: string;
     command?: string;
@@ -128,6 +140,7 @@ export interface FileEditAction extends OpenHandsActionEvent<"edit"> {
 
 export interface RejectAction extends OpenHandsActionEvent<"reject"> {
   source: "agent";
+  agent_name?: string;
   args: {
     thought: string;
   };

--- a/frontend/src/types/core/observations.ts
+++ b/frontend/src/types/core/observations.ts
@@ -4,6 +4,7 @@ import { OpenHandsObservationEvent } from "./base";
 export interface AgentStateChangeObservation
   extends OpenHandsObservationEvent<"agent_state_changed"> {
   source: "agent";
+  agent_name?: string;
   extras: {
     agent_state: AgentState;
   };
@@ -11,6 +12,7 @@ export interface AgentStateChangeObservation
 
 export interface CommandObservation extends OpenHandsObservationEvent<"run"> {
   source: "agent";
+  agent_name?: string;
   extras: {
     command: string;
     hidden?: boolean;
@@ -96,6 +98,7 @@ export interface EditObservation extends OpenHandsObservationEvent<"edit"> {
 
 export interface ErrorObservation extends OpenHandsObservationEvent<"error"> {
   source: "user";
+  agent_name?: string;
   extras: {
     error_id?: string;
   };

--- a/frontend/src/types/message.tsx
+++ b/frontend/src/types/message.tsx
@@ -13,6 +13,8 @@ export interface ActionMessage {
   // A friendly message that can be put in the chat log
   message: string;
 
+  agent_name?: string;
+
   // The timestamp of the message
   timestamp: string;
 
@@ -57,6 +59,8 @@ export interface ObservationMessage {
 
   // A friendly message that can be put in the chat log
   message: string;
+
+  agent_name?: string;
 
   // The timestamp of the message
   timestamp: string;

--- a/openhands/events/event.py
+++ b/openhands/events/event.py
@@ -137,3 +137,14 @@ class Event:
     @response_id.setter
     def response_id(self, value: str) -> None:
         self._response_id = value
+
+    # optional field
+    @property
+    def agent_name(self) -> str:
+        if hasattr(self, '_agent_name'):
+            return self._agent_name
+        return ''
+
+    @agent_name.setter
+    def agent_name(self, value: str) -> None:
+        self._agent_name = value

--- a/openhands/events/serialization/action.py
+++ b/openhands/events/serialization/action.py
@@ -120,6 +120,9 @@ def action_from_dict(action: dict) -> Action:
             blocking = args.get('blocking', False)
             decoded_action.set_hard_timeout(action['timeout'], blocking=blocking)
 
+        if 'agent_name' in action:
+            decoded_action._agent_name = action.get('agent_name', '')
+
         # Set timestamp if it was provided
         if timestamp:
             decoded_action._timestamp = timestamp

--- a/openhands/events/serialization/event.py
+++ b/openhands/events/serialization/event.py
@@ -23,6 +23,7 @@ TOP_KEYS = [
     'observation',
     'tool_call_metadata',
     'llm_metrics',
+    'agent_name',
 ]
 UNDERSCORE_KEYS = [
     'id',
@@ -31,6 +32,7 @@ UNDERSCORE_KEYS = [
     'cause',
     'tool_call_metadata',
     'llm_metrics',
+    'agent_name',
 ]
 
 DELETE_FROM_TRAJECTORY_EXTRAS = {
@@ -108,6 +110,8 @@ def event_to_dict(event: 'Event') -> dict:
         if key == 'timestamp' and 'timestamp' in d:
             if isinstance(d['timestamp'], datetime):
                 d['timestamp'] = d['timestamp'].isoformat()
+        if key == 'agent_name' and d.get('agent_name') == '':
+            d.pop('agent_name', None)
         if key == 'source' and 'source' in d:
             d['source'] = d['source'].value
         if key == 'recall_type' and 'recall_type' in d:

--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -298,11 +298,15 @@ class EventStream:
 
         self._clean_up_subscriber(subscriber_id, callback_id)
 
-    def add_event(self, event: Event, source: EventSource) -> None:
+    def add_event(
+        self, event: Event, source: EventSource, agent_name: str | None = None
+    ) -> None:
         if event.id != Event.INVALID_ID:
             raise ValueError(
                 f'Event already has an ID:{event.id}. It was probably added back to the EventStream from inside a handler, triggering a loop.'
             )
+        if agent_name is not None:
+            event._agent_name = agent_name
         with self._lock:
             event._id = self._cur_id  # type: ignore [attr-defined]
             self._cur_id += 1

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -313,6 +313,7 @@ class Runtime(FileEditRuntimeMixin):
 
         observation._cause = event.id  # type: ignore[attr-defined]
         observation.tool_call_metadata = event.tool_call_metadata
+        observation.agent_name = event.agent_name
 
         # this might be unnecessary, since source should be set by the event stream when we're here
         source = event.source if event.source else EventSource.AGENT

--- a/tests/unit/test_action_serialization.py
+++ b/tests/unit/test_action_serialization.py
@@ -45,6 +45,7 @@ def test_event_props_serialization_deserialization():
         'id': 42,
         'source': 'agent',
         'timestamp': '2021-08-01T12:00:00',
+        'agent_name': 'TestAgent',
         'action': 'message',
         'args': {
             'content': 'This is a test.',

--- a/tests/unit/test_event_serialization.py
+++ b/tests/unit/test_event_serialization.py
@@ -121,3 +121,32 @@ def test_metrics_none_serialization():
     # Test deserialization
     deserialized = event_from_dict(serialized)
     assert deserialized.llm_metrics is None
+
+
+def test_agent_name_serialization():
+    # Test with agent_name set
+    action = MessageAction(content='Hello, world!')
+    action.agent_name = 'TestAgent'
+
+    # Test serialization
+    serialized = event_to_dict(action)
+    assert 'agent_name' in serialized
+    assert serialized['agent_name'] == 'TestAgent'
+
+    # Test deserialization
+    deserialized = event_from_dict(serialized)
+    assert deserialized.agent_name == 'TestAgent'
+
+
+def test_agent_name_none_serialization():
+    # Test with agent_name not set (None)
+    action = MessageAction(content='Hello, world!')
+    action.agent_name = None
+
+    # Test serialization
+    serialized = event_to_dict(action)
+    assert 'agent_name' not in serialized
+
+    # Test deserialization
+    deserialized = event_from_dict(serialized)
+    assert deserialized.agent_name == ''

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -66,6 +66,7 @@ async def test_memory_on_event_exception_handling(memory, event_stream):
     agent.llm = MagicMock(spec=LLM)
     agent.llm.metrics = Metrics()
     agent.llm.config = AppConfig().get_llm_config()
+    agent.name = 'TestAgent'
 
     # Create a mock runtime
     runtime = MagicMock(spec=Runtime)
@@ -102,6 +103,7 @@ async def test_memory_on_workspace_context_recall_exception_handling(
     agent.llm = MagicMock(spec=LLM)
     agent.llm.metrics = Metrics()
     agent.llm.config = AppConfig().get_llm_config()
+    agent.name = 'TestAgent'
 
     # Create a mock runtime
     runtime = MagicMock(spec=Runtime)

--- a/tests/unit/test_observation_serialization.py
+++ b/tests/unit/test_observation_serialization.py
@@ -43,6 +43,7 @@ def test_observation_event_props_serialization_deserialization():
         'id': 42,
         'source': 'agent',
         'timestamp': '2021-08-01T12:00:00',
+        'agent_name': 'TestAgent',
         'observation': 'run',
         'message': 'Command `ls -l` executed with exit code 0.',
         'extras': {
@@ -118,6 +119,7 @@ def test_legacy_serialization():
         'id': 42,
         'source': 'agent',
         'timestamp': '2021-08-01T12:00:00',
+        'agent_name': 'TestAgent',
         'observation': 'run',
         'message': 'Command `ls -l` executed with exit code 0.',
         'extras': {
@@ -136,6 +138,7 @@ def test_legacy_serialization():
     assert event.success is True
     assert event.command == 'ls -l'
     assert event.hidden is False
+    assert event.agent_name == 'TestAgent'
 
     event_dict = event_to_dict(event)
     assert event_dict['success'] is True


### PR DESCRIPTION
This change adds agent icons to the chat UI for improved multi-agent conversation clarity.

- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

The chat UI now displays icons next to each agent's messages, making it easier to distinguish between different agents participating in the conversation. This improves clarity and helps users follow multi-agent interactions more effectively.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR enhances the OpenHands chat UI by adding agent icons, names, and timestamps to each agent's messages.

Specifically, this PR includes:

- Chat UI modifications to display the agent's name, icon, and timestamp alongside their messages.
- Chat UI modifications to display timestamps for user messages.
- Modifications to the `Event` class, the `agent_controller`, and related functions to include the agent's name in backend.

Future improvements will include:

- A toggle button in the settings panel to enable/disable agent icons.
- Logic to display a single icon for consecutive messages or observations from the same agent.
- Icon customization, allowing users to upload their own images for agent icons

<img height="570" alt="without-icon" src="https://github.com/user-attachments/assets/fd0a8404-e925-4eb7-9de3-13230b195767" /> 
<img height="570" alt="with-icon" src="https://github.com/user-attachments/assets/fbf131e9-caf7-4cf7-a878-f45601cc34a6" /> 
