### PR TITLE
[Fix]: Ensure refresh logic works for restarted conversations in cloud openhands

### DIFF
--- a/frontend/__tests__/context/ws-client-provider.test.tsx
+++ b/frontend/__tests__/context/ws-client-provider.test.tsx
@@ -8,6 +8,7 @@ import {
   WsClientProvider,
   useWsClient,
 } from "#/context/ws-client-provider";
+import { AuthProvider } from "#/context/auth-context";
 
 describe("Propagate error message", () => {
   it("should do nothing when no message was passed from server", () => {
@@ -90,9 +91,11 @@ describe("WsClientProvider", () => {
     const { getByText } = render(<TestComponent />, {
       wrapper: ({ children }) => (
         <QueryClientProvider client={new QueryClient()}>
-          <WsClientProvider conversationId="test-conversation-id">
-            {children}
-          </WsClientProvider>
+          <AuthProvider initialProviderTokens={[]}>
+            <WsClientProvider conversationId="test-conversation-id">
+              {children}
+            </WsClientProvider>
+          </AuthProvider>
         </QueryClientProvider>
       ),
     });

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -9,6 +9,7 @@ import {
   AssistantMessageAction,
   UserMessageAction,
 } from "#/types/core/actions";
+import { useAuth } from "./auth-context";
 
 const isOpenHandsEvent = (event: unknown): event is OpenHandsParsedEvent =>
   typeof event === "object" &&
@@ -110,6 +111,7 @@ export function WsClientProvider({
   );
   const [events, setEvents] = React.useState<Record<string, unknown>[]>([]);
   const lastEventRef = React.useRef<Record<string, unknown> | null>(null);
+  const { providerTokensSet } = useAuth();
 
   const messageRateHandler = useRate({ threshold: 250 });
 
@@ -168,6 +170,7 @@ export function WsClientProvider({
     const query = {
       latest_event_id: lastEvent?.id ?? -1,
       conversation_id: conversationId,
+      providers_set: providerTokensSet,
     };
 
     const baseUrl =

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -14,7 +14,6 @@ from pydantic import (
 )
 from pydantic.json import pydantic_encoder
 
-from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.action import Action
 from openhands.events.action.commands import CmdRunAction
 from openhands.events.stream import EventStream
@@ -319,9 +318,7 @@ class ProviderHandler:
             get_latest: Get the latest working token for the providers if True, otherwise get the existing ones
         """
 
-        # TODO: We should remove `not get_latest` in the future. More
-        # details about the error this fixes is in the next comment below
-        if not self.provider_tokens and not get_latest:
+        if not self.provider_tokens:
             return {}
 
         env_vars: dict[ProviderType, SecretStr] = {}
@@ -341,20 +338,6 @@ class ProviderHandler:
 
                 if token:
                     env_vars[provider] = token
-
-        # TODO: we have an error where reinitializing the runtime doesn't happen with
-        # the provider tokens; thus the code above believes that github isn't a provider
-        # when it really is. We need to share information about current providers set
-        # for the user when the socket event for connect is sent
-        if ProviderType.GITHUB not in env_vars and get_latest:
-            logger.info(
-                f'Force refresh runtime token for user: {self.external_auth_id}'
-            )
-            service = GithubServiceImpl(
-                external_auth_id=self.external_auth_id,
-                external_token_manager=self.external_token_manager,
-            )
-            env_vars[ProviderType.GITHUB] = await service.get_latest_token()
 
         if not expose_secrets:
             return env_vars


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

- This fixes refresh logic for multiple providers in cloud openhands; this, however, is just scaffolding changes and won't have any effect in the upcoming release

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

#7532 included a hotfix where GitHub token refresh failed because provider information was lost for conversations that were restarted. Since the refresh logic only exports the tokens for the providers that are currently set, it wouldn't export any tokens due to the lost provider information. 

This PR ensures that when conversations are joined, the information about which providers are set is available in the runtime. This ensures that refresh logic takes place as expected  

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7e367a1-nikolaik   --name openhands-app-7e367a1   docker.all-hands.dev/all-hands-ai/openhands:7e367a1
```