### PR TITLE
Use short tool descriptions for o4-mini

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -95,7 +95,7 @@ class CodeActAgent(Agent):
         self.response_to_actions_fn = codeact_function_calling.response_to_actions
 
     def _get_tools(self) -> list[ChatCompletionToolParam]:
-        SIMPLIFIED_TOOL_DESCRIPTION_LLM_SUBSTRS = ['gpt-', 'o3', 'o1']
+        SIMPLIFIED_TOOL_DESCRIPTION_LLM_SUBSTRS = ['gpt-', 'o3', 'o1', 'o4']
 
         use_simplified_tool_desc = False
         if self.llm is not None:

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -95,19 +95,21 @@ class CodeActAgent(Agent):
         self.response_to_actions_fn = codeact_function_calling.response_to_actions
 
     def _get_tools(self) -> list[ChatCompletionToolParam]:
-        SIMPLIFIED_TOOL_DESCRIPTION_LLM_SUBSTRS = ['gpt-', 'o3', 'o1', 'o4']
+        # For these models, we use short tool descriptions ( < 1024 tokens)
+        # to avoid hitting the OpenAI token limit for tool descriptions.
+        SHORT_TOOL_DESCRIPTION_LLM_SUBSTRS = ['gpt-', 'o3', 'o1', 'o4']
 
-        use_simplified_tool_desc = False
+        use_short_tool_desc = False
         if self.llm is not None:
-            use_simplified_tool_desc = any(
+            use_short_tool_desc = any(
                 model_substr in self.llm.config.model
-                for model_substr in SIMPLIFIED_TOOL_DESCRIPTION_LLM_SUBSTRS
+                for model_substr in SHORT_TOOL_DESCRIPTION_LLM_SUBSTRS
             )
 
         tools = []
         if self.config.enable_cmd:
             tools.append(
-                create_cmd_run_tool(use_simplified_description=use_simplified_tool_desc)
+                create_cmd_run_tool(use_short_description=use_short_tool_desc)
             )
         if self.config.enable_think:
             tools.append(ThinkTool)
@@ -123,7 +125,7 @@ class CodeActAgent(Agent):
         elif self.config.enable_editor:
             tools.append(
                 create_str_replace_editor_tool(
-                    use_simplified_description=use_simplified_tool_desc
+                    use_short_description=use_short_tool_desc
                 )
             )
         return tools

--- a/openhands/agenthub/codeact_agent/tools/bash.py
+++ b/openhands/agenthub/codeact_agent/tools/bash.py
@@ -22,18 +22,18 @@ _DETAILED_BASH_DESCRIPTION = """Execute a bash command in the terminal within a 
 * Output truncation: If the output exceeds a maximum length, it will be truncated before being returned.
 """
 
-_SIMPLIFIED_BASH_DESCRIPTION = """Execute a bash command in the terminal.
+_SHORT_BASH_DESCRIPTION = """Execute a bash command in the terminal.
 * Long running commands: For commands that may run indefinitely, it should be run in the background and the output should be redirected to a file, e.g. command = `python3 app.py > server.log 2>&1 &`.
 * Interact with running process: If a bash command returns exit code `-1`, this means the process is not yet finished. By setting `is_input` to `true`, the assistant can interact with the running process and send empty `command` to retrieve any additional logs, or send additional text (set `command` to the text) to STDIN of the running process, or send command like `C-c` (Ctrl+C), `C-d` (Ctrl+D), `C-z` (Ctrl+Z) to interrupt the process.
 * One command at a time: You can only execute one bash command at a time. If you need to run multiple commands sequentially, you can use `&&` or `;` to chain them together."""
 
 
 def create_cmd_run_tool(
-    use_simplified_description: bool = False,
+    use_short_description: bool = False,
 ) -> ChatCompletionToolParam:
     description = (
-        _SIMPLIFIED_BASH_DESCRIPTION
-        if use_simplified_description
+        _SHORT_BASH_DESCRIPTION
+        if use_short_description
         else _DETAILED_BASH_DESCRIPTION
     )
     return ChatCompletionToolParam(

--- a/openhands/agenthub/codeact_agent/tools/str_replace_editor.py
+++ b/openhands/agenthub/codeact_agent/tools/str_replace_editor.py
@@ -31,7 +31,7 @@ CRITICAL REQUIREMENTS FOR USING THIS TOOL:
 Remember: when making multiple file edits in a row to the same file, you should prefer to send all edits in a single message with multiple calls to this tool, rather than multiple messages with a single call each.
 """
 
-_SIMPLIFIED_STR_REPLACE_EDITOR_DESCRIPTION = """Custom editing tool for viewing, creating and editing files in plain-text format
+_SHORT_STR_REPLACE_EDITOR_DESCRIPTION = """Custom editing tool for viewing, creating and editing files in plain-text format
 * State is persistent across command calls and discussions with the user
 * If `path` is a file, `view` displays the result of applying `cat -n`. If `path` is a directory, `view` lists non-hidden files and directories up to 2 levels deep
 * The `create` command cannot be used if the specified `path` already exists as a file
@@ -45,11 +45,11 @@ Notes for using the `str_replace` command:
 
 
 def create_str_replace_editor_tool(
-    use_simplified_description: bool = False,
+    use_short_description: bool = False,
 ) -> ChatCompletionToolParam:
     description = (
-        _SIMPLIFIED_STR_REPLACE_EDITOR_DESCRIPTION
-        if use_simplified_description
+        _SHORT_STR_REPLACE_EDITOR_DESCRIPTION
+        if use_short_description
         else _DETAILED_STR_REPLACE_EDITOR_DESCRIPTION
     )
     return ChatCompletionToolParam(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Use short tool descriptions for o4-mini - less than 1024 tokens

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR proposes a fix for o4-mini not supporting more than 1024 tokens per tool description.
Also renamed a bit, for the LLMs to recognize easier what the alternate descriptions do.

---
**Link of any specific issues this addresses.**
Fix #7968 #7894 

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7cd1084-nikolaik   --name openhands-app-7cd1084   docker.all-hands.dev/all-hands-ai/openhands:7cd1084
```