### PR TITLE
fix(backend): Return 400 if trying to open a binary file

### DIFF
--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -96,7 +96,7 @@ Phase 1. READING: read the problem and reword it in clearer terms
 Phase 2. RUNNING: install and run the tests on the repository
    2.1 Follow the readme
    2.2 Install the environment and anything needed
-   2.2 Iterate and figure out how to run the tests 
+   2.2 Iterate and figure out how to run the tests
 
 Phase 3. EXPLORATION: find the files that are related to the problem and possible solutions
    3.1 Use `grep` to search for relevant methods, classes, keywords and error messages.
@@ -238,7 +238,7 @@ def get_config(
 def initialize_runtime(
     runtime: Runtime,
     instance: pd.Series,  # this argument is not required
-    metadata: EvalMetadata
+    metadata: EvalMetadata,
 ):
     """Initialize the runtime for the agent.
 

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -79,32 +79,32 @@ api_key_header = APIKeyHeader(name='X-Session-API-Key', auto_error=False)
 def is_binary_file(file_path):
     """
     Check if a file is binary.
-    
+
     Args:
         file_path (str): Path to the file to check.
-        
+
     Returns:
         bool: True if the file is binary, False otherwise.
     """
     # Number of bytes to check at the beginning of the file
     sample_size = 8192
-    
+
     try:
         # Open the file in binary mode
         with open(file_path, 'rb') as f:
             sample = f.read(sample_size)
-            
+
         # Check for NULL bytes (common in binary files)
         if b'\x00' in sample:
             return True
-            
+
         try:
             sample.decode('utf-8')
             return False
         except UnicodeDecodeError:
             # If decoding fails, it's likely binary
             return True
-            
+
     except IOError:
         return None
 
@@ -388,12 +388,10 @@ class ActionExecutor:
 
     async def read(self, action: FileReadAction) -> Observation:
         assert self.bash_session is not None
-        
+
         # Cannot read binary files
         if is_binary_file(action.path):
-            return ErrorObservation(
-                'ERROR_BINARY_FILE'
-            )
+            return ErrorObservation('ERROR_BINARY_FILE')
 
         if action.impl_source == FileReadSource.OH_ACI:
             result_str, _ = _execute_file_editor(

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -39,13 +39,14 @@ from openhands.events.observation import (
 from openhands.events.serialization import event_to_dict, observation_from_dict
 from openhands.events.serialization.action import ACTION_TYPE_TO_CLASS
 from openhands.integrations.provider import PROVIDER_TOKEN_TYPE
-from openhands.mcp import call_tool_mcp as call_tool_mcp_handler, create_mcp_clients, MCPClient
+from openhands.mcp import MCPClient, create_mcp_clients
+from openhands.mcp import call_tool_mcp as call_tool_mcp_handler
 from openhands.runtime.base import Runtime
 from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.utils.request import send_request
+from openhands.utils.async_utils import call_async_from_sync
 from openhands.utils.http_session import HttpSession
 from openhands.utils.tenacity_stop import stop_if_should_exit
-from openhands.utils.async_utils import call_async_from_sync
 
 
 def _is_retryable_error(exception):
@@ -325,10 +326,11 @@ class ActionExecutionClient(Runtime):
 
     async def call_tool_mcp(self, action: McpAction) -> Observation:
         if self.mcp_clients is None:
-            self.log('debug', f'Creating MCP clients with servers: {self.config.mcp.sse.mcp_servers}')
-            self.mcp_clients = await create_mcp_clients(
-                self.config.mcp.sse.mcp_servers
+            self.log(
+                'debug',
+                f'Creating MCP clients with servers: {self.config.mcp.sse.mcp_servers}',
             )
+            self.mcp_clients = await create_mcp_clients(self.config.mcp.sse.mcp_servers)
         return await call_tool_mcp_handler(self.mcp_clients, action)
 
     async def aclose(self) -> None:

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -139,7 +139,7 @@ async def select_file(file: str, request: Request):
         if 'ERROR_BINARY_FILE' in observation.message:
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                content={'error': f'Unable to open binary files: {file}'},
+                content={'error': f'Unable to open binary file: {file}'},
             )
 
         return JSONResponse(

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -135,6 +135,13 @@ async def select_file(file: str, request: Request):
         return {'code': content}
     elif isinstance(observation, ErrorObservation):
         logger.error(f'Error opening file {file}: {observation}')
+
+        if ('ERROR_BINARY_FILE' in observation.message):
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={'error': f'Unable to open binary files: {file}'},
+            )
+
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={'error': f'Error opening file: {observation}'},

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -138,7 +138,7 @@ async def select_file(file: str, request: Request):
 
         if 'ERROR_BINARY_FILE' in observation.message:
             return JSONResponse(
-                status_code=status.HTTP_400_BAD_REQUEST,
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
                 content={'error': f'Unable to open binary file: {file}'},
             )
 

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -136,7 +136,7 @@ async def select_file(file: str, request: Request):
     elif isinstance(observation, ErrorObservation):
         logger.error(f'Error opening file {file}: {observation}')
 
-        if ('ERROR_BINARY_FILE' in observation.message):
+        if 'ERROR_BINARY_FILE' in observation.message:
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 content={'error': f'Unable to open binary files: {file}'},


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
If the user tries to open a binary file (e.g., https://github.com/Azure-Samples/Machine-Learning-Operationalization/blob/master/samples/python/code/iris/model.pkl), the app throws a 500. This is problematic for SaaS since it may cause a false incident

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Return 400. I was unable to figure out a better way to propagate custom errors from the action execution server in the short time

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5fb00b8-nikolaik   --name openhands-app-5fb00b8   docker.all-hands.dev/all-hands-ai/openhands:5fb00b8
```