### PR TITLE
fix(test) test_memory: initialize in fixture with new dict.

### DIFF
--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -28,7 +28,7 @@ from openhands.storage.memory import InMemoryFileStore
 @pytest.fixture
 def file_store():
     """Create a temporary file store for testing."""
-    return InMemoryFileStore()
+    return InMemoryFileStore({})
 
 
 @pytest.fixture
@@ -190,10 +190,9 @@ async def test_memory_with_microagents():
     assert 'magic word' in observation.microagent_knowledge[0].content
 
 
-def test_memory_repository_info(prompt_dir):
+def test_memory_repository_info(prompt_dir, file_store):
     """Test that Memory adds repository info to RecallObservations."""
-    # Create an in-memory file store and real event stream
-    file_store = InMemoryFileStore()
+    # real event stream
     event_stream = EventStream(sid='test-session', file_store=file_store)
 
     # Create a test repo microagent first
@@ -321,10 +320,9 @@ async def test_memory_with_agent_microagents():
     assert 'magic word' in observation.microagent_knowledge[0].content
 
 
-def test_memory_multiple_repo_microagents(prompt_dir):
+def test_memory_multiple_repo_microagents(prompt_dir, file_store):
     """Test that Memory loads and concatenates multiple repo microagents correctly."""
-    # Create an in-memory file store and real event stream
-    file_store = InMemoryFileStore()
+    # Create real event stream
     event_stream = EventStream(sid='test-session', file_store=file_store)
 
     # Create two test repo microagents


### PR DESCRIPTION
Alternative to https://github.com/All-Hands-AI/OpenHands/pull/7729
Here only the test is changed. 

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Two tests failed on my machine, when ran from VSCode Test. 

On my windows machine, test_memory_multiple_repo_microagents would fail, if run after test_memory_repository_info. The reason was, that while each had an instance of InMemoryFileStore, they both shared the same underlying dict. 

Not sure, why this happens only on my machine, but it was consistent. 

---
**Link of any specific issues this addresses.**
