### PR TITLE
Clean up apt temporary files in app Dockerfile

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -48,7 +48,8 @@ RUN mkdir -p $FILE_STORE_PATH
 RUN mkdir -p $WORKSPACE_BASE
 
 RUN apt-get update -y \
-    && apt-get install -y curl ssh sudo
+    && apt-get install -y curl ssh sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 # Default is 1000, but OSX is often 501
 RUN sed -i 's/^UID_MIN.*/UID_MIN 499/' /etc/login.defs


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---

This pull request includes a small change to the `containers/app/Dockerfile` file. The change ensures that the `apt-get` package lists are cleaned up after installing the necessary packages to reduce the image size. 

* [`containers/app/Dockerfile`](diffhunk://#diff-6cc49007fe4e6fbd7d1eda5a7304a69961b59cfcc59a248890fdcf287015e5d5L51-R52): Added a command to remove `/var/lib/apt/lists/*` after installing packages to clean up package lists and reduce image size.