### PR TITLE
[Fix]: Rm unnecessary provider token serializer

### DIFF
--- a/openhands/server/settings.py
+++ b/openhands/server/settings.py
@@ -97,7 +97,6 @@ class Settings(BaseModel):
             llm_api_key=llm_config.api_key,
             llm_base_url=llm_config.base_url,
             remote_runtime_resource_factor=app_config.sandbox.remote_runtime_resource_factor,
-            provider_tokens={},
         )
         return settings
 
@@ -107,12 +106,7 @@ class POSTSettingsModel(Settings):
     Settings for POST requests
     """
 
-    # Override provider_tokens to accept string tokens from frontend
     provider_tokens: dict[str, str] = {}
-
-    @field_serializer('provider_tokens')
-    def provider_tokens_serializer(self, provider_tokens: dict[str, str]):
-        return provider_tokens
 
 
 class GETSettingsModel(Settings):


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
We used to store `provider_tokens` object in `Settings` before. This requires us to override the serializer in `POSTSettingsModel` so that we could accept the plain strings from the FE.

We've since changed `Settings` object to use `secret_store` instead, making the `provider_token` serializer unnecessary

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7f43b51-nikolaik   --name openhands-app-7f43b51   docker.all-hands.dev/all-hands-ai/openhands:7f43b51
```