### PR TITLE
fix(image-input): enforce image types on upload

### DIFF
--- a/frontend/src/components/features/images/thumbnail.tsx
+++ b/frontend/src/components/features/images/thumbnail.tsx
@@ -10,7 +10,7 @@ export function Thumbnail({ src, size = "small" }: ThumbnailProps) {
     <img
       role="img"
       alt=""
-      src={src}
+      src={src.startsWith("blob:") ? src : ""}
       className={cn(
         "rounded object-cover",
         size === "small" && "w-[62px] h-[62px]",

--- a/frontend/src/components/features/images/thumbnail.tsx
+++ b/frontend/src/components/features/images/thumbnail.tsx
@@ -10,7 +10,7 @@ export function Thumbnail({ src, size = "small" }: ThumbnailProps) {
     <img
       role="img"
       alt=""
-      src={src.startsWith("blob:") ? src : ""}
+      src={src}
       className={cn(
         "rounded object-cover",
         size === "small" && "w-[62px] h-[62px]",

--- a/frontend/src/components/features/images/upload-image-input.tsx
+++ b/frontend/src/components/features/images/upload-image-input.tsx
@@ -7,7 +7,12 @@ interface UploadImageInputProps {
 
 export function UploadImageInput({ onUpload, label }: UploadImageInputProps) {
   const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files) onUpload(Array.from(event.target.files));
+    if (event.target.files) {
+      const validFiles = Array.from(event.target.files).filter((file) =>
+        file.type.startsWith("image/")
+      );
+      onUpload(validFiles);
+    }
   };
 
   return (

--- a/frontend/src/components/features/images/upload-image-input.tsx
+++ b/frontend/src/components/features/images/upload-image-input.tsx
@@ -9,7 +9,7 @@ export function UploadImageInput({ onUpload, label }: UploadImageInputProps) {
   const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
       const validFiles = Array.from(event.target.files).filter((file) =>
-        file.type.startsWith("image/")
+        file.type.startsWith("image/"),
       );
       onUpload(validFiles);
     }


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

Ensure that only images are uploaded on the frontend, by filtering on MIME type
