### PR TITLE
fix: Use SANDBOX_BASE_CONTAINER_IMAGE in resolver workflow

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -179,7 +179,7 @@ jobs:
 
           echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
           echo "SANDBOX_ENV_GITHUB_TOKEN=${{ secrets.PAT_TOKEN || github.token }}" >> $GITHUB_ENV
-          echo "SANDBOX_ENV_BASE_CONTAINER_IMAGE=${{ inputs.base_container_image }}" >> $GITHUB_ENV
+          echo "SANDBOX_BASE_CONTAINER_IMAGE=${{ inputs.base_container_image }}" >> $GITHUB_ENV
 
           # Set branch variables
           echo "TARGET_BRANCH=${{ inputs.target_branch || 'main' }}" >> $GITHUB_ENV


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Fixes an issue where the reusable resolver workflow ignored the `base_container_image` input, preventing users from specifying a custom sandbox image.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

The resolver workflow was incorrectly setting the `SANDBOX_ENV_BASE_CONTAINER_IMAGE` environment variable instead of the expected `SANDBOX_BASE_CONTAINER_IMAGE` when passing the custom base container image input to the OpenHands process. This PR corrects the variable name.

---
**Link of any specific issues this addresses.**

Fixes #7859