### PR TITLE
Move VSCode settings.json setup from Dockerfile to VSCode plugin initialization

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -155,8 +155,7 @@ RUN \
 
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 
-COPY ./code/openhands/runtime/plugins/vscode/settings.json /workspace/.vscode/settings.json
-RUN chmod -R a+rwx /workspace/.vscode/settings.json
+# VSCode settings.json is now handled by the VSCode plugin's initialize method
 
 {{ install_dependencies() }}
 
@@ -171,8 +170,7 @@ RUN chmod -R a+rwx /workspace/.vscode/settings.json
 RUN if [ -d /openhands/code/openhands ]; then rm -rf /openhands/code/openhands; fi
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 
-COPY ./code/openhands/runtime/plugins/vscode/settings.json /workspace/.vscode/settings.json
-RUN chmod -R a+rwx /workspace/.vscode/settings.json
+# VSCode settings.json is now handled by the VSCode plugin's initialize method
 
 COPY ./code/openhands /openhands/code/openhands
 RUN chmod a+rwx /openhands/code/openhands/__init__.py

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -155,8 +155,6 @@ RUN \
 
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 
-# VSCode settings.json is now handled by the VSCode plugin's initialize method
-
 {{ install_dependencies() }}
 
 # ================================================================
@@ -169,8 +167,6 @@ COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 # ================================================================
 RUN if [ -d /openhands/code/openhands ]; then rm -rf /openhands/code/openhands; fi
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
-
-# VSCode settings.json is now handled by the VSCode plugin's initialize method
 
 COPY ./code/openhands /openhands/code/openhands
 RUN chmod a+rwx /openhands/code/openhands/__init__.py


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**
Improves the VSCode plugin initialization by moving the settings.json setup from the Docker build process to the runtime initialization. This will help fix VSCode not adhering to settings.json in the openhands cloud environment.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**
This PR moves the VSCode settings.json setup from the Dockerfile.j2 template to the VSCode plugin initialization code. 
This change:

1. Removes the lines from the Dockerfile.j2 template that were copying the VSCode settings.json file during the build process
2. Adds a new `_setup_vscode_settings` method to the VSCodePlugin class that creates the /workspace/.vscode directory and copies the settings.json file there
3. Modifies the `initialize` method to call the new method during initialization

This approach fixes the issue in the OpenHands cloud, where the /workspace folder mount will override the .vscode/ folder in the runtime images.

---
**Link of any specific issues this addresses.**
N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f018dd4-nikolaik   --name openhands-app-f018dd4   docker.all-hands.dev/all-hands-ai/openhands:f018dd4
```