### PR TITLE
[Refactor] Rename codeact_* agent options to simple name

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -216,13 +216,13 @@ model = "gpt-4o"
 [agent]
 
 # Whether the browsing tool is enabled
-codeact_enable_browsing = true
+enable_browsing = true
 
 # Whether the LLM draft editor is enabled
-codeact_enable_llm_editor = false
+enable_llm_editor = false
 
 # Whether the IPython tool is enabled
-codeact_enable_jupyter = true
+enable_jupyter = true
 
 # LLM config group to use
 #llm_config = 'your-llm-config-group'

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -354,12 +354,12 @@ Les options de configuration de l'agent sont définies dans les sections `[agent
   - Valeur par défaut : `true`
   - Description : Si l'appel de fonction est activé
 
-- `codeact_enable_browsing`
+- `enable_browsing`
   - Type : `bool`
   - Valeur par défaut : `false`
   - Description : Si le délégué de navigation est activé dans l'espace d'action (fonctionne uniquement avec l'appel de fonction)
 
-- `codeact_enable_llm_editor`
+- `enable_llm_editor`
   - Type : `bool`
   - Valeur par défaut : `false`
   - Description : Si l'éditeur LLM est activé dans l'espace d'action (fonctionne uniquement avec l'appel de fonction)

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -348,12 +348,12 @@ dockerコマンドで使用する場合は、`-e LLM_<option>`として渡しま
   - デフォルト値: `true`
   - 説明: 関数呼び出しが有効かどうか
 
-- `codeact_enable_browsing`
+- `enable_browsing`
   - 型: `bool`
   - デフォルト値: `false`
   - 説明: アクションスペースでブラウジングデリゲートが有効かどうか（関数呼び出しでのみ機能）
 
-- `codeact_enable_llm_editor`
+- `enable_llm_editor`
   - 型: `bool`
   - デフォルト値: `false`
   - 説明: アクションスペースでLLMエディタが有効かどうか（関数呼び出しでのみ機能）

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -292,17 +292,17 @@ As opções de configuração do agente são definidas nas seções `[agent]` e 
   - Padrão: `true`
   - Descrição: Se a chamada de função está habilitada
 
-- `codeact_enable_browsing`
+- `enable_browsing`
   - Tipo: `bool`
   - Padrão: `false`
   - Descrição: Se o delegado de navegação está habilitado no espaço de ação (funciona apenas com chamada de função)
 
-- `codeact_enable_llm_editor`
+- `enable_llm_editor`
   - Tipo: `bool`
   - Padrão: `false`
   - Descrição: Se o editor LLM está habilitado no espaço de ação (funciona apenas com chamada de função)
 
-- `codeact_enable_jupyter`
+- `enable_jupyter`
   - Tipo: `bool`
   - Padrão: `false`
   - Descrição: Se o Jupyter está habilitado no espaço de ação

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/configuration-options.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/configuration-options.md
@@ -349,17 +349,17 @@ Agent 配置选项在 `config.toml` 文件的 `[agent]` 和 `[agent.<agent_name>
   - 默认值: `true`
   - 描述: 是否启用函数调用
 
-- `codeact_enable_browsing`
+- `enable_browsing`
   - 类型: `bool`
   - 默认值: `false`
   - 描述: 是否在 action space 中启用浏览代理(仅适用于函数调用)
 
-- `codeact_enable_llm_editor`
+- `enable_llm_editor`
   - 类型: `bool`
   - 默认值: `false`
   - 描述: 是否在 action space 中启用 LLM 编辑器(仅适用于函数调用)
 
-- `codeact_enable_jupyter`
+- `enable_jupyter`
   - 类型: `bool`
   - 默认值: `false`
   - 描述: 是否在 action space 中启用 Jupyter

--- a/docs/modules/usage/configuration-options.md
+++ b/docs/modules/usage/configuration-options.md
@@ -291,17 +291,17 @@ The agent configuration options are defined in the `[agent]` and `[agent.<agent_
   - Default: `true`
   - Description: Whether function calling is enabled
 
-- `codeact_enable_browsing`
+- `enable_browsing`
   - Type: `bool`
   - Default: `false`
   - Description: Whether browsing delegate is enabled in the action space (only works with function calling)
 
-- `codeact_enable_llm_editor`
+- `enable_llm_editor`
   - Type: `bool`
   - Default: `false`
   - Description: Whether LLM editor is enabled in the action space (only works with function calling)
 
-- `codeact_enable_jupyter`
+- `enable_jupyter`
   - Type: `bool`
   - Default: `false`
   - Description: Whether Jupyter is enabled in the action space

--- a/evaluation/benchmarks/commit0/run_infer.py
+++ b/evaluation/benchmarks/commit0/run_infer.py
@@ -131,9 +131,9 @@ def get_config(
         )
     )
     agent_config = AgentConfig(
-        codeact_enable_jupyter=False,
-        codeact_enable_browsing=RUN_WITH_BROWSING,
-        codeact_enable_llm_editor=False,
+        enable_jupyter=False,
+        enable_browsing=RUN_WITH_BROWSING,
+        enable_llm_editor=False,
     )
     config.set_agent_config(agent_config)
     return config

