### PR TITLE
chore - Skip building Ubuntu runtime image on PR

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -28,6 +28,32 @@ env:
   RELEVANT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
+  define-matrix:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    outputs:
+      base_image: ${{ steps.define-base-images.outputs.base_image }}
+    steps:
+      - name: Define base images
+        shell: bash
+        id: define-base-images
+        run: |
+          # Only build nikolaik on PRs, otherwise build both nikolaik and ubuntu.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            json=$(jq -n -c '{
+              base_image: [
+                { image: "nikolaik/python-nodejs:python3.12-nodejs22", tag: "nikolaik" }
+              ]
+            }')
+          else
+            json=$(jq -n -c '{
+              base_image: [
+                { image: "nikolaik/python-nodejs:python3.12-nodejs22", tag: "nikolaik" },
+                { image: "ubuntu:24.04", tag: "ubuntu" }
+              ]
+            }')
+          fi
+          echo "base_image=$json" >> "$GITHUB_OUTPUT"
+
   # Builds the OpenHands Docker images
   ghcr_build_app:
     name: Build App Image
@@ -84,13 +110,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    needs: define-matrix
     strategy:
       matrix:
-        base_image:
-          - image: 'nikolaik/python-nodejs:python3.12-nodejs22'
-            tag: nikolaik
-          - image: 'ubuntu:24.04'
-            tag: ubuntu
+        base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -209,12 +232,12 @@ jobs:
   # Run unit tests with the Docker runtime Docker images as root
   test_runtime_root:
     name: RT Unit Tests (Root)
-    needs: [ghcr_build_runtime]
+    needs: [ghcr_build_runtime, define-matrix]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
-        base_image: ['nikolaik', 'ubuntu']
+        base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -225,12 +248,12 @@ jobs:
         if: github.event.pull_request.head.repo.fork
         uses: actions/download-artifact@v4
         with:
-          name: runtime-${{ matrix.base_image }}
+          name: runtime-${{ matrix.base_image.tag }}
           path: /tmp
       - name: Load runtime image for fork
         if: github.event.pull_request.head.repo.fork
         run: |
-          docker load --input /tmp/runtime-${{ matrix.base_image }}.tar
+          docker load --input /tmp/runtime-${{ matrix.base_image.tag }}.tar
       - name: Cache Poetry dependencies
         uses: useblacksmith/cache@v5
         with:
@@ -260,7 +283,7 @@ jobs:
           # Install to be able to retry on failures for flaky tests
           poetry run pip install pytest-rerunfailures
 
-          image_name=ghcr.io/${{ env.REPO_OWNER }}/runtime:${{ env.RELEVANT_SHA }}-${{ matrix.base_image }}
+          image_name=ghcr.io/${{ env.REPO_OWNER }}/runtime:${{ env.RELEVANT_SHA }}-${{ matrix.base_image.tag }}
 
           # Setting RUN_AS_OPENHANDS to false means use root.
           # That should mean SANDBOX_USER_ID is ignored but some tests do not check for RUN_AS_OPENHANDS.
@@ -280,10 +303,10 @@ jobs:
   test_runtime_oh:
     name: RT Unit Tests (openhands)
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: [ghcr_build_runtime]
+    needs: [ghcr_build_runtime, define-matrix]
     strategy:
       matrix:
-        base_image: [nikolaik, ubuntu]
+        base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -294,12 +317,12 @@ jobs:
         if: github.event.pull_request.head.repo.fork
         uses: actions/download-artifact@v4
         with:
-          name: runtime-${{ matrix.base_image }}
+          name: runtime-${{ matrix.base_image.tag }}
           path: /tmp
       - name: Load runtime image for fork
         if: github.event.pull_request.head.repo.fork
         run: |
-          docker load --input /tmp/runtime-${{ matrix.base_image }}.tar
+          docker load --input /tmp/runtime-${{ matrix.base_image.tag }}.tar
       - name: Cache Poetry dependencies
         uses: useblacksmith/cache@v5
         with:
@@ -328,7 +351,7 @@ jobs:
           # Install to be able to retry on failures for flaky tests
           poetry run pip install pytest-rerunfailures
 
-          image_name=ghcr.io/${{ env.REPO_OWNER }}/runtime:${{ env.RELEVANT_SHA }}-${{ matrix.base_image }}
+          image_name=ghcr.io/${{ env.REPO_OWNER }}/runtime:${{ env.RELEVANT_SHA }}-${{ matrix.base_image.tag }}
 
           TEST_RUNTIME=docker \
           SANDBOX_USER_ID=$(id -u) \

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -39,18 +39,14 @@ jobs:
         run: |
           # Only build nikolaik on PRs, otherwise build both nikolaik and ubuntu.
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            json=$(jq -n -c '{
-              base_image: [
+            json=$(jq -n -c '[
                 { image: "nikolaik/python-nodejs:python3.12-nodejs22", tag: "nikolaik" }
-              ]
-            }')
+              ]')
           else
-            json=$(jq -n -c '{
-              base_image: [
+            json=$(jq -n -c '[
                 { image: "nikolaik/python-nodejs:python3.12-nodejs22", tag: "nikolaik" },
                 { image: "ubuntu:24.04", tag: "ubuntu" }
-              ]
-            }')
+              ]')
           fi
           echo "base_image=$json" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

A new runtime image option based on Ubuntu was added in #7691. It is currently taking a lot of time to build, and so this PR removes it from the PR process while keeping it in other builds such as tags. This will require some work arounds when we need to test a PR that specifically changes the ubuntu build, but it is worth it to improve builds in general.

To determine which images to build, a step is added that outputs the build matrix configuration as json, which is a [common pattern](https://codefresh.io/learn/github-actions/github-actions-matrix/).


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:81be9c0-nikolaik   --name openhands-app-81be9c0   docker.all-hands.dev/all-hands-ai/openhands:81be9c0
```