### PR TITLE
Add conversation metrics endpoint

### DIFF
--- a/openhands/server/routes/conversation.py
+++ b/openhands/server/routes/conversation.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.runtime.base import Runtime
@@ -22,6 +23,62 @@ async def get_remote_runtime_config(request: Request):
             'session_id': session_id,
         }
     )
+
+
+class ConversationMetrics(BaseModel):
+    """Model for conversation metrics."""
+
+    model: str
+    total_cost: float
+    total_input_tokens: int
+    total_output_tokens: int
+    total_cache_hit_tokens: int
+
+
+@app.get('/metrics', response_model=ConversationMetrics)
+async def get_conversation_metrics(request: Request):
+    """Get metrics for the current conversation.
+
+    Returns:
+        JSONResponse: A JSON response containing:
+            - model: The LLM model being used
+            - total_cost: The total cost for the conversation so far
+            - total_input_tokens: The total number of input tokens used
+            - total_output_tokens: The total number of output tokens used
+            - total_cache_hit_tokens: The total number of cache hit tokens
+    """
+    try:
+        # Get the agent controller from the conversation
+        controller = request.state.conversation.runtime.agent_session.controller
+        if not controller or not controller.agent or not controller.agent.llm:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content={'error': 'LLM not found for this conversation'},
+            )
+
+        # Get the metrics from the LLM
+        llm = controller.agent.llm
+        metrics = llm.metrics
+
+        # Get the accumulated token usage
+        token_usage = metrics._accumulated_token_usage
+
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={
+                'model': metrics.model_name,
+                'total_cost': metrics.accumulated_cost,
+                'total_input_tokens': token_usage.prompt_tokens,
+                'total_output_tokens': token_usage.completion_tokens,
+                'total_cache_hit_tokens': token_usage.cache_read_tokens,
+            },
+        )
+    except Exception as e:
+        logger.error(f'Error getting conversation metrics: {e}')
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={'error': f'Error getting conversation metrics: {e}'},
+        )
 
 
 @app.get('/vscode-url')

--- a/tests/unit/test_conversation_routes.py
+++ b/tests/unit/test_conversation_routes.py
@@ -1,6 +1,6 @@
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi import Request
 from fastapi.responses import JSONResponse
 
@@ -54,7 +54,9 @@ async def test_get_conversation_metrics():
     mock_request.state.conversation = mock_conversation
 
     # Mock JSONResponse
-    with patch('openhands.server.routes.conversation.JSONResponse') as mock_json_response:
+    with patch(
+        'openhands.server.routes.conversation.JSONResponse'
+    ) as mock_json_response:
         mock_json_response.return_value = JSONResponse(
             status_code=200,
             content={
@@ -67,7 +69,7 @@ async def test_get_conversation_metrics():
         )
 
         # Call the function
-        result = await get_conversation_metrics(mock_request)
+        await get_conversation_metrics(mock_request)
 
         # Verify JSONResponse was called with correct arguments
         mock_json_response.assert_called_once_with(

--- a/tests/unit/test_conversation_routes.py
+++ b/tests/unit/test_conversation_routes.py
@@ -1,0 +1,82 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from openhands.llm.metrics import Metrics, TokenUsage
+from openhands.server.routes.conversation import get_conversation_metrics
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_metrics():
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+
+    # Create mock metrics
+    mock_metrics = MagicMock(spec=Metrics)
+    mock_metrics.model_name = 'test-model'
+    mock_metrics.accumulated_cost = 0.25
+    mock_metrics._accumulated_token_usage = TokenUsage(
+        model='test-model',
+        prompt_tokens=100,
+        completion_tokens=50,
+        cache_read_tokens=20,
+        cache_write_tokens=10,
+        response_id='test-response',
+    )
+
+    # Create mock LLM
+    mock_llm = MagicMock()
+    mock_llm.metrics = mock_metrics
+
+    # Create mock agent
+    mock_agent = MagicMock()
+    mock_agent.llm = mock_llm
+
+    # Create mock controller
+    mock_controller = MagicMock()
+    mock_controller.agent = mock_agent
+
+    # Create mock agent_session
+    mock_agent_session = MagicMock()
+    mock_agent_session.controller = mock_controller
+
+    # Create mock runtime
+    mock_runtime = MagicMock()
+    mock_runtime.agent_session = mock_agent_session
+
+    # Create mock conversation
+    mock_conversation = MagicMock()
+    mock_conversation.runtime = mock_runtime
+
+    # Set up request state
+    mock_request.state.conversation = mock_conversation
+
+    # Mock JSONResponse
+    with patch('openhands.server.routes.conversation.JSONResponse') as mock_json_response:
+        mock_json_response.return_value = JSONResponse(
+            status_code=200,
+            content={
+                'model': 'test-model',
+                'total_cost': 0.25,
+                'total_input_tokens': 100,
+                'total_output_tokens': 50,
+                'total_cache_hit_tokens': 20,
+            },
+        )
+
+        # Call the function
+        result = await get_conversation_metrics(mock_request)
+
+        # Verify JSONResponse was called with correct arguments
+        mock_json_response.assert_called_once_with(
+            status_code=200,
+            content={
+                'model': 'test-model',
+                'total_cost': 0.25,
+                'total_input_tokens': 100,
+                'total_output_tokens': 50,
+                'total_cache_hit_tokens': 20,
+            },
+        )


### PR DESCRIPTION
This PR adds a new API endpoint `/conversation/{id}/metrics` which returns:

- The model being used
- The total cost for the conversation so far
- The total number of tokens used so far in the conversation (input, output, cache hit)

The implementation leverages the existing metrics tracking in the LLM class, which already tracks these metrics for each conversation.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:cb7351a-nikolaik   --name openhands-app-cb7351a   docker.all-hands.dev/all-hands-ai/openhands:cb7351a
```