### PR TITLE
Fixes spurious triggering of advanced mode caused by model case mismatch

### DIFF
--- a/frontend/src/utils/is-custom-model.ts
+++ b/frontend/src/utils/is-custom-model.ts
@@ -12,11 +12,13 @@ export const isCustomModel = (models: string[], model: string): boolean => {
 
   const organizedModels = organizeModelsAndProviders(models);
   const { provider: extractedProvider, model: extractedModel } =
-    extractModelAndProvider(model);
+    extractModelAndProvider(model.toLowerCase()); // Convert to lowercase
 
   const isKnownModel =
-    extractedProvider in organizedModels &&
-    organizedModels[extractedProvider].models.includes(extractedModel);
+    extractedProvider.toLowerCase() in organizedModels &&
+    organizedModels[extractedProvider.toLowerCase()].models
+      .map(m => m.toLowerCase())
+      .includes(extractedModel.toLowerCase());
 
   return !isKnownModel;
 };


### PR DESCRIPTION
Fixes #7789

When selecting a model that is not the default, advanced mode is incorrectly enabled due to a case mismatch in the model name check. For example, "openai" vs. "OpenAI" are treated as different, leading the app to assume a custom model is selected, thus triggering advanced mode.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
PR fixes the issue by lowering the case of variable employed to determine advanced mode activation.


---
[**Link of any specific issues this addresses.**](https://github.com/All-Hands-AI/OpenHands/issues/7789)