--- a/evaluation/benchmarks/discoverybench/run_infer.py
+++ b/evaluation/benchmarks/discoverybench/run_infer.py
@@ -79,8 +79,8 @@ def get_config(
     agent_config.enable_prompt_extensions = False
     agent_config = AgentConfig(
         function_calling=False,
-        codeact_enable_jupyter=True,
-        codeact_enable_browsing_delegate=True,
+        enable_jupyter=True,
+        enable_browsing=True,
     )
     config.set_agent_config(agent_config)
     return config

--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -225,9 +225,9 @@ def get_config(
         )
     )
     agent_config = AgentConfig(
-        codeact_enable_jupyter=False,
-        codeact_enable_browsing=RUN_WITH_BROWSING,
-        codeact_enable_llm_editor=False,
+        enable_jupyter=False,
+        enable_browsing=RUN_WITH_BROWSING,
+        enable_llm_editor=False,
         condenser=metadata.condenser_config,
         enable_prompt_extensions=False,
     )

--- a/evaluation/benchmarks/testgeneval/run_infer.py
+++ b/evaluation/benchmarks/testgeneval/run_infer.py
@@ -158,9 +158,9 @@ def get_config(
         )
     )
     agent_config = AgentConfig(
-        codeact_enable_jupyter=False,
-        codeact_enable_browsing=RUN_WITH_BROWSING,
-        codeact_enable_llm_editor=False,
+        enable_jupyter=False,
+        enable_browsing=RUN_WITH_BROWSING,
+        enable_llm_editor=False,
         condenser=metadata.condenser_config,
         enable_prompt_extensions=False,
     )

--- a/evaluation/integration_tests/run_infer.py
+++ b/evaluation/integration_tests/run_infer.py
@@ -62,9 +62,9 @@ def get_config(
         )
     )
     agent_config = AgentConfig(
-        codeact_enable_jupyter=True,
-        codeact_enable_browsing=True,
-        codeact_enable_llm_editor=False,
+        enable_jupyter=True,
+        enable_browsing=True,
+        enable_llm_editor=False,
     )
     config.set_agent_config(agent_config)
     return config

--- a/openhands/agenthub/codeact_agent/README.md
+++ b/openhands/agenthub/codeact_agent/README.md
@@ -53,9 +53,9 @@ The agent provides several built-in tools:
 ## Configuration
 
 Tools can be enabled/disabled through configuration parameters:
