### PR TITLE
Add PostHog analytics tracking for new conversations

### DIFF
--- a/openhands/server/analytics.py
+++ b/openhands/server/analytics.py
@@ -7,6 +7,7 @@ import posthog
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.config.server_config import ServerConfig
+from openhands.server.shared import SettingsStoreImpl, config
 
 
 class UserAnalytics:
@@ -16,6 +17,7 @@ class UserAnalytics:
     """
 
     _instance: Optional[UserAnalytics] = None
+    _user_consent_cache: Dict[str, bool] = {}
 
     def __init__(self, server_config: ServerConfig):
         """
@@ -45,7 +47,42 @@ class UserAnalytics:
             logger.error(f'Failed to initialize PostHog: {e}')
             self.initialized = False
 
-    def track_event(
+    async def has_user_consented(self, user_id: str) -> bool:
+        """
+        Check if the user has consented to analytics.
+
+        Args:
+            user_id: The ID of the user
+
+        Returns:
+            True if the user has consented, False otherwise
+        """
+        if not user_id:
+            return False
+
+        # Check if we have the consent in cache
+        if user_id in self._user_consent_cache:
+            return self._user_consent_cache[user_id]
+
+        try:
+            # Load user settings to check consent
+            settings_store = await SettingsStoreImpl.get_instance(config, user_id)
+            settings = await settings_store.load()
+
+            # Check if the user has explicitly consented
+            has_consented = (
+                settings is not None and settings.user_consents_to_analytics is True
+            )
+
+            # Cache the result
+            self._user_consent_cache[user_id] = has_consented
+
+            return has_consented
+        except Exception as e:
+            logger.error(f'Error checking user consent for analytics: {e}')
+            return False
+
+    async def track_event(
         self, user_id: str, event_name: str, properties: Dict[str, Any] | None = None
     ) -> bool:
         """
@@ -66,6 +103,14 @@ class UserAnalytics:
             logger.debug(f'Not tracking event {event_name}: No user ID provided')
             return False
 
+        # Check if the user has consented to analytics
+        has_consented = await self.has_user_consented(user_id)
+        if not has_consented:
+            logger.debug(
+                f'Not tracking event {event_name}: User has not consented to analytics'
+            )
+            return False
+
         try:
             # Send the event to PostHog
             posthog.capture(
@@ -77,7 +122,7 @@ class UserAnalytics:
             logger.error(f'Failed to track event {event_name}: {e}')
             return False
 
-    def track_conversation_created(
+    async def track_conversation_created(
         self,
         user_id: str,
         conversation_id: str,
@@ -104,7 +149,7 @@ class UserAnalytics:
             'has_repository': has_repository,
             'has_images': has_images,
         }
-        return self.track_event(user_id, 'conversation_created', properties)
+        return await self.track_event(user_id, 'conversation_created', properties)
 
     @classmethod
     def get_instance(cls, server_config: ServerConfig) -> UserAnalytics:

--- a/openhands/server/analytics.py
+++ b/openhands/server/analytics.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import posthog
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.server.config.server_config import ServerConfig
+
+
+class UserAnalytics:
+    """
+    Handles user analytics tracking using PostHog.
+    Respects user opt-in settings for analytics.
+    """
+
+    _instance: Optional[UserAnalytics] = None
+
+    def __init__(self, server_config: ServerConfig):
+        """
+        Initialize the UserAnalytics class.
+
+        Args:
+            server_config: The server configuration containing PostHog client key
+        """
+        self.posthog_client_key = server_config.posthog_client_key
+        self.initialized = False
+        self._initialize_posthog()
+
+    def _initialize_posthog(self) -> None:
+        """Initialize the PostHog client."""
+        if not self.posthog_client_key:
+            logger.warning('PostHog client key not found, analytics will be disabled')
+            return
+
+        try:
+            # Initialize PostHog with the client key
+            posthog_host = os.environ.get('POSTHOG_HOST', 'https://app.posthog.com')
+            posthog.api_key = self.posthog_client_key
+            posthog.host = posthog_host
+            self.initialized = True
+            logger.info('PostHog analytics initialized successfully')
+        except Exception as e:
+            logger.error(f'Failed to initialize PostHog: {e}')
+            self.initialized = False
+
+    def track_event(
+        self, user_id: str, event_name: str, properties: Dict[str, Any] | None = None
+    ) -> bool:
+        """
+        Track an event in PostHog if the user has opted into analytics.
+
+        Args:
+            user_id: The ID of the user
+            event_name: The name of the event to track
+            properties: Additional properties to include with the event
+
+        Returns:
+            True if the event was tracked, False otherwise
+        """
+        if not self.initialized:
+            return False
+
+        if not user_id:
+            logger.debug(f'Not tracking event {event_name}: No user ID provided')
+            return False
+
+        try:
+            # Send the event to PostHog
+            posthog.capture(
+                distinct_id=user_id, event=event_name, properties=properties or {}
+            )
+            logger.debug(f'Tracked event {event_name} for user {user_id}')
+            return True
+        except Exception as e:
+            logger.error(f'Failed to track event {event_name}: {e}')
+            return False
+
+    def track_conversation_created(
+        self,
+        user_id: str,
+        conversation_id: str,
+        has_initial_message: bool,
+        has_repository: bool,
+        has_images: bool,
+    ) -> bool:
+        """
+        Track when a user creates a new conversation.
+
+        Args:
+            user_id: The ID of the user
+            conversation_id: The ID of the conversation
+            has_initial_message: Whether the conversation was created with an initial message
+            has_repository: Whether the conversation was created with a repository
+            has_images: Whether the conversation was created with images
+
+        Returns:
+            True if the event was tracked, False otherwise
+        """
+        properties = {
+            'conversation_id': conversation_id,
+            'has_initial_message': has_initial_message,
+            'has_repository': has_repository,
+            'has_images': has_images,
+        }
+        return self.track_event(user_id, 'conversation_created', properties)
+
+    @classmethod
+    def get_instance(cls, server_config: ServerConfig) -> UserAnalytics:
+        """
+        Get or create the singleton instance of UserAnalytics.
+
+        Args:
+            server_config: The server configuration
+
+        Returns:
+            The UserAnalytics instance
+        """
+        if cls._instance is None:
+            cls._instance = UserAnalytics(server_config)
+        return cls._instance

--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -10,6 +10,7 @@ from fastapi import (
 
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands import __version__
+from openhands.server.middleware import MonitoringMiddleware
 from openhands.server.routes.conversation import app as conversation_api_router
 from openhands.server.routes.feedback import app as feedback_api_router
 from openhands.server.routes.files import app as files_api_router
@@ -52,3 +53,6 @@ app.include_router(manage_conversation_api_router)
 app.include_router(settings_router)
 app.include_router(git_api_router)
 app.include_router(trajectory_router)
+
+# Add the monitoring middleware
+app.add_middleware(MonitoringMiddleware)

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -207,3 +207,18 @@ class ProviderTokenMiddleware(SessionMiddlewareInterface):
                 request.state.provider_tokens = None
 
         return await call_next(request)
+
+
+class MonitoringMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to attach the monitoring listener to the request state.
+    """
+
+    async def dispatch(self, request: Request, call_next: Callable):
+        # Attach the monitoring listener to the request state
+        request.state.monitoring_listener = shared.monitoring_listener
+
+        # Continue processing the request
+        response = await call_next(request)
+
+        return response

--- a/openhands/server/monitoring.py
+++ b/openhands/server/monitoring.py
@@ -1,5 +1,10 @@
+from typing import Optional
+
 from openhands.core.config.app_config import AppConfig
+from openhands.core.logger import openhands_logger as logger
 from openhands.events.event import Event
+from openhands.server.analytics import UserAnalytics
+from openhands.server.config.server_config import load_server_config
 
 
 class MonitoringListener:
@@ -8,6 +13,11 @@ class MonitoringListener:
 
     Implementations should be non-disruptive, do not raise or block to perform I/O.
     """
+
+    def __init__(self):
+        """Initialize the MonitoringListener."""
+        self.server_config = load_server_config()
+        self.user_analytics = UserAnalytics.get_instance(self.server_config)
 
     def on_session_event(self, event: Event) -> None:
         """
@@ -29,6 +39,40 @@ class MonitoringListener:
         Does not currently capture whether it succeed.
         """
         pass
+
+    def on_conversation_created(
+        self,
+        user_id: str,
+        conversation_id: str,
+        has_initial_message: bool = False,
+        has_repository: bool = False,
+        has_images: bool = False,
+        user_consents_to_analytics: Optional[bool] = None,
+    ) -> None:
+        """
+        Track when a new conversation is created.
+
+        Args:
+            user_id: The ID of the user
+            conversation_id: The ID of the conversation
+            has_initial_message: Whether the conversation was created with an initial message
+            has_repository: Whether the conversation was created with a repository
+            has_images: Whether the conversation was created with images
+            user_consents_to_analytics: Whether the user has consented to analytics
+        """
+        # Only track if the user has explicitly consented to analytics
+        if user_consents_to_analytics is True:
+            try:
+                self.user_analytics.track_conversation_created(
+                    user_id,
+                    conversation_id,
+                    has_initial_message,
+                    has_repository,
+                    has_images,
+                )
+            except Exception as e:
+                # Don't let analytics failures affect the application
+                logger.error(f'Error tracking conversation creation: {e}')
 
     @classmethod
     def get_instance(

--- a/openhands/server/monitoring.py
+++ b/openhands/server/monitoring.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from openhands.core.config.app_config import AppConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.event import Event
@@ -33,23 +31,16 @@ class MonitoringListener:
         """
         pass
 
-    def on_create_conversation(self) -> None:
-        """
-        Track the beginning of conversation creation.
-        Does not currently capture whether it succeed.
-        """
-        pass
-
-    async def on_conversation_created(
+    async def on_create_conversation(
         self,
-        user_id: str,
-        conversation_id: str,
+        user_id: str = None,
+        conversation_id: str = None,
         has_initial_message: bool = False,
         has_repository: bool = False,
         has_images: bool = False,
     ) -> None:
         """
-        Track when a new conversation is created.
+        Track the beginning of conversation creation.
 
         Args:
             user_id: The ID of the user
@@ -58,6 +49,11 @@ class MonitoringListener:
             has_repository: Whether the conversation was created with a repository
             has_images: Whether the conversation was created with images
         """
+        # If no user_id or conversation_id is provided, just log the event without tracking
+        if not user_id or not conversation_id:
+            logger.debug("Conversation creation started")
+            return
+            
         try:
             # The UserAnalytics class will check for user consent internally
             await self.user_analytics.track_conversation_created(

--- a/openhands/server/monitoring.py
+++ b/openhands/server/monitoring.py
@@ -40,14 +40,13 @@ class MonitoringListener:
         """
         pass
 
-    def on_conversation_created(
+    async def on_conversation_created(
         self,
         user_id: str,
         conversation_id: str,
         has_initial_message: bool = False,
         has_repository: bool = False,
         has_images: bool = False,
-        user_consents_to_analytics: Optional[bool] = None,
     ) -> None:
         """
         Track when a new conversation is created.
@@ -58,21 +57,19 @@ class MonitoringListener:
             has_initial_message: Whether the conversation was created with an initial message
             has_repository: Whether the conversation was created with a repository
             has_images: Whether the conversation was created with images
-            user_consents_to_analytics: Whether the user has consented to analytics
         """
-        # Only track if the user has explicitly consented to analytics
-        if user_consents_to_analytics is True:
-            try:
-                self.user_analytics.track_conversation_created(
-                    user_id,
-                    conversation_id,
-                    has_initial_message,
-                    has_repository,
-                    has_images,
-                )
-            except Exception as e:
-                # Don't let analytics failures affect the application
-                logger.error(f'Error tracking conversation creation: {e}')
+        try:
+            # The UserAnalytics class will check for user consent internally
+            await self.user_analytics.track_conversation_created(
+                user_id,
+                conversation_id,
+                has_initial_message,
+                has_repository,
+                has_images,
+            )
+        except Exception as e:
+            # Don't let analytics failures affect the application
+            logger.error(f'Error tracking conversation creation: {e}')
 
     @classmethod
     def get_instance(

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -176,20 +176,14 @@ async def new_conversation(request: Request, data: InitSessionRequest):
 
         # Track conversation creation in analytics
         try:
-            # Get user settings to check if they've opted into analytics
-            settings_store = await SettingsStoreImpl.get_instance(config, user_id)
-            settings = await settings_store.load()
-
-            # Track the event if we have settings and the user has consented
-            if settings:
-                request.state.monitoring_listener.on_conversation_created(
-                    user_id=user_id,
-                    conversation_id=conversation_id,
-                    has_initial_message=bool(initial_user_msg),
-                    has_repository=bool(selected_repository),
-                    has_images=bool(image_urls),
-                    user_consents_to_analytics=settings.user_consents_to_analytics,
-                )
+            # The UserAnalytics class will check for user consent internally
+            await request.state.monitoring_listener.on_conversation_created(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                has_initial_message=bool(initial_user_msg),
+                has_repository=bool(selected_repository),
+                has_images=bool(image_urls),
+            )
         except Exception as e:
             # Don't let analytics failures affect the application
             logger.error(f'Error tracking conversation creation analytics: {e}')

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -177,7 +177,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
         # Track conversation creation in analytics
         try:
             # The UserAnalytics class will check for user consent internally
-            await request.state.monitoring_listener.on_conversation_created(
+            await request.state.monitoring_listener.on_create_conversation(
                 user_id=user_id,
                 conversation_id=conversation_id,
                 has_initial_message=bool(initial_user_msg),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ google-cloud-aiplatform = "*"
 anthropic = {extras = ["vertex"], version = "*"}
 tree-sitter = "^0.24.0"
 bashlex = "^0.18"
+posthog = "^3.5.0"
 pyjwt = "^2.9.0"
 dirhash = "*"
 python-frontmatter = "^1.1.0"

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -1,5 +1,6 @@
+import asyncio
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from openhands.server.analytics import UserAnalytics
 from openhands.server.config.server_config import ServerConfig
@@ -17,9 +18,19 @@ class TestUserAnalytics(unittest.TestCase):
         mock_posthog.api_key = 'test_key'
 
     @patch('openhands.server.analytics.posthog')
-    def test_track_event(self, mock_posthog):
+    @patch('openhands.server.analytics.UserAnalytics.has_user_consented')
+    def test_track_event(self, mock_has_consented, mock_posthog):
+        # Setup
         analytics = UserAnalytics(self.mock_server_config)
-        result = analytics.track_event('user123', 'test_event', {'prop': 'value'})
+        mock_has_consented.return_value = asyncio.Future()
+        mock_has_consented.return_value.set_result(True)
+
+        # Execute
+        result = asyncio.run(
+            analytics.track_event('user123', 'test_event', {'prop': 'value'})
+        )
+
+        # Assert
         self.assertTrue(result)
         mock_posthog.capture.assert_called_once_with(
             distinct_id='user123', event='test_event', properties={'prop': 'value'}
@@ -27,22 +38,52 @@ class TestUserAnalytics(unittest.TestCase):
 
     @patch('openhands.server.analytics.posthog')
     def test_track_event_no_user_id(self, mock_posthog):
+        # Setup
         analytics = UserAnalytics(self.mock_server_config)
-        result = analytics.track_event('', 'test_event')
+
+        # Execute
+        result = asyncio.run(analytics.track_event('', 'test_event'))
+
+        # Assert
         self.assertFalse(result)
         mock_posthog.capture.assert_not_called()
 
     @patch('openhands.server.analytics.posthog')
-    def test_track_conversation_created(self, mock_posthog):
+    @patch('openhands.server.analytics.UserAnalytics.has_user_consented')
+    def test_track_event_no_consent(self, mock_has_consented, mock_posthog):
+        # Setup
         analytics = UserAnalytics(self.mock_server_config)
-        result = analytics.track_conversation_created(
-            'user123', 'conv456', True, False, True
+        mock_has_consented.return_value = asyncio.Future()
+        mock_has_consented.return_value.set_result(False)
+
+        # Execute
+        result = asyncio.run(analytics.track_event('user123', 'test_event'))
+
+        # Assert
+        self.assertFalse(result)
+        mock_posthog.capture.assert_not_called()
+
+    @patch('openhands.server.analytics.posthog')
+    @patch('openhands.server.analytics.UserAnalytics.track_event')
+    def test_track_conversation_created(self, mock_track_event, mock_posthog):
+        # Setup
+        analytics = UserAnalytics(self.mock_server_config)
+        mock_track_event.return_value = asyncio.Future()
+        mock_track_event.return_value.set_result(True)
+
+        # Execute
+        result = asyncio.run(
+            analytics.track_conversation_created(
+                'user123', 'conv456', True, False, True
+            )
         )
+
+        # Assert
         self.assertTrue(result)
-        mock_posthog.capture.assert_called_once_with(
-            distinct_id='user123',
-            event='conversation_created',
-            properties={
+        mock_track_event.assert_called_once_with(
+            'user123',
+            'conversation_created',
+            {
                 'conversation_id': 'conv456',
                 'has_initial_message': True,
                 'has_repository': False,
@@ -55,6 +96,27 @@ class TestUserAnalytics(unittest.TestCase):
         analytics1 = UserAnalytics.get_instance(self.mock_server_config)
         analytics2 = UserAnalytics.get_instance(self.mock_server_config)
         self.assertIs(analytics1, analytics2)
+
+    @patch('openhands.server.analytics.SettingsStoreImpl')
+    async def test_has_user_consented(self, mock_settings_store):
+        # Setup
+        analytics = UserAnalytics(self.mock_server_config)
+        mock_settings = MagicMock()
+        mock_settings.user_consents_to_analytics = True
+
+        mock_store_instance = AsyncMock()
+        mock_store_instance.load.return_value = mock_settings
+
+        mock_settings_store.get_instance.return_value = asyncio.Future()
+        mock_settings_store.get_instance.return_value.set_result(mock_store_instance)
+
+        # Execute
+        result = await analytics.has_user_consented('user123')
+
+        # Assert
+        self.assertTrue(result)
+        mock_settings_store.get_instance.assert_called_once()
+        mock_store_instance.load.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from openhands.server.analytics import UserAnalytics
+from openhands.server.config.server_config import ServerConfig
+
+
+class TestUserAnalytics(unittest.TestCase):
+    def setUp(self):
+        self.mock_server_config = MagicMock(spec=ServerConfig)
+        self.mock_server_config.posthog_client_key = 'test_key'
+
+    @patch('openhands.server.analytics.posthog')
+    def test_initialization(self, mock_posthog):
+        analytics = UserAnalytics(self.mock_server_config)
+        self.assertTrue(analytics.initialized)
+        mock_posthog.api_key = 'test_key'
+
+    @patch('openhands.server.analytics.posthog')
+    def test_track_event(self, mock_posthog):
+        analytics = UserAnalytics(self.mock_server_config)
+        result = analytics.track_event('user123', 'test_event', {'prop': 'value'})
+        self.assertTrue(result)
+        mock_posthog.capture.assert_called_once_with(
+            distinct_id='user123', event='test_event', properties={'prop': 'value'}
+        )
+
+    @patch('openhands.server.analytics.posthog')
+    def test_track_event_no_user_id(self, mock_posthog):
+        analytics = UserAnalytics(self.mock_server_config)
+        result = analytics.track_event('', 'test_event')
+        self.assertFalse(result)
+        mock_posthog.capture.assert_not_called()
+
+    @patch('openhands.server.analytics.posthog')
+    def test_track_conversation_created(self, mock_posthog):
+        analytics = UserAnalytics(self.mock_server_config)
+        result = analytics.track_conversation_created(
+            'user123', 'conv456', True, False, True
+        )
+        self.assertTrue(result)
+        mock_posthog.capture.assert_called_once_with(
+            distinct_id='user123',
+            event='conversation_created',
+            properties={
+                'conversation_id': 'conv456',
+                'has_initial_message': True,
+                'has_repository': False,
+                'has_images': True,
+            },
+        )
+
+    @patch('openhands.server.analytics.posthog')
+    def test_singleton_pattern(self, mock_posthog):
+        analytics1 = UserAnalytics.get_instance(self.mock_server_config)
+        analytics2 = UserAnalytics.get_instance(self.mock_server_config)
+        self.assertIs(analytics1, analytics2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
This PR adds PostHog tracking for when a user starts a new conversation via the API endpoint.

### Changes
- Created a new `UserAnalytics` class that respects user opt-in settings for analytics
- Added PostHog tracking for new conversation creation
- Added a new middleware to attach the monitoring listener to the request state
- Added unit tests for the analytics functionality
- Implemented user consent caching to avoid repeated settings lookups
- Made analytics methods async to properly handle settings loading
- Reused existing `on_create_conversation` method instead of creating a new one

### Testing
- Added unit tests for the UserAnalytics class
- Manually verified that analytics events are only sent when the user has opted in

### Dependencies
- Added posthog dependency to pyproject.toml