### PR TITLE
[Evaluation] Fix run_infer.py path in TAC

### DIFF
--- a/evaluation/benchmarks/the_agent_company/scripts/run_infer.sh
+++ b/evaluation/benchmarks/the_agent_company/scripts/run_infer.sh
@@ -145,7 +145,7 @@ while IFS= read -r task_image; do
     docker pull $task_image
 
     # Build the Python command
-    COMMAND="poetry run python run_infer.py \
+    COMMAND="poetry run python -m evaluation.benchmarks.the_agent_company.run_infer \
             --agent-llm-config \"$AGENT_LLM_CONFIG\" \
             --env-llm-config \"$ENV_LLM_CONFIG\" \
             --outputs-path \"$OUTPUTS_PATH\" \


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

The old way only works when running under `evaluation/benchmarks/the_agent_company` folder.


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:88f66ca-nikolaik   --name openhands-app-88f66ca   docker.all-hands.dev/all-hands-ai/openhands:88f66ca
```