-- `codeact_enable_browsing`: Enable browser interaction tools
-- `codeact_enable_jupyter`: Enable IPython code execution
-- `codeact_enable_llm_editor`: Enable LLM-based file editing (falls back to string replacement editor if disabled)
+- `enable_browsing`: Enable browser interaction tools
+- `enable_jupyter`: Enable IPython code execution
+- `enable_llm_editor`: Enable LLM-based file editing (falls back to string replacement editor if disabled)
 
 ## Micro-agents
 

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -69,9 +69,9 @@ class CodeActAgent(Agent):
         self.reset()
 
         built_in_tools = codeact_function_calling.get_tools(
-            codeact_enable_browsing=self.config.codeact_enable_browsing,
-            codeact_enable_jupyter=self.config.codeact_enable_jupyter,
-            codeact_enable_llm_editor=self.config.codeact_enable_llm_editor,
+            enable_browsing=self.config.enable_browsing,
+            enable_jupyter=self.config.enable_jupyter,
+            enable_llm_editor=self.config.enable_llm_editor,
             llm=self.llm,
         )
 

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -240,9 +240,9 @@ def response_to_actions(response: ModelResponse) -> list[Action]:
 
 
 def get_tools(
-    codeact_enable_browsing: bool = False,
-    codeact_enable_llm_editor: bool = False,
-    codeact_enable_jupyter: bool = False,
+    enable_browsing: bool = False,
+    enable_llm_editor: bool = False,
+    enable_jupyter: bool = False,
     llm: LLM | None = None,
 ) -> list[ChatCompletionToolParam]:
     SIMPLIFIED_TOOL_DESCRIPTION_LLM_SUBSTRS = ['gpt-', 'o3', 'o1']
@@ -259,12 +259,12 @@ def get_tools(
         ThinkTool,
         FinishTool,
     ]
-    if codeact_enable_browsing:
+    if enable_browsing:
         tools.append(WebReadTool)
         tools.append(BrowserTool)
-    if codeact_enable_jupyter:
+    if enable_jupyter:
         tools.append(IPythonTool)
-    if codeact_enable_llm_editor:
+    if enable_llm_editor:
         tools.append(LLMBasedFileEditTool)
     else:
         tools.append(

--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -10,10 +10,9 @@ class AgentConfig(BaseModel):
     """Configuration for the agent.
 
     Attributes:
-        function_calling: Whether function calling is enabled. Default is True.
-        codeact_enable_browsing: Whether browsing delegate is enabled in the action space. Default is False. Only works with function calling.
-        codeact_enable_llm_editor: Whether LLM editor is enabled in the action space. Default is False. Only works with function calling.
-        codeact_enable_jupyter: Whether Jupyter is enabled in the action space. Default is False.
+        enable_browsing: Whether browsing delegate is enabled in the action space. Default is False. Only works with function calling.
+        enable_llm_editor: Whether LLM editor is enabled in the action space. Default is False. Only works with function calling.
+        enable_jupyter: Whether Jupyter is enabled in the action space. Default is False.
         llm_config: The name of the llm config to use. If specified, this will override global llm config.
         enable_prompt_extensions: Whether to use prompt extensions (e.g., microagents, inject runtime info). Default is True.
         disabled_microagents: A list of microagents to disable (by name, without .py extension, e.g. ["github", "lint"]). Default is None.
@@ -23,9 +22,9 @@ class AgentConfig(BaseModel):
     """
 
     llm_config: str | None = Field(default=None)
-    codeact_enable_browsing: bool = Field(default=True)
-    codeact_enable_llm_editor: bool = Field(default=False)
-    codeact_enable_jupyter: bool = Field(default=True)
+    enable_browsing: bool = Field(default=True)
+    enable_llm_editor: bool = Field(default=False)
+    enable_jupyter: bool = Field(default=True)
     enable_prompt_extensions: bool = Field(default=True)
     disabled_microagents: list[str] = Field(default_factory=list)
     enable_history_truncation: bool = Field(default=True)

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -150,7 +150,7 @@ class Runtime(FileEditRuntimeMixin):
 
         # Load mixins
         FileEditRuntimeMixin.__init__(
-            self, enable_llm_editor=config.get_agent_config().codeact_enable_llm_editor
+            self, enable_llm_editor=config.get_agent_config().enable_llm_editor
         )
 
         self.user_id = user_id

--- a/tests/runtime/test_stress_remote_runtime.py
+++ b/tests/runtime/test_stress_remote_runtime.py
@@ -82,9 +82,9 @@ def get_config() -> AppConfig:
         workspace_mount_path=None,
     )
     agent_config = AgentConfig(
-        codeact_enable_jupyter=False,
-        codeact_enable_browsing=False,
-        codeact_enable_llm_editor=False,
+        enable_jupyter=False,
+        enable_browsing=False,
+        enable_llm_editor=False,
     )
     config.set_agent_config(agent_config)
     return config

