### PR TITLE
Add return type annotations to methods in session directory

### DIFF
--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -58,7 +58,7 @@ class AgentSession:
         file_store: FileStore,
         status_callback: Callable | None = None,
         user_id: str | None = None,
-    ):
+    ) -> None:
         """Initializes a new instance of the Session class
 
         Parameters:

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -89,7 +89,7 @@ class AgentSession:
         selected_branch: str | None = None,
         initial_message: MessageAction | None = None,
         replay_json: str | None = None,
-    ):
+    ) -> None:
         """Starts the Agent session
         Parameters:
         - runtime_name: The name of the runtime associated with the session
@@ -188,7 +188,7 @@ class AgentSession:
                 },
             )
 
-    async def close(self):
+    async def close(self) -> None:
         """Closes the Agent session"""
         if self._closed:
             return
@@ -245,7 +245,7 @@ class AgentSession:
         assert isinstance(replay_events[0], MessageAction)
         return replay_events[0]
 
-    def _create_security_analyzer(self, security_analyzer: str | None):
+    def _create_security_analyzer(self, security_analyzer: str | None) -> None:
         """Creates a SecurityAnalyzer instance that will be used to analyze the agent actions
 
         Parameters:

--- a/openhands/server/session/conversation.py
+++ b/openhands/server/session/conversation.py
@@ -38,10 +38,10 @@ class Conversation:
             headless_mode=False,
         )
 
-    async def connect(self):
+    async def connect(self) -> None:
         await self.runtime.connect()
 
-    async def disconnect(self):
+    async def disconnect(self) -> None:
         if self.event_stream:
             self.event_stream.close()
         asyncio.create_task(call_sync_from_async(self.runtime.close))

--- a/openhands/server/session/conversation.py
+++ b/openhands/server/session/conversation.py
@@ -18,7 +18,7 @@ class Conversation:
 
     def __init__(
         self, sid: str, file_store: FileStore, config: AppConfig, user_id: str | None
-    ):
+    ) -> None:
         self.sid = sid
         self.config = config
         self.file_store = file_store

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -73,7 +73,7 @@ class Session:
         self.loop = asyncio.get_event_loop()
         self.user_id = user_id
 
-    async def close(self):
+    async def close(self) -> None:
         if self.sio:
             await self.sio.emit(
                 'oh_event',
@@ -90,7 +90,7 @@ class Session:
         settings: Settings,
         initial_message: MessageAction | None,
         replay_json: str | None,
-    ):
+    ) -> None:
         self.agent_session.event_stream.add_event(
             AgentStateChangedObservation('', AgentState.LOADING),
             EventSource.ENVIRONMENT,
@@ -194,10 +194,10 @@ class Session:
             'info', msg_id, f'Retrying LLM request, {retries} / {max}'
         )
 
-    def on_event(self, event: Event):
+    def on_event(self, event: Event) -> None:
         asyncio.get_event_loop().run_until_complete(self._on_event(event))
 
-    async def _on_event(self, event: Event):
+    async def _on_event(self, event: Event) -> None:
         """Callback function for events that mainly come from the agent.
         Event is the base class for any agent action and observation.
 
@@ -235,7 +235,7 @@ class Session:
             event_dict['source'] = EventSource.AGENT
             await self.send(event_dict)
 
-    async def dispatch(self, data: dict):
+    async def dispatch(self, data: dict) -> None:
         event = event_from_dict(data.copy())
         # This checks if the model supports images
         if isinstance(event, MessageAction) and event.image_urls:
@@ -253,7 +253,7 @@ class Session:
                     return
         self.agent_session.event_stream.add_event(event, EventSource.USER)
 
-    async def send(self, data: dict[str, object]):
+    async def send(self, data: dict[str, object]) -> None:
         if asyncio.get_running_loop() != self.loop:
             self.loop.create_task(self._send(data))
             return
@@ -273,11 +273,11 @@ class Session:
             self.is_alive = False
             return False
 
-    async def send_error(self, message: str):
+    async def send_error(self, message: str) -> None:
         """Sends an error message to the client."""
         await self.send({'error': True, 'message': message})
 
-    async def _send_status_message(self, msg_type: str, id: str, message: str):
+    async def _send_status_message(self, msg_type: str, id: str, message: str) -> None:
         """Sends a status message to the client."""
         if msg_type == 'error':
             agent_session = self.agent_session
@@ -292,7 +292,7 @@ class Session:
             {'status_update': True, 'type': msg_type, 'id': id, 'message': message}
         )
 
-    def queue_status_message(self, msg_type: str, id: str, message: str):
+    def queue_status_message(self, msg_type: str, id: str, message: str) -> None:
         """Queues a status message to be sent asynchronously."""
         asyncio.run_coroutine_threadsafe(
             self._send_status_message(msg_type, id, message), self.loop

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -53,7 +53,7 @@ class Session:
         file_store: FileStore,
         sio: socketio.AsyncServer | None,
         user_id: str | None = None,
-    ):
+    ) -> None:
         self.sid = sid
         self.sio = sio
         self.last_active_ts = int(time.time())


### PR DESCRIPTION
This PR adds return type annotations to methods in the openhands/server/session directory to comply with strict mypy checks. The changes are focused only on the session directory as requested.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:961ea97-nikolaik   --name openhands-app-961ea97   docker.all-hands.dev/all-hands-ai/openhands:961ea97
```