### PR TITLE
Update repo microagent docs with frontend action handling information

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -49,6 +49,16 @@ Frontend:
   - Available variables: VITE_BACKEND_HOST, VITE_USE_TLS, VITE_INSECURE_SKIP_VERIFY, VITE_FRONTEND_PORT
 - Internationalization:
   - Generate i18n declaration file: `npm run make-i18n`
+- Action Handling:
+  - Actions are defined in `frontend/src/types/action-type.ts`
+  - The `HANDLED_ACTIONS` array in `frontend/src/state/chat-slice.ts` determines which actions are displayed as collapsible UI elements
+  - To add a new action type to the UI:
+    1. Add the action type to the `HANDLED_ACTIONS` array
+    2. Implement the action handling in `addAssistantAction` function in chat-slice.ts
+    3. Add a translation key in the format `ACTION_MESSAGE$ACTION_NAME` to the i18n files
+  - Actions with `thought` property are displayed in the UI based on their action type:
+    - Regular actions (like "run", "edit") display the thought as a separate message
+    - Special actions (like "think") are displayed as collapsible elements only
 
 
 ## Template for Github Pull Request

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -59,7 +59,9 @@ If you are starting a pull request (PR), please follow the template in `.github/
 
 These details may or may not be useful for your current task.
 
-### Action Handling:
+### Frontend
+
+#### Action Handling:
 - Actions are defined in `frontend/src/types/action-type.ts`
 - The `HANDLED_ACTIONS` array in `frontend/src/state/chat-slice.ts` determines which actions are displayed as collapsible UI elements
 - To add a new action type to the UI:

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -49,18 +49,23 @@ Frontend:
   - Available variables: VITE_BACKEND_HOST, VITE_USE_TLS, VITE_INSECURE_SKIP_VERIFY, VITE_FRONTEND_PORT
 - Internationalization:
   - Generate i18n declaration file: `npm run make-i18n`
-- Action Handling:
-  - Actions are defined in `frontend/src/types/action-type.ts`
-  - The `HANDLED_ACTIONS` array in `frontend/src/state/chat-slice.ts` determines which actions are displayed as collapsible UI elements
-  - To add a new action type to the UI:
-    1. Add the action type to the `HANDLED_ACTIONS` array
-    2. Implement the action handling in `addAssistantAction` function in chat-slice.ts
-    3. Add a translation key in the format `ACTION_MESSAGE$ACTION_NAME` to the i18n files
-  - Actions with `thought` property are displayed in the UI based on their action type:
-    - Regular actions (like "run", "edit") display the thought as a separate message
-    - Special actions (like "think") are displayed as collapsible elements only
 
 
 ## Template for Github Pull Request
 
 If you are starting a pull request (PR), please follow the template in `.github/pull_request_template.md`.
+
+## Implementation Details
+
+These details may or may not be useful for your current task.
+
+### Action Handling:
+- Actions are defined in `frontend/src/types/action-type.ts`
+- The `HANDLED_ACTIONS` array in `frontend/src/state/chat-slice.ts` determines which actions are displayed as collapsible UI elements
+- To add a new action type to the UI:
+  1. Add the action type to the `HANDLED_ACTIONS` array
+  2. Implement the action handling in `addAssistantAction` function in chat-slice.ts
+  3. Add a translation key in the format `ACTION_MESSAGE$ACTION_NAME` to the i18n files
+- Actions with `thought` property are displayed in the UI based on their action type:
+  - Regular actions (like "run", "edit") display the thought as a separate message
+  - Special actions (like "think") are displayed as collapsible elements only


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
This PR updates the repository microagent documentation to include information about how actions are displayed in the frontend UI, particularly focusing on the handling of collapsible action elements.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Added a new section to the `.openhands/microagents/repo.md` file under the Frontend section that explains:

1. How actions are defined and handled in the frontend codebase
2. The role of the `HANDLED_ACTIONS` array in determining which actions are displayed as collapsible UI elements
3. Step-by-step instructions for adding new action types to the UI
4. How actions with `thought` property are displayed differently based on their action type

This documentation will help developers understand how to properly implement new action types in the frontend UI and avoid issues like the recent duplication of "think" actions.

---
**Link of any specific issues this addresses.**
Related to PR #7852 which fixed the display of "think" actions in the UI

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:cb37b2e-nikolaik   --name openhands-app-cb37b2e   docker.all-hands.dev/all-hands-ai/openhands:cb37b2e
```