--- a/tests/unit/test_codeact_agent.py
+++ b/tests/unit/test_codeact_agent.py
@@ -80,9 +80,9 @@ def test_step_with_pending_actions(agent: CodeActAgent):
 
 def test_get_tools_default():
     tools = get_tools(
-        codeact_enable_jupyter=True,
-        codeact_enable_llm_editor=True,
-        codeact_enable_browsing=True,
+        enable_jupyter=True,
+        enable_llm_editor=True,
+        enable_browsing=True,
     )
     assert len(tools) > 0
 
@@ -97,9 +97,9 @@ def test_get_tools_default():
 def test_get_tools_with_options():
     # Test with all options enabled
     tools = get_tools(
-        codeact_enable_browsing=True,
-        codeact_enable_jupyter=True,
-        codeact_enable_llm_editor=True,
+        enable_browsing=True,
+        enable_jupyter=True,
+        enable_llm_editor=True,
     )
     tool_names = [tool['function']['name'] for tool in tools]
     assert 'browser' in tool_names
@@ -108,9 +108,9 @@ def test_get_tools_with_options():
 
     # Test with all options disabled
     tools = get_tools(
-        codeact_enable_browsing=False,
-        codeact_enable_jupyter=False,
-        codeact_enable_llm_editor=False,
+        enable_browsing=False,
+        enable_jupyter=False,
+        enable_llm_editor=False,
     )
     tool_names = [tool['function']['name'] for tool in tools]
     assert 'browser' not in tool_names

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -835,7 +835,7 @@ def test_api_keys_repr_str():
     # Test AgentConfig
     # No attrs in AgentConfig have 'key' or 'token' in their name
     agent_config = AgentConfig(
-        enable_prompt_extensions=True, codeact_enable_browsing=False
+        enable_prompt_extensions=True, enable_browsing=False
     )
     for attr_name in AgentConfig.model_fields.keys():
         if not attr_name.startswith('__'):
@@ -941,7 +941,7 @@ max_budget_per_task = 4.0
 enable_prompt_extensions = true
 
 [agent.BrowsingAgent]
-codeact_enable_jupyter = false
+enable_jupyter = false
 """
 
     with open(temp_toml_file, 'w') as f:
@@ -952,7 +952,7 @@ codeact_enable_jupyter = false
     codeact_config = default_config.get_agent_configs().get('CodeActAgent')
     assert codeact_config.enable_prompt_extensions is True
     browsing_config = default_config.get_agent_configs().get('BrowsingAgent')
-    assert browsing_config.codeact_enable_jupyter is False
+    assert browsing_config.enable_jupyter is False
 
 
 def test_get_agent_config_arg(temp_toml_file):
@@ -963,11 +963,11 @@ max_budget_per_task = 4.0
 
 [agent.CodeActAgent]
 enable_prompt_extensions = false
-codeact_enable_browsing = false
+enable_browsing = false
 
 [agent.BrowsingAgent]
 enable_prompt_extensions = true
-codeact_enable_jupyter = false
+enable_jupyter = false
 """
 
     with open(temp_toml_file, 'w') as f:
@@ -975,11 +975,11 @@ codeact_enable_jupyter = false
 
     agent_config = get_agent_config_arg('CodeActAgent', temp_toml_file)
     assert not agent_config.enable_prompt_extensions
-    assert not agent_config.codeact_enable_browsing
+    assert not agent_config.enable_browsing
 
     agent_config2 = get_agent_config_arg('BrowsingAgent', temp_toml_file)
     assert agent_config2.enable_prompt_extensions
-    assert not agent_config2.codeact_enable_jupyter
+    assert not agent_config2.enable_jupyter
 
 
 def test_agent_config_custom_group_name(temp_toml_file):
