### PR TITLE
fix(check-unlocalized-strings): make HTML tag test case-insens

### DIFF
--- a/frontend/scripts/check-unlocalized-strings.cjs
+++ b/frontend/scripts/check-unlocalized-strings.cjs
@@ -275,8 +275,8 @@ function isCommonDevelopmentString(str) {
 
   // HTML tags and attributes
   if (
-    /^<[a-z0-9]+>.*<\/[a-z0-9]+>$/.test(str) ||
-    /^<[a-z0-9]+ [^>]+\/>$/.test(str)
+    /^<[a-z0-9]+(?:\s[^>]*)?>.*<\/[a-z0-9]+>$/i.test(str) ||
+    /^<[a-z0-9]+ [^>]+\/>$/i.test(str)
   ) {
     return true;
   }


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

When  checking for unlocalized strings pre-commit, it is possible for tag names to be upper case, 
and/or contain attributes, so ensure that we catch those in the regexp
