### PR TITLE
Add HTTP method option to Git service fetch_data functions

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -8,9 +8,11 @@ from pydantic import SecretStr
 from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.service_types import (
     AuthenticationError,
+    BaseGitService,
     GitService,
     ProviderType,
     Repository,
+    RequestMethod,
     SuggestedTask,
     TaskType,
     UnknownException,
@@ -20,7 +22,7 @@ from openhands.server.types import AppMode
 from openhands.utils.import_utils import get_impl
 
 
-class GitHubService(GitService):
+class GitHubService(BaseGitService, GitService):
     BASE_URL = 'https://api.github.com'
     token: SecretStr = SecretStr('')
     refresh = False
@@ -60,27 +62,35 @@ class GitHubService(GitService):
         return self.token
 
     async def _fetch_data(
-        self, url: str, params: dict | None = None, method: str = 'get'
+        self,
+        url: str,
+        params: dict | None = None,
+        method: RequestMethod = RequestMethod.GET,
     ) -> tuple[Any, dict]:
         try:
             async with httpx.AsyncClient() as client:
                 github_headers = await self._get_github_headers()
 
-                # Helper function to make the appropriate request based on method
-                async def make_request(headers):
-                    if method.lower() == 'post':
-                        return await client.post(url, headers=headers, json=params)
-                    else:
-                        return await client.get(url, headers=headers, params=params)
-
                 # Make initial request
-                response = await make_request(github_headers)
+                response = await self.make_request(
+                    client=client,
+                    url=url,
+                    headers=github_headers,
+                    params=params,
+                    method=method,
+                )
 
                 # Handle token refresh if needed
                 if self.refresh and self._has_token_expired(response.status_code):
                     await self.get_latest_token()
                     github_headers = await self._get_github_headers()
-                    response = await make_request(github_headers)
+                    response = await self.make_request(
+                        client=client,
+                        url=url,
+                        headers=github_headers,
+                        params=params,
+                        method=method,
+                    )
 
                 response.raise_for_status()
                 headers = {}

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Protocol
 
+from httpx import AsyncClient
 from pydantic import BaseModel, SecretStr
 
 from openhands.server.types import AppMode
@@ -55,6 +56,26 @@ class UnknownException(ValueError):
     """Raised when there is an issue with GitHub communcation."""
 
     pass
+
+
+class RequestMethod(Enum):
+    POST = 'post'
+    GET = 'get'
+
+
+class BaseGitService:
+    @staticmethod
+    async def make_request(
+        client: AsyncClient,
+        url: str,
+        headers: dict,
+        params: dict | None,
+        method: RequestMethod = RequestMethod.GET,
+    ):
+        print('invoked method')
+        if method == RequestMethod.POST:
+            return await client.post(url, headers=headers, json=params)
+        return await client.get(url, headers=headers, params=params)
 
 
 class GitService(Protocol):

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -72,7 +72,6 @@ class BaseGitService:
         params: dict | None,
         method: RequestMethod = RequestMethod.GET,
     ):
-        print('invoked method')
         if method == RequestMethod.POST:
             return await client.post(url, headers=headers, json=params)
         return await client.get(url, headers=headers, params=params)

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -65,7 +65,7 @@ class RequestMethod(Enum):
 
 class BaseGitService:
     @staticmethod
-    async def make_request(
+    async def execute_request(
         client: AsyncClient,
         url: str,
         headers: dict,

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -64,8 +64,8 @@ class RequestMethod(Enum):
 
 
 class BaseGitService:
-    @staticmethod
     async def execute_request(
+        self,
         client: AsyncClient,
         url: str,
         headers: dict,

--- a/tests/unit/test_github_service.py
+++ b/tests/unit/test_github_service.py
@@ -59,7 +59,7 @@ async def test_github_service_fetch_data():
 
     with patch('httpx.AsyncClient', return_value=mock_client):
         service = GitHubService(user_id=None, token=SecretStr('test-token'))
-        _ = await service._fetch_data('https://api.github.com/user')
+        _ = await service._make_request('https://api.github.com/user')
 
         # Verify the request was made with correct headers
         mock_client.get.assert_called_once()
@@ -78,4 +78,4 @@ async def test_github_service_fetch_data():
         mock_client.get.return_value = mock_response
 
         with pytest.raises(AuthenticationError):
-            _ = await service._fetch_data('https://api.github.com/user')
+            _ = await service._make_request('https://api.github.com/user')


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
This is an internal change and doesn't a user friendly description

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR adds an optional parameter `method` to the `_fetch_data` function in both `github_service.py` and `gitlab_service.py`. The parameter defaults to "get" for backward compatibility and accepts "post" as an alternative option.

When the method is set to "post", the client will perform a POST request with the parameters sent as JSON in the request body, rather than as query parameters in a GET request.

The implementation uses a helper function to avoid code duplication when making the initial request and when retrying after token refresh.

This change allows for more flexibility in API interactions, particularly for endpoints that require POST requests.

---
**Link of any specific issues this addresses.**
N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fd39b45-nikolaik   --name openhands-app-fd39b45   docker.all-hands.dev/all-hands-ai/openhands:fd39b45
```