### PR TITLE
Fix chat background on mobile devices

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -48,7 +48,7 @@ export function ChatMessage({
         "rounded-xl relative",
         "flex flex-col gap-2",
         type === "user" && " max-w-[305px] p-4 bg-tertiary self-end",
-        type === "assistant" && "mt-6 max-w-full bg-tranparent",
+        type === "assistant" && "mt-6 max-w-full bg-transparent",
       )}
     >
       <CopyToClipboardButton

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -121,7 +121,7 @@ function AppContent() {
   function renderMain() {
     if (width <= 640) {
       return (
-        <div className="rounded-xl overflow-hidden border border-neutral-600 w-full">
+        <div className="rounded-xl overflow-hidden border border-neutral-600 w-full bg-base-secondary">
           <ChatInterface />
         </div>
       );


### PR DESCRIPTION
## Description
This PR fixes an issue where the chat pane background becomes transparent/black on mobile devices instead of maintaining the gray/blue background seen on desktop.

## Changes
- Added the `bg-base-secondary` class to the mobile wrapper div in `conversation.tsx`

## Root Cause
On desktop, the ChatInterface is wrapped in a ResizablePanel with `firstClassName` that includes `bg-base-secondary`, but on mobile (width <= 640px), the wrapper div was missing this background class.

## Testing
- All tests pass
- The chat background should now display correctly on mobile devices with the same gray/blue background as on desktop

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:023e8b0-nikolaik   --name openhands-app-023e8b0   docker.all-hands.dev/all-hands-ai/openhands:023e8b0
```