### PR TITLE
Fix ValueError when latest_event_id is undefined

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -49,7 +49,7 @@ async def connect(connection_id: str, environ):
     try:
         latest_event_id = int(latest_event_id_str)
     except ValueError:
-        logger.warning(
+        logger.debug(
             f'Invalid latest_event_id value: {latest_event_id_str}, defaulting to -1'
         )
         latest_event_id = -1

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -46,7 +46,6 @@ async def connect(connection_id: str, environ):
     logger.info(f'sio:connect: {connection_id}')
     query_params = parse_qs(environ.get('QUERY_STRING', ''))
     latest_event_id_str = query_params.get('latest_event_id', [-1])[0]
-    # Handle case when latest_event_id is 'undefined' or other non-integer values
     try:
         latest_event_id = int(latest_event_id_str)
     except ValueError:

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -49,7 +49,9 @@ async def connect(connection_id: str, environ):
     try:
         latest_event_id = int(latest_event_id_str)
     except ValueError:
-        logger.warning(f"Invalid latest_event_id value: {latest_event_id_str}, defaulting to -1")
+        logger.warning(
+            f'Invalid latest_event_id value: {latest_event_id_str}, defaulting to -1'
+        )
         latest_event_id = -1
     conversation_id = query_params.get('conversation_id', [None])[0]
     raw_list = query_params.get('providers_set', [])

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -45,7 +45,13 @@ def create_provider_tokens_object(
 async def connect(connection_id: str, environ):
     logger.info(f'sio:connect: {connection_id}')
     query_params = parse_qs(environ.get('QUERY_STRING', ''))
-    latest_event_id = int(query_params.get('latest_event_id', [-1])[0])
+    latest_event_id_str = query_params.get('latest_event_id', [-1])[0]
+    # Handle case when latest_event_id is 'undefined' or other non-integer values
+    try:
+        latest_event_id = int(latest_event_id_str)
+    except ValueError:
+        logger.warning(f"Invalid latest_event_id value: {latest_event_id_str}, defaulting to -1")
+        latest_event_id = -1
     conversation_id = query_params.get('conversation_id', [None])[0]
     raw_list = query_params.get('providers_set', [])
     providers_list = []


### PR DESCRIPTION
## Description
This PR fixes an error that occurs when the `latest_event_id` query parameter is set to "undefined" in the socket connection. The error was:

```
ValueError: invalid literal for int() with base 10: "undefined"
```

## Changes
- Added a try-except block to handle non-integer values for `latest_event_id`
- When an invalid value is encountered, it defaults to -1 and logs a warning

## Testing
The change is minimal and handles a specific edge case without changing the existing behavior for valid inputs.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b5f5c3d-nikolaik   --name openhands-app-b5f5c3d   docker.all-hands.dev/all-hands-ai/openhands:b5f5c3d
```