### PR TITLE
Fix issue #7888: Update resolver doc to refer to repo.md instead of the old file

### DIFF
--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -183,7 +183,7 @@ python -m openhands.resolver.send_pull_request --issue-number ISSUE_NUMBER --use
 
 ## Providing Custom Instructions
 
-You can customize how the AI agent approaches issue resolution by adding a `.openhands_instructions` file to the root of your repository. If present, this file's contents will be injected into the prompt for openhands edits.
+You can customize how the AI agent approaches issue resolution by adding a repository microagent file at `.openhands/microagents/repo.md` in your repository. This file's contents will be automatically loaded when working with your repository. For more information about repository microagents, see [Repository Instructions](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents#2-repository-instructions-private).
 
 ## Troubleshooting
 

--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -183,7 +183,7 @@ python -m openhands.resolver.send_pull_request --issue-number ISSUE_NUMBER --use
 
 ## Providing Custom Instructions
 
-You can customize how the AI agent approaches issue resolution by adding a repository microagent file at `.openhands/microagents/repo.md` in your repository. This file's contents will be automatically loaded when working with your repository. For more information about repository microagents, see [Repository Instructions](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents#2-repository-instructions-private).
+You can customize how the AI agent approaches issue resolution by adding a repository microagent file at `.openhands/microagents/repo.md` in your repository. This file's contents will be automatically loaded in the prompt when working with your repository. For more information about repository microagents, see [Repository Instructions](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents#2-repository-instructions-private).
 
 ## Troubleshooting
 


### PR DESCRIPTION
(from openhands)
1. Remove the outdated guidance about using `.openhands_instructions` file which was causing confusion and had been deprecated
2. Add clear documentation about the current correct approach using `.openhands/microagents/repo.md`
3. Provide a direct link to detailed documentation about repository instructions

The patch shows a clear replacement of the old instructions with the new ones in the resolver README.md file. This update ensures users will be directed to the correct method for customizing AI agent behavior, which should prevent the original issue where users were trying to use the deprecated `.openhands_instructions` approach unsuccessfully.

The changes are straightforward documentation updates that will help users avoid the original problem by pointing them to the current supported method.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6c8ed4a-nikolaik   --name openhands-app-6c8ed4a   docker.all-hands.dev/all-hands-ai/openhands:6c8ed4a
```