### PR TITLE
Fix issue #8145: Correct name for max_tokens for condenser in config.template.toml 

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -391,7 +391,7 @@ type = "noop"
 #[llm.condenser]
 #model = "gpt-4o"
 #temperature = 0.1
-#max_tokens = 1024
+#max_input_tokens = 1024
 
 #################################### Eval ####################################
 # Configuration for the evaluation, please refer to the specific evaluation


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

This PR fixes issue [#8162](https://github.com/All-Hands-AI/OpenHands/pull/8164)

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

Proper variable name in ``config.template.toml`` when using condenser, from ``max_tokens`` to ``max_input_tokens``

---
**Link of any specific issues this addresses.**

[#8162](https://github.com/All-Hands-AI/OpenHands/pull/8164)

