### PR TITLE
fix(memory): Fix empty string content handling in ConversationMemory

### DIFF
--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -230,8 +230,8 @@ class ConversationMemory:
             pending_tool_call_action_messages[llm_response.id] = Message(
                 role=getattr(assistant_msg, 'role', 'assistant'),
                 # tool call content SHOULD BE a string
-                content=[TextContent(text=assistant_msg.content or '')]
-                if assistant_msg.content
+                content=[TextContent(text=assistant_msg.content)]
+                if assistant_msg.content and assistant_msg.content.strip()
                 else [],
                 tool_calls=assistant_msg.tool_calls,
             )

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -231,7 +231,7 @@ class ConversationMemory:
                 role=getattr(assistant_msg, 'role', 'assistant'),
                 # tool call content SHOULD BE a string
                 content=[TextContent(text=assistant_msg.content or '')]
-                if assistant_msg.content is not None
+                if assistant_msg.content
                 else [],
                 tool_calls=assistant_msg.tool_calls,
             )


### PR DESCRIPTION
Fix #8147 