### PR TITLE
fix: mypy errors in windows

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -11,6 +11,7 @@ import base64
 import mimetypes
 import os
 import shutil
+import sys
 import tempfile
 import time
 import traceback
@@ -478,11 +479,13 @@ class ActionExecutor:
                 assert file_stat is not None
                 # restore the original file permissions if the file already exists
                 os.chmod(filepath, file_stat.st_mode)
-                os.chown(filepath, file_stat.st_uid, file_stat.st_gid)
+                if sys.platform != 'win32':
+                    os.chown(filepath, file_stat.st_uid, file_stat.st_gid)
             else:
                 # set the new file permissions if the file is new
                 os.chmod(filepath, 0o664)
-                os.chown(filepath, self.user_id, self.user_id)
+                if sys.platform != 'win32':
+                    os.chown(filepath, self.user_id, self.user_id)
         except PermissionError as e:
             return ErrorObservation(
                 f'File {filepath} written, but failed to change ownership and permissions: {e}'

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -111,7 +111,7 @@ class LocalRuntime(ActionExecutionClient):
         headless_mode: bool = True,
     ):
         self.config = config
-        self._user_id = os.getuid()
+        self._user_id = os.getuid() # type: ignore
         self._username = os.getenv('USER')
 
         if self.config.workspace_base is not None:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Fixes:
```py
openhands\runtime\action_execution_server.py:481: error: Module has no attribute "chown"  [attr-defined]
openhands\runtime\action_execution_server.py:485: error: Module has no attribute "chown"  [attr-defined]
openhands\runtime\impl\local\local_runtime.py:114: error: Module has no attribute "getuid"; maybe "getpid" or "getppid"?  [attr-defined]
```

---
**Link of any specific issues this addresses.**
