### PR TITLE
Fix git provider

### DIFF
--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -119,7 +119,11 @@ def initialize_repository_for_runtime(
     if selected_repository and provider_tokens:
         logger.debug(f'Selected repository {selected_repository}.')
         repo_directory = call_async_from_sync(
-            runtime.clone_repo, GENERAL_TIMEOUT, github_token, selected_repository, None
+            runtime.clone_repo,
+            GENERAL_TIMEOUT,
+            provider_tokens,
+            selected_repository,
+            None,
         )
         # Run setup script if it exists
         runtime.maybe_run_setup_script()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

When using `main.py` with a GITHUB_TOKEN in env, got:
>  File "/Users/enyst/repos/odie/openhands/runtime/base.py", line 344, in clone_repo
    git_token = git_provider_tokens[chosen_provider].token
                ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^

> ERROR:root:<class 'TypeError'>: 'SecretStr' object is not subscriptable

This PR proposes a quick fix for that.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7acd3ec-nikolaik   --name openhands-app-7acd3ec   docker.all-hands.dev/all-hands-ai/openhands:7acd3ec
```