### PR TITLE
(Chore): Rm legacy resolver code

### DIFF
--- a/openhands/resolver/io_utils.py
+++ b/openhands/resolver/io_utils.py
@@ -9,6 +9,7 @@ def load_all_resolver_outputs(output_jsonl: str) -> Iterable[ResolverOutput]:
         for line in f:
             yield ResolverOutput.model_validate(json.loads(line))
 
+
 def load_single_resolver_output(output_jsonl: str, issue_number: int) -> ResolverOutput:
     for resolver_output in load_all_resolver_outputs(output_jsonl):
         if resolver_output.issue.number == issue_number:

--- a/openhands/resolver/io_utils.py
+++ b/openhands/resolver/io_utils.py
@@ -9,7 +9,6 @@ def load_all_resolver_outputs(output_jsonl: str) -> Iterable[ResolverOutput]:
         for line in f:
             yield ResolverOutput.model_validate(json.loads(line))
 
-
 def load_single_resolver_output(output_jsonl: str, issue_number: int) -> ResolverOutput:
     for resolver_output in load_all_resolver_outputs(output_jsonl):
         if resolver_output.issue.number == issue_number:

--- a/openhands/resolver/send_pull_request.py
+++ b/openhands/resolver/send_pull_request.py
@@ -549,40 +549,12 @@ def process_single_issue(
         )
 
 
-def process_all_successful_issues(
-    output_dir: str,
-    token: str,
-    username: str,
-    platform: ProviderType,
-    pr_type: str,
     llm_config: LLMConfig,
     fork_owner: str | None,
     base_domain: str | None = None,
 ) -> None:
     # Determine default base_domain based on platform
     if base_domain is None:
