### PR TITLE
Fixing bug #8214 -ImportError During pip install --upgrade pip on Github Actions

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -88,6 +88,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade pip
 
       - name: Get latest versions and create requirements.txt
         run: |
@@ -225,11 +228,11 @@ jobs:
             // Perform package installation
             if (isExperimentalLabel || isIssueCommentExperimental || isReviewCommentExperimental) {
               console.log("Installing experimental OpenHands...");
-              await exec.exec("python -m pip install --upgrade pip");
+              
               await exec.exec("pip install git+https://github.com/all-hands-ai/openhands.git");
             } else {
               console.log("Installing from requirements.txt...");
-              await exec.exec("python -m pip install --upgrade pip");
+              
               await exec.exec("pip install -r /tmp/requirements.txt");
             }
 


### PR DESCRIPTION
to resolve bug #8214 

- [ ]  Modified `openhands-resolver.yml` file
- [ ] Added a task to upgrade pip just after the `python` setup task
- [ ] Removed the upgrade pip in the `Install Openhands` step


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Trying to upgrade the pre-installed python environment's pip on github actions runner
---
**Link of any specific issues this addresses:**
#8214 
