### PR TITLE
Fix failing unit test on main

### DIFF
--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -1235,7 +1235,7 @@ async def test_condenser_metrics_included():
 
     # Attach the condenser to the agent
     agent.condenser = condenser
-    
+
     # Mock the system message to avoid ID issues
     system_message = SystemMessageAction(content='Test system message')
     system_message._source = EventSource.AGENT
@@ -1303,10 +1303,10 @@ async def test_condenser_metrics_included():
 @pytest.mark.asyncio
 async def test_first_user_message_with_identical_content(test_event_stream, mock_agent):
     """Test that _first_user_message correctly identifies the first user message.
-    
+
     This test verifies that messages with identical content but different IDs are properly
     distinguished, and that the result is correctly cached.
-    
+
     The issue we're checking is that the comparison (action == self._first_user_message())
     should correctly differentiate between messages with the same content but different IDs.
     """

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -877,7 +877,7 @@ async def test_context_window_exceeded_error_handling(
 async def test_run_controller_with_context_window_exceeded_with_truncation(
     mock_agent, mock_runtime, mock_memory, test_event_stream
 ):
-    """Tests that the controller can make progress after handling context window exceeded errors, as long as enable_history_truncation is ON"""
+    """Tests that the controller can make progress after handling context window exceeded errors, as long as enable_history_truncation is ON."""
 
     class StepState:
         def __init__(self):
@@ -1302,11 +1302,11 @@ async def test_condenser_metrics_included():
 
 @pytest.mark.asyncio
 async def test_first_user_message_with_identical_content(test_event_stream, mock_agent):
-    """
-    Test that _first_user_message correctly identifies the first user message
-    even when multiple messages have identical content but different IDs.
-    Also verifies that the result is properly cached.
-
+    """Test that _first_user_message correctly identifies the first user message.
+    
+    This test verifies that messages with identical content but different IDs are properly
+    distinguished, and that the result is correctly cached.
+    
     The issue we're checking is that the comparison (action == self._first_user_message())
     should correctly differentiate between messages with the same content but different IDs.
     """

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -1235,6 +1235,11 @@ async def test_condenser_metrics_included():
 
     # Attach the condenser to the agent
     agent.condenser = condenser
+    
+    # Mock the system message to avoid ID issues
+    from openhands.events.action.message import SystemMessageAction
+    system_message = SystemMessageAction(content='Test system message')
+    agent.get_system_message.return_value = system_message
 
     # Mock agent step to return a CondensationAction
     action = CondensationAction(

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -1237,8 +1237,9 @@ async def test_condenser_metrics_included():
     agent.condenser = condenser
     
     # Mock the system message to avoid ID issues
-    from openhands.events.action.message import SystemMessageAction
     system_message = SystemMessageAction(content='Test system message')
+    system_message._source = EventSource.AGENT
+    system_message._id = -1
     agent.get_system_message.return_value = system_message
 
     # Mock agent step to return a CondensationAction

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -23,6 +23,7 @@ from openhands.llm.metrics import Metrics
 from openhands.memory.memory import Memory
 from openhands.runtime.base import Runtime
 from openhands.storage.memory import InMemoryFileStore
+from openhands.events.action.message import SystemMessageAction
 
 
 @pytest.fixture
@@ -67,14 +68,10 @@ def mock_agent():
     agent.llm.config = AppConfig().get_llm_config()
 
     # Add a proper system message mock
-    from openhands.events.action.message import SystemMessageAction
-
     system_message = SystemMessageAction(content='Test system message')
     system_message._source = EventSource.AGENT
-    # Don't set the ID here, as it will be set by the event stream
+    system_message._id = -1  # Set invalid ID to avoid the ID check
     agent.get_system_message.return_value = system_message
-    
-    return agent
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -77,7 +77,6 @@ def mock_agent():
 @pytest.mark.asyncio
 async def test_memory_on_event_exception_handling(memory, event_stream, mock_agent):
     """Test that exceptions in Memory.on_event are properly handled via status callback."""
-
     # Create a mock runtime
     runtime = MagicMock(spec=Runtime)
     runtime.event_stream = event_stream
@@ -107,7 +106,6 @@ async def test_memory_on_workspace_context_recall_exception_handling(
     memory, event_stream, mock_agent
 ):
     """Test that exceptions in Memory._on_workspace_context_recall are properly handled via status callback."""
-
     # Create a mock runtime
     runtime = MagicMock(spec=Runtime)
     runtime.event_stream = event_stream
@@ -269,9 +267,7 @@ REPOSITORY INSTRUCTIONS: This is a test repository.
 
 @pytest.mark.asyncio
 async def test_memory_with_agent_microagents():
-    """
-    Test that Memory processes microagent based on trigger words from agent messages.
-    """
+    """Test that Memory processes microagent based on trigger words from agent messages."""
     # Create a mock event stream
     event_stream = MagicMock(spec=EventStream)
 

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -11,7 +11,7 @@ from openhands.core.config import AppConfig
 from openhands.core.main import run_controller
 from openhands.core.schema.agent import AgentState
 from openhands.events.action.agent import RecallAction
-from openhands.events.action.message import MessageAction
+from openhands.events.action.message import MessageAction, SystemMessageAction
 from openhands.events.event import EventSource
 from openhands.events.observation.agent import (
     RecallObservation,
@@ -23,7 +23,6 @@ from openhands.llm.metrics import Metrics
 from openhands.memory.memory import Memory
 from openhands.runtime.base import Runtime
 from openhands.storage.memory import InMemoryFileStore
-from openhands.events.action.message import SystemMessageAction
 
 
 @pytest.fixture

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -71,8 +71,10 @@ def mock_agent():
 
     system_message = SystemMessageAction(content='Test system message')
     system_message._source = EventSource.AGENT
-    system_message._id = -1  # Set invalid ID to avoid the ID check
+    # Don't set the ID here, as it will be set by the event stream
     agent.get_system_message.return_value = system_message
+    
+    return agent
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
This PR fixes mocking in one of the test files to make sure unit tests are passing again.


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b9d4d10-nikolaik   --name openhands-app-b9d4d10   docker.all-hands.dev/all-hands-ai/openhands:b9d4d10
```