### PR TITLE
[Bug]: Ensure repository search only returns public repositories

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -104,13 +104,15 @@ class GitHubService(GitService):
     ) -> list[Repository]:
         MAX_REPOS = 1000
         PER_PAGE = 100  # Maximum allowed by GitHub API
-        all_repos: list[dict]= []
+        all_repos: list[dict] = []
         page = 1
 
         while len(all_repos) < MAX_REPOS:
             params = {'page': str(page), 'per_page': str(PER_PAGE)}
             if installation_id:
-                url = f'{self.BASE_URL}/user/installations/{installation_id}/repositories'
+                url = (
+                    f'{self.BASE_URL}/user/installations/{installation_id}/repositories'
+                )
                 response, headers = await self._fetch_data(url, params)
                 response = response.get('repositories', [])
             else:
@@ -136,7 +138,7 @@ class GitHubService(GitService):
                 id=repo.get('id'),
                 full_name=repo.get('full_name'),
                 stargazers_count=repo.get('stargazers_count'),
-                git_provider=ProviderType.GITHUB
+                git_provider=ProviderType.GITHUB,
             )
             for repo in all_repos
         ]
@@ -151,7 +153,14 @@ class GitHubService(GitService):
         self, query: str, per_page: int, sort: str, order: str
     ) -> list[Repository]:
         url = f'{self.BASE_URL}/search/repositories'
-        params = {'q': query, 'per_page': per_page, 'sort': sort, 'order': order}
+        # Add is:public to the query to ensure we only search for public repositories
+        query_with_visibility = f'{query} is:public'
+        params = {
+            'q': query_with_visibility,
+            'per_page': per_page,
+            'sort': sort,
+            'order': order,
+        }
 
         response, _ = await self._fetch_data(url, params)
         repos = response.get('items', [])
@@ -161,7 +170,7 @@ class GitHubService(GitService):
                 id=repo.get('id'),
                 full_name=repo.get('full_name'),
                 stargazers_count=repo.get('stargazers_count'),
-                git_provider=ProviderType.GITHUB
+                git_provider=ProviderType.GITHUB,
             )
             for repo in repos
         ]

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -98,15 +98,15 @@ class GitLabService(GitService):
     async def search_repositories(
         self, query: str, per_page: int = 30, sort: str = 'updated', order: str = 'desc'
     ) -> list[Repository]:
-        url = f'{self.BASE_URL}/search'
+        url = f'{self.BASE_URL}/projects'
         params = {
-            'scope': 'projects',
             'search': query,
             'per_page': per_page,
-            'order_by': sort,
+            'order_by': 'last_activity_at',
             'sort': order,
-            'visibility': 'public',  # Ensure we only search for public repositories
+            'visibility': 'public',
         }
+
         response, _ = await self._fetch_data(url, params)
         repos = [
             Repository(

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -1,8 +1,8 @@
 import os
 from typing import Any
+from urllib.parse import quote_plus
 
 import httpx
-from urllib.parse import quote_plus 
 from pydantic import SecretStr
 
 from openhands.integrations.service_types import (
@@ -105,6 +105,7 @@ class GitLabService(GitService):
             'per_page': per_page,
             'order_by': sort,
             'sort': order,
+            'visibility': 'public',  # Ensure we only search for public repositories
         }
         response, _ = await self._fetch_data(url, params)
         repos = [
@@ -112,11 +113,11 @@ class GitLabService(GitService):
                 id=repo.get('id'),
                 full_name=repo.get('path_with_namespace'),
                 stargazers_count=repo.get('star_count'),
-                git_provider=ProviderType.GITLAB
+                git_provider=ProviderType.GITLAB,
             )
             for repo in response
         ]
-        
+
         return repos
 
     async def get_repositories(
@@ -124,7 +125,7 @@ class GitLabService(GitService):
     ) -> list[Repository]:
         if installation_id:
             return []  # Not implementing installation_token case yet
-        
+
         MAX_REPOS = 1000
         PER_PAGE = 100  # Maximum allowed by GitLab API
         all_repos: list[dict] = []
@@ -136,7 +137,7 @@ class GitLabService(GitService):
             'pushed': 'last_activity_at',
             'updated': 'last_activity_at',
             'created': 'created_at',
-            'full_name': 'name'
+            'full_name': 'name',
         }.get(sort, 'last_activity_at')
 
         while len(all_repos) < MAX_REPOS:
@@ -146,7 +147,7 @@ class GitLabService(GitService):
                 'order_by': order_by,
                 'sort': 'desc',  # GitLab uses sort for direction (asc/desc)
                 'owned': 1,  # Use 1 instead of True
-                'membership': 1  # Use 1 instead of True
+                'membership': 1,  # Use 1 instead of True
             }
             response, headers = await self._fetch_data(url, params)
 
@@ -168,7 +169,7 @@ class GitLabService(GitService):
                 id=repo.get('id'),
                 full_name=repo.get('path_with_namespace'),
                 stargazers_count=repo.get('star_count'),
-                git_provider=ProviderType.GITLAB
+                git_provider=ProviderType.GITLAB,
             )
             for repo in all_repos
         ]


### PR DESCRIPTION
- [X ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
- Fix issue where private repos were being listed in the public section for the repo dropdown

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR modifies the `search_repositories` functions in both GitHubService and GitLabService to ensure they only search for public repositories.

- For GitHub: Added `is:public` to the search query
- For GitLab: Added `visibility: public` parameter to the API request

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9e43785-nikolaik   --name openhands-app-9e43785   docker.all-hands.dev/all-hands-ai/openhands:9e43785
```