### PR TITLE
[Feat]: Improve resolver inline pr comment localization

### DIFF
--- a/openhands/integrations/github/templates/pr_update_prompt.j2
+++ b/openhands/integrations/github/templates/pr_update_prompt.j2
@@ -1,7 +1,7 @@
 You are checked out to branch {{ branch_name }}, which has an open PR #{{ pr_number }}.
 A comment on the PR (below) has been addressed to you. Do NOT respond to this comment via the GitHub API. 
 
-{% if file_location %} The comment is on the file `{{ file_location }}`{% endif %}.
+{% if file_location %} The comment is in the file `{{ file_location }}` on line #{{ line_number }}{% endif %}.
 
 # Comment
 {{ pr_comment }}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
- Include comment location for inline PR comments for cloud resolver

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR adds the line number where a inline PR comment is left for cloud resolver


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2b8c1df-nikolaik   --name openhands-app-2b8c1df   docker.all-hands.dev/all-hands-ai/openhands:2b8c1df
```