### PR TITLE
hotifx(frontend): Respect settings form mode

### DIFF
--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -516,6 +516,47 @@ describe("Form submission", () => {
       expect(submitButton).toBeDisabled();
     });
   });
+
+  it("should clear advanced settings when saving basic settings", async () => {
+    const getSettingsSpy = vi.spyOn(OpenHands, "getSettings");
+    getSettingsSpy.mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      llm_model: "openai/gpt-4o",
+      llm_base_url: "https://api.openai.com/v1/chat/completions",
+      llm_api_key_set: true,
+      confirmation_mode: true,
+    });
+    const saveSettingsSpy = vi.spyOn(OpenHands, "saveSettings");
+    renderLlmSettingsScreen();
+
+    await screen.findByTestId("llm-settings-screen");
+    const advancedSwitch = screen.getByTestId("advanced-settings-switch");
+    await userEvent.click(advancedSwitch);
+
+    const provider = screen.getByTestId("llm-provider-input");
+    const model = screen.getByTestId("llm-model-input");
+
+    // select provider
+    await userEvent.click(provider);
+    const providerOption = screen.getByText("Anthropic");
+    await userEvent.click(providerOption);
+
+    // select model
+    await userEvent.click(model);
+    const modelOption = screen.getByText("claude-3-5-sonnet-20241022");
+    await userEvent.click(modelOption);
+
+    const submitButton = screen.getByTestId("submit-button");
+    await userEvent.click(submitButton);
+
+    expect(saveSettingsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        llm_model: "anthropic/claude-3-5-sonnet-20241022",
+        llm_base_url: "",
+        confirmation_mode: false,
+      }),
+    );
+  });
 });
 
 describe("Status toasts", () => {

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -22,6 +22,7 @@ import { useConfig } from "#/hooks/query/use-config";
 import { isCustomModel } from "#/utils/is-custom-model";
 import { LlmSettingsInputsSkeleton } from "#/components/features/settings/llm-settings/llm-settings-inputs-skeleton";
 import { KeyStatusIcon } from "#/components/features/settings/key-status-icon";
+import { DEFAULT_SETTINGS } from "#/services/settings";
 
 function LlmSettingsScreen() {
   const { t } = useTranslation();
@@ -101,6 +102,13 @@ function LlmSettingsScreen() {
       {
         LLM_MODEL: fullLlmModel,
         llm_api_key: apiKey || null,
+
+        // reset advanced settings
+        LLM_BASE_URL: DEFAULT_SETTINGS.LLM_BASE_URL,
+        AGENT: DEFAULT_SETTINGS.AGENT,
+        CONFIRMATION_MODE: DEFAULT_SETTINGS.CONFIRMATION_MODE,
+        SECURITY_ANALYZER: DEFAULT_SETTINGS.SECURITY_ANALYZER,
+        ENABLE_DEFAULT_CONDENSER: DEFAULT_SETTINGS.ENABLE_DEFAULT_CONDENSER,
       },
       {
         onSuccess: handleSuccessfulMutation,
@@ -126,7 +134,7 @@ function LlmSettingsScreen() {
       {
         LLM_MODEL: model,
         LLM_BASE_URL: baseUrl,
-        llm_api_key: apiKey,
+        llm_api_key: apiKey || null,
         AGENT: agent,
         CONFIRMATION_MODE: confirmationMode,
         ENABLE_DEFAULT_CONDENSER: enableDefaultCondenser,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
If the user was in advanced mode (e.g., they had set a base URL), switched to basic, and saved changes, their changes would be applied but still in advanced mode.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Ensure advanced settings are set to defaults when switching back to basic

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3346d34-nikolaik   --name openhands-app-3346d34   docker.all-hands.dev/all-hands-ai/openhands:3346d34
```