### PR TITLE
Fix VS Code iframe reload issue

### DIFF
--- a/frontend/src/components/layout/tab-content.tsx
+++ b/frontend/src/components/layout/tab-content.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { useLocation } from "react-router";
+import { lazy, Suspense } from "react";
+import { LoadingSpinner } from "../shared/loading-spinner";
+import { VSCodeProvider } from "../../routes/vscode-tab";
+
+// Lazy load all tab components
+const EditorTab = lazy(() => import("../../routes/editor"));
+const BrowserTab = lazy(() => import("../../routes/browser-tab"));
+const JupyterTab = lazy(() => import("../../routes/jupyter-tab"));
+const ServedTab = lazy(() => import("../../routes/served-tab"));
+const TerminalTab = lazy(() => import("../../routes/terminal-tab"));
+const VSCodeTab = lazy(() => import("../../routes/vscode-tab"));
+
+interface TabContentProps {
+  conversationPath: string;
+}
+
+export function TabContent({ conversationPath }: TabContentProps) {
+  const location = useLocation();
+  const currentPath = location.pathname;
+  
+  // Determine which tab is active based on the current path
+  const isEditorActive = currentPath === conversationPath;
+  const isBrowserActive = currentPath === `${conversationPath}/browser`;
+  const isJupyterActive = currentPath === `${conversationPath}/jupyter`;
+  const isServedActive = currentPath === `${conversationPath}/served`;
+  const isTerminalActive = currentPath === `${conversationPath}/terminal`;
+  const isVSCodeActive = currentPath === `${conversationPath}/vscode`;
+
+  return (
+    <VSCodeProvider>
+      <div className="h-full w-full relative">
+        {/* Each tab content is always loaded but only visible when active */}
+        <Suspense fallback={<div className="flex items-center justify-center h-full"><LoadingSpinner /></div>}>
+          <div className={`absolute inset-0 ${isEditorActive ? 'block' : 'hidden'}`}>
+            <EditorTab />
+          </div>
+          <div className={`absolute inset-0 ${isBrowserActive ? 'block' : 'hidden'}`}>
+            <BrowserTab />
+          </div>
+          <div className={`absolute inset-0 ${isJupyterActive ? 'block' : 'hidden'}`}>
+            <JupyterTab />
+          </div>
+          <div className={`absolute inset-0 ${isServedActive ? 'block' : 'hidden'}`}>
+            <ServedTab />
+          </div>
+          <div className={`absolute inset-0 ${isTerminalActive ? 'block' : 'hidden'}`}>
+            <TerminalTab />
+          </div>
+          <div className={`absolute inset-0 ${isVSCodeActive ? 'block' : 'hidden'}`}>
+            <VSCodeTab />
+          </div>
+        </Suspense>
+      </div>
+    </VSCodeProvider>
+  );
+}

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@heroui/react";
 import React from "react";
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 import { useDispatch, useSelector } from "react-redux";
 import { FaServer, FaExternalLinkAlt } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
@@ -41,6 +41,7 @@ import { RootState } from "#/store";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { useDocumentTitleFromState } from "#/hooks/use-document-title-from-state";
 import { transformVSCodeUrl } from "#/utils/vscode-url-helper";
+import { TabContent } from "#/components/layout/tab-content";
 
 function AppContent() {
   useConversationConfig();
@@ -113,6 +114,9 @@ function AppContent() {
   } = useDisclosure();
 
   function renderMain() {
+    const location = useLocation();
+    const basePath = `/conversations/${conversationId}`;
+    
     if (width <= 640) {
       return (
         <div className="rounded-xl overflow-hidden border border-neutral-600 w-full bg-base-secondary">
@@ -197,7 +201,15 @@ function AppContent() {
               },
             ]}
           >
-            <Outlet />
+            {/* Use both Outlet and TabContent */}
+            <div className="h-full w-full">
+              {/* Keep the Outlet for React Router to work properly */}
+              <div className="hidden">
+                <Outlet />
+              </div>
+              {/* Use TabContent to keep all tabs loaded but only show the active one */}
+              <TabContent conversationPath={basePath} />
+            </div>
           </Container>
         }
       />


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR fixes an issue with the VS Code tab in the OpenHands UI where the iframe would reload every time a user switched to or from the tab. Now, the VS Code iframe stays loaded in the background, eliminating the waiting time when switching tabs.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR implements a new approach to tab management in the frontend:

1. Created a new TabContent component that keeps all tab content loaded but only displays the active one
2. Implemented a VSCodeProvider context to manage the VS Code URL state globally
3. Modified the conversation component to use the new TabContent approach while maintaining compatibility with React Router

Design decisions:
- Used React Context to share the VS Code URL state across components
- Kept the Outlet component hidden but present to maintain React Router functionality
- Used absolute positioning with display:none/block to toggle visibility without unmounting components

This approach ensures that the VS Code iframe remains loaded in the DOM even when not visible, eliminating the reload delay when switching tabs.

---
**Link of any specific issues this addresses:**

N/A