### PR TITLE
Fix issue #7826: Chat input box is too small

### DIFF
--- a/frontend/__tests__/components/chat/chat-input.test.tsx
+++ b/frontend/__tests__/components/chat/chat-input.test.tsx
@@ -217,6 +217,26 @@ describe("ChatInput", () => {
     expect(onImagePaste).toHaveBeenCalledWith([file]);
   });
 
+  it("should have appropriate default dimensions", () => {
+    render(<ChatInput onSubmit={onSubmitMock} />);
+    const container = screen.getByTestId("chat-input");
+
+    // Check minimum height
+    expect(container.className).toContain("min-h-6");
+
+    // Check the textarea does not have a minimum width by default
+    const textarea = screen.getByRole("textbox");
+    expect(textarea.className).not.toContain("min-w-[300px]");
+  });
+
+  it("should apply minimum width when className contains it", () => {
+    render(<ChatInput onSubmit={onSubmitMock} className="min-w-[300px]" />);
+
+    // Check the textarea has minimum width when provided in className
+    const textarea = screen.getByRole("textbox");
+    expect(textarea.className).toContain("min-w-[300px]");
+  });
+
   it("should not submit when Enter is pressed during IME composition", async () => {
     const user = userEvent.setup();
     render(<ChatInput onSubmit={onSubmitMock} />);

--- a/frontend/__tests__/components/chat/interactive-chat-box.test.tsx
+++ b/frontend/__tests__/components/chat/interactive-chat-box.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, afterEach, vi, it, expect } from "vitest";
+import { InteractiveChatBox } from "#/components/features/chat/interactive-chat-box";
+
+describe("InteractiveChatBox", () => {
+  const onSubmitMock = vi.fn();
+  const onStopMock = vi.fn();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the chat input", () => {
+    render(<InteractiveChatBox onSubmit={onSubmitMock} onStop={onStopMock} />);
+    expect(screen.getByTestId("interactive-chat-box")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+  });
+
+  it("should not apply min-width when there is no text", () => {
+    render(<InteractiveChatBox onSubmit={onSubmitMock} onStop={onStopMock} value="" />);
+
+    const chatInput = screen.getByTestId("chat-input").querySelector("textarea");
+    expect(chatInput).toBeTruthy();
+    expect(chatInput?.className).not.toContain("min-w-[300px]");
+  });
+
+  it("should apply min-width when there is text", () => {
+    render(<InteractiveChatBox onSubmit={onSubmitMock} onStop={onStopMock} value="Hello, world!" />);
+
+    const chatInput = screen.getByTestId("chat-input").querySelector("textarea");
+    expect(chatInput).toBeTruthy();
+    expect(chatInput?.className).toContain("min-w-[300px]");
+  });
+});

--- a/frontend/src/components/features/chat/interactive-chat-box.tsx
+++ b/frontend/src/components/features/chat/interactive-chat-box.tsx
@@ -73,7 +73,10 @@ export function InteractiveChatBox({
           onStop={onStop}
           value={value}
           onImagePaste={handleUpload}
-          className="py-[10px]"
+          className={cn(
+            "py-[10px]",
+            value && value.length > 0 ? "min-w-[300px]" : "",
+          )}
           buttonClassName="py-[10px]"
         />
       </div>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR addresses the issue of the chat input box being too small by:
- Dynamically adjusting the size of the chat input box based on content
- Adding a minimum width of 300px when there's text in the input
- Keeping the default size small when there's no text
- Adding comprehensive tests to verify the behavior

---
**Link of any specific issues this addresses.**
#7826