### PR TITLE
[Fix]: fetch latest token when existing token doesn't exist

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -47,7 +47,7 @@ class GitHubService(BaseGitService, GitService):
 
     async def _get_github_headers(self) -> dict:
         """Retrieve the GH Token from settings store to construct the headers."""
-        if self.token:
+        if not self.token:
             self.token = await self.get_latest_token()
 
         return {

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -47,7 +47,7 @@ class GitHubService(BaseGitService, GitService):
 
     async def _get_github_headers(self) -> dict:
         """Retrieve the GH Token from settings store to construct the headers."""
-        if self.user_id and not self.token:
+        if self.token:
             self.token = await self.get_latest_token()
 
         return {

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -48,7 +48,7 @@ class GitLabService(BaseGitService, GitService):
         """
         Retrieve the GitLab Token to construct the headers
         """
-        if self.user_id and not self.token:
+        if not self.token:
             self.token = await self.get_latest_token()
 
         return {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR is fixing the scenarios where we fetch the latest token. 

Previously we made it a requirement that `user_id` exist for this to happen. But really the conditions that need to be met are that `token` is not already set

The function `get_latest_token` is responsible for checking whether it has the necessary attributes for fetching the latest token (via `user_id`, `external_auth_id`, etc)

This change enforces the separation of concerns such that refresh takes place as expected 

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:99f6ad4-nikolaik   --name openhands-app-99f6ad4   docker.all-hands.dev/all-hands-ai/openhands:99f6ad4
```