### PR TITLE
Enables condensation by default

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -7,10 +7,7 @@ import socketio
 
 from openhands.controller.agent import Agent
 from openhands.core.config import AppConfig
-from openhands.core.config.condenser_config import (
-    LLMSummarizingCondenserConfig,
-    StructuredSummaryCondenserConfig,
-)
+from openhands.core.config.condenser_config import LLMSummarizingCondenserConfig
 from openhands.core.logger import OpenHandsLoggerAdapter
 from openhands.core.schema import AgentState
 from openhands.events.action import MessageAction, NullAction
@@ -128,20 +125,9 @@ class Session:
         agent_config = self.config.get_agent_config(agent_cls)
 
         if settings.enable_default_condenser:
-            # If function-calling is active we can use the structured summary
-            # condenser for more reliable summaries.
-            if llm.is_function_calling_active():
-                default_condenser_config = StructuredSummaryCondenserConfig(
-                    llm_config=llm.config, keep_first=3, max_size=80
-                )
-
-            # Otherwise, we'll fall back to the unstructured summary condenser.
-            # This is a good default but struggles more than the structured
-            # summary condenser with long messages.
-            else:
-                default_condenser_config = LLMSummarizingCondenserConfig(
-                    llm_config=llm.config, keep_first=3, max_size=80
-                )
+            default_condenser_config = LLMSummarizingCondenserConfig(
+                llm_config=llm.config, keep_first=3, max_size=80
+            )
 
             self.logger.info(f'Enabling default condenser: {default_condenser_config}')
             agent_config.condenser = default_condenser_config

--- a/openhands/server/settings.py
+++ b/openhands/server/settings.py
@@ -30,7 +30,7 @@ class Settings(BaseModel):
     llm_base_url: str | None = None
     remote_runtime_resource_factor: int | None = None
     secrets_store: SecretStore = Field(default_factory=SecretStore, frozen=True)
-    enable_default_condenser: bool = False
+    enable_default_condenser: bool = True
     enable_sound_notifications: bool = False
     user_consents_to_analytics: bool | None = None
     sandbox_base_container_image: str | None = None


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Enables memory condensation, which gives cheaper and longer-running sessions by summarizing old events.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR updates the server settings to support condensation by default, and updates the default condenser to use the current best-performing summarizing strategy.

In a head-to-head, `StructuredSummaryCondenser` solved 2/50 more instances than `LLMSummarizingCondenser`, but the latter was more resource-efficient (solving more instances with the same number of turns/time/cost/tokens) than both the former _and_ the default no-condensation strategy. On the whole, the `LLMSummarizingCondenser` was cheaper as well.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:363ec18-nikolaik   --name openhands-app-363ec18   docker.all-hands.dev/all-hands-ai/openhands:363ec18
```