### PR TITLE
Make extraction of poetry_venvs_path more robust

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -206,19 +206,31 @@ class LocalRuntime(ActionExecutionClient):
         env['PYTHONPATH'] = f'{code_repo_path}:$PYTHONPATH'
         env['OPENHANDS_REPO_PATH'] = code_repo_path
         env['LOCAL_RUNTIME_MODE'] = '1'
+        # Extract the poetry venv by parsing output of a shell command
+        # Equivalent to:
         # run poetry show -v | head -n 1 | awk '{print $2}'
-        poetry_venvs_path = (
+        poetry_show_first_line = (
             subprocess.check_output(
                 ['poetry', 'show', '-v'],
                 env=env,
                 cwd=code_repo_path,
                 text=True,
+                # Redirect stderr to stdout
+                # Needed since there might be a message on stderr like
+                # "Skipping virtualenv creation, as specified in config file."
+                # which will cause the command to fail
+                stderr=subprocess.STDOUT, 
                 shell=False,
             )
             .splitlines()[0]
-            .split(':')[1]
-            .strip()
         )
+        if not poetry_show_first_line.lower().startswith('found:'):
+            raise RuntimeError(
+                "Cannot find poetry venv path. Please check your poetry installation."
+                f"First line of poetry show -v: {poetry_show_first_line}"
+            )
+        # Split off the 'Found:' part
+        poetry_venvs_path = poetry_show_first_line.split(':')[1].strip()
         env['POETRY_VIRTUALENVS_PATH'] = poetry_venvs_path
         logger.debug(f'POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}')
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

The parsing of poetry_venvs_path failed in certain installation scenarios where `Skipping virtualenv creation, as specified in config file.` would be logged to stderr. The redirection fixes that

I also added a few more comments and more graceful error handling
