### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/prompting/microagents-overview.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/prompting/microagents-overview.md
@@ -13,7 +13,7 @@ OpenHandsがリポジトリで動作する際:
 
 1. リポジトリに`.openhands/microagents/`が存在する場合、そこからリポジトリ固有の指示を読み込みます。
 2. 会話のキーワードによってトリガーされる一般的なガイドラインを読み込みます。
-現在の[パブリックMicroagents](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents/knowledge)を参照してください。
+現在の[パブリックMicroagents](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents)を参照してください。
 
 ## Microagentのフォーマット
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/prompting/microagents-public.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/prompting/microagents-public.md
@@ -88,4 +88,4 @@ triggers:
 - ビルド時間とイメージサイズを最適化
 ```
 
-より多くの例については、[現在のパブリックマイクロエージェント](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents/knowledge)をご覧ください。
+より多くの例については、[現在のパブリックマイクロエージェント](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents)をご覧ください。

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/prompting/microagents-overview.md
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/prompting/microagents-overview.md
@@ -13,7 +13,7 @@ Quando o OpenHands trabalha com um repositório, ele:
 
 1. Carrega instruções específicas do repositório de `.openhands/microagents/`, se presentes no repositório.
 2. Carrega diretrizes gerais acionadas por palavras-chave nas conversas.
-Veja os [Microagentes Públicos](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents/knowledge) atuais.
+Veja os [Microagentes Públicos](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents) atuais.
 
 ## Formato do Microagente
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/prompting/microagents-public.md
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/prompting/microagents-public.md
@@ -4,7 +4,7 @@
 
 Microagentes públicos são diretrizes especializadas acionadas por palavras-chave para todos os usuários do OpenHands.
 Eles são definidos em arquivos markdown no diretório
-[`microagents/`](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents/knowledge).
+[`microagents/`](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents).
 
 Microagentes públicos:
 - Monitoram comandos recebidos em busca de suas palavras-chave de acionamento.
@@ -149,5 +149,5 @@ Lembre-se de:
 - Otimizar para tempo de build e tamanho da imagem
 ```
 
-Veja os [microagentes públicos atuais](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents/knowledge) para
+Veja os [microagentes públicos atuais](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents) para
 mais exemplos.

--- a/docs/modules/usage/prompting/microagents-keyword.md
+++ b/docs/modules/usage/prompting/microagents-keyword.md
@@ -46,4 +46,4 @@ Keyword-triggered microagents:
 - Apply their specialized knowledge and capabilities.
 - Follow defined guidelines and restrictions.
 
-[See examples of microagents triggered by keywords in the official OpenHands repository](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents/knowledge)
+[See examples of microagents triggered by keywords in the official OpenHands repository](https://github.com/All-Hands-AI/OpenHands/tree/main/microagents)


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

Some broken links have been corrected in the documentation.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

https://github.com/All-Hands-AI/OpenHands/tree/main/microagents/knowledge link no longer works.
Perhaps the correct url is https://github.com/All-Hands-AI/OpenHands/tree/main/microagents.

Related PR: https://github.com/All-Hands-AI/OpenHands/pull/8114/files

---
**Link of any specific issues this addresses.**
