### PR TITLE
disable visual browsing

### DIFF
--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -29,7 +29,7 @@ class AgentConfig(BaseModel):
     enable_prompt_extensions: bool = Field(default=True)
     disabled_microagents: list[str] = Field(default_factory=list)
     enable_history_truncation: bool = Field(default=True)
-    enable_som_visual_browsing: bool = Field(default=True)
+    enable_som_visual_browsing: bool = Field(default=False)
     condenser: CondenserConfig = Field(
         default_factory=lambda: NoOpCondenserConfig(type='noop')
     )


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

CHANGELOG: disabled visual browsing by default. This will be turned back on once we can figure out some issues with cost/tokens

**End-user friendly description of the problem this fixes or functionality that this introduces.**

We're getting reports of this costing $$$

We're working on a condenser related fix here (blocked by https://github.com/All-Hands-AI/OpenHands/issues/7850), but for now let's turn it off by default

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a23f842-nikolaik   --name openhands-app-a23f842   docker.all-hands.dev/all-hands-ai/openhands:a23f842
```