### PR TITLE
Fix: Update last_active_ts in dispatch method to prevent inactive sessions from persisting

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -237,6 +237,10 @@ class Session:
             await self.send(event_dict)
 
     async def dispatch(self, data: dict):
+        # Update last_active_ts when receiving data from client
+        # This ensures the session is considered active when the client sends data
+        self.last_active_ts = int(time.time())
+        
         event = event_from_dict(data.copy())
         # This checks if the model supports images
         if isinstance(event, MessageAction) and event.image_urls:


### PR DESCRIPTION
## Problem
Agent loops are supposed to be stopped after a certain period of time with no connections, but they currently persist forever.

## Root Cause
The `last_active_ts` timestamp is only updated when:
1. The session is created
2. When data is sent to the client via `_send`

But it is not updated when data is received from the client via `dispatch`. This means that if a client is only receiving data but not sending any, the session will be considered inactive and might be closed.

## Fix
Update the `last_active_ts` timestamp in the `dispatch` method to ensure the session is considered active when the client sends data.