### PR TITLE
Fix broken markdown link for Anthropic billing settings

### DIFF
--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -95,7 +95,7 @@ OpenHands requires an API key to access most language models. Here's how to get 
 
 1. [Create an Anthropic account](https://console.anthropic.com/)
 2. [Generate an API key](https://console.anthropic.com/settings/keys)
-3. [Set up billing(https://console.anthropic.com/settings/billing)
+3. [Set up billing](https://console.anthropic.com/settings/billing)
 
 Consider setting usage limits to control costs.
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
N/A

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR fixes a broken markdown link in the installation documentation. The link to Anthropic's billing settings page was missing a closing bracket, which caused the markdown to render incorrectly when searching for 'console.anthropic.com/settings/billing'.

Changed from:
`[Set up billing(https://console.anthropic.com/settings/billing)`

To:
`[Set up billing](https://console.anthropic.com/settings/billing)`

---
**Link of any specific issues this addresses.**
N/A