### PR TITLE
chore: improve logging for "not a git repository"

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -610,7 +610,7 @@ class Runtime(FileEditRuntimeMixin):
 
         return CommandResult(content=content, exit_code=exit_code)
 
-    def get_git_changes(self, cwd: str) -> list[dict[str, str]]:
+    def get_git_changes(self, cwd: str) -> list[dict[str, str]] | None:
         self.git_handler.set_cwd(cwd)
         return self.git_handler.get_git_changes()
 

--- a/openhands/runtime/utils/git_handler.py
+++ b/openhands/runtime/utils/git_handler.py
@@ -153,18 +153,15 @@ class GitHandler:
             else []
         )
 
-    def get_git_changes(self) -> list[dict[str, str]]:
+    def get_git_changes(self) -> list[dict[str, str]] | None:
         """
         Retrieves the list of changed files in the Git repository.
 
         Returns:
-            list[dict[str, str]]: A list of dictionaries containing file paths and statuses.
-
-        Raises:
-            RuntimeError: If the directory is not a Git repository.
+            list[dict[str, str]] | None: A list of dictionaries containing file paths and statuses. None if not a git repository.
         """
         if not self._is_git_repo():
-            raise RuntimeError('Not a git repository')
+            return None
 
         changes_list = self._get_changed_files()
         result = parse_git_changes(changes_list)

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -202,6 +202,11 @@ async def git_changes(request: Request, conversation_id: str):
 
     try:
         changes = await call_sync_from_async(runtime.get_git_changes, cwd)
+        if changes is None:
+            return JSONResponse(
+                status_code=500,
+                content={'error': 'Not a git repository'},
+            )
         return changes
     except AgentRuntimeUnavailableError as e:
         logger.error(f'Runtime unavailable: {e}')


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


Make the logging less annoying: https://openhands-ai.slack.com/archives/C078L0FUGUX/p1744997184575849

Still works:

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/59dbe2c1-631e-419c-ad11-7ca74af75747" />

while the annoying stack traces are gone

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e95d8e1-nikolaik   --name openhands-app-e95d8e1   docker.all-hands.dev/all-hands-ai/openhands:e95d8e1
```