### PR TITLE
Minor refactoring: remove step and task-creation in AgentController

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -293,9 +293,6 @@ class AgentController:
         # Set the agent state to ERROR after storing the reason
         await self.set_agent_state_to(AgentState.ERROR)
 
-    def step(self):
-        asyncio.create_task(self._step_with_exception_handling())
-
     async def _step_with_exception_handling(self):
         try:
             await self._step()
@@ -416,7 +413,7 @@ class AgentController:
                 f'Stepping agent after event: {type(event).__name__}',
                 extra={'msg_type': 'STEPPING_AGENT'},
             )
-            self.step()
+            await self._step_with_exception_handling()
         elif isinstance(event, MessageAction) and event.source == EventSource.USER:
             # If we received a user message but aren't stepping, log why
             self.log(


### PR DESCRIPTION
Makes the code simpler and debuggable at no cost in performance

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Maybe I am misunderstanding something, but seems like `AgentController.step` was an unnecessary and even harmful indirection. The creation of an asyncio task (instead of awaiting) means the core logic of the step was not debuggable. It drove me a bit crazy to find out why things never stopped at breakpoints. At the same time, it seems that this was pointless, since the only call of step was within `_on_event`, and the only call of that one was wrapped by `run_until_complete`, so the results of `step` were actually always "awaited" in the synchronous `AgentController.on_event`, and the indirection over the task creation had no benefits.

I may be missing something, but if I'm not, removing the indirection would improve the code. Would also reduce the public interface, since step is unused