### PR TITLE
Update dockerfile to remove vulnerabilities in Debian 12

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -14,6 +14,7 @@ ENV POETRY_VIRTUALENVS_PATH=/openhands/poetry \
 
 # Install base system dependencies
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         wget curl sudo apt-utils git jq tmux \
         {%- if 'ubuntu' in base_image and (base_image.endswith(':latest') or base_image.endswith(':24.04')) -%}
@@ -22,6 +23,10 @@ RUN apt-get update && \
         libgl1-mesa-glx \
         {% endif -%}
         libasound2-plugins libatomic1 && \
+    # Remove packages with CVEs and no updates yet, if present
+    (apt-get remove -y libaom3 || true) && \
+    (apt-get remove -y libjxl0.7 || true) && \
+    (apt-get remove -y libopenexr-3-1-30 || true) && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

As counted by the trivy scanner, we have 7 CVE critical vulnerabilities in our runtime image, inherited from the base image ` nikolaik/python-nodejs:python3.12-nodejs22`.

Running `apt-get upgrade` removes one of them (and many non-criticals). The others have no upgrades available for the base distribution of debian 12 (bookworm).

Removing these packages removed another 4: libaom3, libjxl0.7, libopenexr-3-1-30. Here are the warnings about additional packages that were removed along with them.
```
The following packages will be REMOVED:
  imagemagick imagemagick-6.q16 libaom3 libasound2-plugins libavcodec59 libheif1 libmagickcore-6.q16-6 libmagickcore-6.q16-6-extra libmagickcore-6.q16-dev
  libmagickcore-dev libmagickwand-6.q16-6 libmagickwand-6.q16-dev libmagickwand-dev

The following packages will be REMOVED:
  libopenexr-3-1-30 libopenexr-dev
```

This leaves two criticals relating to zlib, which are false positives as the source vulnerability is not part of the binary package. [CVE-2023-45853](https://security-tracker.debian.org/tracker/CVE-2023-45853).

## Potential impacts 

If we need these image libraries for anything, this could be a problem. However, the only thing I can imagine would use them is the headless browsing.

Doing the upgrade across the board could impact image size, caching, and compatibility. However, it won't do that every time, only when that layer is updated.


 
---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:afde494-nikolaik   --name openhands-app-afde494   docker.all-hands.dev/all-hands-ai/openhands:afde494
```