### PR TITLE
[Fix]: Sort github repos in memory for cloud openhands

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -203,12 +203,9 @@ class GitHubService(BaseGitService, GitService):
 
         if app_mode == AppMode.SAAS:
             if sort == "pushed":
-                print("repos fetchd", all_repos)
                 all_repos.sort(
                     key=self.parse_pushed_at_date, reverse=True
                 )
-
-                print("sorted repos", all_repos)
         
         # Convert to Repository objects
         return [

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -218,9 +218,6 @@ class GitHubService(BaseGitService, GitService):
             for repo in all_repos
         ]
 
-    
-
-
     async def get_installation_ids(self) -> list[int]:
         url = f'{self.BASE_URL}/user/installations'
         response, _ = await self._make_request(url)

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -203,9 +203,12 @@ class GitHubService(BaseGitService, GitService):
 
         if app_mode == AppMode.SAAS:
             if sort == "pushed":
+                print("repos fetchd", all_repos)
                 all_repos.sort(
                     key=self.parse_pushed_at_date, reverse=True
                 )
+
+                print("sorted repos", all_repos)
         
         # Convert to Repository objects
         return [

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -192,6 +192,11 @@ class GitHubService(BaseGitService, GitService):
                 # If we've already reached MAX_REPOS, no need to check other installations
                 if len(all_repos) >= MAX_REPOS:
                     break
+            
+            if sort == "pushed":
+                all_repos.sort(
+                    key=self.parse_pushed_at_date, reverse=True
+                )
         else:
             # Original behavior for non-SaaS mode
             params = {'per_page': str(PER_PAGE), 'sort': sort}
@@ -201,12 +206,6 @@ class GitHubService(BaseGitService, GitService):
             all_repos = await self._fetch_paginated_repos(url, params, MAX_REPOS)
 
 
-        if app_mode == AppMode.SAAS:
-            if sort == "pushed":
-                all_repos.sort(
-                    key=self.parse_pushed_at_date, reverse=True
-                )
-        
         # Convert to Repository objects
         return [
             Repository(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR sorts github repos by when the repo was last pushed to in memory

We do this because github api  doesn't support sorting by this parameter for app installation repos



---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:643a967-nikolaik   --name openhands-app-643a967   docker.all-hands.dev/all-hands-ai/openhands:643a967
```