### PR TITLE
Fix: "start from scratch" button results in a "no query provided" error

### DIFF
--- a/frontend/__tests__/components/features/github/code-not-in-github-link.test.tsx
+++ b/frontend/__tests__/components/features/github/code-not-in-github-link.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CodeNotInGitHubLink } from "#/components/features/github/code-not-in-github-link";
+import { useDispatch } from "react-redux";
+import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
+import { setInitialPrompt } from "#/state/initial-query-slice";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies
+vi.mock("react-redux", () => ({
+  useDispatch: vi.fn(),
+}));
+
+vi.mock("#/hooks/mutation/use-create-conversation", () => ({
+  useCreateConversation: vi.fn(),
+}));
+
+vi.mock("#/state/initial-query-slice", () => ({
+  setInitialPrompt: vi.fn(),
+}));
+
+describe("CodeNotInGitHubLink", () => {
+  const mockDispatch = vi.fn();
+  const mockCreateConversation = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDispatch as any).mockReturnValue(mockDispatch);
+    (useCreateConversation as any).mockReturnValue({
+      mutate: mockCreateConversation,
+    });
+  });
+
+  it("renders correctly", () => {
+    render(<CodeNotInGitHubLink />);
+    expect(screen.getByText(/Code not in GitHub\?/)).toBeInTheDocument();
+    expect(screen.getByText("Start from scratch")).toBeInTheDocument();
+  });
+
+  it("calls createConversation with allowEmptyQuery when clicked", () => {
+    render(<CodeNotInGitHubLink />);
+    
+    fireEvent.click(screen.getByText("Start from scratch"));
+    
+    expect(mockDispatch).toHaveBeenCalledWith(setInitialPrompt(""));
+    expect(mockCreateConversation).toHaveBeenCalledWith({
+      q: "",
+      allowEmptyQuery: true,
+    });
+  });
+});

--- a/frontend/__tests__/hooks/mutation/use-create-conversation.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-create-conversation.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook, act } from "@testing-library/react";
+import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
+import OpenHands from "#/api/open-hands";
+import { useNavigate } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies
+vi.mock("react-router", () => ({
+  useNavigate: vi.fn(),
+}));
+
+vi.mock("react-redux", () => ({
+  useDispatch: vi.fn(),
+  useSelector: vi.fn(),
+}));
+
+vi.mock("#/api/open-hands", () => ({
+  default: {
+    createConversation: vi.fn(),
+  },
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: vi.fn(),
+  },
+}));
+
+describe("useCreateConversation", () => {
+  const mockNavigate = vi.fn();
+  const mockDispatch = vi.fn();
+  const mockQueryClient = new QueryClient();
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useNavigate as any).mockReturnValue(mockNavigate);
+    (useDispatch as any).mockReturnValue(mockDispatch);
+    (useSelector as any).mockReturnValue({
+      selectedRepository: null,
+      files: [],
+      replayJson: null,
+    });
+    (OpenHands.createConversation as any).mockResolvedValue({
+      conversation_id: "test-id",
+    });
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={mockQueryClient}>{children}</QueryClientProvider>
+  );
+
+  it("should throw an error when no query, repository, files, or replayJson is provided", async () => {
+    const { result } = renderHook(() => useCreateConversation(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({ q: "" })).rejects.toThrow(
+        "No query provided"
+      );
+    });
+  });
+
+  it("should allow empty query when allowEmptyQuery is true", async () => {
+    const { result } = renderHook(() => useCreateConversation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ q: "", allowEmptyQuery: true });
+    });
+
+    expect(OpenHands.createConversation).toHaveBeenCalledWith(
+      undefined,
+      "",
+      [],
+      undefined
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/conversations/test-id");
+  });
+});

--- a/frontend/src/components/features/github/code-not-in-github-link.tsx
+++ b/frontend/src/components/features/github/code-not-in-github-link.tsx
@@ -12,7 +12,7 @@ export function CodeNotInGitHubLink() {
   const handleStartFromScratch = () => {
     // Set the initial prompt and create a new conversation
     dispatch(setInitialPrompt(INITIAL_PROMPT));
-    createConversation({ q: INITIAL_PROMPT });
+    createConversation({ q: INITIAL_PROMPT, allowEmptyQuery: true });
   };
 
   return (

--- a/frontend/src/hooks/mutation/use-create-conversation.ts
+++ b/frontend/src/hooks/mutation/use-create-conversation.ts
@@ -16,8 +16,12 @@ export const useCreateConversation = () => {
   );
 
   return useMutation({
-    mutationFn: async (variables: { q?: string }) => {
+    mutationFn: async (variables: {
+      q?: string;
+      allowEmptyQuery?: boolean;
+    }) => {
       if (
+        !variables.allowEmptyQuery &&
         !variables.q?.trim() &&
         !selectedRepository &&
         files.length === 0 &&


### PR DESCRIPTION
## Description

This PR fixes issue #7621 where clicking the "start from scratch" button on the hero page results in a "no query provided" toast error.

## Changes

- Added an `allowEmptyQuery` parameter to the `useCreateConversation` hook to allow empty queries when explicitly starting from scratch
- Updated the `CodeNotInGitHubLink` component to use the new parameter
- Added tests to verify the fix works correctly

Fixes #7621

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dc152c6a496a47848729039feed579c8)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d6935e3-nikolaik   --name openhands-app-d6935e3   docker.all-hands.dev/all-hands-ai/openhands:d6935e3
```