### PR TITLE
[Fix]: Ensure provider tokens exist when restarting conversations on local installation

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -20,14 +20,18 @@ from openhands.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderToken
 from openhands.integrations.service_types import ProviderType
 from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.server.shared import (
+    SecretsStoreImpl,
     SettingsStoreImpl,
     config,
     conversation_manager,
+    server_config,
     sio,
 )
+from openhands.server.types import AppMode
 from openhands.storage.conversation.conversation_validator import (
     create_conversation_validator,
 )
+from openhands.storage.data_models.user_secrets import UserSecrets
 
 
 def create_provider_tokens_object(
@@ -74,6 +78,9 @@ async def connect(connection_id: str, environ):
     settings_store = await SettingsStoreImpl.get_instance(config, user_id)
     settings = await settings_store.load()
 
+    sercets_store = await SecretsStoreImpl.get_instance(config, user_id)
+    user_secrets: UserSecrets = await sercets_store.load()
+
     if not settings:
         raise ConnectionRefusedError(
             'Settings not found', {'msg_id': 'CONFIGURATION$SETTINGS_NOT_FOUND'}
@@ -82,9 +89,12 @@ async def connect(connection_id: str, environ):
     if settings:
         session_init_args = {**settings.__dict__, **session_init_args}
 
-    session_init_args['git_provider_tokens'] = create_provider_tokens_object(
-        providers_set
-    )
+    git_provider_tokens = user_secrets.provider_tokens
+    if server_config.app_mode == AppMode.SAAS:
+        git_provider_tokens = create_provider_tokens_object(providers_set)
+
+    session_init_args['git_provider_tokens'] = git_provider_tokens
+
     conversation_init_data = ConversationInitData(**session_init_args)
 
     event_stream = await conversation_manager.join_conversation(

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -78,8 +78,8 @@ async def connect(connection_id: str, environ):
     settings_store = await SettingsStoreImpl.get_instance(config, user_id)
     settings = await settings_store.load()
 
-    sercets_store = await SecretsStoreImpl.get_instance(config, user_id)
-    user_secrets: UserSecrets = await sercets_store.load()
+    secrets_store = await SecretsStoreImpl.get_instance(config, user_id)
+    user_secrets: UserSecrets = await secrets_store.load()
 
     if not settings:
         raise ConnectionRefusedError(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR ensures that when we restart a conversation on local installation we're setting the git provider information from user secrets


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b567a15-nikolaik   --name openhands-app-b567a15   docker.all-hands.dev/all-hands-ai/openhands:b567a15
```