### PR TITLE
feat: Combining condensers

### DIFF
--- a/openhands/core/config/condenser_config.py
+++ b/openhands/core/config/condenser_config.py
@@ -154,9 +154,10 @@ class StructuredSummaryCondenserConfig(BaseModel):
 
     model_config = {'extra': 'forbid'}
 
+
 class CondenserPipelineConfig(BaseModel):
     """Configuration for the CondenserPipeline.
-    
+
     Not currently supported by the TOML or ENV_VAR configuration strategies.
     """
 
@@ -167,6 +168,7 @@ class CondenserPipelineConfig(BaseModel):
     )
 
     model_config = {'extra': 'forbid'}
+
 
 # Type alias for convenience
 CondenserConfig = (

--- a/openhands/core/config/condenser_config.py
+++ b/openhands/core/config/condenser_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal, cast
 
 from pydantic import BaseModel, Field, ValidationError
@@ -152,6 +154,19 @@ class StructuredSummaryCondenserConfig(BaseModel):
 
     model_config = {'extra': 'forbid'}
 
+class CondenserPipelineConfig(BaseModel):
+    """Configuration for the CondenserPipeline.
+    
+    Not currently supported by the TOML or ENV_VAR configuration strategies.
+    """
+
+    type: Literal['pipeline'] = Field('pipeline')
+    condensers: list[CondenserConfig] = Field(
+        default_factory=list,
+        description='List of condenser configurations to be used in the pipeline.',
+    )
+
+    model_config = {'extra': 'forbid'}
 
 # Type alias for convenience
 CondenserConfig = (
@@ -163,6 +178,7 @@ CondenserConfig = (
     | AmortizedForgettingCondenserConfig
     | LLMAttentionCondenserConfig
     | StructuredSummaryCondenserConfig
+    | CondenserPipelineConfig
 )
 
 

--- a/openhands/memory/condenser/impl/__init__.py
+++ b/openhands/memory/condenser/impl/__init__.py
@@ -21,6 +21,7 @@ from openhands.memory.condenser.impl.recent_events_condenser import (
 from openhands.memory.condenser.impl.structured_summary_condenser import (
     StructuredSummaryCondenser,
 )
+from openhands.memory.condenser.impl.pipeline import CondenserPipeline
 
 __all__ = [
     'AmortizedForgettingCondenser',
@@ -32,4 +33,5 @@ __all__ = [
     'BrowserOutputCondenser',
     'RecentEventsCondenser',
     'StructuredSummaryCondenser',
+    'CondenserPipeline',
 ]

--- a/openhands/memory/condenser/impl/__init__.py
+++ b/openhands/memory/condenser/impl/__init__.py
@@ -15,13 +15,13 @@ from openhands.memory.condenser.impl.no_op_condenser import NoOpCondenser
 from openhands.memory.condenser.impl.observation_masking_condenser import (
     ObservationMaskingCondenser,
 )
+from openhands.memory.condenser.impl.pipeline import CondenserPipeline
 from openhands.memory.condenser.impl.recent_events_condenser import (
     RecentEventsCondenser,
 )
 from openhands.memory.condenser.impl.structured_summary_condenser import (
     StructuredSummaryCondenser,
 )
-from openhands.memory.condenser.impl.pipeline import CondenserPipeline
 
 __all__ = [
     'AmortizedForgettingCondenser',

--- a/openhands/memory/condenser/impl/pipeline.py
+++ b/openhands/memory/condenser/impl/pipeline.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from openhands.controller.state.state import State
+from openhands.core.config.condenser_config import CondenserPipelineConfig
+from openhands.events.action.agent import CondensationAction
+from openhands.memory.condenser.condenser import Condenser
+from openhands.memory.view import View
+
+class CondenserPipeline(Condenser):
+    """Combines multiple condensers into a single condenser.
+
+    This is useful for creating a pipeline of condensers that can be chained together to achieve very specific condensation aims. Each condenser is run in sequence, passing the output view of one to the next, until we reach the end or a `CondensationAction` is returned instead.
+    """
+    def __init__(self, *condenser: Condenser) -> None:
+        self.condensers = list(condenser)
+        super().__init__()
+
+    @contextmanager
+    def metadata_batch(self, state: State):
+        try:
+            yield
+        finally:
+            # The parent class assumes the metadata is stored in the "calling
+            # condenser" -- since we're not threading a State through to each
+            # step in the pipeline, we need to walk back through the pipeline
+            # and manually collect the relevant metadata.
+            for condenser in self.condensers:
+                condenser.write_metadata(state)
+
+    def condense(self, view: View) -> View | CondensationAction:
+        result: View | CondensationAction = view
+        for condenser in self.condensers:
+            result = condenser.condense(result)
+            if isinstance(result, CondensationAction):
+                break
+        return result
+    
+    @classmethod
+    def from_config(
+        cls, config: CondenserPipelineConfig
+    ) -> CondenserPipeline:
+        condensers = [Condenser.from_config(c) for c in config.condensers]
+        return CondenserPipeline(*condensers)

--- a/openhands/memory/condenser/impl/pipeline.py
+++ b/openhands/memory/condenser/impl/pipeline.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+
 from openhands.controller.state.state import State
 from openhands.core.config.condenser_config import CondenserPipelineConfig
-from openhands.memory.condenser.condenser import Condenser, Condensation
+from openhands.memory.condenser.condenser import Condensation, Condenser
 from openhands.memory.view import View
+
 
 class CondenserPipeline(Condenser):
     """Combines multiple condensers into a single condenser.
 
     This is useful for creating a pipeline of condensers that can be chained together to achieve very specific condensation aims. Each condenser is run in sequence, passing the output view of one to the next, until we reach the end or a `CondensationAction` is returned instead.
     """
+
     def __init__(self, *condenser: Condenser) -> None:
         self.condensers = list(condenser)
         super().__init__()
@@ -34,12 +37,11 @@ class CondenserPipeline(Condenser):
             if isinstance(result, Condensation):
                 break
         return result
-    
+
     @classmethod
-    def from_config(
-        cls, config: CondenserPipelineConfig
-    ) -> CondenserPipeline:
+    def from_config(cls, config: CondenserPipelineConfig) -> CondenserPipeline:
         condensers = [Condenser.from_config(c) for c in config.condensers]
         return CondenserPipeline(*condensers)
-    
+
+
 CondenserPipeline.register_config(CondenserPipelineConfig)

--- a/openhands/memory/condenser/impl/pipeline.py
+++ b/openhands/memory/condenser/impl/pipeline.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from openhands.controller.state.state import State
 from openhands.core.config.condenser_config import CondenserPipelineConfig
-from openhands.events.action.agent import CondensationAction
-from openhands.memory.condenser.condenser import Condenser
+from openhands.memory.condenser.condenser import Condenser, Condensation
 from openhands.memory.view import View
 
 class CondenserPipeline(Condenser):
@@ -28,11 +27,11 @@ class CondenserPipeline(Condenser):
             for condenser in self.condensers:
                 condenser.write_metadata(state)
 
-    def condense(self, view: View) -> View | CondensationAction:
-        result: View | CondensationAction = view
+    def condense(self, view: View) -> View | Condensation:
+        result: View | Condensation = view
         for condenser in self.condensers:
             result = condenser.condense(result)
-            if isinstance(result, CondensationAction):
+            if isinstance(result, Condensation):
                 break
         return result
     

--- a/openhands/memory/condenser/impl/pipeline.py
+++ b/openhands/memory/condenser/impl/pipeline.py
@@ -42,3 +42,5 @@ class CondenserPipeline(Condenser):
     ) -> CondenserPipeline:
         condensers = [Condenser.from_config(c) for c in config.condensers]
         return CondenserPipeline(*condensers)
+    
+CondenserPipeline.register_config(CondenserPipelineConfig)

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -126,15 +126,17 @@ class Session:
         agent_config = self.config.get_agent_config(agent_cls)
 
         if settings.enable_default_condenser:
-            # Default condenser chains a summarizing condenser to keep number of
-            # relevant events down with a browser output condenser to keep the
-            # total size of browser observations limited.
+            # Default condenser chains a condenser that limits browser the total
+            # size of browser observations with a condenser that limits the size
+            # of the view given to the LLM. The order matters: with the browser
+            # output first, the summarizer will only see the most recent browser
+            # output, which should keep the summarization cost down.
             default_condenser_config = CondenserPipelineConfig(
                 condensers=[
+                    BrowserOutputCondenserConfig(),
                     LLMSummarizingCondenserConfig(
                         llm_config=llm.config, keep_first=3, max_size=80
                     ),
-                    BrowserOutputCondenserConfig()
                 ]
             )
 

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -7,7 +7,11 @@ import socketio
 
 from openhands.controller.agent import Agent
 from openhands.core.config import AppConfig
-from openhands.core.config.condenser_config import BrowserOutputCondenserConfig, CondenserPipelineConfig, LLMSummarizingCondenserConfig
+from openhands.core.config.condenser_config import (
+    BrowserOutputCondenserConfig,
+    CondenserPipelineConfig,
+    LLMSummarizingCondenserConfig,
+)
 from openhands.core.logger import OpenHandsLoggerAdapter
 from openhands.core.schema import AgentState
 from openhands.events.action import MessageAction, NullAction

--- a/tests/unit/test_condenser.py
+++ b/tests/unit/test_condenser.py
@@ -122,7 +122,7 @@ class RollingCondenserTestHarness:
         for event in events:
             # Set the event's ID -- this is normally done by the event stream,
             # but this harness is intended to act as a testing stand-in.
-            if not hasattr(event, "_id"):
+            if not hasattr(event, '_id'):
                 event._id = len(state.history)
 
             state.history.append(event)
@@ -714,6 +714,7 @@ def test_structured_summary_condenser_keeps_first_and_summary_events(mock_llm):
         if i > max_size:
             assert isinstance(view[keep_first], AgentCondensationObservation)
 
+
 def test_condenser_pipeline_from_config():
     """Test that CondenserPipeline condensers can be created from configuration objects."""
     config = CondenserPipelineConfig(
@@ -734,7 +735,8 @@ def test_condenser_pipeline_from_config():
     assert isinstance(condenser.condensers[0], NoOpCondenser)
     assert isinstance(condenser.condensers[1], BrowserOutputCondenser)
     assert isinstance(condenser.condensers[2], LLMSummarizingCondenser)
-    
+
+
 def test_condenser_pipeline_chains_sub_condensers():
     """Test that the CondenserPipeline chains sub-condensers and combines their behavior."""
     MAX_SIZE = 10

--- a/tests/unit/test_condenser.py
+++ b/tests/unit/test_condenser.py
@@ -749,10 +749,10 @@ def test_condenser_pipeline_chains_sub_condensers():
     harness = RollingCondenserTestHarness(condenser)
     events = [
         BrowserOutputObservation(
-            f"Observation {i}", url="", trigger_by_action=ActionType.BROWSE
+            f'Observation {i}', url='', trigger_by_action=ActionType.BROWSE
         )
         if i % 3 == 0
-        else create_test_event(f"Event {i}")
+        else create_test_event(f'Event {i}')
         for i in range(0, MAX_SIZE * NUMBER_OF_CONDENSATIONS)
     ]
 
@@ -770,7 +770,7 @@ def test_condenser_pipeline_chains_sub_condensers():
         ]
 
         for event in browser_outputs[:-ATTENTION_WINDOW]:
-            assert "Content Omitted" in str(event)
+            assert 'Content Omitted' in str(event)
 
         for event in browser_outputs[-ATTENTION_WINDOW:]:
-            assert "Content Omitted" not in str(event)
+            assert 'Content Omitted' not in str(event)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


This PR adds a new condenser that chains together multiple condensers without modifying the interface. The design follows the proposal in #7850 almost verbatim:

1. A new `CondenserPipeline` that is parameterized by a list of condensers.
2. The `CondenserPipeline.condense` function chains each sub-condenser together, until all condensers have had a chance to act or one returns a `CondensationAction` instead of a `View`.

In addition, this PR updates the default condenser configuration to chain a `BrowserOutputCondenser` with the existing `LLMSummarizingCondenser`.

---
**Link of any specific issues this addresses.**

A partial solution to #7850 -- this PR does not intend to address configuration from `config.toml` or environment variables.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:efc8d96-nikolaik   --name openhands-app-efc8d96   docker.all-hands.dev/all-hands-ai/openhands:efc8d96
```