### PR TITLE
Add external auth id to `/repos` route

### DIFF
--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -15,7 +15,11 @@ from openhands.integrations.service_types import (
     UnknownException,
     User,
 )
-from openhands.server.auth import get_access_token, get_provider_tokens
+from openhands.server.auth import (
+    get_access_token, 
+    get_provider_tokens, 
+    get_user_id
+)
 from openhands.server.shared import server_config
 
 app = APIRouter(prefix='/api/user')
@@ -26,10 +30,13 @@ async def get_user_repositories(
     sort: str = 'pushed',
     provider_tokens: PROVIDER_TOKEN_TYPE | None = Depends(get_provider_tokens),
     access_token: SecretStr | None = Depends(get_access_token),
+    user_id: str | None = Depends(get_user_id)
 ):
     if provider_tokens:
         client = ProviderHandler(
-            provider_tokens=provider_tokens, external_auth_token=access_token
+            provider_tokens=provider_tokens, 
+            external_auth_token=access_token,
+            external_auth_id=user_id
         )
 
         try:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR adds information about the `external_auth_id` set for the `/repositories` route

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:87a5e09-nikolaik   --name openhands-app-87a5e09   docker.all-hands.dev/all-hands-ai/openhands:87a5e09
```