### PR TITLE
chore - Remove redundant cache saving from CI

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -120,7 +120,7 @@ jobs:
             ~/.cache/pypoetry
             ~/.virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-          lookup-only: true
+          # This is the one that saves the cache, the others set 'lookup-only: true'
           restore-keys: |
             ${{ runner.os }}-poetry-
       - name: Install poetry via pipx
@@ -301,13 +301,13 @@ jobs:
         run: |
           docker load --input /tmp/runtime-${{ matrix.base_image }}.tar
       - name: Cache Poetry dependencies
-        # This is the one that saves the cache, the others set 'lookup-only: true'
         uses: useblacksmith/cache@v5
         with:
           path: |
             ~/.cache/pypoetry
             ~/.virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          lookup-only: true
           restore-keys: |
             ${{ runner.os }}-poetry-
       - name: Set up Python

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -118,9 +118,9 @@ jobs:
         with:
           path: |
             ~/.cache/pypoetry
-            ~/.cache/ms-playwright
             ~/.virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          lookup-only: true
           restore-keys: |
             ${{ runner.os }}-poetry-
       - name: Install poetry via pipx
@@ -170,9 +170,9 @@ jobs:
         with:
           path: |
             ~/.cache/pypoetry
-            ~/.cache/ms-playwright
             ~/.virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          lookup-only: true
           restore-keys: |
             ${{ runner.os }}-poetry-
       - name: Set up Python
@@ -236,9 +236,9 @@ jobs:
         with:
           path: |
             ~/.cache/pypoetry
-            ~/.cache/ms-playwright
             ~/.virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          lookup-only: true
           restore-keys: |
             ${{ runner.os }}-poetry-
       - name: Set up Python
@@ -301,6 +301,7 @@ jobs:
         run: |
           docker load --input /tmp/runtime-${{ matrix.base_image }}.tar
       - name: Cache Poetry dependencies
+        # This is the one that saves the cache, the others set 'lookup-only: true'
         uses: useblacksmith/cache@v5
         with:
           path: |


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

We've been seeing the "Post Cache Poetry Dependencies" step take 9 minutes, which is a lot of time to spend saving a cache. It would be good to evaluate if too much is being pulled in, but this first step is to disable the cache save on all but the first use of it using the `lookup-only` option.

https://github.com/marketplace/actions/blacksmith-cache

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7682988-nikolaik   --name openhands-app-7682988   docker.all-hands.dev/all-hands-ai/openhands:7682988
```