### PR TITLE
Fix and simplify local runtime init

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -214,10 +214,6 @@ class LocalRuntime(ActionExecutionClient):
         python_bin_path = os.path.dirname(interpreter_path)
         env_root_path = os.path.dirname(python_bin_path)
 
-        # Set POETRY_VIRTUALENVS_PATH for Jupyter plugin
-        env['POETRY_VIRTUALENVS_PATH'] = env_root_path
-        logger.debug(f'Derived POETRY_VIRTUALENVS_PATH: {env_root_path}')
-
         # Prepend the interpreter's bin directory to PATH for subprocesses
         env['PATH'] = f'{python_bin_path}{os.pathsep}{env.get("PATH", "")}'
         logger.debug(f'Updated PATH for subprocesses: {env["PATH"]}')

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -5,6 +5,7 @@ This runtime runs the action_execution_server directly on the local machine with
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import threading
 from typing import Callable
@@ -204,38 +205,25 @@ class LocalRuntime(ActionExecutionClient):
         env = os.environ.copy()
         # Get the code repo path
         code_repo_path = os.path.dirname(os.path.dirname(openhands.__file__))
-        env['PYTHONPATH'] = f'{code_repo_path}:$PYTHONPATH'
+        env['PYTHONPATH'] = f'{code_repo_path}{os.pathsep}{env.get("PYTHONPATH", "")}'
         env['OPENHANDS_REPO_PATH'] = code_repo_path
         env['LOCAL_RUNTIME_MODE'] = '1'
-        # Get the poetry venv path using 'poetry env info --path'
-        try:
-            poetry_venvs_path = subprocess.check_output(  # noqa: ASYNC101
-                ['poetry', 'env', 'info', '--path'],
-                env=env,
-                cwd=code_repo_path,
-                text=True,
-                stderr=subprocess.PIPE,
-                shell=False,
-            ).strip()
-            # Verify it's a valid path (basic check)
-            if not os.path.isdir(poetry_venvs_path):
-                raise ValueError(f"'{poetry_venvs_path}' is not a valid directory.")
-        except (subprocess.CalledProcessError, FileNotFoundError, ValueError) as e:
-            # Attempt to fall back to environment variable if set
-            poetry_venvs_path = env.get('POETRY_VIRTUALENVS_PATH', '')
-            if not poetry_venvs_path or not os.path.isdir(poetry_venvs_path):
-                raise RuntimeError(
-                    'Cannot find poetry venv path using `poetry env info --path` or POETRY_VIRTUALENVS_PATH env var. '
-                    'Please check your poetry installation and ensure a virtual environment exists.'
-                ) from e
-            logger.warning(
-                f'Using fallback POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}'
-            )
 
-        env['POETRY_VIRTUALENVS_PATH'] = poetry_venvs_path
-        logger.debug(f'POETRY_VIRTUALENVS_PATH: {poetry_venvs_path}')
+        # Derive environment paths using sys.executable
+        interpreter_path = sys.executable
+        python_bin_path = os.path.dirname(interpreter_path)
+        env_root_path = os.path.dirname(python_bin_path)
 
-        check_dependencies(code_repo_path, poetry_venvs_path)
+        # Set POETRY_VIRTUALENVS_PATH for Jupyter plugin
+        env['POETRY_VIRTUALENVS_PATH'] = env_root_path
+        logger.debug(f'Derived POETRY_VIRTUALENVS_PATH: {env_root_path}')
+
+        # Prepend the interpreter's bin directory to PATH for subprocesses
+        env['PATH'] = f'{python_bin_path}{os.pathsep}{env.get("PATH", "")}'
+        logger.debug(f'Updated PATH for subprocesses: {env["PATH"]}')
+
+        # Check dependencies using the derived env_root_path
+        check_dependencies(code_repo_path, env_root_path)
         self.server_process = subprocess.Popen(  # noqa: ASYNC101
             cmd,
             stdout=subprocess.PIPE,

--- a/openhands/runtime/plugins/jupyter/__init__.py
+++ b/openhands/runtime/plugins/jupyter/__init__.py
@@ -48,13 +48,7 @@ class JupyterPlugin(Plugin):
                     'OPENHANDS_REPO_PATH environment variable is not set. '
                     'This is required for the jupyter plugin to work with LocalRuntime.'
                 )
-            # assert POETRY_VIRTUALENVS_PATH is set
-            poetry_venvs_path = os.environ.get('POETRY_VIRTUALENVS_PATH')
-            if not poetry_venvs_path:
-                raise ValueError(
-                    'POETRY_VIRTUALENVS_PATH environment variable is not set. '
-                    'This is required for the jupyter plugin to work with LocalRuntime.'
-                )
+            # The correct environment is ensured by the PATH in LocalRuntime.
             poetry_prefix = f'cd {code_repo_path}\n'
         jupyter_launch_command = (
             f"{prefix}/bin/bash << 'EOF'\n"


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

The first PR broke a mamba setup, reported here:
- https://github.com/All-Hands-AI/OpenHands/issues/7995

Cc: @xingyaoww 

As @MischaPanch  pointed out, POETRY_VIRTUALENVS_PATH isn't actually used by the local runtime nor Jupyter plugin itself. Do we really need it in local runtime? Removing it would clean out a subprocess that we started just for it, too, and the startup is faster!

Without it:
```
AgentFinishAction(final_thought='I have successfully added a line of dashes at the start of the `OpenHands/README.md` file. If you need any more modifications or have other tasks, feel free to let me know!', task_completed='true', outputs={}, thought='', action=<ActionType.FINISH: 'finish'>)
```

---
**Link of any specific issues this addresses.**
Fix https://github.com/All-Hands-AI/OpenHands/issues/7995

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:07e0273-nikolaik   --name openhands-app-07e0273   docker.all-hands.dev/all-hands-ai/openhands:07e0273
```