### PR TITLE
[feature] add optional extended field to agent config

### DIFF
--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel, Field, ValidationError
 
 from openhands.core.config.condenser_config import CondenserConfig, NoOpCondenserConfig
+from openhands.core.config.extended_config import ExtendedConfig
 from openhands.core.logger import openhands_logger as logger
 
 
@@ -34,6 +35,8 @@ class AgentConfig(BaseModel):
     condenser: CondenserConfig = Field(
         default_factory=lambda: NoOpCondenserConfig(type='noop')
     )
+    extended: ExtendedConfig = Field(default_factory=lambda: ExtendedConfig({}))
+    """Extended configuration for the agent."""
 
     model_config = {'extra': 'forbid'}
 


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Added support optional `extended` property to agent configuration, for implementations that require additional config not in the default schema.
For example:

```toml
[agents.CustomAgent.extended]
foo = "bar"
```

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This is the minimal change to get some customizability in agent configuration. However, longer term I would love to have support for custom config schemas too, similar to how the `AgentConfig.condenser` supports a union of different config types for different condensers.

In particular, I would propose having the Agent class include a class-level attribute (e.g. `Agent.config_class = AgentConfig`) that can be overridden in derived implementations, and then the config loader will chose the appropriate config schema at loading time. If the maintainers are open to this more structured approach, I'd be happy to contribute a PR. I don't believe it negates the usefulness of the unstructured `extended` field, though.