### PR TITLE
Fix issue #8135: [Bug]: UI of repo selector misaligns on small screens

### DIFF
--- a/frontend/src/components/features/home/repo-selection-form.test.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.test.tsx
@@ -135,4 +135,33 @@ describe("RepositorySelectionForm", () => {
       screen.getByText("HOME$FAILED_TO_LOAD_REPOSITORIES"),
     ).toBeInTheDocument();
   });
+
+  test("has responsive width on mobile screens", () => {
+    // Setup loaded repositories
+    mockUseUserRepositories.mockReturnValue({
+      data: {
+        pages: [
+          {
+            data: [
+              {
+                id: 1,
+                full_name: "user/repo1",
+                git_provider: "github",
+                is_public: true,
+              },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<RepositorySelectionForm onRepoSelection={mockOnRepoSelection} />);
+
+    // Check if dropdown has responsive width classes
+    const dropdown = screen.getByTestId("repo-dropdown");
+    const wrapper = dropdown.closest("label");
+    expect(wrapper).toHaveClass("w-full", "max-w-[500px]");
+  });
 });

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -18,7 +18,7 @@ function RepositoryLoadingState() {
   return (
     <div
       data-testid="repo-dropdown-loading"
-      className="flex items-center gap-2 max-w-[500px] h-10 px-3 bg-tertiary border border-[#717888] rounded"
+      className="flex items-center gap-2 w-full max-w-[500px] h-10 px-3 bg-tertiary border border-[#717888] rounded"
     >
       <Spinner size="sm" />
       <span className="text-sm">{t("HOME$LOADING_REPOSITORIES")}</span>
@@ -32,7 +32,7 @@ function RepositoryErrorState() {
   return (
     <div
       data-testid="repo-dropdown-error"
-      className="flex items-center gap-2 max-w-[500px] h-10 px-3 bg-tertiary border border-[#717888] rounded text-red-500"
+      className="flex items-center gap-2 w-full max-w-[500px] h-10 px-3 bg-tertiary border border-[#717888] rounded text-red-500"
     >
       <span className="text-sm">{t("HOME$FAILED_TO_LOAD_REPOSITORIES")}</span>
     </div>
@@ -57,7 +57,7 @@ function RepositoryDropdown({
       name="repo-dropdown"
       placeholder="Select a repo"
       items={items}
-      wrapperClassName="max-w-[500px]"
+      wrapperClassName="w-full max-w-[500px]"
       onSelectionChange={onSelectionChange}
       onInputChange={onInputChange}
     />

--- a/frontend/src/components/features/settings/settings-dropdown-input.tsx
+++ b/frontend/src/components/features/settings/settings-dropdown-input.tsx
@@ -53,12 +53,13 @@ export function SettingsDropdownInput({
         placeholder={placeholder}
         className="w-full"
         classNames={{
-          popoverContent: "bg-tertiary rounded-xl border border-[#717888]",
+          popoverContent:
+            "bg-tertiary rounded-xl border border-[#717888] max-w-[calc(100vw-2rem)] sm:max-w-none",
         }}
         inputProps={{
           classNames: {
             inputWrapper:
-              "bg-tertiary border border-[#717888] h-10 w-full rounded p-2 placeholder:italic",
+              "bg-tertiary border border-[#717888] h-10 w-full rounded p-2 placeholder:italic text-sm sm:text-base",
           },
         }}
       >


### PR DESCRIPTION
This pull request fixes #8135.

The changes made directly address the UI misalignment issue on smaller screens through several key modifications:

1. Added `w-full` class to all repository selection components (loading state, error state, and dropdown) to ensure they take up the full width of their container while maintaining a maximum width of 500px. This ensures proper scaling on mobile devices.

2. Modified the settings dropdown input component to be more mobile-friendly by:
   - Adding `max-w-[calc(100vw-2rem)]` to prevent overflow on mobile screens
   - Including responsive text sizing (`text-sm sm:text-base`)
   - Adding a mobile-specific max-width constraint that switches to unconstrained on larger screens

3. Added a new test case specifically to verify responsive behavior on mobile screens, ensuring the dropdown has both `w-full` and `max-w-[500px]` classes.

These changes will prevent the misalignment issue by:
- Ensuring the repo selector properly fills its container width on mobile
- Preventing overflow issues with the dropdown
- Maintaining a consistent layout across different screen sizes
- Implementing proper responsive design practices

The comprehensive nature of these changes, combined with the added test coverage, indicates this should successfully resolve the reported alignment issues on smaller screens.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:27531a9-nikolaik   --name openhands-app-27531a9   docker.all-hands.dev/all-hands-ai/openhands:27531a9
```