### PR TITLE
fix: Add error handling for scenarios where tmux is unavailable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ check-dependencies:
 ifeq ($(INSTALL_DOCKER),)
 	@$(MAKE) -s check-docker
 endif
+	@$(MAKE) -s check-tmux
 	@$(MAKE) -s check-poetry
 	@echo "$(GREEN)Dependencies checked successfully.$(RESET)"
 
@@ -98,6 +99,15 @@ check-docker:
 		echo "$(BLUE)$(shell docker --version) is already installed.$(RESET)"; \
 	else \
 		echo "$(RED)Docker is not installed. Please install Docker to continue.$(RESET)"; \
+		exit 1; \
+	fi
+
+check-tmux:
+	@echo "$(YELLOW)Checking tmux installation...$(RESET)"
+	@if command -v tmux > /dev/null; then \
+		echo "$(BLUE)$(shell tmux -V) is already installed.$(RESET)"; \
+	else \
+		echo "$(RED)tmux is not installed. Please install tmux to continue.$(RESET)"; \
 		exit 1; \
 	fi
 

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -68,7 +68,10 @@ def check_dependencies(code_repo_path: str, poetry_venvs_path: str):
     import libtmux
 
     server = libtmux.Server()
-    session = server.new_session(session_name='test-session')
+    try:
+        session = server.new_session(session_name='test-session')
+    except Exception as e:
+        raise ValueError('tmux is not properly installed or available on the path.')
     pane = session.attached_pane
     pane.send_keys('echo "test"')
     pane_output = '\n'.join(pane.cmd('capture-pane', '-p').stdout)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Fixes an issue where the application, when running using the local runtime, would throw a generic exception if `tmux` is not available

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

- Add exception handling and logging to indicate `tmux` unavailability
- Add a step in Makefile to check `tmux` availability

---
**Link of any specific issues this addresses.**
