### PR TITLE
Update VSCode version from 1.94.0 to 1.98.2 in extensions

### DIFF
--- a/openhands/runtime/utils/vscode-extensions/hello-world/package.json
+++ b/openhands/runtime/utils/vscode-extensions/hello-world/package.json
@@ -5,7 +5,7 @@
     "version": "0.0.1",
     "publisher": "openhands",
     "engines": {
-        "vscode": "^1.94.0"
+        "vscode": "^1.98.2"
     },
     "categories": [
         "Other"

--- a/openhands/runtime/utils/vscode-extensions/memory-monitor/package.json
+++ b/openhands/runtime/utils/vscode-extensions/memory-monitor/package.json
@@ -5,7 +5,7 @@
     "version": "0.1.0",
     "publisher": "openhands",
     "engines": {
-        "vscode": "^1.94.0"
+        "vscode": "^1.98.2"
     },
     "categories": [
         "Other",


### PR DESCRIPTION
This PR updates the VSCode version requirement in the VSCode extensions from 1.94.0 to 1.98.2.

Changes:
- Updated VSCode version in memory-monitor extension
- Updated VSCode version in hello-world extension

This ensures compatibility with the latest VSCode version.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c648868-nikolaik   --name openhands-app-c648868   docker.all-hands.dev/all-hands-ai/openhands:c648868
```