### PR TITLE
fix: Update folder security dialog styling

### DIFF
--- a/openhands/core/cli.py
+++ b/openhands/core/cli.py
@@ -618,10 +618,11 @@ def check_folder_security_agreement(current_dir):
                     f'{current_dir}\n\n'
                     'OpenHands may read and execute files in this folder with your permission.'
                 ),
-                style='#ffffff',
+                style=COLOR_GREY,
                 read_only=True,
                 wrap_lines=True,
-            )
+            ),
+            style=f'fg:{COLOR_GREY}',
         )
 
         clear()
@@ -786,9 +787,6 @@ async def main(loop: asyncio.AbstractEventLoop):
 
     if not check_folder_security_agreement(current_dir):
         # User rejected, exit application
-        event_stream.add_event(
-            ChangeAgentStateAction(AgentState.STOPPED), EventSource.ENVIRONMENT
-        )
         return
 
     # Clear the terminal


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

- Folder security dialog text content not visible in terminals with white color schemes

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

- Update the folder security dialog styling to display the text content properly in terminals with white color schemes
- Remove unnecessary agent state change action event when folder security confirmation prompt is rejected by the user


---
**Link of any specific issues this addresses.**
