### PR TITLE
add list support in setting attributes from env variables

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -88,8 +88,8 @@ def load_from_env(
                     # Attempt to cast the env var to type hinted in the dataclass
                     if field_type is bool:
                         cast_value = str(value).lower() in ['true', '1']
-                    # parse dicts like SANDBOX_RUNTIME_STARTUP_ENV_VARS
-                    elif get_origin(field_type) is dict:
+                    # parse dicts and lists like SANDBOX_RUNTIME_STARTUP_ENV_VARS and SANDBOX_RUNTIME_EXTRA_BUILD_ARGS                                                                                                                                     │
+                    elif get_origin(field_type) is dict or get_origin(field_type) is list: 
                         cast_value = literal_eval(value)
                     else:
                         if field_type is not None:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
When passing extra build-args for the sandbox image build via environment variables I was getting a parsing error
export SANDBOX_RUNTIME_EXTRA_BUILD_ARGS='[
"--add-host=host.docker.internal:host-gateway",
"--build-arg=https_proxy=https://myproxy:912",
"--build-arg=http_proxy=https://myproxy:912",
"--build-arg=no_proxy=localhost,127.0.0.1,host.docker.internal"
]'

```
08:17:57 - openhands:ERROR: docker.py:197 - Command output:                                                                                                                                                                                                                                                                                                                                                                               
An error occurred: Command '['docker', 'buildx', 'build', '--progress=plain', '--build-arg=OPENHANDS_RUNTIME_VERSION=0.36.0', '--build-arg=OPENHANDS_RUNTIME_BUILD_TIME=2025-05-06T08:17:57.223150', '--tag=ghcr.io/all-hands-ai/runtime:oh_v0.36.0_nc7i6aoib35e
t328_3sh7uu287j1yn9c9', '--load', '[', '\n', ' ', ' ', '"', '-', '-', 'a', 'd', 'd', '-', 'h', 'o', 's', 't', '=', 'h', 'o', 's', 't', '.', 'd', 'o', 'c', 'k', 'e', 'r', '.', 'i', 'n', 't', 'e', 'r', 'n', 'a', 'l', ':', 'h', 'o', 's', 't', '-', 'g', 'a', '
t', 'e', 'w', 'a', 'y', '"', ',', '\n', ' ', ' ', '"', '-', '-', 'b', 'u', 'i', 'l', 'd', '-', 'a', 'r', 'g', '=', 'h', 't', 't', 'p', 's', '_', 'p', 'r', 'o', 'x', 'y', '=', 'h', 't', 't', 'p', 's', ':', '/', '/', [...]', '"', '\n', ']', '/tmp/tmpcz16szwj']' returned non-zero exit status 1.
```

The `config.toml`  approach was working fine with:
`runtime_extra_build_args = ["--add-host=host.docker.internal:host-gateway", "--build-arg=https_proxy=https://myproxy:912", "--build-arg=https_proxy=https://myproxy:912", "--build-arg=no_proxy=localhost,127.0.0.1,host.docker.internal"]`

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Added support to parse lists (in addition to dict) in environment variables like SANDBOX_RUNTIME_EXTRA_BUILD_ARGS. [docker.py](https://github.com/All-Hands-AI/OpenHands/blob/4c1ae6fd8da5c2280cfbfe8f6a4a2fcd92cb644d/openhands/runtime/builder/docker.py#L66) expects extra_build_args as list

---
**Link of any specific issues this addresses:**
https://github.com/All-Hands-AI/OpenHands/issues/8016