### PR TITLE
(Chore): Rm deprecate `/installations` route

### DIFF
--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -92,35 +92,6 @@ async def get_user(
 async def get_github_installation_ids(
     provider_tokens: PROVIDER_TOKEN_TYPE | None = Depends(get_provider_tokens),
     access_token: SecretStr | None = Depends(get_access_token),
-):
-    if provider_tokens and ProviderType.GITHUB in provider_tokens:
-        token = provider_tokens[ProviderType.GITHUB]
-
-        client = GithubServiceImpl(
-            user_id=token.user_id, external_auth_token=access_token, token=token.token
-        )
-        try:
-            installations_ids: list[int] = await client.get_installation_ids()
-            return installations_ids
-
-        except AuthenticationError as e:
-            return JSONResponse(
-                content=str(e),
-                status_code=status.HTTP_401_UNAUTHORIZED,
-            )
-
-        except UnknownException as e:
-            return JSONResponse(
-                content=str(e),
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
-
-    return JSONResponse(
-        content='GitHub token required.',
-        status_code=status.HTTP_401_UNAUTHORIZED,
-    )
-
-
 @app.get('/search/repositories', response_model=list[Repository])
 async def search_repositories(
     query: str,

--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -88,10 +88,6 @@ async def get_user(
     )
 
 
-@app.get('/installations', response_model=list[int])
-async def get_github_installation_ids(
-    provider_tokens: PROVIDER_TOKEN_TYPE | None = Depends(get_provider_tokens),
-    access_token: SecretStr | None = Depends(get_access_token),
 @app.get('/search/repositories', response_model=list[Repository])
 async def search_repositories(
     query: str,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR removes a deprecated route in `git.py`

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1c5eee8-nikolaik   --name openhands-app-1c5eee8   docker.all-hands.dev/all-hands-ai/openhands:1c5eee8
```