### PR TITLE
Allow cmd execution after running a background command

### DIFF
--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -505,9 +505,19 @@ class BashSession:
                 )
             )
 
+        # Get initial state before sending command
+        initial_pane_output = self._get_pane_content()
+        initial_ps1_matches = CmdOutputMetadata.matches_ps1_metadata(
+            initial_pane_output
+        )
+        initial_ps1_count = len(initial_ps1_matches)
+        logger.debug(f'Initial PS1 count: {initial_ps1_count}')
+
         start_time = time.time()
         last_change_time = start_time
-        last_pane_output = self._get_pane_content()
+        last_pane_output = (
+            initial_pane_output  # Use initial output as the starting point
+        )
 
         # When prev command is still running, and we are trying to send a new command
         if (
@@ -516,15 +526,20 @@ class BashSession:
                 BashCommandStatus.HARD_TIMEOUT,
                 BashCommandStatus.NO_CHANGE_TIMEOUT,
             }
-            and not last_pane_output.endswith(
-                CMD_OUTPUT_PS1_END
+            and not last_pane_output.rstrip().endswith(
+                CMD_OUTPUT_PS1_END.rstrip()
             )  # prev command is not completed
             and not is_input
             and command != ''  # not input and not empty command
         ):
             _ps1_matches = CmdOutputMetadata.matches_ps1_metadata(last_pane_output)
+            # Use initial_ps1_matches if _ps1_matches is empty, otherwise use _ps1_matches
+            # This handles the case where the prompt might be scrolled off screen but existed before
+            current_matches_for_output = (
+                _ps1_matches if _ps1_matches else initial_ps1_matches
+            )
             raw_command_output = self._combine_outputs_between_matches(
-                last_pane_output, _ps1_matches
+                last_pane_output, current_matches_for_output
             )
             metadata = CmdOutputMetadata()  # No metadata available
             metadata.suffix = (
@@ -577,23 +592,32 @@ class BashSession:
             logger.debug(f"BEGIN OF PANE CONTENT: {cur_pane_output.split('\n')[:10]}")
             logger.debug(f"END OF PANE CONTENT: {cur_pane_output.split('\n')[-10:]}")
             ps1_matches = CmdOutputMetadata.matches_ps1_metadata(cur_pane_output)
+            current_ps1_count = len(ps1_matches)
+
             if cur_pane_output != last_pane_output:
                 last_pane_output = cur_pane_output
                 last_change_time = time.time()
                 logger.debug(f'CONTENT UPDATED DETECTED at {last_change_time}')
 
-            # 1) Execution completed
-            # if the last command output contains the end marker
-            if cur_pane_output.rstrip().endswith(CMD_OUTPUT_PS1_END.rstrip()):
+            # 1) Execution completed:
+            # Condition 1: A new prompt has appeared since the command started.
+            # Condition 2: The prompt count hasn't increased (potentially because the initial one scrolled off),
+            # BUT the *current* visible pane ends with a prompt, indicating completion.
+            if (
+                current_ps1_count > initial_ps1_count
+                or cur_pane_output.rstrip().endswith(CMD_OUTPUT_PS1_END.rstrip())
+            ):
                 return self._handle_completed_command(
                     command,
                     pane_content=cur_pane_output,
                     ps1_matches=ps1_matches,
                 )
 
+            # Timeout checks should only trigger if a new prompt hasn't appeared yet.
+
             # 2) Execution timed out since there's no change in output
             # for a while (self.NO_CHANGE_TIMEOUT_SECONDS)
-            # We ignore this if the command is *blocking
+            # We ignore this if the command is *blocking*
             time_since_last_change = time.time() - last_change_time
             logger.debug(
                 f'CHECKING NO CHANGE TIMEOUT ({self.NO_CHANGE_TIMEOUT_SECONDS}s): elapsed {time_since_last_change}. Action blocking: {action.blocking}'
@@ -609,10 +633,12 @@ class BashSession:
                 )
 
             # 3) Execution timed out due to hard timeout
+            elapsed_time = time.time() - start_time
             logger.debug(
-                f'CHECKING HARD TIMEOUT ({action.timeout}s): elapsed {time.time() - start_time}'
+                f'CHECKING HARD TIMEOUT ({action.timeout}s): elapsed {elapsed_time:.2f}'
             )
-            if action.timeout and time.time() - start_time >= action.timeout:
+            if action.timeout and elapsed_time >= action.timeout:
+                logger.debug('Hard timeout triggered.')
                 return self._handle_hard_timeout_command(
                     command,
                     pane_content=cur_pane_output,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Allow cmd execution after running a background command

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Bug: Background commands (e.g., python -m http.server &) incorrectly time out instead of returning immediately. This happens because the completion logic checks if the entire terminal output ends with the PS1 prompt marker. If the background process prints any output after the prompt marker appears but before the next check cycle, the check fails, leading to a false timeout (NO_CHANGE_TIMEOUT).

Motivation: this is important for frontend debugging - agent wants to start an http server in the background and in the mean time, continues to do development work.

Reproduction: Run a background command that prints output shortly after launch, like python3 -m http.server 8080 &. Observe that it triggers a timeout observation instead of completing immediately with exit code 0.

Solution: The completion logic in BashSession.execute is updated. Instead of checking output.endswith(PS1_MARKER), it now counts the number of PS1 markers before and after sending the command. If the count increases, it signifies the shell has processed the command and is ready for input, correctly handling immediate returns from background tasks.



---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:99ba123-nikolaik   --name openhands-app-99ba123   docker.all-hands.dev/all-hands-ai/openhands:99ba123
```