### PR TITLE
Fix issue #7826: [Bug]: Chat input box is too small

### DIFF
--- a/frontend/__tests__/components/chat/chat-input.test.tsx
+++ b/frontend/__tests__/components/chat/chat-input.test.tsx
@@ -224,7 +224,7 @@ describe("ChatInput", () => {
     const textarea = screen.getByRole("textbox");
     expect(textarea).toBeInTheDocument();
     
-    // The actual verification of maxRows=8 is handled internally by the TextareaAutosize component
+    // The actual verification of maxRows=16 is handled internally by the TextareaAutosize component
     // and affects how many rows the textarea can expand to
   });
 

--- a/frontend/__tests__/components/chat/chat-input.test.tsx
+++ b/frontend/__tests__/components/chat/chat-input.test.tsx
@@ -217,6 +217,17 @@ describe("ChatInput", () => {
     expect(onImagePaste).toHaveBeenCalledWith([file]);
   });
 
+  it("should use the default maxRows value", () => {
+    // We can't directly test the maxRows prop as it's not exposed in the DOM
+    // Instead, we'll verify the component renders with the default props
+    render(<ChatInput onSubmit={onSubmitMock} />);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeInTheDocument();
+    
+    // The actual verification of maxRows=8 is handled internally by the TextareaAutosize component
+    // and affects how many rows the textarea can expand to
+  });
+
   it("should not submit when Enter is pressed during IME composition", async () => {
     const user = userEvent.setup();
     render(<ChatInput onSubmit={onSubmitMock} />);

--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -29,7 +29,7 @@ export function ChatInput({
   disabled,
   showButton = true,
   value,
-  maxRows = 4,
+  maxRows = 8,
   onSubmit,
   onStop,
   onChange,

--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -29,7 +29,7 @@ export function ChatInput({
   disabled,
   showButton = true,
   value,
-  maxRows = 8,
+  maxRows = 16,
   onSubmit,
   onStop,
   onChange,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Increases the maximum height of the chat input box to provide more space for typing longer messages.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR increases the `maxRows` parameter of the chat input component from 4 to 16, allowing the textarea to expand to a much taller height when users type more content. This addresses the issue where the chat input box was too small for comfortable typing.

The fix is intentionally minimal and focused on the height issue, rather than adding dynamic width behavior which was not part of the original issue.

---
**Link of any specific issues this addresses.**
Fixes #7826

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e500ac4-nikolaik   --name openhands-app-e500ac4   docker.all-hands.dev/all-hands-ai/openhands:e500ac4
```