### PR TITLE
Fix: Display accumulated token usage in frontend metrics

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -66,7 +66,7 @@ from openhands.events.observation import (
 )
 from openhands.events.serialization.event import event_to_trajectory, truncate_content
 from openhands.llm.llm import LLM
-from openhands.llm.metrics import Metrics, TokenUsage
+from openhands.llm.metrics import Metrics
 
 # note: RESUME is only available on web GUI
 TRAFFIC_CONTROL_REMINDER = (
@@ -1119,40 +1119,30 @@ class AgentController:
         Args:
             action: The action to attach metrics to
         """
+        # Create a minimal metrics object with just what the frontend needs
         metrics = Metrics(model_name=self.agent.llm.metrics.model_name)
         metrics.accumulated_cost = self.agent.llm.metrics.accumulated_cost
-
-        # Use the accumulated token usage instead of just the latest usage
-        # This ensures the frontend displays the total tokens used across all calls
         metrics._accumulated_token_usage = (
             self.agent.llm.metrics.accumulated_token_usage
         )
 
-        # Also add the latest usage for logging purposes
-        if self.agent.llm.metrics.token_usages:
-            latest_usage = self.agent.llm.metrics.token_usages[-1]
-            metrics.add_token_usage(
-                prompt_tokens=latest_usage.prompt_tokens,
-                completion_tokens=latest_usage.completion_tokens,
-                cache_read_tokens=latest_usage.cache_read_tokens,
-                cache_write_tokens=latest_usage.cache_write_tokens,
-                response_id=latest_usage.response_id,
-            )
         action.llm_metrics = metrics
 
-        # Log the metrics information for frontend display
-        log_usage: TokenUsage | None = (
-            metrics.token_usages[-1] if metrics.token_usages else None
-        )
-        accumulated_usage = metrics.accumulated_token_usage
+        # Log the metrics information for debugging
+        # Get the latest usage directly from the agent's metrics
+        latest_usage = None
+        if self.agent.llm.metrics.token_usages:
+            latest_usage = self.agent.llm.metrics.token_usages[-1]
+
+        accumulated_usage = self.agent.llm.metrics.accumulated_token_usage
         self.log(
             'debug',
             f'Action metrics - accumulated_cost: {metrics.accumulated_cost}, '
             f'latest tokens (prompt/completion/cache_read/cache_write): '
-            f'{log_usage.prompt_tokens if log_usage else 0}/'
-            f'{log_usage.completion_tokens if log_usage else 0}/'
-            f'{log_usage.cache_read_tokens if log_usage else 0}/'
-            f'{log_usage.cache_write_tokens if log_usage else 0}, '
+            f'{latest_usage.prompt_tokens if latest_usage else 0}/'
+            f'{latest_usage.completion_tokens if latest_usage else 0}/'
+            f'{latest_usage.cache_read_tokens if latest_usage else 0}/'
+            f'{latest_usage.cache_write_tokens if latest_usage else 0}, '
             f'accumulated tokens (prompt/completion): '
             f'{accumulated_usage.prompt_tokens}/'
             f'{accumulated_usage.completion_tokens}',

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -1114,13 +1114,21 @@ class AgentController:
 
         To avoid performance issues with long conversations, we only keep:
         - accumulated_cost: The current total cost
-        - latest token_usage: Token statistics from the most recent API call
+        - accumulated_token_usage: Accumulated token statistics across all API calls
 
         Args:
             action: The action to attach metrics to
         """
         metrics = Metrics(model_name=self.agent.llm.metrics.model_name)
         metrics.accumulated_cost = self.agent.llm.metrics.accumulated_cost
+
+        # Use the accumulated token usage instead of just the latest usage
+        # This ensures the frontend displays the total tokens used across all calls
+        metrics._accumulated_token_usage = (
+            self.agent.llm.metrics.accumulated_token_usage
+        )
+
+        # Also add the latest usage for logging purposes
         if self.agent.llm.metrics.token_usages:
             latest_usage = self.agent.llm.metrics.token_usages[-1]
             metrics.add_token_usage(
@@ -1136,14 +1144,18 @@ class AgentController:
         log_usage: TokenUsage | None = (
             metrics.token_usages[-1] if metrics.token_usages else None
         )
+        accumulated_usage = metrics.accumulated_token_usage
         self.log(
             'debug',
             f'Action metrics - accumulated_cost: {metrics.accumulated_cost}, '
-            f'tokens (prompt/completion/cache_read/cache_write): '
+            f'latest tokens (prompt/completion/cache_read/cache_write): '
             f'{log_usage.prompt_tokens if log_usage else 0}/'
             f'{log_usage.completion_tokens if log_usage else 0}/'
             f'{log_usage.cache_read_tokens if log_usage else 0}/'
-            f'{log_usage.cache_write_tokens if log_usage else 0}',
+            f'{log_usage.cache_write_tokens if log_usage else 0}, '
+            f'accumulated tokens (prompt/completion): '
+            f'{accumulated_usage.prompt_tokens}/'
+            f'{accumulated_usage.completion_tokens}',
             extra={'msg_type': 'METRICS'},
         )
 

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -458,6 +458,63 @@ async def test_step_max_budget_headless(mock_agent, mock_event_stream):
 
 
 @pytest.mark.asyncio
+async def test_prepare_metrics_for_frontend(mock_agent, mock_event_stream):
+    """Test that _prepare_metrics_for_frontend correctly prepares metrics for the frontend."""
+    # Set up test data in the agent's metrics
+    mock_agent.llm.metrics.model_name = "test-model"
+    mock_agent.llm.metrics.accumulated_cost = 0.25
+    
+    # Add some token usage data
+    mock_agent.llm.metrics.add_token_usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        cache_read_tokens=10,
+        cache_write_tokens=5,
+        response_id="test-response-1"
+    )
+    
+    # Add another token usage to ensure accumulated values are correct
+    mock_agent.llm.metrics.add_token_usage(
+        prompt_tokens=200,
+        completion_tokens=75,
+        cache_read_tokens=20,
+        cache_write_tokens=10,
+        response_id="test-response-2"
+    )
+    
+    # Create controller and action
+    controller = AgentController(
+        agent=mock_agent,
+        event_stream=mock_event_stream,
+        max_iterations=10,
+        sid='test',
+        confirmation_mode=False,
+        headless_mode=True,
+    )
+    
+    action = MessageAction(content="Test message")
+    
+    # Call the method being tested
+    controller._prepare_metrics_for_frontend(action)
+    
+    # Verify the metrics were correctly prepared
+    assert action.llm_metrics is not None
+    assert action.llm_metrics.model_name == "test-model"
+    assert action.llm_metrics.accumulated_cost == 0.25
+    
+    # Verify accumulated token usage was correctly copied
+    assert action.llm_metrics.accumulated_token_usage.prompt_tokens == 300  # 100 + 200
+    assert action.llm_metrics.accumulated_token_usage.completion_tokens == 125  # 50 + 75
+    assert action.llm_metrics.accumulated_token_usage.cache_read_tokens == 30  # 10 + 20
+    assert action.llm_metrics.accumulated_token_usage.cache_write_tokens == 15  # 5 + 10
+    
+    # Verify we didn't copy the individual token usages list
+    assert len(action.llm_metrics.token_usages) == 0
+    
+    await controller.close()
+
+
+@pytest.mark.asyncio
 async def test_reset_with_pending_action_no_observation(mock_agent, mock_event_stream):
     """Test reset() when there's a pending action with tool call metadata but no observation."""
     controller = AgentController(


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Fixes an issue where the token usage metrics displayed in the frontend were showing only the latest request token count instead of the accumulated total across all requests. This ensures users can accurately track their total token usage throughout a conversation.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR fixes the token usage metrics displayed in the frontend by ensuring the accumulated token usage is properly passed from the backend to the frontend.

The root cause was in the `_prepare_metrics_for_frontend` method in `agent_controller.py`, which was creating a new `Metrics` object with only the latest token usage, not the accumulated usage that was being properly tracked in the backend.

The fix adds code to copy the accumulated token usage from the agent's metrics to the new metrics object sent to the frontend, ensuring that the frontend displays the correct accumulated token counts.

---
**Link of any specific issues this addresses.**

No specific issue ticket, but addresses a bug where `metrics.usage.completion_tokens` displayed in the frontend was not accurate.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f527741-nikolaik   --name openhands-app-f527741   docker.all-hands.dev/all-hands-ai/openhands:f527741
```