### PR TITLE
feat: prompt agent to follow PR template when create new PR

### DIFF
--- a/frontend/__tests__/components/chat/action-suggestions.test.tsx
+++ b/frontend/__tests__/components/chat/action-suggestions.test.tsx
@@ -98,7 +98,7 @@ describe("ActionSuggestions", () => {
     const pushBranchPrompt =
       "Please push the changes to a remote branch on GitHub, but do NOT create a pull request. Please use the exact SAME branch name as the one you are currently on.";
     const createPRPrompt =
-      "Please push the changes to GitHub and open a pull request. Please create a meaningful branch name that describes the changes.";
+      "Please push the changes to GitHub and open a pull request. Please create a meaningful branch name that describes the changes. If a pull request template exists in the repository, please follow it when creating the PR description.";
 
     // Verify the prompts are different
     expect(pushBranchPrompt).not.toEqual(createPRPrompt);

--- a/frontend/src/components/features/chat/action-suggestions.tsx
+++ b/frontend/src/components/features/chat/action-suggestions.tsx
@@ -38,7 +38,7 @@ export function ActionSuggestions({
     }, but do NOT create a ${pr}. Please use the exact SAME branch name as the one you are currently on.`,
     createPR: `Please push the changes to ${
       isGitLab ? "GitLab" : "GitHub"
-    } and open a ${pr}. Please create a meaningful branch name that describes the changes.`,
+    } and open a ${pr}. Please create a meaningful branch name that describes the changes. If a ${pr} template exists in the repository, please follow it when creating the ${prShort} description.`,
     pushToPR: `Please push the latest changes to the existing ${pr}.`,
   };
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Prompt agent to follow existing PR template when create new PR

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0f055c3-nikolaik   --name openhands-app-0f055c3   docker.all-hands.dev/all-hands-ai/openhands:0f055c3
```