### PR TITLE
Bugfixes: MCPConfig Attribute error and always using default prompt templates

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -148,6 +148,15 @@ api_key = ""
 # Model to use. (For Headless / CLI only -  In Web this is overridden by Session Init)
 model = "gpt-4o"
 
+# You can provide a custom example for in context learning, useful when customizing tools
+# For backwards compatibility, not setting this field will lead to default in-context learning examples being used
+# which may fail if you have disabled the default tools.
+# In that case, you should set custom_in_context_learning_example to fix this.
+# Note that you can just set it to an empty string, which is enough for the default example to not be activated
+# SPECIAL CASE: if using openhands models, the default in context learning examples will never be used
+# in_context_learning_example=""
+
+
 # Number of retries to attempt when an operation fails with the LLM.
 # Increase this value to allow more attempts before giving up
 #num_retries = 8

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -44,6 +44,10 @@ class LLMConfig(BaseModel):
         native_tool_calling: Whether to use native tool calling if supported by the model. Can be True, False, or not set.
         reasoning_effort: The effort to put into reasoning. This is a string that can be one of 'low', 'medium', 'high', or 'none'. Exclusive for o1 models.
         seed: The seed to use for the LLM.
+        in_context_learning_example: A custom example provided by the user. If not None (even with an empty string),
+            the default in context learning examples will not be used.
+            It may be necessary to pass it if default tools have been disabled to prevent runtime errors due to
+            the tool set not being compatible with the default in-context learning example.
     """
 
     model: str = Field(default='claude-3-7-sonnet-20250219')
@@ -84,6 +88,7 @@ class LLMConfig(BaseModel):
     native_tool_calling: bool | None = Field(default=None)
     reasoning_effort: str | None = Field(default='high')
     seed: int | None = Field(default=None)
+    in_context_learning_example: str | None = Field(default=None)
 
     model_config = {'extra': 'forbid'}
 

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -224,13 +224,24 @@ class LLM(RetryMixin, DebugMixin):
             original_fncall_messages = copy.deepcopy(messages)
             mock_fncall_tools = None
             # if the agent or caller has defined tools, and we mock via prompting, convert the messages
+
+            custom_in_context_learning_example = self.config.in_context_learning_example
+            if (
+                'openhands-lm' not in self.config.model
+                and custom_in_context_learning_example is None
+            ):
+                # backwards compatibility
+                add_in_context_learning_example = True
+            else:
+                # user has provided an explicit example, not adding default one
+                add_in_context_learning_example = False
+
             if mock_function_calling and 'tools' in kwargs:
                 messages = convert_fncall_messages_to_non_fncall_messages(
                     messages,
                     kwargs['tools'],
-                    add_in_context_learning_example=bool(
-                        'openhands-lm' not in self.config.model
-                    ),
+                    add_default_in_context_learning_example=add_in_context_learning_example,
+                    custom_in_context_learning_example=self.config.in_context_learning_example,
                 )
                 kwargs['messages'] = messages
 

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -331,9 +331,9 @@ class ActionExecutionClient(Runtime):
         if self.mcp_clients is None:
             self.log(
                 'debug',
-                f'Creating MCP clients with servers: {self.config.mcp.sse.mcp_servers}',
+                f'Creating MCP clients with servers: {self.config.mcp.mcp_servers}',
             )
-            self.mcp_clients = await create_mcp_clients(self.config.mcp.sse.mcp_servers)
+            self.mcp_clients = await create_mcp_clients(self.config.mcp.mcp_servers)
         return await call_tool_mcp_handler(self.mcp_clients, action)
 
     async def aclose(self) -> None:

--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -7,7 +7,7 @@ import pytest
 from litellm import ChatCompletionToolParam
 
 from openhands.llm.fn_call_converter import (
-    IN_CONTEXT_LEARNING_EXAMPLE_PREFIX,
+    DEFAULT_IN_CONTEXT_LEARNING_EXAMPLE_PREFIX,
     IN_CONTEXT_LEARNING_EXAMPLE_SUFFIX,
     FunctionCallConversionError,
     convert_fncall_messages_to_non_fncall_messages,
@@ -270,7 +270,7 @@ NON_FNCALL_MESSAGES = [
         'content': [
             {
                 'type': 'text',
-                'text': IN_CONTEXT_LEARNING_EXAMPLE_PREFIX
+                'text': DEFAULT_IN_CONTEXT_LEARNING_EXAMPLE_PREFIX
                 + "<uploaded_files>\n/workspace/astropy__astropy__5.1\n</uploaded_files>\nI've uploaded a python code repository in the directory astropy__astropy__5.1. LONG DESCRIPTION:\n\n"
                 + IN_CONTEXT_LEARNING_EXAMPLE_SUFFIX,
             }


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
The AttributeError is self-explanatory
 
As for the in-context prompts: in #7919 it was allowed to disable default tools.
But with them disabled, the attempt to use the default in context learning pre/postfix would lead to errors.

As a bonus feature in addition to the fix, the user is allowed to pass custom examples, which should be very useful when
also using custom tools.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Fixes bugs, adds a new configuration option in a backwards compatible way

---
**Link of any specific issues this addresses.**
