### PR TITLE
[Fix]: Building runtime image with unspecified base container img 

### DIFF
--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -46,7 +46,7 @@ class SandboxConfig(BaseModel):
     pause_closed_runtimes: bool = Field(default=True)
     rm_all_containers: bool = Field(default=False)
     api_key: str | None = Field(default=None)
-    base_container_image: str | None = Field(
+    base_container_image: str = Field(
         default='nikolaik/python-nodejs:python3.12-nodejs22'
     )
     runtime_container_image: str | None = Field(default=None)

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -1,6 +1,6 @@
 import os
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 
 class SandboxConfig(BaseModel):
@@ -46,7 +46,7 @@ class SandboxConfig(BaseModel):
     pause_closed_runtimes: bool = Field(default=True)
     rm_all_containers: bool = Field(default=False)
     api_key: str | None = Field(default=None)
-    base_container_image: str = Field(
+    base_container_image: str | None = Field(
         default='nikolaik/python-nodejs:python3.12-nodejs22'
     )
     runtime_container_image: str | None = Field(default=None)
@@ -98,3 +98,9 @@ class SandboxConfig(BaseModel):
             raise ValueError(f'Invalid sandbox configuration: {e}')
 
         return sandbox_mapping
+    
+    @model_validator(mode="after")
+    def set_default_base_image(self) -> "SandboxConfig":
+        if self.base_container_image is None:
+            self.base_container_image = 'nikolaik/python-nodejs:python3.12-nodejs22'
+        return self


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Currently the resolver is down on `fix-me-experimental`. The error logs is
```
ERROR:root:<class 'ValueError'>: Neither runtime container image nor base container image is set
```

This issue was introduced in #7612


#### Issue reason

We've allowed `base_container_image` to be `None`. This means when we run the resolver in experimental mode, and fail to specify `base_container_image` we get this error when building the runtime. 

This PR simply checks if the value for `base_container_image` is `None` and overrides it with a default

---
**Link of any specific issues this addresses.**
