### PR TITLE
Add support for pre-commit.sh git hook (Fixed PR #8095)

### DIFF
--- a/.openhands/pre-commit.sh
+++ b/.openhands/pre-commit.sh
@@ -6,12 +6,12 @@ echo "Running OpenHands pre-commit hook..."
 frontend_changes=$(git diff --cached --name-only | grep "^frontend/")
 if [ -n "$frontend_changes" ]; then
     echo "Frontend changes detected. Running frontend checks..."
-    
+
     # Check if frontend directory exists
     if [ -d "frontend" ]; then
         # Change to frontend directory
         cd frontend || exit 1
-        
+
         # Run lint:fix
         echo "Running npm lint:fix..."
         npm run lint:fix
@@ -19,7 +19,7 @@ if [ -n "$frontend_changes" ]; then
             echo "Frontend linting failed. Please fix the issues before committing."
             exit 1
         fi
-        
+
         # Run build
         echo "Running npm build..."
         npm run build
@@ -27,7 +27,7 @@ if [ -n "$frontend_changes" ]; then
             echo "Frontend build failed. Please fix the issues before committing."
             exit 1
         fi
-        
+
         # Run tests
         echo "Running npm test..."
         npm test
@@ -35,10 +35,10 @@ if [ -n "$frontend_changes" ]; then
             echo "Frontend tests failed. Please fix the failing tests before committing."
             exit 1
         fi
-        
+
         # Return to the original directory
         cd ..
-        
+
         echo "Frontend checks passed!"
     else
         echo "Frontend directory not found. Skipping frontend checks."

--- a/.openhands/pre-commit.sh
+++ b/.openhands/pre-commit.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+echo "Running OpenHands pre-commit hook..."
+
+# Check if frontend directory has changed
+frontend_changes=$(git diff --cached --name-only | grep "^frontend/")
+if [ -n "$frontend_changes" ]; then
+    echo "Frontend changes detected. Running frontend checks..."
+    
+    # Check if frontend directory exists
+    if [ -d "frontend" ]; then
+        # Change to frontend directory
+        cd frontend || exit 1
+        
+        # Run lint:fix
+        echo "Running npm lint:fix..."
+        npm run lint:fix
+        if [ $? -ne 0 ]; then
+            echo "Frontend linting failed. Please fix the issues before committing."
+            exit 1
+        fi
+        
+        # Run build
+        echo "Running npm build..."
+        npm run build
+        if [ $? -ne 0 ]; then
+            echo "Frontend build failed. Please fix the issues before committing."
+            exit 1
+        fi
+        
+        # Run tests
+        echo "Running npm test..."
+        npm test
+        if [ $? -ne 0 ]; then
+            echo "Frontend tests failed. Please fix the failing tests before committing."
+            exit 1
+        fi
+        
+        # Return to the original directory
+        cd ..
+        
+        echo "Frontend checks passed!"
+    else
+        echo "Frontend directory not found. Skipping frontend checks."
+    fi
+else
+    echo "No frontend changes detected. Skipping frontend checks."
+fi
+
+echo "Pre-commit checks passed!"
+exit 0

--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -2,4 +2,11 @@
 
 echo "Setting up the environment..."
 
+# Install pre-commit package
 python -m pip install pre-commit
+
+# Install pre-commit hooks if .git directory exists
+if [ -d ".git" ]; then
+    echo "Installing pre-commit hooks..."
+    pre-commit install
+fi

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ check out our [documentation](https://docs.all-hands.dev/modules/usage/getting-s
 There you'll find resources on how to use different LLM providers,
 troubleshooting resources, and advanced configuration options.
 
+### Custom Scripts
+
+OpenHands supports custom scripts that run at different points in the runtime lifecycle:
+
+- **setup.sh**: Place this script in the `.openhands` directory of your repository to run custom setup commands when the runtime initializes.
+- **pre-commit.sh**: Place this script in the `.openhands` directory to add a custom git pre-commit hook that runs before each commit. This can be used to enforce code quality standards, run tests, or perform other checks before allowing commits.
+
 ## 🤝 How to Join the Community
 
 OpenHands is a community-driven project, and we welcome contributions from everyone. We do most of our communication

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -124,6 +124,8 @@ def initialize_repository_for_runtime(
     )
     # Run setup script if it exists
     runtime.maybe_run_setup_script()
+    # Set up git hooks if pre-commit.sh exists
+    runtime.maybe_setup_git_hooks()
 
     return repo_directory
 

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -131,7 +131,7 @@ class GitLabService(BaseGitService, GitService):
 
                 payload = {
                     'query': query,
-                    'variables': variables,
+                    'variables': variables if variables is not None else {},
                 }
 
                 response = await client.post(

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -72,6 +72,7 @@ STATUS_MESSAGES = {
     'STATUS$CONTAINER_STARTED': 'Container started.',
     'STATUS$WAITING_FOR_CLIENT': 'Waiting for client...',
     'STATUS$SETTING_UP_WORKSPACE': 'Setting up workspace...',
+    'STATUS$SETTING_UP_GIT_HOOKS': 'Setting up git hooks...',
 }
 
 
@@ -417,6 +418,62 @@ class Runtime(FileEditRuntimeMixin):
         obs = self.run_action(action)
         if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
             self.log('error', f'Setup script failed: {obs.content}')
+            
+    def maybe_setup_git_hooks(self):
+        """Set up git hooks if .openhands/pre-commit.sh exists in the workspace or repository."""
+        pre_commit_script = '.openhands/pre-commit.sh'
+        read_obs = self.read(FileReadAction(path=pre_commit_script))
+        if isinstance(read_obs, ErrorObservation):
+            return
+            
+        if self.status_callback:
+            self.status_callback(
+                'info', 'STATUS$SETTING_UP_GIT_HOOKS', 'Setting up git hooks...'
+            )
+            
+        # Ensure the git hooks directory exists
+        action = CmdRunAction('mkdir -p .git/hooks')
+        obs = self.run_action(action)
+        if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
+            self.log('error', f'Failed to create git hooks directory: {obs.content}')
+            return
+            
+        # Make the pre-commit script executable
+        action = CmdRunAction(f'chmod +x {pre_commit_script}')
+        obs = self.run_action(action)
+        if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
+            self.log('error', f'Failed to make pre-commit script executable: {obs.content}')
+            return
+            
+        # Create the pre-commit hook that calls our script
+        pre_commit_hook = '.git/hooks/pre-commit'
+        pre_commit_hook_content = f"""#!/bin/bash
+# This hook was installed by OpenHands
+# It calls the pre-commit script in the .openhands directory
+
+if [ -x "{pre_commit_script}" ]; then
+    source "{pre_commit_script}"
+    exit $?
+else
+    echo "Warning: {pre_commit_script} not found or not executable"
+    exit 0
+fi
+"""
+        
+        # Write the pre-commit hook
+        write_obs = self.write(FileWriteAction(path=pre_commit_hook, content=pre_commit_hook_content))
+        if isinstance(write_obs, ErrorObservation):
+            self.log('error', f'Failed to write pre-commit hook: {write_obs.content}')
+            return
+            
+        # Make the pre-commit hook executable
+        action = CmdRunAction(f'chmod +x {pre_commit_hook}')
+        obs = self.run_action(action)
+        if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
+            self.log('error', f'Failed to make pre-commit hook executable: {obs.content}')
+            return
+            
+        self.log('info', 'Git pre-commit hook installed successfully')
 
     def get_microagents_from_selected_repo(
         self, selected_repository: str | None

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -447,8 +447,37 @@ class Runtime(FileEditRuntimeMixin):
             )
             return
 
-        # Create the pre-commit hook that calls our script
+        # Check if there's an existing pre-commit hook
         pre_commit_hook = '.git/hooks/pre-commit'
+        pre_commit_local = '.git/hooks/pre-commit.local'
+        
+        # Read the existing pre-commit hook if it exists
+        read_obs = self.read(FileReadAction(path=pre_commit_hook))
+        if not isinstance(read_obs, ErrorObservation):
+            # If the existing hook wasn't created by OpenHands, preserve it
+            if "This hook was installed by OpenHands" not in read_obs.content:
+                self.log('info', 'Preserving existing pre-commit hook')
+                # Move the existing hook to pre-commit.local
+                action = CmdRunAction(f'mv {pre_commit_hook} {pre_commit_local}')
+                obs = self.run_action(action)
+                if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
+                    self.log(
+                        'error', 
+                        f'Failed to preserve existing pre-commit hook: {obs.content}'
+                    )
+                    return
+                
+                # Make it executable
+                action = CmdRunAction(f'chmod +x {pre_commit_local}')
+                obs = self.run_action(action)
+                if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
+                    self.log(
+                        'error', 
+                        f'Failed to make preserved hook executable: {obs.content}'
+                    )
+                    return
+
+        # Create the pre-commit hook that calls our script
         pre_commit_hook_content = f"""#!/bin/bash
 # This hook was installed by OpenHands
 # It calls the pre-commit script in the .openhands directory

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -418,33 +418,35 @@ class Runtime(FileEditRuntimeMixin):
         obs = self.run_action(action)
         if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
             self.log('error', f'Setup script failed: {obs.content}')
-            
+
     def maybe_setup_git_hooks(self):
         """Set up git hooks if .openhands/pre-commit.sh exists in the workspace or repository."""
         pre_commit_script = '.openhands/pre-commit.sh'
         read_obs = self.read(FileReadAction(path=pre_commit_script))
         if isinstance(read_obs, ErrorObservation):
             return
-            
+
         if self.status_callback:
             self.status_callback(
                 'info', 'STATUS$SETTING_UP_GIT_HOOKS', 'Setting up git hooks...'
             )
-            
+
         # Ensure the git hooks directory exists
         action = CmdRunAction('mkdir -p .git/hooks')
         obs = self.run_action(action)
         if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
             self.log('error', f'Failed to create git hooks directory: {obs.content}')
             return
-            
+
         # Make the pre-commit script executable
         action = CmdRunAction(f'chmod +x {pre_commit_script}')
         obs = self.run_action(action)
         if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
-            self.log('error', f'Failed to make pre-commit script executable: {obs.content}')
+            self.log(
+                'error', f'Failed to make pre-commit script executable: {obs.content}'
+            )
             return
-            
+
         # Create the pre-commit hook that calls our script
         pre_commit_hook = '.git/hooks/pre-commit'
         pre_commit_hook_content = f"""#!/bin/bash
@@ -459,20 +461,24 @@ else
     exit 0
 fi
 """
-        
+
         # Write the pre-commit hook
-        write_obs = self.write(FileWriteAction(path=pre_commit_hook, content=pre_commit_hook_content))
+        write_obs = self.write(
+            FileWriteAction(path=pre_commit_hook, content=pre_commit_hook_content)
+        )
         if isinstance(write_obs, ErrorObservation):
             self.log('error', f'Failed to write pre-commit hook: {write_obs.content}')
             return
-            
+
         # Make the pre-commit hook executable
         action = CmdRunAction(f'chmod +x {pre_commit_hook}')
         obs = self.run_action(action)
         if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
-            self.log('error', f'Failed to make pre-commit hook executable: {obs.content}')
+            self.log(
+                'error', f'Failed to make pre-commit hook executable: {obs.content}'
+            )
             return
-            
+
         self.log('info', 'Git pre-commit hook installed successfully')
 
     def get_microagents_from_selected_repo(

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -327,6 +327,7 @@ class AgentSession:
             git_provider_tokens, selected_repository, selected_branch
         )
         await call_sync_from_async(self.runtime.maybe_run_setup_script)
+        await call_sync_from_async(self.runtime.maybe_setup_git_hooks)
 
         self.logger.debug(
             f'Runtime initialized with plugins: {[plugin.name for plugin in self.runtime.plugins]}'

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -1,12 +1,13 @@
-import os
-import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from openhands.events import EventStream
 from openhands.events.action import FileReadAction
-from openhands.events.observation import CmdOutputObservation, ErrorObservation, FileReadObservation
+from openhands.events.observation import (
+    CmdOutputObservation,
+    ErrorObservation,
+    FileReadObservation,
+)
 from openhands.runtime.base import Runtime
 
 
@@ -18,10 +19,10 @@ class TestGitHooks:
         mock_runtime.status_callback = None
         mock_runtime.read.return_value = FileReadObservation(
             content="#!/bin/bash\necho 'Test pre-commit hook'\nexit 0",
-            path='.openhands/pre-commit.sh'
+            path='.openhands/pre-commit.sh',
         )
         mock_runtime.run_action.return_value = CmdOutputObservation(
-            content="", exit_code=0, command="test command"
+            content='', exit_code=0, command='test command'
         )
         mock_runtime.write.return_value = None
         return mock_runtime
@@ -29,37 +30,43 @@ class TestGitHooks:
     def test_maybe_setup_git_hooks_success(self, mock_runtime):
         # Test successful setup of git hooks
         Runtime.maybe_setup_git_hooks(mock_runtime)
-        
+
         # Verify that the runtime tried to read the pre-commit script
-        mock_runtime.read.assert_called_with(FileReadAction(path='.openhands/pre-commit.sh'))
-        
+        mock_runtime.read.assert_called_with(
+            FileReadAction(path='.openhands/pre-commit.sh')
+        )
+
         # Verify that the runtime created the git hooks directory
         # We can't directly compare the CmdRunAction objects, so we check if run_action was called
         assert mock_runtime.run_action.called
-        
+
         # Verify that the runtime made the pre-commit script executable
         # We can't directly compare the CmdRunAction objects, so we check if run_action was called
         assert mock_runtime.run_action.called
-        
+
         # Verify that the runtime wrote the pre-commit hook
         mock_runtime.write.assert_called_once()
-        
+
         # Verify that the runtime made the pre-commit hook executable
         # We can't directly compare the CmdRunAction objects, so we check if run_action was called
         assert mock_runtime.run_action.call_count >= 3
-        
+
         # Verify that the runtime logged success
-        mock_runtime.log.assert_called_with('info', 'Git pre-commit hook installed successfully')
+        mock_runtime.log.assert_called_with(
+            'info', 'Git pre-commit hook installed successfully'
+        )
 
     def test_maybe_setup_git_hooks_no_script(self, mock_runtime):
         # Test when pre-commit script doesn't exist
-        mock_runtime.read.return_value = ErrorObservation(content="File not found")
-        
+        mock_runtime.read.return_value = ErrorObservation(content='File not found')
+
         Runtime.maybe_setup_git_hooks(mock_runtime)
-        
+
         # Verify that the runtime tried to read the pre-commit script
-        mock_runtime.read.assert_called_with(FileReadAction(path='.openhands/pre-commit.sh'))
-        
+        mock_runtime.read.assert_called_with(
+            FileReadAction(path='.openhands/pre-commit.sh')
+        )
+
         # Verify that no other actions were taken
         mock_runtime.run_action.assert_not_called()
         mock_runtime.write.assert_not_called()
@@ -67,16 +74,18 @@ class TestGitHooks:
     def test_maybe_setup_git_hooks_mkdir_failure(self, mock_runtime):
         # Test failure to create git hooks directory
         mock_runtime.run_action.return_value = CmdOutputObservation(
-            content="Permission denied", exit_code=1, command="mkdir -p .git/hooks"
+            content='Permission denied', exit_code=1, command='mkdir -p .git/hooks'
         )
-        
+
         Runtime.maybe_setup_git_hooks(mock_runtime)
-        
+
         # Verify that the runtime tried to create the git hooks directory
         assert mock_runtime.run_action.called
-        
+
         # Verify that the runtime logged an error
-        mock_runtime.log.assert_called_with('error', 'Failed to create git hooks directory: Permission denied')
-        
+        mock_runtime.log.assert_called_with(
+            'error', 'Failed to create git hooks directory: Permission denied'
+        )
+
         # Verify that no other actions were taken
         mock_runtime.write.assert_not_called()

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -1,8 +1,8 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
-from openhands.events.action import FileReadAction
+from openhands.events.action import CmdRunAction, FileReadAction, FileWriteAction
 from openhands.events.observation import (
     CmdOutputObservation,
     ErrorObservation,
@@ -17,10 +17,21 @@ class TestGitHooks:
         # Create a mock runtime
         mock_runtime = MagicMock(spec=Runtime)
         mock_runtime.status_callback = None
-        mock_runtime.read.return_value = FileReadObservation(
-            content="#!/bin/bash\necho 'Test pre-commit hook'\nexit 0",
-            path='.openhands/pre-commit.sh',
-        )
+        
+        # Set up read to return different values based on the path
+        def mock_read(action):
+            if action.path == '.openhands/pre-commit.sh':
+                return FileReadObservation(
+                    content="#!/bin/bash\necho 'Test pre-commit hook'\nexit 0",
+                    path='.openhands/pre-commit.sh',
+                )
+            elif action.path == '.git/hooks/pre-commit':
+                # Simulate no existing pre-commit hook
+                return ErrorObservation(content='File not found')
+            return ErrorObservation(content='Unexpected path')
+            
+        mock_runtime.read.side_effect = mock_read
+        
         mock_runtime.run_action.return_value = CmdOutputObservation(
             content='', exit_code=0, command='test command'
         )
@@ -32,7 +43,7 @@ class TestGitHooks:
         Runtime.maybe_setup_git_hooks(mock_runtime)
 
         # Verify that the runtime tried to read the pre-commit script
-        mock_runtime.read.assert_called_with(
+        assert mock_runtime.read.call_args_list[0] == call(
             FileReadAction(path='.openhands/pre-commit.sh')
         )
 
@@ -45,7 +56,7 @@ class TestGitHooks:
         assert mock_runtime.run_action.called
 
         # Verify that the runtime wrote the pre-commit hook
-        mock_runtime.write.assert_called_once()
+        assert mock_runtime.write.called
 
         # Verify that the runtime made the pre-commit hook executable
         # We can't directly compare the CmdRunAction objects, so we check if run_action was called
@@ -58,7 +69,7 @@ class TestGitHooks:
 
     def test_maybe_setup_git_hooks_no_script(self, mock_runtime):
         # Test when pre-commit script doesn't exist
-        mock_runtime.read.return_value = ErrorObservation(content='File not found')
+        mock_runtime.read.side_effect = lambda action: ErrorObservation(content='File not found')
 
         Runtime.maybe_setup_git_hooks(mock_runtime)
 
@@ -73,9 +84,14 @@ class TestGitHooks:
 
     def test_maybe_setup_git_hooks_mkdir_failure(self, mock_runtime):
         # Test failure to create git hooks directory
-        mock_runtime.run_action.return_value = CmdOutputObservation(
-            content='Permission denied', exit_code=1, command='mkdir -p .git/hooks'
-        )
+        def mock_run_action(action):
+            if isinstance(action, CmdRunAction) and action.command == 'mkdir -p .git/hooks':
+                return CmdOutputObservation(
+                    content='Permission denied', exit_code=1, command='mkdir -p .git/hooks'
+                )
+            return CmdOutputObservation(content='', exit_code=0, command=action.command)
+            
+        mock_runtime.run_action.side_effect = mock_run_action
 
         Runtime.maybe_setup_git_hooks(mock_runtime)
 
@@ -89,3 +105,44 @@ class TestGitHooks:
 
         # Verify that no other actions were taken
         mock_runtime.write.assert_not_called()
+        
+    def test_maybe_setup_git_hooks_with_existing_hook(self, mock_runtime):
+        # Test when there's an existing pre-commit hook
+        def mock_read(action):
+            if action.path == '.openhands/pre-commit.sh':
+                return FileReadObservation(
+                    content="#!/bin/bash\necho 'Test pre-commit hook'\nexit 0",
+                    path='.openhands/pre-commit.sh',
+                )
+            elif action.path == '.git/hooks/pre-commit':
+                # Simulate existing pre-commit hook
+                return FileReadObservation(
+                    content="#!/bin/bash\necho 'Existing hook'\nexit 0",
+                    path='.git/hooks/pre-commit',
+                )
+            return ErrorObservation(content='Unexpected path')
+            
+        mock_runtime.read.side_effect = mock_read
+
+        Runtime.maybe_setup_git_hooks(mock_runtime)
+
+        # Verify that the runtime tried to read both scripts
+        assert len(mock_runtime.read.call_args_list) >= 2
+        
+        # Verify that the runtime preserved the existing hook
+        assert mock_runtime.log.call_args_list[0] == call('info', 'Preserving existing pre-commit hook')
+        
+        # Verify that the runtime moved the existing hook
+        move_calls = [
+            call for call in mock_runtime.run_action.call_args_list 
+            if isinstance(call[0][0], CmdRunAction) and 'mv' in call[0][0].command
+        ]
+        assert len(move_calls) > 0
+        
+        # Verify that the runtime wrote the new pre-commit hook
+        assert mock_runtime.write.called
+        
+        # Verify that the runtime logged success
+        assert mock_runtime.log.call_args_list[-1] == call(
+            'info', 'Git pre-commit hook installed successfully'
+        )

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -1,0 +1,82 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openhands.events import EventStream
+from openhands.events.action import FileReadAction
+from openhands.events.observation import CmdOutputObservation, ErrorObservation, FileReadObservation
+from openhands.runtime.base import Runtime
+
+
+class TestGitHooks:
+    @pytest.fixture
+    def mock_runtime(self):
+        # Create a mock runtime
+        mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime.status_callback = None
+        mock_runtime.read.return_value = FileReadObservation(
+            content="#!/bin/bash\necho 'Test pre-commit hook'\nexit 0",
+            path='.openhands/pre-commit.sh'
+        )
+        mock_runtime.run_action.return_value = CmdOutputObservation(
+            content="", exit_code=0, command="test command"
+        )
+        mock_runtime.write.return_value = None
+        return mock_runtime
+
+    def test_maybe_setup_git_hooks_success(self, mock_runtime):
+        # Test successful setup of git hooks
+        Runtime.maybe_setup_git_hooks(mock_runtime)
+        
+        # Verify that the runtime tried to read the pre-commit script
+        mock_runtime.read.assert_called_with(FileReadAction(path='.openhands/pre-commit.sh'))
+        
+        # Verify that the runtime created the git hooks directory
+        # We can't directly compare the CmdRunAction objects, so we check if run_action was called
+        assert mock_runtime.run_action.called
+        
+        # Verify that the runtime made the pre-commit script executable
+        # We can't directly compare the CmdRunAction objects, so we check if run_action was called
+        assert mock_runtime.run_action.called
+        
+        # Verify that the runtime wrote the pre-commit hook
+        mock_runtime.write.assert_called_once()
+        
+        # Verify that the runtime made the pre-commit hook executable
+        # We can't directly compare the CmdRunAction objects, so we check if run_action was called
+        assert mock_runtime.run_action.call_count >= 3
+        
+        # Verify that the runtime logged success
+        mock_runtime.log.assert_called_with('info', 'Git pre-commit hook installed successfully')
+
+    def test_maybe_setup_git_hooks_no_script(self, mock_runtime):
+        # Test when pre-commit script doesn't exist
+        mock_runtime.read.return_value = ErrorObservation(content="File not found")
+        
+        Runtime.maybe_setup_git_hooks(mock_runtime)
+        
+        # Verify that the runtime tried to read the pre-commit script
+        mock_runtime.read.assert_called_with(FileReadAction(path='.openhands/pre-commit.sh'))
+        
+        # Verify that no other actions were taken
+        mock_runtime.run_action.assert_not_called()
+        mock_runtime.write.assert_not_called()
+
+    def test_maybe_setup_git_hooks_mkdir_failure(self, mock_runtime):
+        # Test failure to create git hooks directory
+        mock_runtime.run_action.return_value = CmdOutputObservation(
+            content="Permission denied", exit_code=1, command="mkdir -p .git/hooks"
+        )
+        
+        Runtime.maybe_setup_git_hooks(mock_runtime)
+        
+        # Verify that the runtime tried to create the git hooks directory
+        assert mock_runtime.run_action.called
+        
+        # Verify that the runtime logged an error
+        mock_runtime.log.assert_called_with('error', 'Failed to create git hooks directory: Permission denied')
+        
+        # Verify that no other actions were taken
+        mock_runtime.write.assert_not_called()


### PR DESCRIPTION
This PR is a fixed version of PR #8095 with resolved merge conflicts.

Original PR description:

This PR adds support for a `pre-commit.sh` script that gets installed as a git pre-commit hook in the repository.

## Changes

- Added a new `maybe_setup_git_hooks` method to the Runtime class that checks for and installs the pre-commit hook
- Modified the runtime initialization to call this method after running the setup script
- Added a sample pre-commit.sh script that runs npm commands when changes are detected in the frontend directory
- Added documentation in the README about the new feature
- Added unit tests for the new functionality

The pre-commit hook will run npm lint:fix, npm build, and npm test when changes are detected in the frontend/ directory.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:de85be1-nikolaik   --name openhands-app-de85be1   docker.all-hands.dev/all-hands-ai/openhands:de85be1
```