### PR TITLE
[Fix]: mismatch between repo object definition between FE and BE

### DIFF
--- a/frontend/__tests__/components/features/git/git-repo-selector.test.tsx
+++ b/frontend/__tests__/components/features/git/git-repo-selector.test.tsx
@@ -56,12 +56,16 @@ describe("GitRepositorySelector", () => {
         full_name: "test/repo1",
         git_provider: "github" as Provider,
         stargazers_count: 100,
+        is_public: true,
+        pushed_at: "2023-01-01T00:00:00Z",
       },
       {
         id: 2,
         full_name: "test/repo2",
         git_provider: "github" as Provider,
         stargazers_count: 200,
+        is_public: true,
+        pushed_at: "2023-01-02T00:00:00Z",
       },
     ];
 

--- a/frontend/src/types/git.d.ts
+++ b/frontend/src/types/git.d.ts
@@ -19,6 +19,7 @@ interface GitRepository {
   id: number;
   full_name: string;
   git_provider: Provider;
+  is_public: boolean;
   stargazers_count?: number;
   link_header?: string;
 }

--- a/frontend/src/types/git.d.ts
+++ b/frontend/src/types/git.d.ts
@@ -22,6 +22,7 @@ interface GitRepository {
   is_public: boolean;
   stargazers_count?: number;
   link_header?: string;
+  pushed_at?: string;
 }
 
 interface GitHubCommit {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR simply adds the `is_public` field to the repo object definition in the FE

This is to ensure there isn't a mismatch between the type defined in the BE and FE.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:99eb510-nikolaik   --name openhands-app-99eb510   docker.all-hands.dev/all-hands-ai/openhands:99eb510
```