### PR TITLE
Add RateLimitError and handle rate limiting in GitLab and GitHub services

### DIFF
--- a/frontend/__tests__/components/chat/chat-interface.test.tsx
+++ b/frontend/__tests__/components/chat/chat-interface.test.tsx
@@ -45,7 +45,7 @@ describe("Empty state", () => {
   it("should render suggestions if empty", () => {
     const { store } = renderWithProviders(<ChatInterface />, {
       preloadedState: {
-        chat: { 
+        chat: {
           messages: [],
           systemMessage: {
             content: "",
@@ -76,7 +76,7 @@ describe("Empty state", () => {
   it("should render the default suggestions", () => {
     renderWithProviders(<ChatInterface />, {
       preloadedState: {
-        chat: { 
+        chat: {
           messages: [],
           systemMessage: {
             content: "",
@@ -114,7 +114,7 @@ describe("Empty state", () => {
       const user = userEvent.setup();
       const { store } = renderWithProviders(<ChatInterface />, {
         preloadedState: {
-          chat: { 
+          chat: {
             messages: [],
             systemMessage: {
               content: "",
@@ -151,7 +151,7 @@ describe("Empty state", () => {
       const user = userEvent.setup();
       const { rerender } = renderWithProviders(<ChatInterface />, {
         preloadedState: {
-          chat: { 
+          chat: {
             messages: [],
             systemMessage: {
               content: "",

--- a/frontend/__tests__/components/chat/chat-interface.test.tsx
+++ b/frontend/__tests__/components/chat/chat-interface.test.tsx
@@ -45,7 +45,7 @@ describe("Empty state", () => {
   it("should render suggestions if empty", () => {
     const { store } = renderWithProviders(<ChatInterface />, {
       preloadedState: {
-        chat: {
+        chat: { 
           messages: [],
           systemMessage: {
             content: "",
@@ -76,7 +76,7 @@ describe("Empty state", () => {
   it("should render the default suggestions", () => {
     renderWithProviders(<ChatInterface />, {
       preloadedState: {
-        chat: {
+        chat: { 
           messages: [],
           systemMessage: {
             content: "",
@@ -114,7 +114,7 @@ describe("Empty state", () => {
       const user = userEvent.setup();
       const { store } = renderWithProviders(<ChatInterface />, {
         preloadedState: {
-          chat: {
+          chat: { 
             messages: [],
             systemMessage: {
               content: "",
@@ -151,7 +151,7 @@ describe("Empty state", () => {
       const user = userEvent.setup();
       const { rerender } = renderWithProviders(<ChatInterface />, {
         preloadedState: {
-          chat: {
+          chat: { 
             messages: [],
             systemMessage: {
               content: "",

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -11,6 +11,7 @@ from openhands.integrations.service_types import (
     BaseGitService,
     GitService,
     ProviderType,
+    RateLimitError,
     Repository,
     RequestMethod,
     SuggestedTask,
@@ -102,6 +103,9 @@ class GitHubService(BaseGitService, GitService):
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
                 raise AuthenticationError('Invalid Github token')
+            elif e.response.status_code == 429:
+                logger.warning(f'Rate limit exceeded on GitHub API: {e}')
+                raise RateLimitError('GitHub API rate limit exceeded')
 
             logger.warning(f'Status error on GH API: {e}')
             raise UnknownException('Unknown error')
@@ -266,6 +270,9 @@ class GitHubService(BaseGitService, GitService):
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
                 raise AuthenticationError('Invalid Github token')
+            elif e.response.status_code == 429:
+                logger.warning(f'Rate limit exceeded on GitHub API: {e}')
+                raise RateLimitError('GitHub API rate limit exceeded')
 
             logger.warning(f'Status error on GH API: {e}')
             raise UnknownException('Unknown error')

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -45,7 +45,7 @@ class GitHubService(BaseGitService, GitService):
 
     @property
     def provider(self) -> str:
-        return ProviderType.GITLAB.value
+        return ProviderType.GITHUB.value
     
     async def _get_github_headers(self) -> dict:
         """Retrieve the GH Token from settings store to construct the headers."""

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -5,13 +5,10 @@ from typing import Any
 import httpx
 from pydantic import SecretStr
 
-from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.service_types import (
-    AuthenticationError,
     BaseGitService,
     GitService,
     ProviderType,
-    RateLimitError,
     Repository,
     RequestMethod,
     SuggestedTask,
@@ -46,6 +43,10 @@ class GitHubService(BaseGitService, GitService):
         if base_domain:
             self.BASE_URL = f'https://{base_domain}/api/v3'
 
+    @property
+    def provider(self) -> str:
+        return ProviderType.GITLAB.value
+    
     async def _get_github_headers(self) -> dict:
         """Retrieve the GH Token from settings store to construct the headers."""
         if not self.token:
@@ -101,18 +102,9 @@ class GitHubService(BaseGitService, GitService):
                 return response.json(), headers
 
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise AuthenticationError('Invalid Github token')
-            elif e.response.status_code == 429:
-                logger.warning(f'Rate limit exceeded on GitHub API: {e}')
-                raise RateLimitError('GitHub API rate limit exceeded')
-
-            logger.warning(f'Status error on GH API: {e}')
-            raise UnknownException('Unknown error')
-
+            raise self.handle_http_status_error(e)
         except httpx.HTTPError as e:
-            logger.warning(f'HTTP error on GH API: {e}')
-            raise UnknownException('Unknown error')
+            raise self.handle_http_error(e)
 
     async def get_user(self) -> User:
         url = f'{self.BASE_URL}/user'
@@ -268,18 +260,9 @@ class GitHubService(BaseGitService, GitService):
                 return dict(result)
 
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise AuthenticationError('Invalid Github token')
-            elif e.response.status_code == 429:
-                logger.warning(f'Rate limit exceeded on GitHub API: {e}')
-                raise RateLimitError('GitHub API rate limit exceeded')
-
-            logger.warning(f'Status error on GH API: {e}')
-            raise UnknownException('Unknown error')
-
+            raise self.handle_http_status_error(e)
         except httpx.HTTPError as e:
-            logger.warning(f'HTTP error on GH API: {e}')
-            raise UnknownException('Unknown error')
+            raise self.handle_http_error(e)
 
     async def get_suggested_tasks(self) -> list[SuggestedTask]:
         """Get suggested tasks for the authenticated user across all repositories.

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -4,13 +4,10 @@ from typing import Any
 import httpx
 from pydantic import SecretStr
 
-from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.service_types import (
-    AuthenticationError,
     BaseGitService,
     GitService,
     ProviderType,
-    RateLimitError,
     Repository,
     RequestMethod,
     UnknownException,
@@ -25,6 +22,7 @@ class GitLabService(BaseGitService, GitService):
     GRAPHQL_URL = 'https://gitlab.com/api/graphql'
     token: SecretStr = SecretStr('')
     refresh = False
+    
 
     def __init__(
         self,
@@ -45,6 +43,10 @@ class GitLabService(BaseGitService, GitService):
             self.BASE_URL = f'https://{base_domain}/api/v4'
             self.GRAPHQL_URL = f'https://{base_domain}/api/graphql'
 
+    @property
+    def provider(self) -> str:
+        return ProviderType.GITLAB.value
+    
     async def _get_gitlab_headers(self) -> dict[str, Any]:
         """
         Retrieve the GitLab Token to construct the headers
@@ -101,18 +103,9 @@ class GitLabService(BaseGitService, GitService):
                 return response.json(), headers
 
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise AuthenticationError('Invalid GitLab token')
-            elif e.response.status_code == 429:
-                logger.warning(f'Rate limit exceeded on GitLab API: {e}')
-                raise RateLimitError('GitLab API rate limit exceeded')
-
-            logger.warning(f'Status error on GL API: {e}')
-            raise UnknownException('Unknown error')
-
+            raise self.handle_http_status_error(e)
         except httpx.HTTPError as e:
-            logger.warning(f'HTTP error on GL API: {e}')
-            raise UnknownException('Unknown error')
+            raise self.handle_http_error(e)
 
     async def execute_graphql_query(self, query: str, variables: dict[str, Any]) -> Any:
         """
@@ -160,18 +153,9 @@ class GitLabService(BaseGitService, GitService):
 
                 return result.get('data')
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise AuthenticationError('Invalid GitLab token')
-            elif e.response.status_code == 429:
-                logger.warning(f'Rate limit exceeded on GitLab API: {e}')
-                raise RateLimitError('GitLab API rate limit exceeded')
-
-            logger.warning(f'Status error on GL API: {e}')
-            raise UnknownException('Unknown error')
-
+            raise self.handle_http_status_error(e)
         except httpx.HTTPError as e:
-            logger.warning(f'HTTP error on GL API: {e}')
-            raise UnknownException('Unknown error')
+            raise self.handle_http_error(e)
 
     async def get_user(self) -> User:
         url = f'{self.BASE_URL}/user'

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -10,6 +10,7 @@ from openhands.integrations.service_types import (
     BaseGitService,
     GitService,
     ProviderType,
+    RateLimitError,
     Repository,
     RequestMethod,
     UnknownException,
@@ -102,6 +103,9 @@ class GitLabService(BaseGitService, GitService):
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
                 raise AuthenticationError('Invalid GitLab token')
+            elif e.response.status_code == 429:
+                logger.warning(f'Rate limit exceeded on GitLab API: {e}')
+                raise RateLimitError('GitLab API rate limit exceeded')
 
             logger.warning(f'Status error on GL API: {e}')
             raise UnknownException('Unknown error')
@@ -158,6 +162,9 @@ class GitLabService(BaseGitService, GitService):
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
                 raise AuthenticationError('Invalid GitLab token')
+            elif e.response.status_code == 429:
+                logger.warning(f'Rate limit exceeded on GitLab API: {e}')
+                raise RateLimitError('GitLab API rate limit exceeded')
 
             logger.warning(f'Status error on GL API: {e}')
             raise UnknownException('Unknown error')

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -61,7 +61,7 @@ class UnknownException(ValueError):
 
 
 class RateLimitError(ValueError):
-    """Raised when API rate limits are exceeded."""
+    """Raised when the git provider's API rate limits are exceeded."""
 
     pass
 

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -1,9 +1,11 @@
+from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Protocol
+from typing import Any, Protocol
 
-from httpx import AsyncClient
+from httpx import AsyncClient, HTTPError, HTTPStatusError
 from pydantic import BaseModel, SecretStr
 
+from openhands.core.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 
@@ -69,7 +71,20 @@ class RequestMethod(Enum):
     GET = 'get'
 
 
-class BaseGitService:
+class BaseGitService(ABC):
+    @property
+    def provider(self) -> str:
+        raise NotImplementedError('Subclasses must implement the provider property')
+
+    # Method used to satisfy mypy for abstract class definition
+    @abstractmethod
+    async def _make_request(
+        self,
+        url: str,
+        params: dict | None = None,
+        method: RequestMethod = RequestMethod.GET,
+    ) -> tuple[Any, dict]: ...
+
     async def execute_request(
         self,
         client: AsyncClient,
@@ -81,6 +96,22 @@ class BaseGitService:
         if method == RequestMethod.POST:
             return await client.post(url, headers=headers, json=params)
         return await client.get(url, headers=headers, params=params)
+
+    def handle_http_status_error(
+        self, e: HTTPStatusError
+    ) -> AuthenticationError | RateLimitError | UnknownException:
+        if e.response.status_code == 401:
+            return AuthenticationError(f'Invalid {self.provider} token')
+        elif e.response.status_code == 429:
+            logger.warning(f'Rate limit exceeded on {self.provider} API: {e}')
+            return RateLimitError('GitHub API rate limit exceeded')
+
+        logger.warning(f'Status error on {self.provider} API: {e}')
+        return UnknownException('Unknown error')
+
+    def handle_http_error(self, e: HTTPError) -> UnknownException:
+        logger.warning(f'HTTP error on {self.provider} API: {e}')
+        return UnknownException('Unknown error')
 
 
 class GitService(Protocol):

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -58,6 +58,12 @@ class UnknownException(ValueError):
     pass
 
 
+class RateLimitError(ValueError):
+    """Raised when API rate limits are exceeded."""
+
+    pass
+
+
 class RequestMethod(Enum):
     POST = 'post'
     GET = 'get'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
1. Adds a new `RateLimitError` class in `service_types.py`
2. Updates `BaseGitService` to return appriopriate err types
3. Dedups the error handling logic for the service classes (for both rest + graphql apis)

---
**Link of any specific issues this addresses.**


---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bef787e-nikolaik   --name openhands-app-bef787e   docker.all-hands.dev/all-hands-ai/openhands:bef787e
```