### PR TITLE
hotfix(backend): Exclude open PRs when fetching suggested tasks

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -312,7 +312,7 @@ class GitHubService(GitService):
             for pr in data['pullRequests']['nodes']:
                 repo_name = pr['repository']['nameWithOwner']
 
-                # Always add open PRs
+                # Start with default task type
                 task_type = TaskType.OPEN_PR
 
                 # Check for specific states
@@ -333,14 +333,16 @@ class GitHubService(GitService):
                 ):
                     task_type = TaskType.UNRESOLVED_COMMENTS
 
-                tasks.append(
-                    SuggestedTask(
-                        task_type=task_type,
-                        repo=repo_name,
-                        issue_number=pr['number'],
-                        title=pr['title'],
+                # Only add the task if it's not OPEN_PR
+                if task_type != TaskType.OPEN_PR:
+                    tasks.append(
+                        SuggestedTask(
+                            task_type=task_type,
+                            repo=repo_name,
+                            issue_number=pr['number'],
+                            title=pr['title'],
+                        )
                     )
-                )
 
             # Process issues
             for issue in data['issues']['nodes']:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5aaccb3-nikolaik   --name openhands-app-5aaccb3   docker.all-hands.dev/all-hands-ai/openhands:5aaccb3
```