### PR TITLE
[Evaluation] Fix KeyError when the instance failed prematurely

### DIFF
--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -864,7 +864,7 @@ if __name__ == '__main__':
                     # Also make sure git_patch is not empty - otherwise we fall back to previous attempt (empty patch is worse than anything else)
                     if (
                         instance['instance_id'] not in added_instance_ids
-                        and instance['test_result']['git_patch'].strip()
+                        and instance['test_result'].get('git_patch', '').strip()
                     ):
                         fout.write(line)
                         added_instance_ids.add(instance['instance_id'])


### PR DESCRIPTION
This PR fixes a KeyError that happened on my machine when an instance may have failed prematurely and the test_result didn't record a patch apparently.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d672949-nikolaik   --name openhands-app-d672949   docker.all-hands.dev/all-hands-ai/openhands:d672949
```