### PR TITLE
feat: Make git functions in runtime/base.py async

### DIFF
--- a/openhands/runtime/utils/git_handler.py
+++ b/openhands/runtime/utils/git_handler.py
@@ -1,6 +1,5 @@
-import asyncio
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Callable
 
 
 @dataclass
@@ -24,14 +23,10 @@ class GitHandler:
 
     def __init__(
         self,
-        execute_shell_fn: Union[
-            Callable[[str, str | None], CommandResult],
-            Callable[[str, str | None], Awaitable[CommandResult]],
-        ],
+        execute_shell_fn: Callable[[str, str | None], Awaitable[CommandResult]],
     ):
         self.execute = execute_shell_fn
         self.cwd: str | None = None
-        self._is_async = asyncio.iscoroutinefunction(execute_shell_fn)
 
     def set_cwd(self, cwd: str):
         """
@@ -43,13 +38,8 @@ class GitHandler:
         self.cwd = cwd
 
     async def _execute_async(self, cmd: str, cwd: str | None) -> CommandResult:
-        """Execute the command asynchronously if the execute function is async."""
-        if self._is_async:
-            # Cast to Awaitable[CommandResult] to satisfy mypy
-            return await self.execute(cmd, cwd)  # type: ignore
-        else:
-            # Cast to CommandResult to satisfy mypy
-            return self.execute(cmd, cwd)  # type: ignore
+        """Execute the command asynchronously."""
+        return await self.execute(cmd, cwd)
 
     async def _is_git_repo(self) -> bool:
         """

--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -22,20 +22,10 @@ from openhands.events.observation import (
     FileReadObservation,
 )
 from openhands.runtime.base import Runtime
-from openhands.server.data_models.conversation_info import ConversationInfo
 from openhands.server.file_config import (
     FILES_TO_IGNORE,
 )
-from openhands.server.shared import (
-    ConversationStoreImpl,
-    config,
-    conversation_manager,
-)
 from openhands.server.user_auth import get_user_id
-from openhands.server.utils import get_conversation_store
-from openhands.storage.conversation.conversation_store import ConversationStore
-from openhands.storage.data_models.conversation_metadata import ConversationMetadata
-from openhands.storage.data_models.conversation_status import ConversationStatus
 from openhands.utils.async_utils import call_sync_from_async
 
 app = APIRouter(prefix='/api/conversations/{conversation_id}')
@@ -195,20 +185,10 @@ async def git_changes(
     user_id: str = Depends(get_user_id),
 ):
     runtime: Runtime = request.state.conversation.runtime
-    conversation_store = await ConversationStoreImpl.get_instance(
-        config,
-        user_id,
-    )
-
-    cwd = await get_cwd(
-        conversation_store,
-        conversation_id,
-        runtime.config.workspace_mount_path_in_sandbox,
-    )
-    logger.info(f'Getting git changes in {cwd}')
+    logger.info(f'Getting git changes in {runtime.git_dir}')
 
     try:
-        changes = await call_sync_from_async(runtime.get_git_changes, cwd)
+        changes = await call_sync_from_async(runtime.get_git_changes)
         if changes is None:
             return JSONResponse(
                 status_code=404,
@@ -234,18 +214,12 @@ async def git_diff(
     request: Request,
     path: str,
     conversation_id: str,
-    conversation_store = Depends(get_conversation_store),
 ):
     runtime: Runtime = request.state.conversation.runtime
-
-    cwd = await get_cwd(
-        conversation_store,
-        conversation_id,
-        runtime.config.workspace_mount_path_in_sandbox,
-    )
+    logger.info(f'Getting git diff for {path} in {runtime.git_dir}')
 
     try:
-        diff = await call_sync_from_async(runtime.get_git_diff, path, cwd)
+        diff = await call_sync_from_async(runtime.get_git_diff, path)
         return diff
     except AgentRuntimeUnavailableError as e:
         logger.error(f'Error getting diff: {e}')
@@ -253,46 +227,3 @@ async def git_diff(
             status_code=500,
             content={'error': f'Error getting diff: {e}'},
         )
-
-
-async def get_cwd(
-    conversation_store: ConversationStore,
-    conversation_id: str,
-    workspace_mount_path_in_sandbox: str,
-):
-    metadata = await conversation_store.get_metadata(conversation_id)
-    is_running = await conversation_manager.is_agent_loop_running(conversation_id)
-    conversation_info = await _get_conversation_info(metadata, is_running)
-
-    cwd = workspace_mount_path_in_sandbox
-    if conversation_info and conversation_info.selected_repository:
-        repo_dir = conversation_info.selected_repository.split('/')[-1]
-        cwd = os.path.join(cwd, repo_dir)
-
-    return cwd
-
-
-async def _get_conversation_info(
-    conversation: ConversationMetadata,
-    is_running: bool,
-) -> ConversationInfo | None:
-    try:
-        title = conversation.title
-        if not title:
-            title = f'Conversation {conversation.conversation_id[:5]}'
-        return ConversationInfo(
-            conversation_id=conversation.conversation_id,
-            title=title,
-            last_updated_at=conversation.last_updated_at,
-            created_at=conversation.created_at,
-            selected_repository=conversation.selected_repository,
-            status=ConversationStatus.RUNNING
-            if is_running
-            else ConversationStatus.STOPPED,
-        )
-    except Exception as e:
-        logger.error(
-            f'Error loading conversation {conversation.conversation_id}: {str(e)}',
-            extra={'session_id': conversation.conversation_id},
-        )
-        return None


### PR DESCRIPTION
This PR makes the git-related functions in `openhands/runtime/base.py` async to improve performance and responsiveness.

### Changes
- Updated `_execute_shell_fn_git_handler`, `get_git_changes`, and `get_git_diff` methods in `Runtime` class to be async
- Modified the `GitHandler` class to work with async execute functions
- Simplified the GitHandler to always use async functions
- Added `git_dir` property to the Runtime class to store the git repository directory
- Set `git_dir` during `clone_or_init_repo` and removed `cwd` parameters from git-related methods
- Removed the `get_cwd` function from `openhands/server/routes/files.py` as it is no longer needed
- Updated tests to work with the async methods

All tests are passing.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1385d92-nikolaik   --name openhands-app-1385d92   docker.all-hands.dev/all-hands-ai/openhands:1385d92
```