### PR TITLE
Add edit title functionality to main conversation UI

### DIFF
--- a/frontend/src/components/features/chat/chat-header.tsx
+++ b/frontend/src/components/features/chat/chat-header.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { EllipsisButton } from "../conversation-panel/ellipsis-button";
+import { ConversationCardContextMenu } from "../conversation-panel/conversation-card-context-menu";
+import { useUpdateConversation } from "#/hooks/mutation/use-update-conversation";
+import { useUserConversation } from "#/hooks/query/use-user-conversation";
+import { useConversation } from "#/context/conversation-context";
+
+export function ChatHeader() {
+  const { conversationId } = useConversation();
+  const { data: conversation } = useUserConversation(conversationId || null);
+  const { mutate: updateConversation } = useUpdateConversation();
+
+  const [contextMenuVisible, setContextMenuVisible] = React.useState(false);
+  const [titleMode, setTitleMode] = React.useState<"view" | "edit">("view");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleChangeTitle = (title: string) => {
+    if (conversationId && title !== conversation?.title) {
+      updateConversation({
+        id: conversationId,
+        conversation: { title },
+      });
+    }
+  };
+
+  const handleBlur = () => {
+    if (inputRef.current?.value) {
+      const trimmed = inputRef.current.value.trim();
+      handleChangeTitle(trimmed);
+      inputRef.current!.value = trimmed;
+    } else {
+      // reset the value if it's empty
+      inputRef.current!.value = conversation?.title || "";
+    }
+
+    setTitleMode("view");
+  };
+
+  const handleKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.currentTarget.blur();
+    }
+  };
+
+  const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    if (titleMode === "edit") {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  const handleEdit = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setTitleMode("edit");
+    setContextMenuVisible(false);
+  };
+
+  React.useEffect(() => {
+    if (titleMode === "edit") {
+      inputRef.current?.focus();
+    }
+  }, [titleMode]);
+
+  if (!conversation) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-between w-full px-4 py-2 border-b border-neutral-600">
+      <div className="flex items-center gap-2 flex-1 min-w-0 overflow-hidden mr-2">
+        {titleMode === "edit" && (
+          <input
+            ref={inputRef}
+            data-testid="chat-header-title-input"
+            onClick={handleInputClick}
+            onBlur={handleBlur}
+            onKeyUp={handleKeyUp}
+            type="text"
+            defaultValue={conversation.title}
+            className="text-sm leading-6 font-semibold bg-transparent w-full"
+          />
+        )}
+        {titleMode === "view" && (
+          <h1
+            data-testid="chat-header-title"
+            className="text-sm leading-6 font-semibold bg-transparent truncate overflow-hidden"
+            title={conversation.title}
+          >
+            {conversation.title}
+          </h1>
+        )}
+      </div>
+
+      <div className="flex items-center">
+        <div className="pl-2">
+          <EllipsisButton
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              setContextMenuVisible((prev) => !prev);
+            }}
+          />
+        </div>
+        <div className="relative">
+          {contextMenuVisible && (
+            <ConversationCardContextMenu
+              onClose={() => setContextMenuVisible(false)}
+              onEdit={handleEdit}
+              position="bottom"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -19,6 +19,7 @@ import { useWsClient } from "#/context/ws-client-provider";
 import { Messages } from "./messages";
 import { ChatSuggestions } from "./chat-suggestions";
 import { ActionSuggestions } from "./action-suggestions";
+import { ChatHeader } from "./chat-header";
 
 import { ScrollToBottomButton } from "#/components/shared/buttons/scroll-to-bottom-button";
 import { LoadingSpinner } from "#/components/shared/loading-spinner";
@@ -120,6 +121,7 @@ export function ChatInterface() {
 
   return (
     <div className="h-full flex flex-col justify-between">
+      <ChatHeader />
       {messages.length === 0 && (
         <ChatSuggestions onSuggestionsClick={setMessageToSend} />
       )}


### PR DESCRIPTION
## Description
This PR adds the ability to edit the conversation title in the main UI, similar to how it works in the conversation list.

## Changes
- Created a new `ChatHeader` component that displays the conversation title and provides an edit option
- Added the new component to the `ChatInterface`
- Reused existing functionality from the conversation card to maintain consistency

## Testing
- Manually tested the edit title functionality in the main UI
- Verified that the title updates correctly in both the main UI and the conversation list

## Screenshots
N/A

## Related Issues
N/A