### PR TITLE
Fix issue #8145: Add docs about runtime tests

### DIFF
--- a/tests/runtime/README.md
+++ b/tests/runtime/README.md
@@ -1,0 +1,59 @@
+## Runtime Tests
+
+This folder contains integration tests that verify the functionality of OpenHands' runtime environments and their interactions with various tools and features.
+
+### What are Runtime Tests?
+
+Runtime tests focus on testing:
+- Different runtime environments (Docker, Local, Remote, Runloop, Daytona)
+- Tool interactions within these environments (bash commands, browsing, file operations)
+- Environment setup and configuration
+- Resource management and cleanup
+- Browser-based operations and file viewing capabilities
+- IPython/Jupyter integration
+- Environment variables and configuration handling
+
+### How are they different from Unit Tests?
+
+While unit tests in `tests/unit/` focus on testing individual components in isolation, runtime tests verify:
+1. Integration between components
+2. Actual execution of commands in different runtime environments
+3. System-level interactions (file system, network, browser)
+4. Environment setup and teardown
+5. Tool functionality in real runtime contexts
+
+### Running the Tests
+
+Run all runtime tests:
+
+```bash
+poetry run pytest ./tests/runtime
+```
+
+Run specific test file:
+
+```bash
+poetry run pytest ./tests/runtime/test_bash.py
+```
+
+Run specific test:
+
+```bash
+poetry run pytest ./tests/runtime/test_bash.py::test_bash_command_env
+```
+
+For verbose output, add the `-v` flag (more verbose: `-vv` and `-vvv`):
+
+```bash
+poetry run pytest -v ./tests/runtime/test_bash.py
+```
+
+### Environment Variables
+
+The runtime tests can be configured using environment variables:
+- `TEST_IN_CI`: Set to 'True' when running in CI environment
+- `TEST_RUNTIME`: Specify the runtime to test ('docker', 'local', 'remote', 'runloop', 'daytona')
+- `RUN_AS_OPENHANDS`: Set to 'True' to run tests as openhands user (default), 'False' for root
+- `SANDBOX_BASE_CONTAINER_IMAGE`: Specify a custom base container image for Docker runtime
+
+For more details on pytest usage, see the [pytest documentation](https://docs.pytest.org/en/latest/contents.html).

--- a/tests/runtime/README.md
+++ b/tests/runtime/README.md
@@ -5,13 +5,14 @@ This folder contains integration tests that verify the functionality of OpenHand
 ### What are Runtime Tests?
 
 Runtime tests focus on testing:
-- Different runtime environments (Docker, Local, Remote, Runloop, Daytona)
-- Tool interactions within these environments (bash commands, browsing, file operations)
+- Tool interactions within a runtime environment (bash commands, browsing, file operations)
 - Environment setup and configuration
 - Resource management and cleanup
 - Browser-based operations and file viewing capabilities
 - IPython/Jupyter integration
 - Environment variables and configuration handling
+
+The tests can be run against different runtime environments (Docker, Local, Remote, Runloop, or Daytona) by setting the TEST_RUNTIME environment variable. By default, tests run using the Docker runtime.
 
 ### How are they different from Unit Tests?
 


### PR DESCRIPTION
This pull request fixes #8145.

The issue has been successfully resolved because:

1. A README.md file was created in the tests/runtime/ directory as requested
2. The documentation clearly explains what runtime tests are and their specific focus (runtime environments, tool interactions, etc.)
3. The README maintains a simple, technical style similar to the tests/unit readme as specifically requested
4. It provides concrete, actionable information about:
   - The purpose and scope of runtime tests
   - Clear differentiation from unit tests through specific examples
   - Exact commands for running tests with different options
   - Configuration options via environment variables
5. The documentation is self-contained and complete without requiring additional setup or verification steps

The changes directly address all aspects of the original issue: creating a readme, explaining what the tests are, differentiating them from unit tests, and providing instructions for local execution. The implementation is appropriately scoped as a documentation-only change that required understanding the codebase but not running tests, exactly as specified in the issue description.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0545c66-nikolaik   --name openhands-app-0545c66   docker.all-hands.dev/all-hands-ai/openhands:0545c66
```