### PR TITLE
fix: reconnect if stream closed

### DIFF
--- a/openhands/runtime/plugins/jupyter/execute_server.py
+++ b/openhands/runtime/plugins/jupyter/execute_server.py
@@ -7,6 +7,7 @@ import re
 from uuid import uuid4
 
 import tornado
+import tornado.websocket
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 from tornado.escape import json_decode, json_encode, url_escape
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
@@ -139,7 +140,7 @@ class JupyterKernel:
         wait=wait_fixed(2),
     )
     async def execute(self, code: str, timeout: int = 120) -> str:
-        if not self.ws:
+        if not self.ws or self.ws.stream.closed():
             await self._connect()
 
         msg_id = uuid4().hex


### PR DESCRIPTION
```
Log date: Feb 4th, 2025
18:15:46 - openhands:ERROR: base.py:208 - Unexpected error while running action: RequestHTTPError: 500 Server Error: Internal Server Error for url: http://localhost:63710/execute_action
Details: Traceback (most recent call last):
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tornado/websocket.py", line 1088, in wrapper
    await fut
tornado.iostream.StreamClosedError: Stream is closed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/openhands/code/openhands/runtime/action_execution_server.py", line 644, in execute_action
    observation = await client.run_action(action)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/code/openhands/runtime/action_execution_server.py", line 209, in run_action
    observation = await getattr(self, action_type)(action)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/code/openhands/runtime/action_execution_server.py", line 316, in run_ipython
    obs = await _jupyter_plugin.run(action)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/code/openhands/runtime/plugins/jupyter/__init__.py", line 113, in run
    obs = await self._run(action)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/code/openhands/runtime/plugins/jupyter/__init__.py", line 106, in _run
    output = await self.kernel.execute(action.code, timeout=action.timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    return await copy(fn, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    do = await self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    result = await action(retry_state)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    return call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
                                     ^^^^^^^^^^^^^^^^^^^
  File "/openhands/micromamba/envs/openhands/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/openhands/micromamba/envs/openhands/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    result = await fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/code/openhands/runtime/plugins/jupyter/execute_server.py", line 150, in execute
    res = await self.ws.write_message(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openhands/poetry/openhands-ai-5O4_aCHf-py3.12/lib/python3.12/site-packages/tornado/websocket.py", line 1090, in wrapper
    raise WebSocketClosedError()
tornado.websocket.WebSocketClosedError
```

---
**Link to any specific issues this addresses.**
Fixes https://github.com/All-Hands-AI/OpenHands/issues/8038
Related issue: https://github.com/jupyter/notebook/issues/1164