### PR TITLE
Always run git init in SaaS mode regardless of workspace_base setting

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -317,18 +317,20 @@ class Runtime(FileEditRuntimeMixin):
         repository_provider: ProviderType = ProviderType.GITHUB,
     ) -> str:
         if not selected_repository:
-            if self.config.workspace_base:
+            # In SaaS mode (indicated by user_id being set), always run git init
+            # In OSS mode, only run git init if workspace_base is not set
+            if self.user_id or not self.config.workspace_base:
+                logger.debug(
+                    'No repository selected. Initializing a new git repository in the workspace.'
+                )
+                action = CmdRunAction(
+                    command='git init',
+                )
+                self.run_action(action)
+            else:
                 logger.info(
                     'In workspace mount mode, not initializing a new git repository.'
                 )
-                return ''
-            logger.debug(
-                'No repository selected. Initializing a new git repository in the workspace.'
-            )
-            action = CmdRunAction(
-                command='git init',
-            )
-            self.run_action(action)
             return ''
 
         provider_domains = {


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

This change ensures that git init is always run in SaaS mode, regardless of the workspace_base setting. This improves the user experience by ensuring that git functionality is always available in SaaS environments.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR modifies the runtime's repository initialization logic to always run git init in SaaS mode, even when workspace_base is set. Previously, the code would skip git initialization when workspace_base was set, which could lead to missing git functionality in SaaS environments.

The change checks for the presence of a user_id (which indicates SaaS mode) and ensures that git init is always run in that case, regardless of the workspace_base setting. In OSS mode, the original behavior is preserved.

---
**Link of any specific issues this addresses.**

N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:12e8e77-nikolaik   --name openhands-app-12e8e77   docker.all-hands.dev/all-hands-ai/openhands:12e8e77
```