### PR TITLE
feature: Add CLI support for `always` confirm mode

### DIFF
--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -185,7 +185,7 @@ def display_event(event: Event, config: AppConfig) -> None:
         if isinstance(event, FileReadObservation):
             display_file_read(event)
         if isinstance(event, AgentStateChangedObservation):
-            display_agent_paused_message(event.agent_state)
+            display_agent_state_change_message(event.agent_state)
 
 
 def display_message(message: str):
@@ -406,13 +406,20 @@ def display_agent_running_message():
     )
 
 
-def display_agent_paused_message(agent_state: str):
-    if agent_state != AgentState.PAUSED:
-        return
-    print_formatted_text('')
-    print_formatted_text(
-        HTML('<gold>Agent paused...</gold> <grey>(Enter /resume to continue)</grey>')
-    )
+def display_agent_state_change_message(agent_state: str):
+    if agent_state == AgentState.PAUSED:
+        print_formatted_text('')
+        print_formatted_text(
+            HTML(
+                '<gold>Agent paused...</gold> <grey>(Enter /resume to continue)</grey>'
+            )
+        )
+    elif agent_state == AgentState.FINISHED:
+        print_formatted_text('')
+        print_formatted_text(HTML('<gold>Task completed...</gold>'))
+    elif agent_state == AgentState.AWAITING_USER_INPUT:
+        print_formatted_text('')
+        print_formatted_text(HTML('<gold>Agent is waiting for your input...</gold>'))
 
 
 # Common input functions

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -486,20 +486,28 @@ async def read_prompt_input(agent_state: str, multiline=False):
         return '/exit'
 
 
-async def read_confirmation_input() -> bool:
+async def read_confirmation_input() -> str:
     try:
         prompt_session = create_prompt_session()
 
         with patch_stdout():
             print_formatted_text('')
             confirmation: str = await prompt_session.prompt_async(
-                HTML('<gold>Proceed with action? (y)es/(n)o > </gold>'),
+                HTML('<gold>Proceed with action? (y)es/(n)o/(a)lways > </gold>'),
             )
 
             confirmation = '' if confirmation is None else confirmation.strip().lower()
-            return confirmation in ['y', 'yes']
+
+            if confirmation in ['y', 'yes']:
+                return 'yes'
+            elif confirmation in ['n', 'no']:
+                return 'no'
+            elif confirmation in ['a', 'always']:
+                return 'always'
+            else:
+                return 'no'
     except (KeyboardInterrupt, EOFError):
-        return False
+        return 'no'
 
 
 async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) -> None:

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -507,7 +507,11 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
 
     def keys_ready():
         for key_press in input.read_keys():
