### PR TITLE
Quick fix local runtime

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -207,30 +207,29 @@ class LocalRuntime(ActionExecutionClient):
         env['PYTHONPATH'] = f'{code_repo_path}:$PYTHONPATH'
         env['OPENHANDS_REPO_PATH'] = code_repo_path
         env['LOCAL_RUNTIME_MODE'] = '1'
-        # Extract the poetry venv by parsing output of a shell command
-        # Equivalent to:
-        # run poetry show -v | head -n 1 | awk '{print $2}'
-        # The first line could be different, this seems fragile, can we do it differently?
-        start_line = ['using virtualenv:', 'found:']
-        poetry_show_first_line = subprocess.check_output(  # noqa: ASYNC101
-            ['poetry', 'show', '-v'],
-            env=env,
-            cwd=code_repo_path,
-            text=True,
-            # Redirect stderr to stdout
-            # Needed since there might be a message on stderr like
-            # "Skipping virtualenv creation, as specified in config file."
-            # which will cause the command to fail
-            stderr=subprocess.STDOUT,
-            shell=False,
-        ).splitlines()[0]
-        if not any(poetry_show_first_line.lower().startswith(line) for line in start_line):
-            raise RuntimeError(
-                'Cannot find poetry venv path. Please check your poetry installation.'
-                f'First line of poetry show -v: {poetry_show_first_line}'
-            )
-        # Split off the initial part
-        poetry_venvs_path = poetry_show_first_line.split(':')[1].strip()
+        # Get the poetry venv path using 'poetry env info --path'
+        try:
+            poetry_venvs_path = subprocess.check_output(  # noqa: ASYNC101
+                ['poetry', 'env', 'info', '--path'],
+                env=env,
+                cwd=code_repo_path,
+                text=True,
+                stderr=subprocess.PIPE,
+                shell=False,
+            ).strip()
+            # Verify it's a valid path (basic check)
+            if not os.path.isdir(poetry_venvs_path):
+                 raise ValueError(f"'{poetry_venvs_path}' is not a valid directory.")
+        except (subprocess.CalledProcessError, FileNotFoundError, ValueError) as e:
+            # Attempt to fall back to environment variable if set
+            poetry_venvs_path = env.get('POETRY_VIRTUALENVS_PATH')
+            if not poetry_venvs_path or not os.path.isdir(poetry_venvs_path):
+                 raise RuntimeError(
+                    'Cannot find poetry venv path using `poetry env info --path` or POETRY_VIRTUALENVS_PATH env var. '
+                    'Please check your poetry installation and ensure a virtual environment exists.'
+                 ) from e
+            logger.warning(f"Using fallback POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}")
+
         env['POETRY_VIRTUALENVS_PATH'] = poetry_venvs_path
         logger.debug(f'POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}')
 

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -219,16 +219,18 @@ class LocalRuntime(ActionExecutionClient):
             ).strip()
             # Verify it's a valid path (basic check)
             if not os.path.isdir(poetry_venvs_path):
-                 raise ValueError(f"'{poetry_venvs_path}' is not a valid directory.")
+                raise ValueError(f"'{poetry_venvs_path}' is not a valid directory.")
         except (subprocess.CalledProcessError, FileNotFoundError, ValueError) as e:
             # Attempt to fall back to environment variable if set
-            poetry_venvs_path = env.get('POETRY_VIRTUALENVS_PATH')
+            poetry_venvs_path = env.get('POETRY_VIRTUALENVS_PATH', '')
             if not poetry_venvs_path or not os.path.isdir(poetry_venvs_path):
-                 raise RuntimeError(
+                raise RuntimeError(
                     'Cannot find poetry venv path using `poetry env info --path` or POETRY_VIRTUALENVS_PATH env var. '
                     'Please check your poetry installation and ensure a virtual environment exists.'
-                 ) from e
-            logger.warning(f"Using fallback POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}")
+                ) from e
+            logger.warning(
+                f'Using fallback POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}'
+            )
 
         env['POETRY_VIRTUALENVS_PATH'] = poetry_venvs_path
         logger.debug(f'POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}')


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Fix local runtime initialization on a different poetry message

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes a quick fix for local runtime initialization failure due to poetry path.

This check seems fragile, on my machine `poetry show -v` has a different message, so it raised an error about poetry venv not found. ~Not sure what's a better one~
Actually, did it differently.

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9102fd0-nikolaik   --name openhands-app-9102fd0   docker.all-hands.dev/all-hands-ai/openhands:9102fd0
```