### PR TITLE
Fix for issue where running unit tests resets local settings

### DIFF
--- a/tests/unit/test_settings_api.py
+++ b/tests/unit/test_settings_api.py
@@ -8,6 +8,8 @@ from pydantic import SecretStr
 from openhands.integrations.provider import ProviderToken, ProviderType
 from openhands.server.app import app
 from openhands.server.user_auth.user_auth import UserAuth
+from openhands.storage.memory import InMemoryFileStore
+from openhands.storage.settings.file_settings_store import FileSettingsStore
 from openhands.storage.settings.settings_store import SettingsStore
 
 
@@ -40,16 +42,22 @@ class MockUserAuth(UserAuth):
 @pytest.fixture
 def test_client():
     # Create a test client
-    with patch(
-        'openhands.server.user_auth.user_auth.UserAuth.get_instance',
-        return_value=MockUserAuth(),
-    ):
-        with patch(
+    with (
+        patch(
+            'openhands.server.user_auth.user_auth.UserAuth.get_instance',
+            return_value=MockUserAuth(),
+        ),
+        patch(
             'openhands.server.routes.settings.validate_provider_token',
             return_value=ProviderType.GITHUB,
-        ):
-            client = TestClient(app)
-            yield client
+        ),
+        patch(
+            'openhands.storage.settings.file_settings_store.FileSettingsStore.get_instance',
+            AsyncMock(return_value=FileSettingsStore(InMemoryFileStore()))
+        )
+    ):
+        client = TestClient(app)
+        yield client
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings_api.py
+++ b/tests/unit/test_settings_api.py
@@ -53,8 +53,8 @@ def test_client():
         ),
         patch(
             'openhands.storage.settings.file_settings_store.FileSettingsStore.get_instance',
-            AsyncMock(return_value=FileSettingsStore(InMemoryFileStore()))
-        )
+            AsyncMock(return_value=FileSettingsStore(InMemoryFileStore())),
+        ),
     ):
         client = TestClient(app)
         yield client


### PR DESCRIPTION
(Due to using file store)

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:78fcbda-nikolaik   --name openhands-app-78fcbda   docker.all-hands.dev/all-hands-ai/openhands:78fcbda
```