### PR TITLE
Add LLMAgentCacheCondenser implementation

### DIFF
--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field, ValidationError
 
-from openhands.core.config.condenser_config import CondenserConfig, NoOpCondenserConfig
+from openhands.core.config.condenser_config import CondenserConfig, LLMAgentCacheCondenserConfig
 from openhands.core.logger import openhands_logger as logger
 
 
@@ -32,7 +32,7 @@ class AgentConfig(BaseModel):
     enable_som_visual_browsing: bool = Field(default=True)
     """Whether to enable SoM (Set of Marks) visual browsing."""
     condenser: CondenserConfig = Field(
-        default_factory=lambda: NoOpCondenserConfig(type='noop')
+        default_factory=lambda: LLMAgentCacheCondenserConfig(type='agentcache')
     )
 
     model_config = {'extra': 'forbid'}

--- a/openhands/core/config/condenser_config.py
+++ b/openhands/core/config/condenser_config.py
@@ -85,6 +85,23 @@ class LLMSummarizingCondenserConfig(BaseModel):
     model_config = {'extra': 'forbid'}
 
 
+class LLMAgentCacheCondenserConfig(BaseModel):
+    """Configuration for LLMAgentCacheCondenser."""
+
+    type: Literal['agentcache'] = Field('agentcache')
+    trigger_word: str = Field(
+        default="CONDENSE!",
+        description='The trigger word that will cause the condenser to activate.',
+    )
+    max_size: int = Field(
+        default=100,
+        description='Maximum size of the condensed history before triggering forgetting.',
+        ge=2,
+    )
+
+    model_config = {'extra': 'forbid'}
+
+
 class AmortizedForgettingCondenserConfig(BaseModel):
     """Configuration for AmortizedForgettingCondenser."""
 
