### PR TITLE
Fix for error on close

### DIFF
--- a/openhands/utils/async_utils.py
+++ b/openhands/utils/async_utils.py
@@ -45,6 +45,10 @@ def call_async_from_sync(
         finally:
             loop_for_thread.close()
 
+    if getattr(EXECUTOR, '_shutdown', False):
+        result = run()
+        return result
+
     future = EXECUTOR.submit(run)
     futures.wait([future], timeout=timeout or None)
     result = future.result()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Added handler for case where ThreadPoolExecutor has already been shutdown. (For headless mode)

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Currently, invocations of headless mode end with the stack trace:
```
Exception ignored in atexit callback: <bound method DockerRuntime.close of <openhands.runtime.impl.docker.docker_runtime.DockerRuntime object at 0xffff602642c0>>
Traceback (most recent call last):
  File "/app/openhands/runtime/impl/docker/docker_runtime.py", line 402, in close
    super().close()
  File "/app/openhands/runtime/impl/action_execution/action_execution_client.py", line 348, in close
    call_async_from_sync(self.aclose)
  File "/app/openhands/utils/async_utils.py", line 48, in call_async_from_sync
    future = EXECUTOR.submit(run)
             ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 170, in submit
    raise RuntimeError('cannot schedule new futures after shutdown')
RuntimeError: cannot schedule new futures after shutdown
```

This is because the exit operation shuts down all thread pool executors. In order to make sure that a graceful shutdown operation is still done, we now invoke the code outside the executor if it is already shutdown. (It is never closed explicitly in our code - only at shutdown)

## Testing
I was able to reproduce the stack trace before the change, and not afterwards. I also confirmed using print statements that the shutdown code was in fact run. (Breakpoints don't work inside a shutdown hook)

---
**Link of any specific issues this addresses.**
