### PR TITLE
Fix issue #7830: Add support for Gemini preview model versions

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -463,10 +463,14 @@ class LLM(RetryMixin, DebugMixin):
 
         # Initialize function calling capability
         # Check if model name is in our supported list
+        model_name = self.config.model.split('/')[-1]
         model_name_supported = (
             self.config.model in FUNCTION_CALLING_SUPPORTED_MODELS
-            or self.config.model.split('/')[-1] in FUNCTION_CALLING_SUPPORTED_MODELS
+            or model_name in FUNCTION_CALLING_SUPPORTED_MODELS
             or any(m in self.config.model for m in FUNCTION_CALLING_SUPPORTED_MODELS)
+            # Handle Gemini preview versions (e.g., gemini-2.5-pro-preview-03-25)
+            or (model_name.startswith('gemini-') and 'preview' in model_name and 
+                any(m in model_name.split('-preview')[0] for m in FUNCTION_CALLING_SUPPORTED_MODELS))
         )
 
         # Handle native_tool_calling user-defined configuration

--- a/tests/test_gemini_preview.py
+++ b/tests/test_gemini_preview.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+from openhands.core.config import LLMConfig
+from openhands.llm.llm import LLM
+
+
+class TestGeminiPreview(unittest.TestCase):
+    @patch('litellm.supports_function_calling')
+    def test_gemini_preview_function_calling(self, mock_supports_function_calling):
+        # Mock litellm.supports_function_calling to return True
+        mock_supports_function_calling.return_value = True
+
+        # Test with regular gemini-2.5-pro model
+        config = LLMConfig(model="gemini/gemini-2.5-pro")
+        llm = LLM(config)
+        self.assertTrue(llm.is_function_calling_active())
+
+        # Test with preview version
+        config = LLMConfig(model="gemini/gemini-2.5-pro-preview-03-25")
+        llm = LLM(config)
+        self.assertTrue(llm.is_function_calling_active())
+
+        # Test with another preview version
+        config = LLMConfig(model="gemini-2.5-pro-preview-04-01")
+        llm = LLM(config)
+        self.assertTrue(llm.is_function_calling_active())
+
+        # Test with a non-supported model
+        config = LLMConfig(model="gemini/gemini-1.0-not-supported")
+        llm = LLM(config)
+        # This should be False since it's not in FUNCTION_CALLING_SUPPORTED_MODELS
+        # and doesn't match the pattern
+        self.assertFalse(llm.is_function_calling_active())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

This PR fixes an issue where users were unable to run agents using the `gemini-2.5-pro-preview-03-25` model. After this fix, OpenHands will properly support Gemini preview model versions, allowing users to use the latest Gemini models with their agents.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

The PR modifies the model name check in the LLM class to handle Gemini preview versions. The issue was that the code only checked for exact matches with `gemini-2.5-pro` in the `FUNCTION_CALLING_SUPPORTED_MODELS` list, but didn't handle preview versions like `gemini-2.5-pro-preview-03-25`.

The solution adds a new condition to the model name check that:
1. Checks if the model name starts with "gemini-"
2. Checks if the model name contains "preview"
3. Extracts the base model name (before "-preview") and checks if it's in the supported models list

This approach ensures that any preview version of a supported Gemini model will be correctly identified as supporting function calling.

A comprehensive test case was added to verify that both regular and preview versions of Gemini models are correctly identified.

---
**Link of any specific issues this addresses.**

Fixes #7830