### PR TITLE
Fix for circular import on ConversationValidator

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -17,11 +17,13 @@ from openhands.events.observation.agent import (
 from openhands.events.serialization import event_to_dict
 from openhands.events.stream import AsyncEventStreamWrapper
 from openhands.server.shared import (
-    ConversationValidatorImpl,
     SettingsStoreImpl,
     config,
     conversation_manager,
     sio,
+)
+from openhands.storage.conversation.conversation_validator import (
+    create_conversation_validator,
 )
 
 
@@ -36,7 +38,7 @@ async def connect(connection_id: str, environ):
         raise ConnectionRefusedError('No conversation_id in query params')
 
     cookies_str = environ.get('HTTP_COOKIE', '')
-    conversation_validator = ConversationValidatorImpl()
+    conversation_validator = create_conversation_validator()
     user_id, github_user_id = await conversation_validator.validate(
         conversation_id, cookies_str
     )

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -17,13 +17,11 @@ from openhands.events.observation.agent import (
 from openhands.events.serialization import event_to_dict
 from openhands.events.stream import AsyncEventStreamWrapper
 from openhands.server.shared import (
+    ConversationValidatorImpl,
     SettingsStoreImpl,
     config,
     conversation_manager,
     sio,
-)
-from openhands.storage.conversation.conversation_validator import (
-    ConversationValidatorImpl,
 )
 
 

--- a/openhands/server/shared.py
+++ b/openhands/server/shared.py
@@ -11,6 +11,7 @@ from openhands.server.conversation_manager.conversation_manager import (
 from openhands.server.monitoring import MonitoringListener
 from openhands.storage import get_file_store
 from openhands.storage.conversation.conversation_store import ConversationStore
+from openhands.storage.conversation.conversation_validator import ConversationValidator
 from openhands.storage.settings.settings_store import SettingsStore
 from openhands.utils.import_utils import get_impl
 
@@ -55,3 +56,9 @@ ConversationStoreImpl = get_impl(
     ConversationStore,  # type: ignore
     server_config.conversation_store_class,
 )
+
+conversation_validator_cls = os.environ.get(
+    'OPENHANDS_CONVERSATION_VALIDATOR_CLS',
+    'openhands.storage.conversation.conversation_validator.ConversationValidator',
+)
+ConversationValidatorImpl = get_impl(ConversationValidator, conversation_validator_cls)

--- a/openhands/server/shared.py
+++ b/openhands/server/shared.py
@@ -11,7 +11,6 @@ from openhands.server.conversation_manager.conversation_manager import (
 from openhands.server.monitoring import MonitoringListener
 from openhands.storage import get_file_store
 from openhands.storage.conversation.conversation_store import ConversationStore
-from openhands.storage.conversation.conversation_validator import ConversationValidator
 from openhands.storage.settings.settings_store import SettingsStore
 from openhands.utils.import_utils import get_impl
 
@@ -56,9 +55,3 @@ ConversationStoreImpl = get_impl(
     ConversationStore,  # type: ignore
     server_config.conversation_store_class,
 )
-
-conversation_validator_cls = os.environ.get(
-    'OPENHANDS_CONVERSATION_VALIDATOR_CLS',
-    'openhands.storage.conversation.conversation_validator.ConversationValidator',
-)
-ConversationValidatorImpl = get_impl(ConversationValidator, conversation_validator_cls)

--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -1,5 +1,21 @@
+import os
+
+from openhands.utils.import_utils import get_impl
+
+
 class ConversationValidator:
     """Storage for conversation metadata. May or may not support multiple users depending on the environment."""
 
     async def validate(self, conversation_id: str, cookies_str: str):
         return None, None
+
+
+def create_conversation_validator():
+    conversation_validator_cls = os.environ.get(
+        'OPENHANDS_CONVERSATION_VALIDATOR_CLS',
+        'openhands.storage.conversation.conversation_validator.ConversationValidator',
+    )
+    ConversationValidatorImpl = get_impl(
+        ConversationValidator, conversation_validator_cls
+    )
+    return ConversationValidatorImpl()

--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -1,17 +1,5 @@
-import os
-
-from openhands.utils.import_utils import get_impl
-
-
 class ConversationValidator:
     """Storage for conversation metadata. May or may not support multiple users depending on the environment."""
 
     async def validate(self, conversation_id: str, cookies_str: str):
         return None, None
-
-
-conversation_validator_cls = os.environ.get(
-    'OPENHANDS_CONVERSATION_VALIDATOR_CLS',
-    'openhands.storage.conversation.conversation_validator.ConversationValidator',
-)
-ConversationValidatorImpl = get_impl(ConversationValidator, conversation_validator_cls)

--- a/openhands/utils/import_utils.py
+++ b/openhands/utils/import_utils.py
@@ -1,4 +1,5 @@
 import importlib
+from functools import lru_cache
 from typing import Type, TypeVar
 
 T = TypeVar('T')
@@ -13,6 +14,7 @@ def import_from(qual_name: str):
     return result
 
 
+@lru_cache()
 def get_impl(cls: Type[T], impl_name: str | None) -> Type[T]:
     """Import a named implementation of the specified class"""
     if impl_name is None:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Follow the existing precedent for ConversationStore and SettingsStore moving the implementation to the `shared` module.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Resolution of the Concrete Implementation should be delayed, or you will get circular imports when trying to override this class. For example - suppose you define a custom implementation:

my_module/my_conversation_validator.py
```
from openhands.storage.conversation.conversation_validator import ConversationValidator

class MyConversationValidator(ConversationValidator):
   ... Beautiful custom logic
 ```
 
 If I specify this class in the environment variable `OPENHANDS_CONVERSATION_VALIDATOR_CLS="my_module.my_conversation_validator.MyConversationValidator"`, I get a circular import error.
 
---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6f67ea0-nikolaik   --name openhands-app-6f67ea0   docker.all-hands.dev/all-hands-ai/openhands:6f67ea0
```