### PR TITLE
fix missing pending tool results for Claude

### DIFF
--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -685,6 +685,7 @@ def test_convert_from_multiple_tool_calls_no_tool_calls():
     )
     assert result == input_messages
 
+
 def test_convert_from_multiple_tool_calls_with_ignore_final_tool_result():
     # Test case with multiple tool calls in one message and ignore_final_tool_result=True
     input_messages = [
@@ -742,12 +743,7 @@ def test_convert_from_multiple_tool_calls_with_ignore_final_tool_result():
                 },
             ],
         },
-        {
-            'role': 'tool',
-            'tool_call_id': 'call2',
-            'name': 'func2',
-            'content': ''
-        }
+        {'role': 'tool', 'tool_call_id': 'call2', 'name': 'func2', 'content': ''},
     ]
 
     result = convert_from_multiple_tool_calls_to_single_tool_call_messages(

--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -684,3 +684,73 @@ def test_convert_from_multiple_tool_calls_no_tool_calls():
         input_messages
     )
     assert result == input_messages
+
+def test_convert_from_multiple_tool_calls_with_ignore_final_tool_result():
+    # Test case with multiple tool calls in one message and ignore_final_tool_result=True
+    input_messages = [
+        {
+            'role': 'assistant',
+            'content': 'Let me help you with that.',
+            'tool_calls': [
+                {
+                    'id': 'call1',
+                    'type': 'function',
+                    'function': {'name': 'func1', 'arguments': '{}'},
+                },
+                {
+                    'id': 'call2',
+                    'type': 'function',
+                    'function': {'name': 'func2', 'arguments': '{}'},
+                },
+            ],
+        },
+        {
+            'role': 'tool',
+            'tool_call_id': 'call1',
+            'content': 'Result 1',
+            'name': 'func1',
+        },
+    ]
+
+    # Expected output should include the pending tool call and an empty tool result
+    expected_output = [
+        {
+            'role': 'assistant',
+            'content': 'Let me help you with that.',
+            'tool_calls': [
+                {
+                    'id': 'call1',
+                    'type': 'function',
+                    'function': {'name': 'func1', 'arguments': '{}'},
+                },
+            ],
+        },
+        {
+            'role': 'tool',
+            'tool_call_id': 'call1',
+            'content': 'Result 1',
+            'name': 'func1',
+        },
+        {
+            'role': 'assistant',
+            'content': '',
+            'tool_calls': [
+                {
+                    'id': 'call2',
+                    'type': 'function',
+                    'function': {'name': 'func2', 'arguments': '{}'},
+                },
+            ],
+        },
+        {
+            'role': 'tool',
+            'tool_call_id': 'call2',
+            'name': 'func2',
+            'content': ''
+        }
+    ]
+
+    result = convert_from_multiple_tool_calls_to_single_tool_call_messages(
+        input_messages, ignore_final_tool_result=True
+    )
+    assert result == expected_output


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Fix for #7512, when we trim the message history for context length, we sometimes get this error from Claude Sonnet:

```
"messages: `tool_use` ids were found without `tool_result` blocks immediately after"
```

Credit to @onezibo for being the first (afaik) to [fix](https://github.com/onezibo/OpenHands/pull/1/files) this using the openhands agent in their fork. This PR is based on that fix with a slight refactor.

---
**Link of any specific issues this addresses.**
