### PR TITLE
Revert "chore - User docker cache mount for vscode server archive (#7…

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -62,8 +62,7 @@ ARG RELEASE_ORG="gitpod-io"
 # ARG USER_UID=1000
 # ARG USER_GID=1000
 
-RUN --mount=type=cache,target=/var/cache/wget \
-    if [ -z "${RELEASE_TAG}" ]; then \
+RUN if [ -z "${RELEASE_TAG}" ]; then \
         echo "The RELEASE_TAG build arg must be set." >&2 && \
         exit 1; \
     fi && \
@@ -75,15 +74,12 @@ RUN --mount=type=cache,target=/var/cache/wget \
     elif [ "${arch}" = "armv7l" ]; then \
         arch="armhf"; \
     fi && \
-    cd /var/cache/wget && \
-    if [ ! -f "${RELEASE_TAG}-linux-${arch}.tar.gz" ]; then \
-        wget https://github.com/${RELEASE_ORG}/openvscode-server/releases/download/${RELEASE_TAG}/${RELEASE_TAG}-linux-${arch}.tar.gz ; \
-    fi && \
-    cd - && \
-    tar -xzf /var/cache/wget/${RELEASE_TAG}-linux-${arch}.tar.gz && \
+    wget https://github.com/${RELEASE_ORG}/openvscode-server/releases/download/${RELEASE_TAG}/${RELEASE_TAG}-linux-${arch}.tar.gz && \
+    tar -xzf ${RELEASE_TAG}-linux-${arch}.tar.gz && \
     if [ -d "${OPENVSCODE_SERVER_ROOT}" ]; then rm -rf "${OPENVSCODE_SERVER_ROOT}"; fi && \
     mv ${RELEASE_TAG}-linux-${arch} ${OPENVSCODE_SERVER_ROOT} && \
-    cp ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/openvscode-server ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/code
+    cp ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/openvscode-server ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/code && \
+    rm -f ${RELEASE_TAG}-linux-${arch}.tar.gz
 
 
 


### PR DESCRIPTION
This reverts #7785, which introduced an optimization that requires buildkit. There are currently processes using google-cloud build that we need to ensure are updated before we can do that.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:14af11a-nikolaik   --name openhands-app-14af11a   docker.all-hands.dev/all-hands-ai/openhands:14af11a
```