### PR TITLE
[Fix]: Log HTTP err type in Git service classes

### DIFF
--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -111,7 +111,7 @@ class BaseGitService(ABC):
         return UnknownException('Unknown error')
 
     def handle_http_error(self, e: HTTPError) -> UnknownException:
-        logger.warning(f'HTTP error on {self.provider} API: {e}')
+        logger.warning(f'HTTP error on {self.provider} API: {type(e).__name__} : {e}')
         return UnknownException('Unknown error')
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR simply logs the type or HTTPX error in github service classes for `httperrors` (in the `BaseGitService` class, so it will be inherited by all Git service classes)

This is because these type of errors don't usually have an error message associated, so it makes debugging these errors a pain (https://www.python-httpx.org/exceptions/ docs to exception hierarchy) 

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6210e58-nikolaik   --name openhands-app-6210e58   docker.all-hands.dev/all-hands-ai/openhands:6210e58
```