### PR TITLE
Increase conversation limit from 9 to 20

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -134,7 +134,7 @@ class OpenHands {
 
   static async getUserConversations(): Promise<Conversation[]> {
     const { data } = await openHands.get<ResultSet<Conversation>>(
-      "/api/conversations?limit=9",
+      "/api/conversations?limit=20",
     );
     return data.results;
   }


### PR DESCRIPTION
This PR increases the hard-coded limit of conversations displayed in the UI from 9 to 20, allowing users to see more of their conversation history without pagination.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0546a04-nikolaik   --name openhands-app-0546a04   docker.all-hands.dev/all-hands-ai/openhands:0546a04
```