### PR TITLE
Add trailing slash to directory paths in UI

### DIFF
--- a/frontend/src/components/features/chat/path-component.tsx
+++ b/frontend/src/components/features/chat/path-component.tsx
@@ -13,6 +13,21 @@ const decodeHtmlEntities = (text: string): string => {
 };
 
 /**
+ * Checks if a path is likely a directory
+ * @param path The full path
+ * @returns True if the path is likely a directory
+ */
+const isLikelyDirectory = (path: string): boolean => {
+  if (!path) return false;
+  // Check if path already ends with a slash
+  if (path.endsWith("/") || path.endsWith("\\")) return true;
+  // Check if path has no extension (simple heuristic)
+  const lastPart = path.split(/[/\\]/).pop() || "";
+  // If the last part has no dots or ends with a dot, it's likely a directory
+  return !lastPart.includes(".") || lastPart.endsWith(".");
+};
+
+/**
  * Extracts the filename from a path
  * @param path The full path
  * @returns The filename (last part of the path)
@@ -21,7 +36,14 @@ const extractFilename = (path: string): string => {
   if (!path) return "";
   // Handle both Unix and Windows paths
   const parts = path.split(/[/\\]/);
-  return parts[parts.length - 1];
+  const filename = parts[parts.length - 1];
+
+  // Add trailing slash for directories
+  if (isLikelyDirectory(path) && !filename.endsWith("/")) {
+    return `${filename}/`;
+  }
+
+  return filename;
 };
 
 /**


### PR DESCRIPTION
This PR adds a trailing slash to directory paths in the UI for better visibility. When displaying file paths in the frontend, directories now have a trailing slash to make it clear they are directories and not files.

Before this change, directory paths were displayed without any visual indication that they were directories. Now, directories will be displayed with a trailing slash, making it easier to distinguish them from files.

The change is implemented in the `PathComponent` by adding a heuristic function that checks if a path is likely a directory and adds a trailing slash if needed.

Old UI:

<img width="354" alt="Screenshot 2025-04-30 at 5 45 44 PM" src="https://github.com/user-attachments/assets/1c17a625-cd48-44ca-a02e-a0d8c9446dda" />

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9348411-nikolaik   --name openhands-app-9348411   docker.all-hands.dev/all-hands-ai/openhands:9348411
```