### PR TITLE
Fix "let's get back on track" message on consecutive headless tasks

### DIFF
--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -148,18 +148,17 @@ async def run_controller(
     )
 
     # start event is a MessageAction with the task, either resumed or new
-    if initial_state is not None:
+    if initial_state is not None and initial_state.last_error:
         # we're resuming the previous session
-        if initial_state.last_error:
-            event_stream.add_event(
-                MessageAction(
-                    content=(
-                        "Let's get back on track. If you experienced errors before, do "
-                        'NOT resume your task. Ask me about it.'
-                    ),
+        event_stream.add_event(
+            MessageAction(
+                content=(
+                    "Let's get back on track. If you experienced errors before, do "
+                    'NOT resume your task. Ask me about it.'
                 ),
-                EventSource.USER,
-            )
+            ),
+            EventSource.USER,
+        )
     else:
         # init with the provided actions
         event_stream.add_event(initial_user_action, EventSource.USER)

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -150,15 +150,16 @@ async def run_controller(
     # start event is a MessageAction with the task, either resumed or new
     if initial_state is not None:
         # we're resuming the previous session
-        event_stream.add_event(
-            MessageAction(
-                content=(
-                    "Let's get back on track. If you experienced errors before, do "
-                    'NOT resume your task. Ask me about it.'
+        if initial_state.last_error:
+            event_stream.add_event(
+                MessageAction(
+                    content=(
+                        "Let's get back on track. If you experienced errors before, do "
+                        'NOT resume your task. Ask me about it.'
+                    ),
                 ),
-            ),
-            EventSource.USER,
-        )
+                EventSource.USER,
+            )
     else:
         # init with the provided actions
         event_stream.add_event(initial_user_action, EventSource.USER)


### PR DESCRIPTION
Fixes #7646

Fix the issue where the message "Let's get back on track..." is sent when resuming a session in headless mode.

* Update `openhands/core/main.py` to check if there was an error in the previous session before sending the message.
* If there was no error, the new task provided in the command is executed without interruption.
