### PR TITLE
[Fix]: Use better auth header for GitLab microagent

### DIFF
--- a/microagents/knowledge/gitlab.md
+++ b/microagents/knowledge/gitlab.md
@@ -30,6 +30,6 @@ Here are some instructions for pushing, but ONLY do this if the user asks you to
 git remote -v && git branch # to find the current org, repo and branch
 git checkout -b create-widget && git add . && git commit -m "Create widget" && git push -u origin create-widget
 curl -X POST "https://gitlab.com/api/v4/projects/$PROJECT_ID/merge_requests" \
-    -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+    -H "Authorization: Bearer $GITLAB_TOKEN" \
     -d '{"source_branch": "create-widget", "target_branch": "openhands-workspace", "title": "Create widget"}'
 ```


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
- Support GitLab API calling for both oauth and PAT tokens

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
We're updating the gitlab microagent to use `Bearer` instead of `PRIVATE-TOKEN` for the auth header when making GitLab API requests

This change ensures that both OAuth + PAT can access the GitLab API appropriately. 

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7d40ca0-nikolaik   --name openhands-app-7d40ca0   docker.all-hands.dev/all-hands-ai/openhands:7d40ca0
```