@@ -1015,8 +1015,8 @@ def test_agent_config_from_toml_section():
     # Test with base config and custom configs
     agent_section = {
         'enable_prompt_extensions': True,
-        'codeact_enable_browsing': True,
-        'CustomAgent1': {'codeact_enable_browsing': False},
+        'enable_browsing': True,
+        'CustomAgent1': {'enable_browsing': False},
         'CustomAgent2': {'enable_prompt_extensions': False},
         'InvalidAgent': {
             'invalid_field': 'some_value'  # This should be skipped but not affect others
@@ -1029,15 +1029,15 @@ def test_agent_config_from_toml_section():
     # Verify the base config was correctly parsed
     assert 'agent' in result
     assert result['agent'].enable_prompt_extensions is True
-    assert result['agent'].codeact_enable_browsing is True
+    assert result['agent'].enable_browsing is True
 
     # Verify custom configs were correctly parsed and inherit from base
     assert 'CustomAgent1' in result
-    assert result['CustomAgent1'].codeact_enable_browsing is False  # Overridden
+    assert result['CustomAgent1'].enable_browsing is False  # Overridden
     assert result['CustomAgent1'].enable_prompt_extensions is True  # Inherited
 
     assert 'CustomAgent2' in result
-    assert result['CustomAgent2'].codeact_enable_browsing is True  # Inherited
+    assert result['CustomAgent2'].enable_browsing is True  # Inherited
     assert result['CustomAgent2'].enable_prompt_extensions is False  # Overridden
 
     # Verify the invalid config was skipped
@@ -1051,10 +1051,10 @@ def test_agent_config_from_toml_section_with_invalid_base():
     # Test with invalid base config but valid custom configs
     agent_section = {
         'invalid_field': 'some_value',  # This should be ignored in base config
-        'codeact_enable_jupyter': 'not_a_bool',  # This should cause validation error
+        'enable_jupyter': 'not_a_bool',  # This should cause validation error
         'CustomAgent': {
-            'codeact_enable_browsing': False,
-            'codeact_enable_jupyter': True,
+            'enable_browsing': False,
+            'enable_jupyter': True,
         },
     }
 
@@ -1063,10 +1063,10 @@ def test_agent_config_from_toml_section_with_invalid_base():
 
     # Verify a default base config was created despite the invalid fields
     assert 'agent' in result
-    assert result['agent'].codeact_enable_browsing is True  # Default value
-    assert result['agent'].codeact_enable_jupyter is True  # Default value
+    assert result['agent'].enable_browsing is True  # Default value
+    assert result['agent'].enable_jupyter is True  # Default value
 
     # Verify custom config was still processed correctly
     assert 'CustomAgent' in result
-    assert result['CustomAgent'].codeact_enable_browsing is False
-    assert result['CustomAgent'].codeact_enable_jupyter is True
+    assert result['CustomAgent'].enable_browsing is False
+    assert result['CustomAgent'].enable_jupyter is True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -834,9 +834,7 @@ def test_api_keys_repr_str():
 
     # Test AgentConfig
     # No attrs in AgentConfig have 'key' or 'token' in their name
-    agent_config = AgentConfig(
-        enable_prompt_extensions=True, enable_browsing=False
-    )
+    agent_config = AgentConfig(enable_prompt_extensions=True, enable_browsing=False)
     for attr_name in AgentConfig.model_fields.keys():
         if not attr_name.startswith('__'):
             assert (


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Renamed agent options from codeact_* to simply the option name, e.g. enable_browsing

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes to clean up the prefix "codeact_" from the agent configuration options that had it: these options are agent options, simply, and if an agent doesn't support them, it will document that and set them (or let them be) False.

`codeact_enable_browsing` -> `enable_browsing` 
`codeact_enable_llm_editor` -> `enable_llm_editor`
`codeact_enable_jupyter` -> `enable_jupyter`

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a991680-nikolaik   --name openhands-app-a991680   docker.all-hands.dev/all-hands-ai/openhands:a991680
```