### PR TITLE
hotifx(frontend): Critical fix for black screen

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,6 @@
         "react-router": "^7.5.2",
         "react-syntax-highlighter": "^15.6.1",
         "react-textarea-autosize": "^8.5.9",
-        "react-toastify": "^11.0.5",
         "remark-gfm": "^4.0.1",
         "sirv-cli": "^3.0.1",
         "socket.io-client": "^4.8.1",
@@ -15460,19 +15459,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-toastify": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
-      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/src/entry.client.tsx
+++ b/frontend/src/entry.client.tsx
@@ -13,21 +13,35 @@ import posthog from "posthog-js";
 import "./i18n";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import store from "./store";
-import { useConfig } from "./hooks/query/use-config";
 import { AuthProvider } from "./context/auth-context";
 import { queryClientConfig } from "./query-client-config";
+import OpenHands from "./api/open-hands";
+import { displayErrorToast } from "./utils/custom-toast-handlers";
 
 function PosthogInit() {
-  const { data: config } = useConfig();
+  const [posthogClientKey, setPosthogClientKey] = React.useState<string | null>(
+    null,
+  );
 
   React.useEffect(() => {
-    if (config?.POSTHOG_CLIENT_KEY) {
-      posthog.init(config.POSTHOG_CLIENT_KEY, {
+    (async () => {
+      try {
+        const config = await OpenHands.getConfig();
+        setPosthogClientKey(config.POSTHOG_CLIENT_KEY);
+      } catch (error) {
+        displayErrorToast("Error fetching PostHog client key");
+      }
+    })();
+  }, []);
+
+  React.useEffect(() => {
+    if (posthogClientKey) {
+      posthog.init(posthogClientKey, {
         api_host: "https://us.i.posthog.com",
         person_profiles: "identified_only",
       });
     }
-  }, [config]);
+  }, [posthogClientKey]);
 
   return null;
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
`useConfig` depends on a React Router hook that checks for the apps current location. The issue is that the `useConfig` hook used in the `PostHogInit` component is outside the hydrated router context

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
Get required data via an API call directly instead of custom hook

---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e2ffc53-nikolaik   --name openhands-app-e2ffc53   docker.all-hands.dev/all-hands-ai/openhands:e2ffc53
```