### PR TITLE
Fix mobile layout for repo picker and suggested tasks

### DIFF
--- a/frontend/__tests__/routes/home-screen.test.tsx
+++ b/frontend/__tests__/routes/home-screen.test.tsx
@@ -91,6 +91,13 @@ describe("HomeScreen", () => {
     screen.getByTestId("task-suggestions");
   });
 
+  it("should have responsive layout for mobile and desktop screens", async () => {
+    renderHomeScreen();
+    
+    const mainContainer = screen.getByTestId("home-screen").querySelector("main");
+    expect(mainContainer).toHaveClass("flex", "flex-col", "md:flex-row");
+  });
+
   it("should filter the suggested tasks based on the selected repository", async () => {
     const retrieveUserGitRepositoriesSpy = vi.spyOn(
       GitService,

--- a/frontend/src/routes/home.tsx
+++ b/frontend/src/routes/home.tsx
@@ -22,7 +22,7 @@ function HomeScreen() {
 
       <hr className="border-[#717888]" />
 
-      <main className="flex justify-between gap-4">
+      <main className="flex flex-col md:flex-row justify-between gap-4">
         <RepoConnector
           onRepoSelection={(title) => setSelectedRepoTitle(title)}
         />


### PR DESCRIPTION
Fixes #8086

This PR makes the layout of the home page responsive, so that on mobile devices the repository picker appears above the suggested tasks, while on larger screens they remain side by side.

Changes:
- Updated the main container in home.tsx to use flex-col on mobile and flex-row on medium screens and larger
- Added a test to verify the responsive layout

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/856a22fb47984d659a8d836657efbb91)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d1f2bd3-nikolaik   --name openhands-app-d1f2bd3   docker.all-hands.dev/all-hands-ai/openhands:d1f2bd3
```