### PR TITLE
Fix action execution server JSONResponse

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -585,7 +585,10 @@ if __name__ == '__main__':
         logger.error(f'Validation error occurred: {exc}')
         return JSONResponse(
             status_code=422,
-            content={'detail': 'Invalid request parameters', 'errors': exc.errors()},
+            content={
+                'detail': 'Invalid request parameters',
+                'errors': str(exc.errors()),
+            },
         )
 
     @app.middleware('http')


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

I was debugging action_execution_server on windows and found this bug. My debugging scenario:

1. Launching server: `poetry run python -u -m openhands.runtime.action_execution_server 37234 --working-dir D:\workspace\ --plugins agent_skills jupyter --username boxuanli --user-id 1000`
2. Calling API endpoint: `curl -X POST -d '...payload...' http://localhost:37234/execute_action`

Without converting to `str`, I sometimes see `{"detail":"An unexpected error occurred. Please try again later."}` from client side when there's an error message that contains bytes. On server side, the error is `TypeError: Object of type bytes is not JSON serializable`.

This PR fixes this bug by converting the error to string.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:07ea4b3-nikolaik   --name openhands-app-07ea4b3   docker.all-hands.dev/all-hands-ai/openhands:07ea4b3
```