### PR TITLE
[Fix]: Allow partial repo object to initialize new conversation

### DIFF
--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -101,6 +101,23 @@ class Repository(BaseModel):
     pushed_at: str | None = None  # ISO 8601 format date string
 
 
+# Used for OpenHands API
+class PartialRepository(BaseModel):
+    full_name: str
+    git_provider: ProviderType
+
+    def convert_to_repo_model(self) -> Repository:
+        return Repository(
+            id=-1,
+            full_name=self.full_name,
+            git_provider=self.git_provider,
+            is_public=False,
+            stargazers_count=None,
+            link_header=None,
+            pushed_at=None,
+        )
+
+
 class AuthenticationError(ValueError):
     """Raised when there is an issue with GitHub authentication."""
 

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -29,9 +29,11 @@ from openhands.server.shared import (
 )
 from openhands.server.types import LLMAuthenticationError, MissingSettingsError
 from openhands.server.user_auth import (
+    get_auth_type,
     get_provider_tokens,
     get_user_id,
 )
+from openhands.server.user_auth.user_auth import AuthType
 from openhands.server.utils import get_conversation_store
 from openhands.storage.conversation.conversation_store import ConversationStore
 from openhands.storage.data_models.conversation_metadata import (
@@ -166,6 +168,7 @@ async def new_conversation(
     data: InitSessionRequest,
     user_id: str = Depends(get_user_id),
     provider_tokens: PROVIDER_TOKEN_TYPE = Depends(get_provider_tokens),
+    auth_type: AuthType | None = Depends(get_auth_type)
 ):
     """Initialize a new session or join an existing one.
 
@@ -184,6 +187,9 @@ async def new_conversation(
     if suggested_task:
         initial_user_msg = suggested_task.get_prompt_for_task()
         conversation_trigger = ConversationTrigger.SUGGESTED_TASK
+
+    if auth_type == AuthType.BEARER:
+        conversation_trigger = ConversationTrigger.OPENHANDS_API
 
     try:
         # Create conversation with initial message

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -50,7 +50,7 @@ app = APIRouter(prefix='/api')
 
 class InitSessionRequest(BaseModel):
     conversation_trigger: ConversationTrigger = ConversationTrigger.GUI
-    selected_repository: Repository | None = None
+    selected_repository: Repository | PartialRepository | None = None
     selected_branch: str | None = None
     initial_user_msg: str | None = None
     image_urls: list[str] | None = None
@@ -69,9 +69,9 @@ async def _create_new_conversation(
     conversation_trigger: ConversationTrigger = ConversationTrigger.GUI,
     attach_convo_id: bool = False,
 ):
-    print("trigger", conversation_trigger)
+    
     logger.info(
-        'Creating conversation',
+        f'Creating conversation with trigger {conversation_trigger}',
         extra={'signal': 'create_conversation', 'user_id': user_id, 'trigger': conversation_trigger.value},
     )
     logger.info('Loading settings')

--- a/openhands/server/user_auth/__init__.py
+++ b/openhands/server/user_auth/__init__.py
@@ -4,7 +4,7 @@ from pydantic import SecretStr
 from openhands.integrations.provider import PROVIDER_TOKEN_TYPE
 from openhands.integrations.service_types import ProviderType
 from openhands.server.settings import Settings
-from openhands.server.user_auth.user_auth import get_user_auth
+from openhands.server.user_auth.user_auth import AuthType, get_user_auth
 from openhands.storage.settings.settings_store import SettingsStore
 
 
@@ -46,3 +46,8 @@ async def get_user_settings_store(request: Request) -> SettingsStore | None:
     user_auth = await get_user_auth(request)
     user_settings_store = await user_auth.get_user_settings_store()
     return user_settings_store
+
+
+async def get_auth_type(request: Request) -> AuthType | None:
+    user_auth = await get_user_auth(request)
+    return user_auth.get_auth_type()

--- a/openhands/server/user_auth/default_user_auth.py
+++ b/openhands/server/user_auth/default_user_auth.py
@@ -51,6 +51,7 @@ class DefaultUserAuth(UserAuth):
         provider_tokens = getattr(secrets_store, 'provider_tokens', None)
         return provider_tokens
 
+
     @classmethod
     async def get_instance(cls, request: Request) -> UserAuth:
         user_auth = DefaultUserAuth()

--- a/openhands/server/user_auth/user_auth.py
+++ b/openhands/server/user_auth/user_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from enum import Enum
 
 from fastapi import Request
 from pydantic import SecretStr
@@ -10,6 +11,11 @@ from openhands.server.settings import Settings
 from openhands.server.shared import server_config
 from openhands.storage.settings.settings_store import SettingsStore
 from openhands.utils.import_utils import get_impl
+
+
+class AuthType(Enum):
+    COOKIE = "cookie"
+    BEARER = "bearer"
 
 
 class UserAuth(ABC):
@@ -44,6 +50,9 @@ class UserAuth(ABC):
         settings = await settings_store.load()
         self._settings = settings
         return settings
+
+    def get_auth_type(self) -> AuthType | None:
+        return None
 
     @classmethod
     @abstractmethod

--- a/openhands/storage/data_models/conversation_metadata.py
+++ b/openhands/storage/data_models/conversation_metadata.py
@@ -7,6 +7,7 @@ class ConversationTrigger(Enum):
     RESOLVER = 'resolver'
     GUI = 'gui'
     SUGGESTED_TASK = 'suggested_task'
+    OPENHANDS_API = 'openhands_api'
 
 
 @dataclass


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
- Only requires repo name + git provider for repo information to start new conversation via openhands api

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR is a fix for OpenHands API. We do the following

1. Define a new type `PartialRepository` which only requires `full_name` and `git_provider` info. This simplifies the api calling to create a new conversation and reduced the burden to specify information like `repo_id`

2. Adds a new trigger type `OPENHANDS_API`


---
**Link of any specific issues this addresses.**
