### PR TITLE
Fix websocket error message handling

### DIFF
--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -152,7 +152,7 @@ export function handleAssistantMessage(message: Record<string, unknown>) {
     handleObservationMessage(message as unknown as ObservationMessage);
   } else if (message.status_update) {
     handleStatusMessage(message as unknown as StatusMessage);
-  } else if (message.error === true && typeof message.message === 'string') {
+  } else if (message.error) {
     // Handle error messages from the server
     trackError({
       message: message.message,

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -152,6 +152,18 @@ export function handleAssistantMessage(message: Record<string, unknown>) {
     handleObservationMessage(message as unknown as ObservationMessage);
   } else if (message.status_update) {
     handleStatusMessage(message as unknown as StatusMessage);
+  } else if (message.error === true && typeof message.message === 'string') {
+    // Handle error messages from the server
+    trackError({
+      message: message.message,
+      source: "websocket",
+      metadata: { raw_message: message },
+    });
+    store.dispatch(
+      addErrorMessage({
+        message: message.message,
+      }),
+    );
   } else {
     const errorMsg = "Unknown message type received";
     trackError({

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -154,14 +154,18 @@ export function handleAssistantMessage(message: Record<string, unknown>) {
     handleStatusMessage(message as unknown as StatusMessage);
   } else if (message.error) {
     // Handle error messages from the server
+    const errorMessage =
+      typeof message.message === "string"
+        ? message.message
+        : String(message.message || "Unknown error");
     trackError({
-      message: message.message,
+      message: errorMessage,
       source: "websocket",
       metadata: { raw_message: message },
     });
     store.dispatch(
       addErrorMessage({
-        message: message.message,
+        message: errorMessage,
       }),
     );
   } else {


### PR DESCRIPTION
## Description
Fixes a regression where websocket messages with `{error: true, message: "..."}` format were not being properly handled, resulting in "unknown message type received" errors instead of displaying the actual error message.

## Changes
- Added a specific handler in `handleAssistantMessage` to check for messages with `error: true` property and display the error message to the user.

## Testing
Built and verified that the frontend code compiles successfully.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:eab4eb2-nikolaik   --name openhands-app-eab4eb2   docker.all-hands.dev/all-hands-ai/openhands:eab4eb2
```