### PR TITLE
Add context window usage metrics to cost modal

### DIFF
--- a/frontend/src/components/features/conversation-panel/__tests__/metrics-modal.test.tsx
+++ b/frontend/src/components/features/conversation-panel/__tests__/metrics-modal.test.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect } from "vitest";
+import { ConversationCard } from "../conversation-card";
+import metricsReducer, { MODEL_CONTEXT_SIZES } from "#/state/metrics-slice";
+
+// Mock the formatTimeDelta function
+vi.mock("#/utils/format-time-delta", () => ({
+  formatTimeDelta: () => "5 minutes",
+}));
+
+// Mock posthog
+vi.mock("posthog-js", () => ({
+  capture: vi.fn(),
+}));
+
+describe("Metrics Modal", () => {
+  const createStore = (initialState = {}) =>
+    configureStore({
+      reducer: {
+        metrics: metricsReducer,
+      },
+      preloadedState: {
+        metrics: {
+          cost: 0.05,
+          usage: {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            cache_read_tokens: 100,
+            cache_write_tokens: 200,
+          },
+          mostRecentUsage: {
+            prompt_tokens: 300,
+            completion_tokens: 150,
+            cache_read_tokens: 50,
+            cache_write_tokens: 100,
+          },
+          modelName: "claude-3-sonnet-20240229",
+          ...initialState,
+        },
+      },
+    });
+
+  it("should display total input and output tokens for the conversation", async () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <ConversationCard
+          title="Test Conversation"
+          selectedRepository={null}
+          lastUpdatedAt={new Date().toISOString()}
+          createdAt={new Date().toISOString()}
+          showOptions
+        />
+      </Provider>,
+    );
+
+    // Open the metrics modal
+    const ellipsisButton = screen.getByTestId("ellipsis-button");
+    await userEvent.click(ellipsisButton);
+
+    const displayCostButton = screen.getByTestId("display-cost-button");
+    await userEvent.click(displayCostButton);
+
+    // Check if the modal is open
+    const modal = screen.getByTestId("metrics-modal");
+    expect(modal).toBeInTheDocument();
+
+    // Check if total input tokens are displayed
+    expect(screen.getByText("Total Input Tokens:")).toBeInTheDocument();
+    expect(screen.getByText("1,000")).toBeInTheDocument();
+
+    // Check if total output tokens are displayed
+    expect(screen.getByText("Total Output Tokens:")).toBeInTheDocument();
+    expect(screen.getByText("500")).toBeInTheDocument();
+  });
+
+  it("should display most recent prompt metrics", async () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <ConversationCard
+          title="Test Conversation"
+          selectedRepository={null}
+          lastUpdatedAt={new Date().toISOString()}
+          createdAt={new Date().toISOString()}
+          showOptions
+        />
+      </Provider>,
+    );
+
+    // Open the metrics modal
+    const ellipsisButton = screen.getByTestId("ellipsis-button");
+    await userEvent.click(ellipsisButton);
+
+    const displayCostButton = screen.getByTestId("display-cost-button");
+    await userEvent.click(displayCostButton);
+
+    // Check if the most recent prompt section is displayed
+    expect(screen.getByText("Most Recent Prompt")).toBeInTheDocument();
+
+    // Check if most recent input tokens are displayed
+    const inputTokensElements = screen.getAllByText("Input Tokens:");
+    expect(inputTokensElements.length).toBeGreaterThan(0);
+    expect(screen.getByText("300")).toBeInTheDocument();
+
+    // Check if most recent output tokens are displayed
+    const outputTokensElements = screen.getAllByText("Output Tokens:");
+    expect(outputTokensElements.length).toBeGreaterThan(0);
+    expect(screen.getByText("150")).toBeInTheDocument();
+  });
+
+  it("should display context window usage percentage", async () => {
+    const store = createStore();
+    const modelName = "claude-3-sonnet-20240229";
+    const contextSize = MODEL_CONTEXT_SIZES[modelName];
+    const totalTokens = 300 + 150; // prompt_tokens + completion_tokens
+    const expectedPercentage = `${((totalTokens / contextSize) * 100).toFixed(2)}%`;
+
+    render(
+      <Provider store={store}>
+        <ConversationCard
+          title="Test Conversation"
+          selectedRepository={null}
+          lastUpdatedAt={new Date().toISOString()}
+          createdAt={new Date().toISOString()}
+          showOptions
+        />
+      </Provider>,
+    );
+
+    // Open the metrics modal
+    const ellipsisButton = screen.getByTestId("ellipsis-button");
+    await userEvent.click(ellipsisButton);
+
+    const displayCostButton = screen.getByTestId("display-cost-button");
+    await userEvent.click(displayCostButton);
+
+    // Check if context window usage is displayed
+    expect(screen.getByText("Context Window Usage:")).toBeInTheDocument();
+    expect(screen.getByText(expectedPercentage)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -327,16 +327,34 @@ export function ConversationCard({
                     </div>
 
                     {/* Context Window Usage */}
-                    {metrics.modelName && (
+                    {metrics.mostRecentUsage && (
                       <div className="mt-3 pt-2 border-t border-neutral-700">
                         <div className="flex justify-between items-center">
                           <span>Context Window Usage:</span>
                           <span className="font-semibold">
                             {(() => {
-                              const { modelName } = metrics;
-                              const contextSize =
-                                MODEL_CONTEXT_SIZES[modelName] ||
-                                MODEL_CONTEXT_SIZES.default;
+                              // Get context window size from model_info if available, otherwise fallback to hardcoded values
+                              let contextSize = MODEL_CONTEXT_SIZES.default;
+
+                              if (
+                                metrics.modelInfo &&
+                                metrics.modelInfo.max_input_tokens
+                              ) {
+                                contextSize =
+                                  metrics.modelInfo.max_input_tokens;
+                              } else if (
+                                metrics.modelInfo &&
+                                metrics.modelInfo.max_tokens
+                              ) {
+                                contextSize = metrics.modelInfo.max_tokens;
+                              } else if (
+                                metrics.modelName &&
+                                MODEL_CONTEXT_SIZES[metrics.modelName]
+                              ) {
+                                contextSize =
+                                  MODEL_CONTEXT_SIZES[metrics.modelName];
+                              }
+
                               const totalTokens =
                                 metrics.mostRecentUsage.prompt_tokens +
                                 metrics.mostRecentUsage.completion_tokens;
@@ -354,10 +372,28 @@ export function ConversationCard({
                             className="bg-blue-600 h-2.5 rounded-full"
                             style={{
                               width: (() => {
-                                const { modelName } = metrics;
-                                const contextSize =
-                                  MODEL_CONTEXT_SIZES[modelName] ||
-                                  MODEL_CONTEXT_SIZES.default;
+                                // Get context window size from model_info if available, otherwise fallback to hardcoded values
+                                let contextSize = MODEL_CONTEXT_SIZES.default;
+
+                                if (
+                                  metrics.modelInfo &&
+                                  metrics.modelInfo.max_input_tokens
+                                ) {
+                                  contextSize =
+                                    metrics.modelInfo.max_input_tokens;
+                                } else if (
+                                  metrics.modelInfo &&
+                                  metrics.modelInfo.max_tokens
+                                ) {
+                                  contextSize = metrics.modelInfo.max_tokens;
+                                } else if (
+                                  metrics.modelName &&
+                                  MODEL_CONTEXT_SIZES[metrics.modelName]
+                                ) {
+                                  contextSize =
+                                    MODEL_CONTEXT_SIZES[metrics.modelName];
+                                }
+
                                 const totalTokens =
                                   metrics.mostRecentUsage.prompt_tokens +
                                   metrics.mostRecentUsage.completion_tokens;

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -12,6 +12,7 @@ import { ConversationCardContextMenu } from "./conversation-card-context-menu";
 import { cn } from "#/utils/utils";
 import { BaseModal } from "../../shared/modals/base-modal/base-modal";
 import { RootState } from "#/store";
+import { MODEL_CONTEXT_SIZES } from "#/state/metrics-slice";
 
 interface ConversationCardProps {
   onClick?: () => void;
@@ -282,7 +283,7 @@ export function ConversationCard({
                       </span>
                     </div>
 
-                    <div className="flex justify-between items-center pt-1">
+                    <div className="flex justify-between items-center pt-1 pb-2">
                       <span className="font-semibold">Total Tokens:</span>
                       <span className="font-bold">
                         {(
@@ -292,6 +293,85 @@ export function ConversationCard({
                       </span>
                     </div>
                   </>
+                )}
+
+                {/* Most Recent Prompt Metrics */}
+                {metrics?.mostRecentUsage && (
+                  <div className="border-t border-neutral-700 pt-4 pb-2">
+                    <h3 className="text-lg font-semibold mb-3">
+                      Most Recent Prompt
+                    </h3>
+
+                    <div className="flex justify-between items-center pb-2">
+                      <span>Input Tokens:</span>
+                      <span className="font-semibold">
+                        {metrics.mostRecentUsage.prompt_tokens.toLocaleString()}
+                      </span>
+                    </div>
+
+                    <div className="flex justify-between items-center pb-2">
+                      <span>Output Tokens:</span>
+                      <span className="font-semibold">
+                        {metrics.mostRecentUsage.completion_tokens.toLocaleString()}
+                      </span>
+                    </div>
+
+                    <div className="flex justify-between items-center pb-2">
+                      <span>Total Tokens:</span>
+                      <span className="font-bold">
+                        {(
+                          metrics.mostRecentUsage.prompt_tokens +
+                          metrics.mostRecentUsage.completion_tokens
+                        ).toLocaleString()}
+                      </span>
+                    </div>
+
+                    {/* Context Window Usage */}
+                    {metrics.modelName && (
+                      <div className="mt-3 pt-2 border-t border-neutral-700">
+                        <div className="flex justify-between items-center">
+                          <span>Context Window Usage:</span>
+                          <span className="font-semibold">
+                            {(() => {
+                              const { modelName } = metrics;
+                              const contextSize =
+                                MODEL_CONTEXT_SIZES[modelName] ||
+                                MODEL_CONTEXT_SIZES.default;
+                              const totalTokens =
+                                metrics.mostRecentUsage.prompt_tokens +
+                                metrics.mostRecentUsage.completion_tokens;
+                              const percentage =
+                                (totalTokens / contextSize) * 100;
+
+                              return `${percentage.toFixed(2)}%`;
+                            })()}
+                          </span>
+                        </div>
+
+                        {/* Progress bar for context window usage */}
+                        <div className="w-full bg-neutral-700 rounded-full h-2.5 mt-2">
+                          <div
+                            className="bg-blue-600 h-2.5 rounded-full"
+                            style={{
+                              width: (() => {
+                                const { modelName } = metrics;
+                                const contextSize =
+                                  MODEL_CONTEXT_SIZES[modelName] ||
+                                  MODEL_CONTEXT_SIZES.default;
+                                const totalTokens =
+                                  metrics.mostRecentUsage.prompt_tokens +
+                                  metrics.mostRecentUsage.completion_tokens;
+                                const percentage =
+                                  (totalTokens / contextSize) * 100;
+
+                                return `${Math.min(percentage, 100)}%`;
+                              })(),
+                            }}
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -91,6 +91,8 @@ export function handleActionMessage(message: ActionMessage) {
     const metrics = {
       cost: message.llm_metrics?.accumulated_cost ?? null,
       usage: message.llm_metrics?.accumulated_token_usage ?? null,
+      token_usages: message.llm_metrics?.token_usages ?? [],
+      model_name: message.llm_metrics?.model_name ?? null,
     };
     store.dispatch(setMetrics(metrics));
   }

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -93,6 +93,7 @@ export function handleActionMessage(message: ActionMessage) {
       usage: message.llm_metrics?.accumulated_token_usage ?? null,
       token_usages: message.llm_metrics?.token_usages ?? [],
       model_name: message.llm_metrics?.model_name ?? null,
+      model_info: message.llm_metrics?.model_info ?? null,
     };
     store.dispatch(setMetrics(metrics));
   }

--- a/frontend/src/state/metrics-slice.ts
+++ b/frontend/src/state/metrics-slice.ts
@@ -1,27 +1,75 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+// Define model context window sizes (in tokens)
+export const MODEL_CONTEXT_SIZES: Record<string, number> = {
+  // Claude models
+  "claude-3-7-sonnet-20250219": 200000,
+  "claude-3-5-sonnet-20241022": 200000,
+  "claude-3-5-sonnet-20240620": 200000,
+  "claude-3-5-haiku-20241022": 200000,
+  "claude-3-haiku-20240307": 200000,
+  "claude-3-opus-20240229": 200000,
+  "claude-3-sonnet-20240229": 200000,
+  // GPT models
+  "gpt-4o": 128000,
+  "gpt-4-turbo": 128000,
+  "gpt-4": 8192,
+  "gpt-3.5-turbo": 16385,
+  // Default fallback
+  default: 100000,
+};
+
+interface TokenUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  model?: string;
+}
+
 interface MetricsState {
   cost: number | null;
-  usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    cache_read_tokens: number;
-    cache_write_tokens: number;
-  } | null;
+  usage: TokenUsage | null;
+  mostRecentUsage: TokenUsage | null;
+  modelName: string | null;
 }
 
 const initialState: MetricsState = {
   cost: null,
   usage: null,
+  mostRecentUsage: null,
+  modelName: null,
 };
 
 const metricsSlice = createSlice({
   name: "metrics",
   initialState,
   reducers: {
-    setMetrics: (state, action: PayloadAction<MetricsState>) => {
+    setMetrics: (
+      state,
+      action: PayloadAction<{
+        cost: number | null;
+        usage: TokenUsage | null;
+        token_usages?: TokenUsage[];
+        model_name?: string;
+      }>,
+    ) => {
       state.cost = action.payload.cost;
       state.usage = action.payload.usage;
+
+      // Set the model name if provided
+      if (action.payload.model_name) {
+        state.modelName = action.payload.model_name;
+      }
+
+      // Set the most recent usage if token_usages is provided and has entries
+      if (
+        action.payload.token_usages &&
+        action.payload.token_usages.length > 0
+      ) {
+        state.mostRecentUsage =
+          action.payload.token_usages[action.payload.token_usages.length - 1];
+      }
     },
   },
 });

--- a/frontend/src/state/metrics-slice.ts
+++ b/frontend/src/state/metrics-slice.ts
@@ -27,11 +27,19 @@ interface TokenUsage {
   model?: string;
 }
 
+interface ModelInfo {
+  max_tokens?: number;
+  max_input_tokens?: number;
+  max_output_tokens?: number;
+  [key: string]: unknown;
+}
+
 interface MetricsState {
   cost: number | null;
   usage: TokenUsage | null;
   mostRecentUsage: TokenUsage | null;
   modelName: string | null;
+  modelInfo: ModelInfo | null;
 }
 
 const initialState: MetricsState = {
@@ -39,6 +47,7 @@ const initialState: MetricsState = {
   usage: null,
   mostRecentUsage: null,
   modelName: null,
+  modelInfo: null,
 };
 
 const metricsSlice = createSlice({
@@ -52,6 +61,7 @@ const metricsSlice = createSlice({
         usage: TokenUsage | null;
         token_usages?: TokenUsage[];
         model_name?: string;
+        model_info?: ModelInfo;
       }>,
     ) => {
       state.cost = action.payload.cost;
@@ -60,6 +70,11 @@ const metricsSlice = createSlice({
       // Set the model name if provided
       if (action.payload.model_name) {
         state.modelName = action.payload.model_name;
+      }
+
+      // Set the model info if provided
+      if (action.payload.model_info) {
+        state.modelInfo = action.payload.model_info;
       }
 
       // Set the most recent usage if token_usages is provided and has entries

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -1178,7 +1178,14 @@ class AgentController:
                 cache_write_tokens=latest_usage.cache_write_tokens,
                 response_id=latest_usage.response_id,
             )
-        action.llm_metrics = metrics
+        # Add model_info to metrics if available
+        if hasattr(self.agent.llm, 'model_info') and self.agent.llm.model_info:
+            # Add model_info to metrics
+            metrics_dict = metrics.get()
+            metrics_dict['model_info'] = self.agent.llm.model_info
+            action.llm_metrics = metrics_dict
+        else:
+            action.llm_metrics = metrics
 
         # Log the metrics information for frontend display
         log_usage: TokenUsage | None = (

--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -161,6 +161,7 @@ class Metrics:
                 latency.model_dump() for latency in self._response_latencies
             ],
             'token_usages': [usage.model_dump() for usage in self._token_usages],
+            'model_name': self.model_name,
         }
 
     def reset(self):


### PR DESCRIPTION
This PR implements the feature request from issue #7554.

Changes:
- Added context window usage metrics to the cost modal
- Added total input tokens for the conversation
- Added total output tokens for the conversation
- Added total input tokens in the most recent prompt
- Added total output tokens in the most recent prompt
- Added percent of context window used in most recent prompt
- Added a progress bar to visualize context window usage
- Uses LiteLLM model_info for accurate context window sizes

Closes #7554

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a7f55b6ef609487698b0b8d10e24ad0d)