### PR TITLE
fix(unittest): Parallel Test failure because of shared memory

### DIFF
--- a/openhands/storage/memory.py
+++ b/openhands/storage/memory.py
@@ -3,14 +3,14 @@ import os
 from openhands.core.logger import openhands_logger as logger
 from openhands.storage.files import FileStore
 
-IN_MEMORY_FILES: dict = {}
-
 
 class InMemoryFileStore(FileStore):
     files: dict[str, str]
 
-    def __init__(self, files: dict[str, str] = IN_MEMORY_FILES):
-        self.files = files
+    def __init__(self, files: dict[str, str] | None = None) -> None:
+        self.files = {}
+        if files is not None:
+            self.files = files
 
     def write(self, path: str, contents: str | bytes) -> None:
         if isinstance(contents, bytes):


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Two tests failed on my machine, when ran from VSCode Test. 

On my windows machine, test_memory_multiple_repo_microagents would fail, if run after test_memory_repository_info. The reason was, that while each had an instance of InMemoryFileStore, they both shared the same underlying dict. 

Not sure, why this happens only on my machine, but it was consistent. 

---
**Link of any specific issues this addresses.**
