### PR TITLE
chore - Switch to slim base image for improved security

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BASE_IMAGE_FOR_HASH_EQUIVALENCE_TEST: nikolaik/python-nodejs:python3.12-nodejs22
+  BASE_IMAGE_FOR_HASH_EQUIVALENCE_TEST: nikolaik/python-nodejs:python3.12-nodejs22-slim
   RELEVANT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         base_image:
-          - image: 'nikolaik/python-nodejs:python3.12-nodejs22'
+          - image: 'nikolaik/python-nodejs:python3.12-nodejs22-slim'
             tag: nikolaik
     steps:
       - name: Checkout

--- a/config.template.toml
+++ b/config.template.toml
@@ -253,7 +253,7 @@ llm_config = 'gpt3'
 #user_id = 1000
 
 # Container image to use for the sandbox
-#base_container_image = "nikolaik/python-nodejs:python3.12-nodejs22"
+#base_container_image = "nikolaik/python-nodejs:python3.12-nodejs22-slim"
 
 # Use host network
 #use_host_network = false

--- a/containers/runtime/README.md
+++ b/containers/runtime/README.md
@@ -3,10 +3,10 @@
 This folder builds a runtime image (sandbox), which will use a dynamically generated `Dockerfile`
 that depends on the `base_image` **AND** a [Python source distribution](https://docs.python.org/3.10/distutils/sourcedist.html) that is based on the current commit of `openhands`.
 
-The following command will generate a `Dockerfile` file for `nikolaik/python-nodejs:python3.12-nodejs22` (the default base image), an updated `config.sh` and the runtime source distribution files/folders into `containers/runtime`:
+The following command will generate a `Dockerfile` file for `nikolaik/python-nodejs:python3.12-nodejs22-slim` (the default base image), an updated `config.sh` and the runtime source distribution files/folders into `containers/runtime`:
 
 ```bash
 poetry run python3 openhands/runtime/utils/runtime_build.py \
-    --base_image nikolaik/python-nodejs:python3.12-nodejs22 \
+    --base_image nikolaik/python-nodejs:python3.12-nodejs22-slim \
     --build_folder containers/runtime
 ```

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -47,7 +47,7 @@ class SandboxConfig(BaseModel):
     rm_all_containers: bool = Field(default=False)
     api_key: str | None = Field(default=None)
     base_container_image: str = Field(
-        default='nikolaik/python-nodejs:python3.12-nodejs22'
+        default='nikolaik/python-nodejs:python3.12-nodejs22-slim'
     )
     runtime_container_image: str | None = Field(default=None)
     user_id: int = Field(default=os.getuid() if hasattr(os, 'getuid') else 1000)

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -14,7 +14,6 @@ ENV POETRY_VIRTUALENVS_PATH=/openhands/poetry \
 
 # Install base system dependencies
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         wget curl sudo apt-utils git jq tmux \
         {%- if 'ubuntu' in base_image and (base_image.endswith(':latest') or base_image.endswith(':24.04')) -%}
@@ -23,10 +22,6 @@ RUN apt-get update && \
         libgl1-mesa-glx \
         {% endif -%}
         libasound2-plugins libatomic1 && \
-    # Remove packages with CVEs and no updates yet, if present
-    (apt-get remove -y libaom3 || true) && \
-    (apt-get remove -y libjxl0.7 || true) && \
-    (apt-get remove -y libopenexr-3-1-30 || true) && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -196,7 +196,7 @@ def base_container_image(request):
                 request.param = None
         if request.param is None:
             request.param = pytest.param(
-                'nikolaik/python-nodejs:python3.12-nodejs22',
+                'nikolaik/python-nodejs:python3.12-nodejs22-slim',
                 'golang:1.23-bookworm',
             )
     print(f'Container image: {request.param}')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -384,7 +384,7 @@ def test_defaults_dict_after_updates(default_config):
     assert defaults_after_updates['sandbox']['timeout']['default'] == 120
     assert (
         defaults_after_updates['sandbox']['base_container_image']['default']
-        == 'nikolaik/python-nodejs:python3.12-nodejs22'
+        == 'nikolaik/python-nodejs:python3.12-nodejs22-slim'
     )
     assert defaults_after_updates == initial_defaults
 

--- a/tests/unit/test_runtime_build.py
+++ b/tests/unit/test_runtime_build.py
@@ -28,7 +28,7 @@ from openhands.runtime.utils.runtime_build import (
 )
 
 OH_VERSION = f'oh_v{oh_version}'
-DEFAULT_BASE_IMAGE = 'nikolaik/python-nodejs:python3.12-nodejs22'
+DEFAULT_BASE_IMAGE = 'nikolaik/python-nodejs:python3.12-nodejs22-slim'
 
 
 @pytest.fixture
@@ -196,7 +196,7 @@ def test_get_runtime_image_repo_and_tag_eventstream():
     assert (
         img_repo == f'{get_runtime_image_repo()}'
         and img_tag
-        == f'{OH_VERSION}_image_nikolaik_s_python-nodejs_tag_python3.12-nodejs22'
+        == f'{OH_VERSION}_image_nikolaik_s_python-nodejs_tag_python3.12-nodejs22-slim'
     )
 
     base_image = 'ubuntu'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Build runtime sandbox based on smaller Docker image.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

We are trying to reduce the vulnerabilities found in image scans using SCA tools like trivy. This change switches to the `slim` variant of our base image so that we don't include packages we don't need. Both slim and the image we were using before are based on the current Debian Stable, Bookworm.

A positive side effect is our image will get smaller. A potential hazard is that some users may be accustomed to certain packages being available which now must be installed. Perhaps we can figure out what some of those are.

---
**Link of any specific issues this addresses.**
