### PR TITLE
Add loading indicator to repository dropdown on home page

### DIFF
--- a/frontend/src/components/features/home/repo-selection-form.test.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { RepositorySelectionForm } from "./repo-selection-form";
+import { useUserRepositories } from "#/hooks/query/use-user-repositories";
+import { useCreateConversation } from "#/hooks/mutation/use-create-conversation";
+import { useIsCreatingConversation } from "#/hooks/use-is-creating-conversation";
+
+// Mock the hooks
+vi.mock("#/hooks/query/use-user-repositories");
+vi.mock("#/hooks/mutation/use-create-conversation");
+vi.mock("#/hooks/use-is-creating-conversation");
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("RepositorySelectionForm", () => {
+  const mockOnRepoSelection = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mock implementations
+    (
+      useUserRepositories as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      data: { pages: [{ data: [] }] },
+      isLoading: false,
+      isError: false,
+    });
+
+    (
+      useCreateConversation as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+    });
+
+    (
+      useIsCreatingConversation as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue(false);
+  });
+
+  test("shows loading indicator when repositories are being fetched", async () => {
+    // Mock loading state
+    (
+      useUserRepositories as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<RepositorySelectionForm onRepoSelection={mockOnRepoSelection} />);
+
+    // Check if loading indicator is displayed
+    expect(screen.getByTestId("repo-dropdown-loading")).toBeInTheDocument();
+    expect(screen.getByText("HOME$LOADING_REPOSITORIES")).toBeInTheDocument();
+  });
+
+  test("shows dropdown when repositories are loaded", async () => {
+    // Mock loaded repositories
+    (
+      useUserRepositories as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      data: {
+        pages: [
+          {
+            data: [
+              { id: "1", full_name: "user/repo1" },
+              { id: "2", full_name: "user/repo2" },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<RepositorySelectionForm onRepoSelection={mockOnRepoSelection} />);
+
+    // Check if dropdown is displayed
+    expect(screen.getByTestId("repo-dropdown")).toBeInTheDocument();
+  });
+
+  test("shows error message when repository fetch fails", async () => {
+    // Mock error state
+    (
+      useUserRepositories as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Failed to fetch repositories"),
+    });
+
+    render(<RepositorySelectionForm onRepoSelection={mockOnRepoSelection} />);
+
+    // Check if error message is displayed
+    expect(screen.getByTestId("repo-dropdown-error")).toBeInTheDocument();
+    expect(
+      screen.getByText("HOME$FAILED_TO_LOAD_REPOSITORIES"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -89,6 +89,36 @@
         "tr": "Yükleniyor...",
         "de": "Wird geladen..."
     },
+    "HOME$LOADING_REPOSITORIES": {
+        "en": "Loading repositories...",
+        "ja": "リポジトリを読み込み中...",
+        "zh-CN": "加载仓库中...",
+        "zh-TW": "載入儲存庫中...",
+        "ko-KR": "저장소 로딩 중...",
+        "no": "Laster repositories...",
+        "it": "Caricamento repository in corso...",
+        "pt": "Carregando repositórios...",
+        "es": "Cargando repositorios...",
+        "ar": "جار تحميل المستودعات...",
+        "fr": "Chargement des dépôts...",
+        "tr": "Depolar yükleniyor...",
+        "de": "Repositories werden geladen..."
+    },
+    "HOME$FAILED_TO_LOAD_REPOSITORIES": {
+        "en": "Failed to load repositories",
+        "ja": "リポジトリの読み込みに失敗しました",
+        "zh-CN": "加载仓库失败",
+        "zh-TW": "載入儲存庫失敗",
+        "ko-KR": "저장소 로딩 실패",
+        "no": "Kunne ikke laste repositories",
+        "it": "Impossibile caricare i repository",
+        "pt": "Falha ao carregar repositórios",
+        "es": "Error al cargar repositorios",
+        "ar": "فشل في تحميل المستودعات",
+        "fr": "Échec du chargement des dépôts",
+        "tr": "Depolar yüklenemedi",
+        "de": "Fehler beim Laden der Repositories"
+    },
     "HOME$OPEN_ISSUE": {
         "en": "Open issue",
         "ja": "オープンな課題",


### PR DESCRIPTION
## Description
This PR adds a loading indicator to the repository dropdown on the main page, addressing the issue where there was no visual feedback when repositories were being fetched.

## Changes
- Added loading state UI to the repository selection form
- Added error state UI when repository fetching fails
- Added tests for both loading and error states
- Added necessary translation keys

## Screenshots
N/A (UI changes only visible during loading state)

## Testing
- Added unit tests for the loading and error states
- Manually verified the loading indicator appears when repositories are being fetched

## Related Issues
N/A