### PR TITLE
frontend: Display think action as action rather than text

### DIFF
--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -104,7 +104,12 @@ export function handleActionMessage(message: ActionMessage) {
   }
 
   if (message.source === "agent") {
-    if (message.args && message.args.thought) {
+    // Only add thought as a message if it's not a "think" action
+    if (
+      message.args &&
+      message.args.thought &&
+      message.action !== ActionType.THINK
+    ) {
       store.dispatch(addAssistantMessage(message.args.thought));
     }
     // Need to convert ActionMessage to RejectAction

--- a/frontend/src/state/chat-slice.ts
+++ b/frontend/src/state/chat-slice.ts
@@ -24,6 +24,7 @@ const HANDLED_ACTIONS: OpenHandsEventType[] = [
   "browse_interactive",
   "edit",
   "recall",
+  "think",
 ];
 
 function getRiskText(risk: ActionSecurityRisk) {


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
This PR fixes an issue where "think" actions were being displayed twice in the UI - once as regular text and once as a collapsible action. It also properly adds "think" to the list of handled actions so they display correctly as collapsible elements.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
1. Added "think" to the HANDLED_ACTIONS array in chat-slice.ts to enable proper display of thinking actions in the UI as collapsable elements

2. Fixed an issue where "think" actions were being displayed twice in the UI by modifying the handleActionMessage function in actions.ts to only add thoughts as regular messages if they're not from a "think" action.

The implementation ensures that "think" actions are only displayed once in the UI as collapsable elements, improving the user experience by reducing duplication and making the UI cleaner.

---
**Link of any specific issues this addresses.**
N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0e5799a-nikolaik   --name openhands-app-0e5799a   docker.all-hands.dev/all-hands-ai/openhands:0e5799a
```