-            if key_press.key == Keys.ControlP:
+            if (
+                key_press.key == Keys.ControlP
+                or key_press.key == Keys.ControlC
+                or key_press.key == Keys.ControlD
+            ):
                 print_formatted_text('')
                 print_formatted_text(HTML('<gold>Pausing the agent...</gold>'))
                 event_stream.add_event(

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -256,9 +256,10 @@ def display_file_edit(event: FileEditAction | FileEditObservation):
 
 
 def display_file_read(event: FileReadObservation):
+    content = event.content.replace('\t', ' ')
     container = Frame(
         TextArea(
-            text=f'{event}',
+            text=content,
             read_only=True,
             style=COLOR_GREY,
             wrap_lines=True,

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -32,7 +32,6 @@ from openhands.events.action import (
     ActionConfirmationStatus,
     ChangeAgentStateAction,
     CmdRunAction,
-    FileEditAction,
     MessageAction,
 )
 from openhands.events.event import Event
@@ -171,6 +170,8 @@ def display_event(event: Event, config: AppConfig) -> None:
         if isinstance(event, Action):
             if hasattr(event, 'thought'):
                 display_message(event.thought)
+            if hasattr(event, 'final_thought'):
+                display_message(event.final_thought)
         if isinstance(event, MessageAction):
             if event.source == EventSource.AGENT:
                 display_message(event.content)
@@ -178,8 +179,6 @@ def display_event(event: Event, config: AppConfig) -> None:
             display_command(event)
         if isinstance(event, CmdOutputObservation):
             display_command_output(event.content)
-        if isinstance(event, FileEditAction):
-            display_file_edit(event)
         if isinstance(event, FileEditObservation):
             display_file_edit(event)
         if isinstance(event, FileReadObservation):
@@ -239,20 +238,19 @@ def display_command_output(output: str):
     print_container(container)
 
 
-def display_file_edit(event: FileEditAction | FileEditObservation):
-    if isinstance(event, FileEditObservation):
-        container = Frame(
-            TextArea(
-                text=event.visualize_diff(n_context_lines=4),
-                read_only=True,
-                wrap_lines=True,
-                lexer=CustomDiffLexer(),
-            ),
-            title='File Edit',
-            style=f'fg:{COLOR_GREY}',
-        )
-        print_formatted_text('')
-        print_container(container)
+def display_file_edit(event: FileEditObservation):
+    container = Frame(
+        TextArea(
+            text=event.visualize_diff(n_context_lines=4),
+            read_only=True,
+            wrap_lines=True,
+            lexer=CustomDiffLexer(),
+        ),
+        title='File Edit',
+        style=f'fg:{COLOR_GREY}',
+    )
+    print_formatted_text('')
+    print_container(container)
 
 
 def display_file_read(event: FileReadObservation):

--- a/tests/unit/test_cli_tui.py
+++ b/tests/unit/test_cli_tui.py
@@ -24,7 +24,6 @@ from openhands.events.action import (
     Action,
     ActionConfirmationStatus,
     CmdRunAction,
-    FileEditAction,
     MessageAction,
 )
 from openhands.events.observation import (
@@ -100,15 +99,6 @@ class TestDisplayFunctions:
         display_event(cmd_output, config)
 
         mock_display_output.assert_called_once_with('Test output')
-
-    @patch('openhands.cli.tui.display_file_edit')
-    def test_display_event_file_edit_action(self, mock_display_file_edit):
-        config = MagicMock(spec=AppConfig)
-        file_edit = FileEditAction(path='test.py', content="print('hello')")
-
-        display_event(file_edit, config)
-
-        mock_display_file_edit.assert_called_once_with(file_edit)
 
     @patch('openhands.cli.tui.display_file_edit')
     def test_display_event_file_edit_observation(self, mock_display_file_edit):

--- a/tests/unit/test_cli_tui.py
+++ b/tests/unit/test_cli_tui.py
@@ -1,4 +1,6 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
 
 from openhands.cli.tui import (
     CustomDiffLexer,
@@ -14,6 +16,7 @@ from openhands.cli.tui import (
     display_usage_metrics,
     display_welcome_message,
     get_session_duration,
+    read_confirmation_input,
 )
 from openhands.core.config import AppConfig
 from openhands.events import EventSource
@@ -259,3 +262,117 @@ class TestUserCancelledError:
     def test_user_cancelled_error(self):
         error = UserCancelledError()
         assert isinstance(error, Exception)
+
+
+class TestReadConfirmationInput:
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_yes(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = 'y'
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'yes'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_yes_full(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = 'yes'
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'yes'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_no(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = 'n'
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'no'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_no_full(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = 'no'
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'no'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_always(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = 'a'
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'always'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_always_full(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = 'always'
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'always'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_invalid(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = 'invalid'
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'no'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_empty(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = ''
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'no'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_none(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.return_value = None
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'no'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_keyboard_interrupt(
+        self, mock_create_session
+    ):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.side_effect = KeyboardInterrupt
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'no'
+
+    @pytest.mark.asyncio
+    @patch('openhands.cli.tui.create_prompt_session')
+    async def test_read_confirmation_input_eof_error(self, mock_create_session):
+        mock_session = AsyncMock()
+        mock_session.prompt_async.side_effect = EOFError
+        mock_create_session.return_value = mock_session
+
+        result = await read_confirmation_input()
+        assert result == 'no'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Introduce an `always` option for confirmation mode that, when selected, bypasses future confirmation prompts for agent actions within the current conversation.
- Minor visual and usability improvements.


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Implement an always option within the confirmation mode feature. If a user chooses this option, all subsequent actions initiated by the agent will be automatically confirmed for the duration of that conversation.
- Improve clarity on agent state changes by showing more messages.
- Improve the readability of `FileRead` action output by removing ^I characters.
- Enable Ctrl-C and Ctrl-D to function as agent pause shortcuts.
- Display agent `final_thought` if available.

---
**Link of any specific issues this addresses:**

n/a
