### PR TITLE
refactor: Refactor CLI agent output display order and verbiage

### DIFF
--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import sys
+import threading
 import time
 
 from prompt_toolkit import PromptSession, print_formatted_text
@@ -63,6 +64,8 @@ COMMANDS = {
     '/settings': 'Display and modify current settings',
     '/resume': 'Resume the agent when paused',
 }
+
+print_lock = threading.Lock()
 
 
 class UsageMetrics:
@@ -164,28 +167,28 @@ def display_initial_user_prompt(prompt: str):
 
 # Prompt output display functions
 def display_event(event: Event, config: AppConfig) -> None:
-    if isinstance(event, Action):
-        if hasattr(event, 'thought'):
-            display_message(event.thought)
-    if isinstance(event, MessageAction):
-        if event.source == EventSource.AGENT:
-            display_message(event.content)
-    if isinstance(event, CmdRunAction):
-        display_command(event)
-    if isinstance(event, CmdOutputObservation):
-        display_command_output(event.content)
-    if isinstance(event, FileEditAction):
-        display_file_edit(event)
-    if isinstance(event, FileEditObservation):
-        display_file_edit(event)
-    if isinstance(event, FileReadObservation):
-        display_file_read(event)
-    if isinstance(event, AgentStateChangedObservation):
-        display_agent_paused_message(event.agent_state)
+    with print_lock:
+        if isinstance(event, Action):
+            if hasattr(event, 'thought'):
+                display_message(event.thought)
+        if isinstance(event, MessageAction):
+            if event.source == EventSource.AGENT:
+                display_message(event.content)
+        if isinstance(event, CmdRunAction):
+            display_command(event)
+        if isinstance(event, CmdOutputObservation):
+            display_command_output(event.content)
+        if isinstance(event, FileEditAction):
+            display_file_edit(event)
+        if isinstance(event, FileEditObservation):
+            display_file_edit(event)
+        if isinstance(event, FileReadObservation):
+            display_file_read(event)
+        if isinstance(event, AgentStateChangedObservation):
+            display_agent_paused_message(event.agent_state)
 
 
 def display_message(message: str):
-    time.sleep(0.2)
     message = message.strip()
 
     if message:
@@ -248,6 +251,7 @@ def display_file_edit(event: FileEditAction | FileEditObservation):
             title='File Edit',
             style=f'fg:{COLOR_GREY}',
         )
+        print_formatted_text('')
         print_container(container)
 
 
@@ -262,6 +266,7 @@ def display_file_read(event: FileReadObservation):
         title='File Read',
         style=f'fg:{COLOR_GREY}',
     )
+    print_formatted_text('')
     print_container(container)
 
 

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -58,8 +58,8 @@ COMMANDS = {
     '/exit': 'Exit the application',
     '/help': 'Display available commands',
     '/init': 'Initialize a new repository',
-    '/status': 'Display session details and usage metrics',
-    '/new': 'Create a new session',
+    '/status': 'Display conversation details and usage metrics',
+    '/new': 'Create a new conversation',
     '/settings': 'Display and modify current settings',
     '/resume': 'Resume the agent when paused',
 }
@@ -136,7 +136,7 @@ def display_banner(session_id: str):
     print_formatted_text(HTML(f'<grey>OpenHands CLI v{__version__}</grey>'))
 
     print_formatted_text('')
-    print_formatted_text(HTML(f'<grey>Initialized session {session_id}</grey>'))
+    print_formatted_text(HTML(f'<grey>Initialized conversation {session_id}</grey>'))
     print_formatted_text('')
 
 
@@ -374,13 +374,13 @@ def get_session_duration(session_init_time: float) -> str:
 def display_shutdown_message(usage_metrics: UsageMetrics, session_id: str):
     duration_str = get_session_duration(usage_metrics.session_init_time)
 
-    print_formatted_text(HTML('<grey>Closing current session...</grey>'))
+    print_formatted_text(HTML('<grey>Closing current conversation...</grey>'))
     print_formatted_text('')
     display_usage_metrics(usage_metrics)
     print_formatted_text('')
-    print_formatted_text(HTML(f'<grey>Session duration: {duration_str}</grey>'))
+    print_formatted_text(HTML(f'<grey>Conversation duration: {duration_str}</grey>'))
     print_formatted_text('')
-    print_formatted_text(HTML(f'<grey>Closed session {session_id}</grey>'))
+    print_formatted_text(HTML(f'<grey>Closed conversation {session_id}</grey>'))
     print_formatted_text('')
 
 
@@ -388,8 +388,8 @@ def display_status(usage_metrics: UsageMetrics, session_id: str):
     duration_str = get_session_duration(usage_metrics.session_init_time)
 
     print_formatted_text('')
-    print_formatted_text(HTML(f'<grey>Session ID: {session_id}</grey>'))
-    print_formatted_text(HTML(f'<grey>Uptime:     {duration_str}</grey>'))
+    print_formatted_text(HTML(f'<grey>Conversation ID: {session_id}</grey>'))
+    print_formatted_text(HTML(f'<grey>Uptime:          {duration_str}</grey>'))
     print_formatted_text('')
     display_usage_metrics(usage_metrics)
 

--- a/tests/unit/test_cli_tui.py
+++ b/tests/unit/test_cli_tui.py
@@ -60,7 +60,7 @@ class TestDisplayFunctions:
         # Check the last call has the session ID
         args, kwargs = mock_print.call_args_list[-2]
         assert session_id in str(args[0])
-        assert 'Initialized session' in str(args[0])
+        assert 'Initialized conversation' in str(args[0])
 
     @patch('openhands.cli.tui.print_formatted_text')
     def test_display_welcome_message(self, mock_print):

--- a/tests/unit/test_cli_tui.py
+++ b/tests/unit/test_cli_tui.py
@@ -135,13 +135,11 @@ class TestDisplayFunctions:
 
         mock_display_message.assert_called_once_with('Thinking about this...')
 
-    @patch('openhands.cli.tui.time.sleep')
     @patch('openhands.cli.tui.print_formatted_text')
-    def test_display_message(self, mock_print, mock_sleep):
+    def test_display_message(self, mock_print):
         message = 'Test message'
         display_message(message)
 
-        mock_sleep.assert_called_once_with(0.2)
         mock_print.assert_called_once()
         args, kwargs = mock_print.call_args
         assert message in str(args[0])


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

- Improve the order in which agent output is printed in the CLI
- Rename 'session' to 'conversation' for consistent terminology

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Adds a lock in the `display_event` function to ensure agent events are printed in the order they are received.

---
**Link of any specific issues this addresses:**
