### PR TITLE
Fix issue #7837: [Bug]: Unit tests for tool use support

### DIFF
--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -449,35 +449,81 @@ def test_completion_retry_with_llm_no_response_error_nonzero_temp(
     This test verifies that when LLMNoResponseError is raised with a non-zero temperature:
     1. The retry mechanism is triggered
     2. The temperature remains unchanged (not set to 0.2)
-    3. After all retries are exhausted, the exception is propagated
+    3. After all retries are exhausted, the error is raised
     """
-    # Define a side effect function that always raises LLMNoResponseError
-    mock_litellm_completion.side_effect = LLMNoResponseError(
-        'LLM did not return a response'
-    )
+    mock_litellm_completion.side_effect = LLMNoResponseError('LLM did not return a response')
 
-    # Create LLM instance and make a completion call with non-zero temperature
     llm = LLM(config=default_config)
-
-    # We expect this to raise an exception after all retries are exhausted
     with pytest.raises(LLMNoResponseError):
         llm.completion(
             messages=[{'role': 'user', 'content': 'Hello!'}],
             stream=False,
-            temperature=0.7,  # Initial temperature is non-zero
+            temperature=0.7,  # Non-zero temperature
         )
 
-    # Verify that litellm_completion was called multiple times (retries happened)
-    # The default_config has num_retries=2, so it should be called 2 times
-    assert mock_litellm_completion.call_count == 2
+    # Verify that litellm_completion was called the expected number of times
+    assert mock_litellm_completion.call_count == default_config.num_retries
 
-    # Check the temperature in the first call (should be 0.7)
-    first_call_kwargs = mock_litellm_completion.call_args_list[0][1]
-    assert first_call_kwargs.get('temperature') == 0.7
+    # Check that all calls used the original temperature
+    for call in mock_litellm_completion.call_args_list:
+        assert call[1].get('temperature') == 0.7
 
-    # Check the temperature in the second call (should remain 0.7, not changed to 0.2)
-    second_call_kwargs = mock_litellm_completion.call_args_list[1][1]
-    assert second_call_kwargs.get('temperature') == 0.7
+
+@patch('openhands.llm.llm.litellm.get_model_info')
+@patch('openhands.llm.llm.httpx.get')
+def test_gemini_25_pro_function_calling(mock_httpx_get, mock_get_model_info):
+    """
+    Test that Gemini 2.5 Pro models have function calling enabled by default.
+    This includes testing various model name formats with different prefixes.
+    """
+    # Mock the model info response
+    mock_get_model_info.return_value = {
+        'max_input_tokens': 8000,
+        'max_output_tokens': 2000,
+    }
+
+    # Mock the httpx response for litellm proxy
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'data': [
+            {
+                'model_name': 'gemini-2.5-pro-preview-03-25',
+                'model_info': {
+                    'max_input_tokens': 8000,
+                    'max_output_tokens': 2000,
+                }
+            }
+        ]
+    }
+    mock_httpx_get.return_value = mock_response
+
+    # Test cases with model names and expected function calling support
+    test_cases = [
+        # Base model names
+        ('gemini-2.5-pro-preview-03-25', True),
+        ('gemini-2.5-pro-exp-03-25', True),
+        # With gemini/ prefix
+        ('gemini/gemini-2.5-pro-preview-03-25', True),
+        ('gemini/gemini-2.5-pro-exp-03-25', True),
+        # With litellm_proxy/ prefix
+        ('litellm_proxy/gemini-2.5-pro-preview-03-25', True),
+        ('litellm_proxy/gemini-2.5-pro-exp-03-25', True),
+        # With openrouter/gemini/ prefix
+        ('openrouter/gemini/gemini-2.5-pro-preview-03-25', True),
+        ('openrouter/gemini/gemini-2.5-pro-exp-03-25', True),
+        # With litellm_proxy/gemini/ prefix
+        ('litellm_proxy/gemini/gemini-2.5-pro-preview-03-25', True),
+        ('litellm_proxy/gemini/gemini-2.5-pro-exp-03-25', True),
+        # Control case - a model that shouldn't have function calling
+        ('gemini-1.0-pro', False),
+    ]
+
+    for model_name, expected_support in test_cases:
+        config = LLMConfig(model=model_name, api_key='test_key')
+        llm = LLM(config)
+
+        assert llm.is_function_calling_active() == expected_support, \
+            f"Expected function calling support to be {expected_support} for model {model_name}"
 
 
 @patch('openhands.llm.llm.litellm_completion')

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -451,7 +451,9 @@ def test_completion_retry_with_llm_no_response_error_nonzero_temp(
     2. The temperature remains unchanged (not set to 0.2)
     3. After all retries are exhausted, the error is raised
     """
-    mock_litellm_completion.side_effect = LLMNoResponseError('LLM did not return a response')
+    mock_litellm_completion.side_effect = LLMNoResponseError(
+        'LLM did not return a response'
+    )
 
     llm = LLM(config=default_config)
     with pytest.raises(LLMNoResponseError):
@@ -491,7 +493,7 @@ def test_gemini_25_pro_function_calling(mock_httpx_get, mock_get_model_info):
                 'model_info': {
                     'max_input_tokens': 8000,
                     'max_output_tokens': 2000,
-                }
+                },
             }
         ]
     }
@@ -522,8 +524,9 @@ def test_gemini_25_pro_function_calling(mock_httpx_get, mock_get_model_info):
         config = LLMConfig(model=model_name, api_key='test_key')
         llm = LLM(config)
 
-        assert llm.is_function_calling_active() == expected_support, \
-            f"Expected function calling support to be {expected_support} for model {model_name}"
+        assert (
+            llm.is_function_calling_active() == expected_support
+        ), f'Expected function calling support to be {expected_support} for model {model_name}'
 
 
 @patch('openhands.llm.llm.litellm_completion')


### PR DESCRIPTION
This pull request fixes #7837.

The changes fully address the original issue by adding comprehensive unit tests that verify function calling support for Gemini 2.5 Pro models. Specifically:

1. A new test function `test_gemini_25_pro_function_calling` was added that tests all required model name variations:
   - Base model names (gemini-2.5-pro-preview-03-25, gemini-2.5-pro-exp-03-25)
   - With gemini/ prefix
   - With litellm_proxy/ prefix
   - With openrouter/gemini/ prefix
   - With litellm_proxy/gemini/ prefix

2. The test properly verifies that `is_function_calling_active()` returns True for all Gemini 2.5 Pro model variations, confirming that the model name check in llm.py (particularly the `any(m in self.config.model for m in FUNCTION_CALLING_SUPPORTED_MODELS)` part) works correctly.

3. The implementation includes proper mocking of external dependencies (litellm.get_model_info and httpx.get) to ensure reliable testing.

4. A control case with 'gemini-1.0-pro' was added to verify that function calling is not enabled for non-supported models, providing additional confidence in the test's accuracy.

The changes directly fulfill the requirements from the issue description and provide a reliable way to verify the function calling support behavior for Gemini 2.5 Pro models.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:147db10-nikolaik   --name openhands-app-147db10   docker.all-hands.dev/all-hands-ai/openhands:147db10
```