### PR TITLE
add an option for a headless backend

### DIFF
--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -1,3 +1,5 @@
+import os
+
 import socketio
 
 from openhands.server.app import app as base_app
@@ -12,9 +14,10 @@ from openhands.server.middleware import (
 )
 from openhands.server.static import SPAStaticFiles
 
-base_app.mount(
-    '/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist'
-)
+if os.getenv('SERVE_FRONTEND', 'true').lower() == 'true':
+    base_app.mount(
+        '/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist'
+    )
 
 base_app.add_middleware(
     LocalhostCORSMiddleware,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Just a little env var, off by default

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:157948a-nikolaik   --name openhands-app-157948a   docker.all-hands.dev/all-hands-ai/openhands:157948a
```