### PR TITLE
(Hotfix): Rm owner req from GitLab repo list

### DIFF
--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -146,7 +146,6 @@ class GitLabService(GitService):
                 'per_page': str(PER_PAGE),
                 'order_by': order_by,
                 'sort': 'desc',  # GitLab uses sort for direction (asc/desc)
-                'owned': 1,  # Use 1 instead of True
                 'membership': 1,  # Use 1 instead of True
             }
             response, headers = await self._fetch_data(url, params)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
- List GitLab repositories for which you have membership, but may not be the owner

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Previously we were fetching repositories for which you had to be both the owner and member. 

We're changing this so that the repo list contains the repos for which you are the member (but may not be the owner).

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:75303b8-nikolaik   --name openhands-app-75303b8   docker.all-hands.dev/all-hands-ai/openhands:75303b8
```