### PR TITLE
Always run git init in SaaS mode regardless of workspace_base setting

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -317,11 +317,7 @@ class Runtime(FileEditRuntimeMixin):
         repository_provider: ProviderType = ProviderType.GITHUB,
     ) -> str:
         if not selected_repository:
-            if self.config.workspace_base:
-                logger.info(
-                    'In workspace mount mode, not initializing a new git repository.'
-                )
-                return ''
+            # Always initialize a git repository in SaaS mode, regardless of workspace_base
             logger.debug(
                 'No repository selected. Initializing a new git repository in the workspace.'
             )


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

This change ensures that git init is always run in SaaS mode, regardless of the workspace_base setting. This improves the user experience by ensuring that git functionality is always available in SaaS environments.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR modifies the runtime's repository initialization logic to always run git init in SaaS mode, even when workspace_base is set. Previously, the code would skip git initialization when workspace_base was set, which could lead to missing git functionality in SaaS environments.

The change is minimal and simply removes the conditional check for workspace_base, ensuring that git init is always run when no repository is selected.

---
**Link of any specific issues this addresses.**

N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ad34ed6-nikolaik   --name openhands-app-ad34ed6   docker.all-hands.dev/all-hands-ai/openhands:ad34ed6
```