### PR TITLE
Revert Python file changes from PR #6397

### DIFF
--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -58,7 +58,7 @@ class AgentSession:
         file_store: FileStore,
         status_callback: Callable | None = None,
         user_id: str | None = None,
-    ) -> None:
+    ):
         """Initializes a new instance of the Session class
 
         Parameters:
@@ -89,7 +89,7 @@ class AgentSession:
         selected_branch: str | None = None,
         initial_message: MessageAction | None = None,
         replay_json: str | None = None,
-    ) -> None:
+    ):
         """Starts the Agent session
         Parameters:
         - runtime_name: The name of the runtime associated with the session
@@ -188,7 +188,7 @@ class AgentSession:
                 },
             )
 
-    async def close(self) -> None:
+    async def close(self):
         """Closes the Agent session"""
         if self._closed:
             return
@@ -245,7 +245,7 @@ class AgentSession:
         assert isinstance(replay_events[0], MessageAction)
         return replay_events[0]
 
-    def _create_security_analyzer(self, security_analyzer: str | None) -> None:
+    def _create_security_analyzer(self, security_analyzer: str | None):
         """Creates a SecurityAnalyzer instance that will be used to analyze the agent actions
 
         Parameters:

--- a/openhands/server/session/conversation.py
+++ b/openhands/server/session/conversation.py
@@ -18,7 +18,7 @@ class Conversation:
 
     def __init__(
         self, sid: str, file_store: FileStore, config: AppConfig, user_id: str | None
-    ) -> None:
+    ):
         self.sid = sid
         self.config = config
         self.file_store = file_store
@@ -38,10 +38,10 @@ class Conversation:
             headless_mode=False,
         )
 
-    async def connect(self) -> None:
+    async def connect(self):
         await self.runtime.connect()
 
-    async def disconnect(self) -> None:
+    async def disconnect(self):
         if self.event_stream:
             self.event_stream.close()
         asyncio.create_task(call_sync_from_async(self.runtime.close))

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -53,7 +53,7 @@ class Session:
         file_store: FileStore,
         sio: socketio.AsyncServer | None,
         user_id: str | None = None,
-    ) -> None:
+    ):
         self.sid = sid
         self.sio = sio
         self.last_active_ts = int(time.time())
@@ -73,7 +73,7 @@ class Session:
         self.loop = asyncio.get_event_loop()
         self.user_id = user_id
 
-    async def close(self) -> None:
+    async def close(self):
         if self.sio:
             await self.sio.emit(
                 'oh_event',
@@ -90,7 +90,7 @@ class Session:
         settings: Settings,
         initial_message: MessageAction | None,
         replay_json: str | None,
-    ) -> None:
+    ):
         self.agent_session.event_stream.add_event(
             AgentStateChangedObservation('', AgentState.LOADING),
             EventSource.ENVIRONMENT,
@@ -194,10 +194,10 @@ class Session:
             'info', msg_id, f'Retrying LLM request, {retries} / {max}'
         )
 
-    def on_event(self, event: Event) -> None:
+    def on_event(self, event: Event):
         asyncio.get_event_loop().run_until_complete(self._on_event(event))
 
-    async def _on_event(self, event: Event) -> None:
+    async def _on_event(self, event: Event):
         """Callback function for events that mainly come from the agent.
         Event is the base class for any agent action and observation.
 
@@ -235,7 +235,7 @@ class Session:
             event_dict['source'] = EventSource.AGENT
             await self.send(event_dict)
 
-    async def dispatch(self, data: dict) -> None:
+    async def dispatch(self, data: dict):
         event = event_from_dict(data.copy())
         # This checks if the model supports images
         if isinstance(event, MessageAction) and event.image_urls:
@@ -253,7 +253,7 @@ class Session:
                     return
         self.agent_session.event_stream.add_event(event, EventSource.USER)
 
-    async def send(self, data: dict[str, object]) -> None:
+    async def send(self, data: dict[str, object]):
         if asyncio.get_running_loop() != self.loop:
             self.loop.create_task(self._send(data))
             return
@@ -273,11 +273,11 @@ class Session:
             self.is_alive = False
             return False
 
-    async def send_error(self, message: str) -> None:
+    async def send_error(self, message: str):
         """Sends an error message to the client."""
         await self.send({'error': True, 'message': message})
 
-    async def _send_status_message(self, msg_type: str, id: str, message: str) -> None:
+    async def _send_status_message(self, msg_type: str, id: str, message: str):
         """Sends a status message to the client."""
         if msg_type == 'error':
             agent_session = self.agent_session
@@ -292,7 +292,7 @@ class Session:
             {'status_update': True, 'type': msg_type, 'id': id, 'message': message}
         )
 
-    def queue_status_message(self, msg_type: str, id: str, message: str) -> None:
+    def queue_status_message(self, msg_type: str, id: str, message: str):
         """Queues a status message to be sent asynchronously."""
         asyncio.run_coroutine_threadsafe(
             self._send_status_message(msg_type, id, message), self.loop


### PR DESCRIPTION
This PR reverts the Python file changes from PR #6397 (Add strict mypy checking) while keeping the configuration changes. Specifically, it removes the explicit return type annotations (`-> None`) that were added to methods in the Python files.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d4c0e75-nikolaik   --name openhands-app-d4c0e75   docker.all-hands.dev/all-hands-ai/openhands:d4c0e75
```