### PR TITLE
Fix status bar to show latest status message in STOPPED state

### DIFF
--- a/frontend/src/components/features/controls/agent-status-bar.tsx
+++ b/frontend/src/components/features/controls/agent-status-bar.tsx
@@ -47,7 +47,11 @@ export function AgentStatusBar() {
       });
       return;
     }
-    if (curAgentState === AgentState.LOADING && message.trim()) {
+    if (
+      (curAgentState === AgentState.LOADING ||
+        curAgentState === AgentState.STOPPED) &&
+      message.trim()
+    ) {
       setStatusMessage(message);
     } else {
       setStatusMessage(AGENT_STATUS_MAP[curAgentState].message);
@@ -56,7 +60,7 @@ export function AgentStatusBar() {
 
   React.useEffect(() => {
     updateStatusMessage();
-  }, [curStatusMessage.id]);
+  }, [curStatusMessage, curAgentState]);
 
   // Handle window focus/blur
   React.useEffect(() => {
@@ -82,7 +86,8 @@ export function AgentStatusBar() {
       setStatusMessage(t(I18nKey.STATUS$CONNECTED)); // Using STATUS$CONNECTED instead of STATUS$CONNECTING
       setIndicatorColor(IndicatorColor.RED);
     } else {
-      setStatusMessage(AGENT_STATUS_MAP[curAgentState].message);
+      // Update the status message based on the current agent state
+      updateStatusMessage();
       setIndicatorColor(AGENT_STATUS_MAP[curAgentState].indicator);
       if (notificationStates.includes(curAgentState)) {
         const message = t(AGENT_STATUS_MAP[curAgentState].message);
@@ -97,7 +102,7 @@ export function AgentStatusBar() {
         }
       }
     }
-  }, [curAgentState, status, notify, t]);
+  }, [curAgentState, status, notify, t, curStatusMessage]);
 
   return (
     <div className="flex flex-col items-center">


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Fixes an issue where the status bar in the frontend would not show the latest status message when the agent is in the STOPPED state. Now users will see the most recent status message even after stopping the agent.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR modifies the `AgentStatusBar` component to show the latest status message when the agent is in the STOPPED state, not just in the LOADING state. Previously, when the agent was stopped, the status bar would always show the default "Agent stopped" message, ignoring any custom status messages.

The changes include:
1. Updating the `updateStatusMessage` function to check for both LOADING and STOPPED states
2. Modifying the `useEffect` hooks to properly update the status message when the agent state or status message changes
3. Ensuring the dependency arrays in the `useEffect` hooks include all necessary dependencies

---
**Link of any specific issues this addresses.**

No specific issue linked.