### PR TITLE
Fix issue #8162: [Bug]: Correct name for max_tokens for condenser in config.template.toml

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -391,7 +391,7 @@ type = "noop"
 #[llm.condenser]
 #model = "gpt-4o"
 #temperature = 0.1
-#max_tokens = 1024
+#max_output_tokens = 1024
 
 #################################### Eval ####################################
 # Configuration for the evaluation, please refer to the specific evaluation


### PR DESCRIPTION
This pull request fixes #8162.

The issue has been successfully resolved because:

1. The core problem was that the template used an incorrect parameter name `max_tokens` which caused parsing issues in the condenser configuration, resulting in warnings and fallback to default settings.

2. The fix directly addresses this by changing the parameter name to `max_output_tokens` in config.template.toml, which matches the expected parameter name in the codebase's LLMConfig class.

3. The change will prevent the reported warning messages:
- "Cannot parse [condenser] config from toml"
- "LLM config 'condenser' not found for condenser"

4. Since this was a documentation/template issue rather than a code bug, the simple parameter name change is sufficient to resolve the problem. Users who copy this template will now have the correct parameter name and their condenser configurations will parse successfully.

The fix is complete and appropriate for the reported issue, requiring no additional changes to resolve the parameter naming mismatch.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9826afb-nikolaik   --name openhands-app-9826afb   docker.all-hands.dev/all-hands-ai/openhands:9826afb
```