### PR TITLE
Fix mypy errors in storage directory

### DIFF
--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -6,11 +6,11 @@ from openhands.utils.import_utils import get_impl
 class ConversationValidator:
     """Storage for conversation metadata. May or may not support multiple users depending on the environment."""
 
-    async def validate(self, conversation_id: str, cookies_str: str):
+    async def validate(self, conversation_id: str, cookies_str: str) -> tuple[None, None]:
         return None, None
 
 
-def create_conversation_validator():
+def create_conversation_validator() -> ConversationValidator:
     conversation_validator_cls = os.environ.get(
         'OPENHANDS_CONVERSATION_VALIDATOR_CLS',
         'openhands.storage.conversation.conversation_validator.ConversationValidator',

--- a/openhands/storage/google_cloud.py
+++ b/openhands/storage/google_cloud.py
@@ -1,10 +1,10 @@
 import os
 
 from google.api_core.exceptions import NotFound
-from google.cloud import storage  # type: ignore
-from google.cloud.storage.blob import Blob  # type: ignore
-from google.cloud.storage.bucket import Bucket  # type: ignore
-from google.cloud.storage.client import Client  # type: ignore
+from google.cloud import storage
+from google.cloud.storage.blob import Blob
+from google.cloud.storage.bucket import Bucket
+from google.cloud.storage.client import Client
 
 from openhands.storage.files import FileStore
 

--- a/openhands/storage/s3.py
+++ b/openhands/storage/s3.py
@@ -60,7 +60,7 @@ class S3FileStore(FileStore):
             response: GetObjectOutputDict = self.client.get_object(
                 Bucket=self.bucket, Key=path
             )
-            with response['Body'] as stream:  # type: ignore
+            with response['Body'] as stream:
                 return str(stream.read().decode('utf-8'))
         except botocore.exceptions.ClientError as e:
             # Catch all S3-related errors


### PR DESCRIPTION
This PR fixes mypy errors in the storage directory by:

* Adding proper return type annotations to functions in `conversation_validator.py`
* Removing unnecessary `# type: ignore` comments in `google_cloud.py`
* Removing unnecessary `# type: ignore` comment in `s3.py`

All changes are strictly related to fixing type errors and improving type safety. There are no functional changes or unrelated modifications.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bf14d5e-nikolaik   --name openhands-app-bf14d5e   docker.all-hands.dev/all-hands-ai/openhands:bf14d5e
```