### PR TITLE
fix: Summarizing prompt tracks version control status

### DIFF
--- a/openhands/memory/condenser/impl/llm_summarizing_condenser.py
+++ b/openhands/memory/condenser/impl/llm_summarizing_condenser.py
@@ -65,11 +65,13 @@ TESTS: {Failing cases, error messages, outputs}
 CHANGES: {Code edits, variable updates}
 DEPS: {Dependencies, imports, external calls}
 INTENT: {Why changes were made, acceptance criteria}
+VC_STATUS: {Repository state, current branch, PR status, commit history}
 
 PRIORITIZE:
 1. Capture key user requirements and constraints
 2. Maintain critical problem context
 3. Keep all sections concise
+4. Update VC_STATUS after each version control operation
 
 SKIP: {Git clones, build logs, file listings}
 
@@ -80,7 +82,8 @@ STATE: mod_float() in card.py updated
 TESTS: test_format() passed
 CHANGES: str(val) replaces f"{val:.16G}"
 DEPS: None modified
-INTENT: Fix precision while maintaining FITS compliance"""
+INTENT: Fix precision while maintaining FITS compliance
+VC_STATUS: Branch: fix-float-precision, PR: #42 "Fix float precision in FITS cards" (open), Latest commit: a1b2c3d "Update mod_float function"""
 
         prompt += '\n\n'
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Extend prompt used by the `LLMSummarizingCondenser` to also track version control information.

---
**Link of any specific issues this addresses.**
