### PR TITLE
(feat): stop auto generate title in converstaion GET

### DIFF
--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -243,24 +243,6 @@ async def get_conversation(
     try:
         metadata = await conversation_store.get_metadata(conversation_id)
         is_running = await conversation_manager.is_agent_loop_running(conversation_id)
-
-        # Check if we need to update the title
-        if is_running and metadata:
-            # Check if the title is a default title (contains the conversation ID)
-            if metadata.title and conversation_id[:5] in metadata.title:
-                # Generate a new title
-                new_title = await auto_generate_title(
-                    conversation_id, get_user_id(request)
-                )
-
-                if new_title:
-                    # Update the metadata
-                    metadata.title = new_title
-                    await conversation_store.save_metadata(metadata)
-
-                    # Refresh metadata after update
-                    metadata = await conversation_store.get_metadata(conversation_id)
-
         conversation_info = await _get_conversation_info(metadata, is_running)
         return conversation_info
     except FileNotFoundError:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This removes `auto_generate_title` from GET /conversations/<id>

Things are still working after this change

<img width="440" alt="image" src="https://github.com/user-attachments/assets/54d89dbe-0cda-4977-80c3-dac3cc9c7e05" />




---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7d66e8f-nikolaik   --name openhands-app-7d66e8f   docker.all-hands.dev/all-hands-ai/openhands:7d66e8f
```