### PR TITLE
fix(llm): retry on InternalServerError and Timeout; handle Gemini returns len(choices) < 1

### DIFF
--- a/openhands/core/exceptions.py
+++ b/openhands/core/exceptions.py
@@ -88,6 +88,16 @@ class LLMResponseError(Exception):
         super().__init__(message)
 
 
+# This exception should be retried
+# Typically, after retry with a non-zero temperature, the LLM will return a response
+class LLMNoResponseError(Exception):
+    def __init__(
+        self,
+        message: str = 'LLM did not return a response. This is only seen in Gemini models so far.',
+    ) -> None:
+        super().__init__(message)
+
+
 class UserCancelledError(Exception):
     def __init__(self, message: str = 'User cancelled the request') -> None:
         super().__init__(message)

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -296,7 +296,8 @@ class LLM(RetryMixin, DebugMixin):
                     )
                 resp.choices[0].message = fn_call_response_message
 
-            if len(resp.choices) < 1:
+            # Check if resp has 'choices' key with at least one item
+            if not resp.get('choices') or len(resp['choices']) < 1:
                 # Just try again
                 raise litellm.InternalServerError(
                     'Response choices is less than 1 - This is only seen in Gemini models so far. Response: '

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -276,7 +276,7 @@ class LLM(RetryMixin, DebugMixin):
                 if len(resp.choices) < 1:
                     # Just try again
                     raise litellm.InternalServerError(
-                        'Response choices is less than 1 - This is only seen in Gemini Pro 2.5 so far. Response: '
+                        'Response choices is less than 1 - This is only seen in Gemini models so far. Response: '
                         + str(resp),
                         self.config.custom_llm_provider,
                         self.config.model,

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -299,7 +299,7 @@ class LLM(RetryMixin, DebugMixin):
             if len(resp.choices) < 1:
                 # Just try again
                 raise litellm.InternalServerError(
-                    'Response choices is less than 1 - This is only seen in Gemini Pro 2.5 so far. Response: '
+                    'Response choices is less than 1 - This is only seen in Gemini models so far. Response: '
                     + str(resp),
                     self.config.custom_llm_provider,
                     self.config.model,

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -37,7 +37,11 @@ from openhands.llm.retry_mixin import RetryMixin
 __all__ = ['LLM']
 
 # tuple of exceptions to retry on
-LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (RateLimitError,)
+LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
+    RateLimitError,
+    litellm.Timeout,
+    litellm.InternalServerError,
+)
 
 # cache prompt supporting models
 # remove this when we gemini and deepseek are supported
@@ -63,6 +67,7 @@ FUNCTION_CALLING_SUPPORTED_MODELS = [
     'o1-2024-12-17',
     'o3-mini-2025-01-31',
     'o3-mini',
+    'gemini-2.5-pro',
 ]
 
 REASONING_EFFORT_SUPPORTED_MODELS = [
@@ -268,7 +273,16 @@ class LLM(RetryMixin, DebugMixin):
             # if we mocked function calling, and we have tools, convert the response back to function calling format
             if mock_function_calling and mock_fncall_tools is not None:
                 logger.debug(f'Response choices: {len(resp.choices)}')
-                assert len(resp.choices) >= 1
+                if len(resp.choices) < 1:
+                    # Just try again
+                    raise litellm.InternalServerError(
+                        'Response choices is less than 1 - This is only seen in Gemini Pro 2.5 so far. Response: '
+                        + str(resp),
+                        self.config.custom_llm_provider,
+                        self.config.model,
+                        response=resp,
+                    )
+
                 non_fncall_response_message = resp.choices[0].message
                 fn_call_messages_with_response = (
                     convert_non_fncall_messages_to_fncall_messages(
@@ -282,6 +296,15 @@ class LLM(RetryMixin, DebugMixin):
                     )
                 resp.choices[0].message = fn_call_response_message
 
+            if len(resp.choices) < 1:
+                # Just try again
+                raise litellm.InternalServerError(
+                    'Response choices is less than 1 - This is only seen in Gemini Pro 2.5 so far. Response: '
+                    + str(resp),
+                    self.config.custom_llm_provider,
+                    self.config.model,
+                    response=resp,
+                )
             message_back: str = resp['choices'][0]['message']['content'] or ''
             tool_calls: list[ChatCompletionMessageToolCall] = resp['choices'][0][
                 'message'

--- a/openhands/llm/retry_mixin.py
+++ b/openhands/llm/retry_mixin.py
@@ -43,10 +43,11 @@ class RetryMixin:
                     # Only change temperature if it's zero or not set
                     current_temp = retry_state.kwargs.get('temperature', 0)
                     if current_temp == 0:
+                        retry_state.kwargs['temperature'] = 1.0
                         logger.warning(
-                            'LLMNoResponseError detected with temperature=0, setting temperature to 0.2 for next attempt'
+                            'LLMNoResponseError detected with temperature=0, setting temperature to 1.0 for next attempt. kwargs: '
+                            + str(retry_state.kwargs)
                         )
-                        retry_state.kwargs['temperature'] = 0.2
                     else:
                         logger.warning(
                             f'LLMNoResponseError detected with temperature={current_temp}, keeping original temperature'

--- a/openhands/llm/retry_mixin.py
+++ b/openhands/llm/retry_mixin.py
@@ -39,11 +39,18 @@ class RetryMixin:
             # Check if the exception is LLMNoResponseError
             exception = retry_state.outcome.exception()
             if isinstance(exception, LLMNoResponseError):
-                logger.warning(
-                    'LLMNoResponseError detected, setting temperature to 0.2 for next attempt'
-                )
                 if hasattr(retry_state, 'kwargs'):
-                    retry_state.kwargs['temperature'] = 0.2
+                    # Only change temperature if it's zero or not set
+                    current_temp = retry_state.kwargs.get('temperature', 0)
+                    if current_temp == 0:
+                        logger.warning(
+                            'LLMNoResponseError detected with temperature=0, setting temperature to 0.2 for next attempt'
+                        )
+                        retry_state.kwargs['temperature'] = 0.2
+                    else:
+                        logger.warning(
+                            f'LLMNoResponseError detected with temperature={current_temp}, keeping original temperature'
+                        )
 
         return retry(
             before_sleep=before_sleep,

--- a/openhands/llm/retry_mixin.py
+++ b/openhands/llm/retry_mixin.py
@@ -39,7 +39,7 @@ class RetryMixin:
             # Check if the exception is LLMNoResponseError
             exception = retry_state.outcome.exception()
             if isinstance(exception, LLMNoResponseError):
-                logger.debug(
+                logger.warning(
                     'LLMNoResponseError detected, setting temperature to 0.2 for next attempt'
                 )
                 if hasattr(retry_state, 'kwargs'):

--- a/openhands/llm/retry_mixin.py
+++ b/openhands/llm/retry_mixin.py
@@ -45,8 +45,7 @@ class RetryMixin:
                     if current_temp == 0:
                         retry_state.kwargs['temperature'] = 1.0
                         logger.warning(
-                            'LLMNoResponseError detected with temperature=0, setting temperature to 1.0 for next attempt. kwargs: '
-                            + str(retry_state.kwargs)
+                            'LLMNoResponseError detected with temperature=0, setting temperature to 1.0 for next attempt.'
                         )
                     else:
                         logger.warning(

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -404,13 +404,6 @@ def test_completion_retry_with_llm_no_response_error_zero_temp(
         if temperature == 0:
             raise LLMNoResponseError('LLM did not return a response')
 
-        # Second call with temperature=0.2 should return a successful response
-        elif temperature == 0.2:
-            return {
-                'choices': [{'message': {'content': 'Successful response after retry'}}]
-            }
-
-        # Any other temperature value should return a different response
         else:
             return {
                 'choices': [
@@ -430,8 +423,7 @@ def test_completion_retry_with_llm_no_response_error_zero_temp(
 
     # Verify the response after retry
     assert (
-        response['choices'][0]['message']['content']
-        == 'Successful response after retry'
+        response['choices'][0]['message']['content'] == 'Response with temperature=1.0'
     )
 
     # Verify that litellm_completion was called twice
@@ -441,9 +433,9 @@ def test_completion_retry_with_llm_no_response_error_zero_temp(
     first_call_kwargs = mock_litellm_completion.call_args_list[0][1]
     assert first_call_kwargs.get('temperature') == 0
 
-    # Check the temperature in the second call (should be 0.2)
+    # Check the temperature in the second call (should be 1.0)
     second_call_kwargs = mock_litellm_completion.call_args_list[1][1]
-    assert second_call_kwargs.get('temperature') == 0.2
+    assert second_call_kwargs.get('temperature') == 1.0
 
 
 @patch('openhands.llm.llm.litellm_completion')
@@ -595,7 +587,7 @@ def test_completion_retry_with_llm_no_response_error_successful_retry(
     # Verify the response after retry
     assert (
         response['choices'][0]['message']['content']
-        == 'Successful response with temperature=0.2'
+        == 'Successful response with temperature=1.0'
     )
 
     # Verify that litellm_completion was called twice
@@ -605,9 +597,9 @@ def test_completion_retry_with_llm_no_response_error_successful_retry(
     first_call_kwargs = mock_litellm_completion.call_args_list[0][1]
     assert first_call_kwargs.get('temperature') == 0
 
-    # Check the temperature in the second call (should be 0.2)
+    # Check the temperature in the second call (should be 1.0)
     second_call_kwargs = mock_litellm_completion.call_args_list[1][1]
-    assert second_call_kwargs.get('temperature') == 0.2
+    assert second_call_kwargs.get('temperature') == 1.0
 
 
 @patch('openhands.llm.llm.litellm_completion')

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -10,7 +10,7 @@ from litellm.exceptions import (
 )
 
 from openhands.core.config import LLMConfig
-from openhands.core.exceptions import OperationCancelled
+from openhands.core.exceptions import LLMNoResponseError, OperationCancelled
 from openhands.core.message import Message, TextContent
 from openhands.llm.llm import LLM
 from openhands.llm.metrics import Metrics, TokenUsage
@@ -383,6 +383,168 @@ def test_completion_keyboard_interrupt_handler(mock_litellm_completion, default_
     assert _should_exit
 
     _should_exit = False
+
+
+@patch('openhands.llm.llm.litellm_completion')
+def test_completion_retry_with_llm_no_response_error_zero_temp(
+    mock_litellm_completion, default_config
+):
+    """
+    Test that the retry decorator properly handles LLMNoResponseError by:
+    1. First call to llm_completion uses temperature=0 and throws LLMNoResponseError
+    2. Second call should have temperature=0.2 and return a successful response
+    """
+
+    # Define a side effect function that checks the temperature parameter
+    # and returns different responses based on it
+    def side_effect(*args, **kwargs):
+        temperature = kwargs.get('temperature', 0)
+
+        # First call with temperature=0 should raise LLMNoResponseError
+        if temperature == 0:
+            raise LLMNoResponseError('LLM did not return a response')
+
+        # Second call with temperature=0.2 should return a successful response
+        elif temperature == 0.2:
+            return {
+                'choices': [{'message': {'content': 'Successful response after retry'}}]
+            }
+
+        # Any other temperature value should return a different response
+        else:
+            return {
+                'choices': [
+                    {'message': {'content': f'Response with temperature={temperature}'}}
+                ]
+            }
+
+    mock_litellm_completion.side_effect = side_effect
+
+    # Create LLM instance and make a completion call
+    llm = LLM(config=default_config)
+    response = llm.completion(
+        messages=[{'role': 'user', 'content': 'Hello!'}],
+        stream=False,
+        temperature=0,  # Initial temperature is 0
+    )
+
+    # Verify the response after retry
+    assert (
+        response['choices'][0]['message']['content']
+        == 'Successful response after retry'
+    )
+
+    # Verify that litellm_completion was called twice
+    assert mock_litellm_completion.call_count == 2
+
+    # Check the temperature in the first call (should be 0)
+    first_call_kwargs = mock_litellm_completion.call_args_list[0][1]
+    assert first_call_kwargs.get('temperature') == 0
+
+    # Check the temperature in the second call (should be 0.2)
+    second_call_kwargs = mock_litellm_completion.call_args_list[1][1]
+    assert second_call_kwargs.get('temperature') == 0.2
+
+
+@patch('openhands.llm.llm.litellm_completion')
+def test_completion_retry_with_llm_no_response_error_nonzero_temp(
+    mock_litellm_completion, default_config
+):
+    """
+    Test that the retry decorator works for LLMNoResponseError when initial temperature is non-zero,
+    and changes the temperature to 0.2 on retry.
+
+    This test verifies that when LLMNoResponseError is raised with a non-zero temperature:
+    1. The retry mechanism is triggered
+    2. The temperature is changed to 0.2 on the retry attempt
+    3. After all retries are exhausted, the exception is propagated
+    """
+    # Define a side effect function that always raises LLMNoResponseError
+    mock_litellm_completion.side_effect = LLMNoResponseError(
+        'LLM did not return a response'
+    )
+
+    # Create LLM instance and make a completion call with non-zero temperature
+    llm = LLM(config=default_config)
+
+    # We expect this to raise an exception after all retries are exhausted
+    with pytest.raises(LLMNoResponseError):
+        llm.completion(
+            messages=[{'role': 'user', 'content': 'Hello!'}],
+            stream=False,
+            temperature=0.7,  # Initial temperature is non-zero
+        )
+
+    # Verify that litellm_completion was called multiple times (retries happened)
+    # The default_config has num_retries=2, so it should be called 2 times
+    assert mock_litellm_completion.call_count == 2
+
+    # Check the temperature in the first call (should be 0.7)
+    first_call_kwargs = mock_litellm_completion.call_args_list[0][1]
+    assert first_call_kwargs.get('temperature') == 0.7
+
+    # Check the temperature in the second call (should be changed to 0.2)
+    second_call_kwargs = mock_litellm_completion.call_args_list[1][1]
+    assert second_call_kwargs.get('temperature') == 0.2
+
+
+@patch('openhands.llm.llm.litellm_completion')
+def test_completion_retry_with_llm_no_response_error_successful_retry(
+    mock_litellm_completion, default_config
+):
+    """
+    Test that the retry decorator works for LLMNoResponseError and successfully retries with temperature=0.2.
+
+    This test verifies that:
+    1. First call to llm_completion throws LLMNoResponseError
+    2. Second call with temperature=0.2 returns a successful response
+    """
+
+    # Define a side effect function that raises LLMNoResponseError on first call
+    # and returns a successful response on second call
+    def side_effect(*args, **kwargs):
+        temperature = kwargs.get('temperature', 0)
+
+        if mock_litellm_completion.call_count == 1:
+            # First call should raise LLMNoResponseError
+            raise LLMNoResponseError('LLM did not return a response')
+        else:
+            # Second call should return a successful response
+            return {
+                'choices': [
+                    {
+                        'message': {
+                            'content': f'Successful response with temperature={temperature}'
+                        }
+                    }
+                ]
+            }
+
+    mock_litellm_completion.side_effect = side_effect
+
+    # Create LLM instance and make a completion call
+    llm = LLM(config=default_config)
+    response = llm.completion(
+        messages=[{'role': 'user', 'content': 'Hello!'}],
+        stream=False,
+    )
+
+    # Verify the response after retry
+    assert (
+        response['choices'][0]['message']['content']
+        == 'Successful response with temperature=0.2'
+    )
+
+    # Verify that litellm_completion was called twice
+    assert mock_litellm_completion.call_count == 2
+
+    # Check the temperature in the first call (should be 0)
+    first_call_kwargs = mock_litellm_completion.call_args_list[0][1]
+    assert first_call_kwargs.get('temperature') == 0
+
+    # Check the temperature in the second call (should be 0.2)
+    second_call_kwargs = mock_litellm_completion.call_args_list[1][1]
+    assert second_call_kwargs.get('temperature') == 0.2
 
 
 @patch('openhands.llm.llm.litellm_completion')


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Gemini a lot of time will return response with choices less than 1, causing errors:

```
"InternalServerError: litellm.InternalServerError: Response choices is less than 1 - This is only seen in Gemini Pro 2.5 so far. Response: ModelResponse(id='chatcmpl-abe113c5-37e5-4740-8292-91faedd8d928', created=1743601076, model='litellm_proxy/gemini-2.5-pro-exp-03-25', object='chat.completion', system_fingerprint=None, choices=[], usage=Usage(completion_tokens=0, prompt_tokens=4501, total_tokens=4501, completion_tokens_details=None, prompt_tokens_details=None), service_tier=None, vertex_ai_grounding_metadata=[], vertex_ai_safety_results=[], vertex_ai_citation_metadata=[])
```

This PR:
- convert it to InternalServerError
- Retry on InternalServerError (some of the time, it fixes stuff), Timeout
- Add gemini-2.5-pro to function calling support model (we at least get decent benchmark performance from it)

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a3ff665-nikolaik   --name openhands-app-a3ff665   docker.all-hands.dev/all-hands-ai/openhands:a3ff665
```