### PR TITLE
Move cloud resolver summary prompt to templates folder

### DIFF
--- a/openhands/integrations/templates/resolver/summary_prompt.j2
+++ b/openhands/integrations/templates/resolver/summary_prompt.j2
@@ -1,0 +1,5 @@
+Please summarize your work.
+ 
+If you answered a question, please re-state the answer to the question
+If you made changes, please create a concise overview on whether the request has been addressed successfully or if there are were issues with the attempt.
+If successful, make sure your changes are pushed to the remote branch.


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

In the past we moved all the cloud resolver prompts to this repo. We missed the summary prompt

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0f85323-nikolaik   --name openhands-app-0f85323   docker.all-hands.dev/all-hands-ai/openhands:0f85323
```