-        base_domain = 'github.com' if platform == ProviderType.GITHUB else 'gitlab.com'
-    output_path = os.path.join(output_dir, 'output.jsonl')
-    for resolver_output in load_all_resolver_outputs(output_path):
-        if resolver_output.success:
-            logger.info(f'Processing issue {resolver_output.issue.number}')
-            process_single_issue(
-                output_dir,
-                resolver_output,
-                token,
-                username,
-                platform,
-                pr_type,
-                llm_config,
-                fork_owner,
-                False,
-                None,
-                None,
-                None,
-                base_domain,
-            )
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(
         description='Send a pull request to Github or Gitlab.'
@@ -703,42 +675,30 @@ def main() -> None:
     if not os.path.exists(my_args.output_dir):
         raise ValueError(f'Output directory {my_args.output_dir} does not exist.')
 
-    if my_args.issue_number == 'all_successful':
-        if not username:
-            raise ValueError('username is required.')
-        process_all_successful_issues(
-            my_args.output_dir,
-            token,
-            username,
-            platform,
-            my_args.pr_type,
-            llm_config,
-            my_args.fork_owner,
-            my_args.base_domain,
-        )
-    else:
-        if not my_args.issue_number.isdigit():
-            raise ValueError(f'Issue number {my_args.issue_number} is not a number.')
-        issue_number = int(my_args.issue_number)
-        output_path = os.path.join(my_args.output_dir, 'output.jsonl')
-        resolver_output = load_single_resolver_output(output_path, issue_number)
-        if not username:
-            raise ValueError('username is required.')
-        process_single_issue(
-            my_args.output_dir,
-            resolver_output,
-            token,
-            username,
-            platform,
-            my_args.pr_type,
-            llm_config,
-            my_args.fork_owner,
-            my_args.send_on_failure,
-            my_args.target_branch,
-            my_args.reviewer,
-            my_args.pr_title,
-            my_args.base_domain,
-        )
+   
+
+    if not my_args.issue_number.isdigit():
+        raise ValueError(f'Issue number {my_args.issue_number} is not a number.')
+    issue_number = int(my_args.issue_number)
+    output_path = os.path.join(my_args.output_dir, 'output.jsonl')
+    resolver_output = load_single_resolver_output(output_path, issue_number)
+    if not username:
+        raise ValueError('username is required.')
+    process_single_issue(
+        my_args.output_dir,
+        resolver_output,
+        token,
+        username,
+        platform,
+        my_args.pr_type,
+        llm_config,
+        my_args.fork_owner,
+        my_args.send_on_failure,
+        my_args.target_branch,
+        my_args.reviewer,
+        my_args.pr_title,
+        my_args.base_domain,
+    )
 
 
 if __name__ == '__main__':

--- a/openhands/resolver/send_pull_request.py
+++ b/openhands/resolver/send_pull_request.py
@@ -16,7 +16,6 @@ from openhands.resolver.interfaces.gitlab import GitlabIssueHandler
 from openhands.resolver.interfaces.issue import Issue
 from openhands.resolver.interfaces.issue_definitions import ServiceContextIssue
 from openhands.resolver.io_utils import (
-    load_all_resolver_outputs,
     load_single_resolver_output,
 )
 from openhands.resolver.patching import apply_diff, parse_patch
@@ -668,8 +667,6 @@ def main() -> None:
 
     if not os.path.exists(my_args.output_dir):
         raise ValueError(f'Output directory {my_args.output_dir} does not exist.')
-
-   
 
     if not my_args.issue_number.isdigit():
         raise ValueError(f'Issue number {my_args.issue_number} is not a number.')

--- a/openhands/resolver/send_pull_request.py
+++ b/openhands/resolver/send_pull_request.py
@@ -549,12 +549,6 @@ def process_single_issue(
         )
 
 
-    llm_config: LLMConfig,
-    fork_owner: str | None,
-    base_domain: str | None = None,
-) -> None:
-    # Determine default base_domain based on platform
-    if base_domain is None:
 def main() -> None:
     parser = argparse.ArgumentParser(
         description='Send a pull request to Github or Gitlab.'

--- a/tests/unit/resolver/github/test_send_pull_request.py
+++ b/tests/unit/resolver/github/test_send_pull_request.py
@@ -18,7 +18,7 @@ from openhands.resolver.send_pull_request import (
     send_pull_request,
     update_existing_pull_request,
 )
-
+from openhands.resolver.send_pull_request import main
 
 @pytest.fixture
 def mock_output_dir():
@@ -1104,7 +1104,6 @@ def test_main(
     mock_process_single_issue,
     mock_parser,
 ):
-    from openhands.resolver.send_pull_request import main
 
     # Setup mock parser
     mock_args = MagicMock()

--- a/tests/unit/resolver/github/test_send_pull_request.py
+++ b/tests/unit/resolver/github/test_send_pull_request.py
@@ -14,7 +14,6 @@ from openhands.resolver.send_pull_request import (
     initialize_repo,
     load_single_resolver_output,
     make_commit,
-    process_all_successful_issues,
     process_single_issue,
     send_pull_request,
     update_existing_pull_request,
@@ -1028,131 +1027,6 @@ def test_process_single_issue_unsuccessful(
     mock_send_pull_request.assert_not_called()
 
 
-@patch('openhands.resolver.send_pull_request.load_all_resolver_outputs')
-@patch('openhands.resolver.send_pull_request.process_single_issue')
-def test_process_all_successful_issues(
-    mock_process_single_issue, mock_load_all_resolver_outputs, mock_llm_config
-):
-    # Create ResolverOutput objects with properly initialized GithubIssue instances
-    resolver_output_1 = ResolverOutput(
-        issue=Issue(
-            owner='test-owner',
-            repo='test-repo',
-            number=1,
-            title='Issue 1',
-            body='Body 1',
-        ),
-        issue_type='issue',
-        instruction='Test instruction 1',
-        base_commit='def456',
-        git_patch='Test patch 1',
-        history=[],
-        metrics={},
-        success=True,
-        comment_success=None,
-        result_explanation='Test success 1',
-        error=None,
-    )
-
-    resolver_output_2 = ResolverOutput(
-        issue=Issue(
-            owner='test-owner',
-            repo='test-repo',
-            number=2,
-            title='Issue 2',
-            body='Body 2',
-        ),
-        issue_type='issue',
-        instruction='Test instruction 2',
-        base_commit='ghi789',
-        git_patch='Test patch 2',
-        history=[],
-        metrics={},
-        success=False,
-        comment_success=None,
-        result_explanation='',
-        error='Test error 2',
-    )
-
-    resolver_output_3 = ResolverOutput(
-        issue=Issue(
-            owner='test-owner',
-            repo='test-repo',
-            number=3,
-            title='Issue 3',
-            body='Body 3',
-        ),
-        issue_type='issue',
-        instruction='Test instruction 3',
-        base_commit='jkl012',
-        git_patch='Test patch 3',
-        history=[],
-        metrics={},
-        success=True,
-        comment_success=None,
-        result_explanation='Test success 3',
-        error=None,
-    )
-
-    mock_load_all_resolver_outputs.return_value = [
-        resolver_output_1,
-        resolver_output_2,
-        resolver_output_3,
-    ]
-
-    # Call the function
-    process_all_successful_issues(
-        'output_dir',
-        'token',
-        'username',
-        ProviderType.GITHUB,
-        'draft',
-        mock_llm_config,  # llm_config
-        None,  # fork_owner
-    )
-
-    # Assert that process_single_issue was called for successful issues only
-    assert mock_process_single_issue.call_count == 2
-
-    # Check that the function was called with the correct arguments for successful issues
-    mock_process_single_issue.assert_has_calls(
-        [
-            call(
-                'output_dir',
-                resolver_output_1,
-                'token',
-                'username',
-                ProviderType.GITHUB,
-                'draft',
-                mock_llm_config,
-                None,
-                False,
-                None,
-                None,
-                None,
-                'github.com',
-            ),
-            call(
-                'output_dir',
-                resolver_output_3,
-                'token',
-                'username',
-                ProviderType.GITHUB,
-                'draft',
-                mock_llm_config,
-                None,
-                False,
-                None,
-                None,
-                None,
-                'github.com',
-            ),
-        ]
-    )
-
-    # Add more assertions as needed to verify the behavior of the function
-
-
 @patch('httpx.get')
 @patch('subprocess.run')
 def test_send_pull_request_branch_naming(
@@ -1217,7 +1091,6 @@ def test_send_pull_request_branch_naming(
 
 
 @patch('openhands.resolver.send_pull_request.argparse.ArgumentParser')
-@patch('openhands.resolver.send_pull_request.process_all_successful_issues')
 @patch('openhands.resolver.send_pull_request.process_single_issue')
 @patch('openhands.resolver.send_pull_request.load_single_resolver_output')
 @patch('openhands.resolver.send_pull_request.identify_token')
@@ -1229,7 +1102,6 @@ def test_main(
     mock_identify_token,
     mock_load_single_resolver_output,
     mock_process_single_issue,
-    mock_process_all_successful_issues,
     mock_parser,
 ):
     from openhands.resolver.send_pull_request import main
@@ -1300,19 +1172,6 @@ def test_main(
     mock_path_exists.assert_called_with('/mock/output')
     mock_load_single_resolver_output.assert_called_with('/mock/output/output.jsonl', 42)
 
-    # Test for 'all_successful' issue number
-    mock_args.issue_number = 'all_successful'
-    main()
-    mock_process_all_successful_issues.assert_called_with(
-        '/mock/output',
-        'mock_token',
-        'mock_username',
-        ProviderType.GITHUB,
-        'draft',
-        llm_config,
-        None,
-        ANY,
-    )
 
     # Test for invalid issue number
     mock_args.issue_number = 'invalid'

--- a/tests/unit/resolver/gitlab/test_gitlab_send_pull_request.py
+++ b/tests/unit/resolver/gitlab/test_gitlab_send_pull_request.py
@@ -19,6 +19,7 @@ from openhands.resolver.send_pull_request import (
     send_pull_request,
     update_existing_pull_request,
 )
+from openhands.resolver.send_pull_request import main
 
 
 @pytest.fixture
@@ -1006,7 +1007,6 @@ def test_main(
     mock_process_single_issue,
     mock_parser,
 ):
-    from openhands.resolver.send_pull_request import main
 
     # Setup mock parser
     mock_args = MagicMock()

--- a/tests/unit/resolver/gitlab/test_gitlab_send_pull_request.py
+++ b/tests/unit/resolver/gitlab/test_gitlab_send_pull_request.py
@@ -15,7 +15,6 @@ from openhands.resolver.send_pull_request import (
     initialize_repo,
     load_single_resolver_output,
     make_commit,
-    process_all_successful_issues,
     process_single_issue,
     send_pull_request,
     update_existing_pull_request,
@@ -929,131 +928,6 @@ def test_process_single_issue_unsuccessful(
     mock_send_pull_request.assert_not_called()
 
 
-@patch('openhands.resolver.send_pull_request.load_all_resolver_outputs')
-@patch('openhands.resolver.send_pull_request.process_single_issue')
-def test_process_all_successful_issues(
-    mock_process_single_issue, mock_load_all_resolver_outputs, mock_llm_config
-):
-    # Create ResolverOutput objects with properly initialized GitlabIssue instances
-    resolver_output_1 = ResolverOutput(
-        issue=Issue(
-            owner='test-owner',
-            repo='test-repo',
-            number=1,
-            title='Issue 1',
-            body='Body 1',
-        ),
-        issue_type='issue',
-        instruction='Test instruction 1',
-        base_commit='def456',
-        git_patch='Test patch 1',
-        history=[],
-        metrics={},
-        success=True,
-        comment_success=None,
-        result_explanation='Test success 1',
-        error=None,
-    )
-
-    resolver_output_2 = ResolverOutput(
-        issue=Issue(
-            owner='test-owner',
-            repo='test-repo',
-            number=2,
-            title='Issue 2',
-            body='Body 2',
-        ),
-        issue_type='issue',
-        instruction='Test instruction 2',
-        base_commit='ghi789',
-        git_patch='Test patch 2',
-        history=[],
-        metrics={},
-        success=False,
-        comment_success=None,
-        result_explanation='',
-        error='Test error 2',
-    )
-
-    resolver_output_3 = ResolverOutput(
-        issue=Issue(
-            owner='test-owner',
-            repo='test-repo',
-            number=3,
-            title='Issue 3',
-            body='Body 3',
-        ),
-        issue_type='issue',
-        instruction='Test instruction 3',
-        base_commit='jkl012',
-        git_patch='Test patch 3',
-        history=[],
-        metrics={},
-        success=True,
-        comment_success=None,
-        result_explanation='Test success 3',
-        error=None,
-    )
-
-    mock_load_all_resolver_outputs.return_value = [
-        resolver_output_1,
-        resolver_output_2,
-        resolver_output_3,
-    ]
-
-    # Call the function
-    process_all_successful_issues(
-        'output_dir',
-        'token',
-        'username',
-        ProviderType.GITLAB,
-        'draft',
-        mock_llm_config,  # llm_config
-        None,  # fork_owner
-    )
-
-    # Assert that process_single_issue was called for successful issues only
-    assert mock_process_single_issue.call_count == 2
-
-    # Check that the function was called with the correct arguments for successful issues
-    mock_process_single_issue.assert_has_calls(
-        [
-            call(
-                'output_dir',
-                resolver_output_1,
-                'token',
-                'username',
-                ProviderType.GITLAB,
-                'draft',
-                mock_llm_config,
-                None,
-                False,
-                None,
-                None,
-                None,
-                'gitlab.com',
-            ),
-            call(
-                'output_dir',
-                resolver_output_3,
-                'token',
-                'username',
-                ProviderType.GITLAB,
-                'draft',
-                mock_llm_config,
-                None,
-                False,
-                None,
-                None,
-                None,
-                'gitlab.com',
-            ),
-        ]
-    )
-
-    # Add more assertions as needed to verify the behavior of the function
-
-
 @patch('httpx.get')
 @patch('subprocess.run')
 def test_send_pull_request_branch_naming(
@@ -1119,7 +993,6 @@ def test_send_pull_request_branch_naming(
 
 
 @patch('openhands.resolver.send_pull_request.argparse.ArgumentParser')
-@patch('openhands.resolver.send_pull_request.process_all_successful_issues')
 @patch('openhands.resolver.send_pull_request.process_single_issue')
 @patch('openhands.resolver.send_pull_request.load_single_resolver_output')
 @patch('openhands.resolver.send_pull_request.identify_token')
@@ -1131,7 +1004,6 @@ def test_main(
     mock_identify_token,
     mock_load_single_resolver_output,
     mock_process_single_issue,
-    mock_process_all_successful_issues,
     mock_parser,
 ):
     from openhands.resolver.send_pull_request import main
@@ -1201,20 +1073,6 @@ def test_main(
     mock_getenv.assert_any_call('GITLAB_TOKEN')
     mock_path_exists.assert_called_with('/mock/output')
     mock_load_single_resolver_output.assert_called_with('/mock/output/output.jsonl', 42)
-
-    # Test for 'all_successful' issue number
-    mock_args.issue_number = 'all_successful'
-    main()
-    mock_process_all_successful_issues.assert_called_with(
-        '/mock/output',
-        'mock_token',
-        'mock_username',
-        ProviderType.GITLAB,
-        'draft',
-        llm_config,
-        None,
-        ANY,
-    )
 
     # Test for invalid issue number
     mock_args.issue_number = 'invalid'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR removes legacy code from `send_pull_request.py`; this was supposed to be a part of #7975

Since we no longer support resolving multiple issues at once, we don't need to support uploading multiple prs at once either


Manual test confirms this doesn't have any breaking changes: https://github.com/malhotra5/test-repo/actions/runs/14586175343/job/40912016153

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a000d8e-nikolaik   --name openhands-app-a000d8e   docker.all-hands.dev/all-hands-ai/openhands:a000d8e
```