### PR TITLE
Fix settings tab clickable area by extending it beyond just the text

### DIFF
--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -67,7 +67,7 @@ function SettingsScreen() {
             to={to}
             className={({ isActive }) =>
               cn(
-                "border-b-2 border-transparent py-2.5 px-4 min-w-[80px] flex items-center justify-center",
+                "border-b-2 border-transparent py-2.5 px-4 min-w-[40px] flex items-center justify-center",
                 isActive && "border-primary",
               )
             }

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -58,7 +58,7 @@ function SettingsScreen() {
 
       <nav
         data-testid="settings-navbar"
-        className="flex items-end gap-12 px-9 border-b border-tertiary"
+        className="flex items-end gap-6 px-9 border-b border-tertiary"
       >
         {navItems.map(({ to, text }) => (
           <NavLink

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -67,12 +67,12 @@ function SettingsScreen() {
             to={to}
             className={({ isActive }) =>
               cn(
-                "border-b-2 border-transparent py-2.5",
+                "border-b-2 border-transparent py-2.5 px-4 min-w-[80px] flex items-center justify-center",
                 isActive && "border-primary",
               )
             }
           >
-            <ul className="text-[#F9FBFE] text-sm">{text}</ul>
+            <span className="text-[#F9FBFE] text-sm">{text}</span>
           </NavLink>
         ))}
       </nav>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Improve the display of settings' tab

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes the issue where the settings page tabs have a very small clickable area limited to just the text.

## Problem
When the text in a settings tab is too narrow, users have difficulty clicking on it to switch tabs because the clickable area is limited to just the text itself.

![image](https://github.com/user-attachments/assets/e0cd868b-6f38-49a2-82d0-5890bbc64e4c)


## Solution
Extended the clickable area of each tab by:
1. Adding horizontal padding (px-4)
2. Setting a minimum width (min-w-[80px])
3. Using flex layout to center the text
4. Replacing the ul element with a more semantically correct span

These changes ensure that each tab has a sufficient clickable area regardless of the text length, improving the user experience.


Clickable area is bigger after this tweak
![image](https://github.com/user-attachments/assets/2380d851-4389-43fa-80d4-17d1bfe79ee8)


## Changes Made
Modified the NavLink component in settings.tsx to:
- Add padding (px-4)
- Set minimum width (min-w-[40px])
- Use flex layout for proper centering
- Replace ul with span element

## Testing
The changes can be tested by:
1. Navigate to the settings page
2. Verify that the entire tab area is clickable, not just the text
3. Confirm that tabs with short text still have a reasonable clickable area

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8aa7c04-nikolaik   --name openhands-app-8aa7c04   docker.all-hands.dev/all-hands-ai/openhands:8aa7c04
```