### PR TITLE
chore: add MCP doc to sidebar

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -215,6 +215,11 @@ const sidebars: SidebarsConfig = {
           label: 'Custom Sandbox',
           id: 'usage/how-to/custom-sandbox-guide',
         },
+        {
+          type: 'doc',
+          label: 'MCP',
+          id: 'usage/mcp',
+        }
       ],
     },
     {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Currently the MCP documentation is not shown in the sidebar of OH doc. This PR adds it under "Advanced Configuration":
<img width="200" alt="Screenshot 2025-05-04 at 15 25 29" src="https://github.com/user-attachments/assets/34147755-6f8f-43ad-a1ca-8d575bb80600" />

---
**Link of any specific issues this addresses:**