@@ -177,6 +194,7 @@ CondenserConfig = (
     | BrowserOutputCondenserConfig
     | RecentEventsCondenserConfig
     | LLMSummarizingCondenserConfig
+    | LLMAgentCacheCondenserConfig
     | AmortizedForgettingCondenserConfig
     | LLMAttentionCondenserConfig
     | StructuredSummaryCondenserConfig
@@ -281,6 +299,7 @@ def create_condenser_config(condenser_type: str, data: dict) -> CondenserConfig:
         'observation_masking': ObservationMaskingCondenserConfig,
         'recent': RecentEventsCondenserConfig,
         'llm': LLMSummarizingCondenserConfig,
+        'agentcache': LLMAgentCacheCondenserConfig,
         'amortized': AmortizedForgettingCondenserConfig,
         'llm_attention': LLMAttentionCondenserConfig,
         'structured': StructuredSummaryCondenserConfig,

--- a/openhands/memory/condenser/impl/__init__.py
+++ b/openhands/memory/condenser/impl/__init__.py
@@ -4,6 +4,9 @@ from openhands.memory.condenser.impl.amortized_forgetting_condenser import (
 from openhands.memory.condenser.impl.browser_output_condenser import (
     BrowserOutputCondenser,
 )
+from openhands.memory.condenser.impl.llm_agent_cache_condenser import (
+    LLMAgentCacheCondenser,
+)
 from openhands.memory.condenser.impl.llm_attention_condenser import (
     ImportantEventSelection,
     LLMAttentionCondenser,
@@ -25,6 +28,7 @@ from openhands.memory.condenser.impl.structured_summary_condenser import (
 
 __all__ = [
     'AmortizedForgettingCondenser',
+    'LLMAgentCacheCondenser',
     'LLMAttentionCondenser',
     'ImportantEventSelection',
     'LLMSummarizingCondenser',

--- a/openhands/memory/condenser/impl/llm_agent_cache_condenser.py
+++ b/openhands/memory/condenser/impl/llm_agent_cache_condenser.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from openhands.core.config.condenser_config import LLMAgentCacheCondenserConfig
+from openhands.events.action.agent import CondensationAction
+from openhands.events.observation.agent import AgentCondensationObservation
+from openhands.memory.condenser.condenser import (
+    Condensation,
+    RollingCondenser,
+    View,
+)
+
+
+class LLMAgentCacheCondenser(RollingCondenser):
+    """A condenser that allows the agent to trigger condensation.
+    
+    This condenser monitors the agent's messages for a trigger word. When the trigger
+    word is found, it condenses the history by keeping the first message and the most
+    recent messages up to the max_size.
+    """
+
+    def __init__(
+        self,
+        trigger_word: str = "CONDENSE!",
+        max_size: int = 100,
+    ):
+        """Initialize the LLMAgentCacheCondenser.
+        
+        Args:
+            trigger_word: The word that triggers condensation when found in agent messages.
+            max_size: The maximum number of events to keep in the history.
+        """
+        self.trigger_word = trigger_word
+        self.max_size = max_size
+        super().__init__()
+
+    def should_condense(self, view: View) -> bool:
+        """Determine if the view should be condensed.
+        
+        The view should be condensed if:
+        1. The number of events exceeds max_size, OR
+        2. The agent's most recent message contains the trigger word.
+        
+        Args:
+            view: The view to check.
+            
+        Returns:
+            bool: True if the view should be condensed, False otherwise.
+        """
+        # Check if the history is too long
+        if len(view) > self.max_size:
+            return True
+            
+        # Check if the agent's most recent message contains the trigger word
+        for event in reversed(view):
+            if hasattr(event, 'message') and isinstance(event.message, str):
+                if self.trigger_word in event.message:
+                    return True
+            # Stop checking once we find any agent message
+            if hasattr(event, 'role') and event.role == 'assistant':
+                break
+                
+        return False
+
+    def get_condensation(self, view: View) -> Condensation:
+        """Get the condensation from a view.
+        
+        This keeps the first message (usually the user's task) and the most recent
+        messages up to max_size/2.
+        
+        Args:
+            view: The view to condense.
+            
+        Returns:
+            Condensation: The condensation action.
+        """
+        # Keep the first message (usually the user's task)
+        head = view[:1]
+        
+        # Calculate how many events to keep from the tail
+        target_size = self.max_size // 2
+        events_from_tail = target_size - len(head) - 1  # -1 for the summary event
+        
+        # Check if there's already a summary event
+        summary_event = (
+            view[1]
+            if len(view) > 1 and isinstance(view[1], AgentCondensationObservation)
+            else AgentCondensationObservation('No events summarized')
+        )
+        
+        # Identify events to be forgotten (those not in head or tail)
+        forgotten_events = []
+        for event in view[1:-events_from_tail]:
+            if not isinstance(event, AgentCondensationObservation):
+                forgotten_events.append(event)
+        
+        # If there are no events to forget, return the view
+        if not forgotten_events:
+            return view
+            
+        # Create a summary that indicates the number of events condensed
+        summary = f"Condensed {len(forgotten_events)} events to save context window space."
+        
+        self.add_metadata('num_events_condensed', len(forgotten_events))
+        
+        return Condensation(
+            action=CondensationAction(
+                forgotten_events_start_id=min(event.id for event in forgotten_events),
+                forgotten_events_end_id=max(event.id for event in forgotten_events),
+                summary=summary,
+                summary_offset=1,  # Place summary after the first event
+            )
+        )
+
+    @classmethod
+    def from_config(
+        cls, config: LLMAgentCacheCondenserConfig
+    ) -> LLMAgentCacheCondenser:
+        """Create a LLMAgentCacheCondenser from a configuration.
+        
+        Args:
+            config: The configuration for the condenser.
+            
+        Returns:
+            LLMAgentCacheCondenser: The configured condenser.
+        """
+        return LLMAgentCacheCondenser(
+            trigger_word=config.trigger_word,
+            max_size=config.max_size,
+        )
+
+
+LLMAgentCacheCondenser.register_config(LLMAgentCacheCondenserConfig)

--- a/test_scripts/test_agent_cache_condenser.py
+++ b/test_scripts/test_agent_cache_condenser.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Test script for the LLMAgentCacheCondenser."""
+
+import sys
+from typing import List, cast
+
+from openhands.agenthub.codeact_agent.codeact_agent import CodeActAgent
+from openhands.controller.state.state import State
+from openhands.core.config import AgentConfig, LLMConfig
+from openhands.core.config.condenser_config import LLMAgentCacheCondenserConfig
+from openhands.events.action.agent import AgentMessageAction
+from openhands.events.event import Event
+from openhands.events.observation.agent import AgentMessageObservation
+from openhands.llm.llm import LLM
+from openhands.memory.condenser.impl.llm_agent_cache_condenser import LLMAgentCacheCondenser
+
+
+def create_test_conversation(num_messages: int = 20) -> List[Event]:
+    """Create a test conversation with a specified number of messages."""
+    events = []
+    
+    # Add initial user message
+    events.append(AgentMessageAction(message="Hello, I need help with a task."))
+    
+    # Add alternating agent and user messages
+    for i in range(num_messages):
+        if i % 2 == 0:
+            # Agent message
+            events.append(AgentMessageObservation(message=f"I'll help you with that. This is message {i}."))
+        else:
+            # User message
+            events.append(AgentMessageAction(message=f"Thanks, here's more information. This is message {i}."))
+    
+    return events
+
+
+def test_agent_cache_condenser():
+    """Test the LLMAgentCacheCondenser with a simulated conversation."""
+    # Create an agent with the LLMAgentCacheCondenser
+    config = AgentConfig()
+    config.condenser = LLMAgentCacheCondenserConfig(
+        type="agentcache",
+        trigger_word="CONDENSE!",
+        max_size=10
+    )
+    
+    llm_config = LLMConfig(
+        model="anthropic/claude-3-7-sonnet-20250219",
+        api_key="YOUR_API_KEY_HERE",
+        caching_prompt=True
+    )
+    
+    agent = CodeActAgent(llm=LLM(llm_config), config=config)
+    
+    # Create a conversation
+    events = create_test_conversation(num_messages=20)
+    
+    # Add a message with the trigger word
+    events.append(AgentMessageObservation(message="Let me think about this. CONDENSE!"))
+    
+    state = State(history=cast(List[Event], events))
+    
+    # Get the condensed history
+    condensed = agent.condenser.condensed_history(state)
+    
+    # Print results
+    print(f"Original history length: {len(state.history)}")
+    if hasattr(condensed, "action"):
+        print(f"Condensation triggered: {condensed.action}")
+        print(f"Summary: {condensed.action.summary}")
+    else:
+        print(f"Condensed history length: {len(condensed)}")
+        print("No condensation triggered")
+
+
+if __name__ == "__main__":
+    test_agent_cache_condenser()

--- a/test_scripts/test_agent_cache_condenser.py
+++ b/test_scripts/test_agent_cache_condenser.py
@@ -8,9 +8,9 @@ from openhands.agenthub.codeact_agent.codeact_agent import CodeActAgent
 from openhands.controller.state.state import State
 from openhands.core.config import AgentConfig, LLMConfig
 from openhands.core.config.condenser_config import LLMAgentCacheCondenserConfig
-from openhands.events.action.agent import AgentMessageAction
+from openhands.events.action.message import MessageAction
 from openhands.events.event import Event
-from openhands.events.observation.agent import AgentMessageObservation
+from openhands.events.observation.agent import AgentThinkObservation
 from openhands.llm.llm import LLM
 from openhands.memory.condenser.impl.llm_agent_cache_condenser import LLMAgentCacheCondenser
 
@@ -20,16 +20,16 @@ def create_test_conversation(num_messages: int = 20) -> List[Event]:
     events = []
     
     # Add initial user message
-    events.append(AgentMessageAction(message="Hello, I need help with a task."))
+    events.append(MessageAction(content="Hello, I need help with a task."))
     
     # Add alternating agent and user messages
     for i in range(num_messages):
         if i % 2 == 0:
             # Agent message
-            events.append(AgentMessageObservation(message=f"I'll help you with that. This is message {i}."))
+            events.append(AgentThinkObservation(content=f"I'll help you with that. This is message {i}."))
         else:
             # User message
-            events.append(AgentMessageAction(message=f"Thanks, here's more information. This is message {i}."))
+            events.append(MessageAction(content=f"Thanks, here's more information. This is message {i}."))
     
     return events
 
@@ -56,7 +56,7 @@ def test_agent_cache_condenser():
     events = create_test_conversation(num_messages=20)
     
     # Add a message with the trigger word
-    events.append(AgentMessageObservation(message="Let me think about this. CONDENSE!"))
+    events.append(AgentThinkObservation(content="Let me think about this. CONDENSE!"))
     
     state = State(history=cast(List[Event], events))
     


### PR DESCRIPTION
This PR adds a new condenser implementation called LLMAgentCacheCondenser that allows the agent to trigger condensation by including a trigger word in its messages. This is useful for long-running conversations where the agent can proactively manage its context window.

Changes:
- Added LLMAgentCacheCondenserConfig to condenser_config.py
- Implemented LLMAgentCacheCondenser class
- Updated the default condenser in AgentConfig to use LLMAgentCacheCondenser
- Added a test script to verify the implementation

This implementation is based on the original condenser_experiment branch but has been cleaned to remove API keys.