### PR TITLE
[WIP, Feat]: dedicated agent tool to open PRs

### DIFF
--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -16,6 +16,7 @@ from openhands.agenthub.codeact_agent.tools import (
     LLMBasedFileEditTool,
     ThinkTool,
     WebReadTool,
+    CreatePRTool,
     create_cmd_run_tool,
     create_str_replace_editor_tool,
 )
@@ -37,6 +38,7 @@ from openhands.events.action import (
     IPythonRunCellAction,
     MessageAction,
 )
+from openhands.events.action.create_pr import CreatePRAction
 from openhands.events.action.mcp import MCPAction
 from openhands.events.event import FileEditSource, FileReadSource
 from openhands.events.tool import ToolCallMetadata
@@ -203,6 +205,20 @@ def response_to_actions(
                     name=tool_call.function.name,
                     arguments=arguments,
                 )
+            # ================================================
+            # CreatePR (opens pull request)
+            # ================================================
+            elif tool_call.function.name == CreatePRTool['function']['name']:
+                if 'source_branch' not in arguments or 'target_branch' not in arguments:
+                    raise FunctionCallValidationError(
+                        f'Missing required argument "source_branch" or "target_branch" in tool call {tool_call.function.name}'
+                    )
+                action = CreatePRAction(
+                    name=tool_call.function.name,
+                    source_branch=arguments.get('source_branch', ''),
+                    target_branch=arguments.get('target_branch', ''),
+                )
+
             else:
                 raise FunctionCallNotExistsError(
                     f'Tool {tool_call.function.name} is not registered. (arguments: {arguments}). Please check the tool name and retry with an existing tool.'

--- a/openhands/agenthub/codeact_agent/tools/__init__.py
+++ b/openhands/agenthub/codeact_agent/tools/__init__.py
@@ -6,6 +6,7 @@ from .llm_based_edit import LLMBasedFileEditTool
 from .str_replace_editor import create_str_replace_editor_tool
 from .think import ThinkTool
 from .web_read import WebReadTool
+from .create_pr import CreatePRTool
 
 __all__ = [
     'BrowserTool',
@@ -16,4 +17,5 @@ __all__ = [
     'create_str_replace_editor_tool',
     'WebReadTool',
     'ThinkTool',
+    'CreatePRTool',
 ]

--- a/openhands/agenthub/codeact_agent/tools/create_pr.py
+++ b/openhands/agenthub/codeact_agent/tools/create_pr.py
@@ -1,0 +1,23 @@
+from litellm import ChatCompletionToolParam, ChatCompletionToolParamFunctionChunk
+
+
+_CREATE_PR_DESCRIPTION = """Use the tool to open a pull request for GitHub or GitLab.
+You should not use the GitHub or GitLab API to open a pull request, and use this tool instead.
+"""
+
+
+CreatePRTool = ChatCompletionToolParam(
+    type='function',
+    function=ChatCompletionToolParamFunctionChunk(
+        name='create_pr',
+        description=_CREATE_PR_DESCRIPTION,
+        parameters={
+            'type': 'object',
+            'properties': {
+                'source_branch': {'type': 'string', 'description': 'branch containing new modifications'},
+                'target_branch': {'type': 'string', 'description': 'branch you request to merge your changes into'}
+            },
+            'required': ['source_branch', 'target_branch']
+        }
+    )
+)

--- a/openhands/core/schema/action.py
+++ b/openhands/core/schema/action.py
@@ -84,7 +84,7 @@ class ActionType(str, Enum):
     """Push a branch to github."""
 
     SEND_PR = 'send_pr'
-    """Send a PR to github."""
+    """Send a PR to github or gitlab."""
 
     RECALL = 'recall'
     """Retrieves content from a user workspace, microagent, or other source."""

--- a/openhands/events/action/__init__.py
+++ b/openhands/events/action/__init__.py
@@ -17,6 +17,7 @@ from openhands.events.action.files import (
 )
 from openhands.events.action.mcp import MCPAction
 from openhands.events.action.message import MessageAction, SystemMessageAction
+from openhands.events.action.create_pr import CreatePRAction
 
 __all__ = [
     'Action',
@@ -38,4 +39,5 @@ __all__ = [
     'AgentThinkAction',
     'RecallAction',
     'MCPAction',
+    'CreatePRAction',
 ]

--- a/openhands/events/action/create_pr.py
+++ b/openhands/events/action/create_pr.py
@@ -1,0 +1,20 @@
+
+
+from dataclasses import dataclass
+from openhands.events.action.action import Action
+
+
+@dataclass
+class CreatePRAction(Action):
+    name: str
+    source_branch: str
+    target_branch: str
+
+    @property
+    def message(self) -> str:
+        return f'Create PR for: {self.source_branch} to {self.target_branch}'
+    
+    def __str__(self) -> str:
+        ret = '**CreatePRAction**\n'
+        ret += f'SOURCE: {self.source_branch}\nTARGET: {self.target_branch}'
+        return ret

--- a/openhands/events/action/create_pr.py
+++ b/openhands/events/action/create_pr.py
@@ -1,6 +1,7 @@
 
 
 from dataclasses import dataclass
+from openhands.core.schema.action import ActionType
 from openhands.events.action.action import Action
 
 
@@ -9,6 +10,7 @@ class CreatePRAction(Action):
     name: str
     source_branch: str
     target_branch: str
+    action: str = ActionType.SEND_PR
 
     @property
     def message(self) -> str:

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -25,6 +25,7 @@ from openhands.events.action import (
     FileReadAction,
     FileWriteAction,
     IPythonRunCellAction,
+    CreatePRAction,
 )
 from openhands.events.action.action import Action
 from openhands.events.action.files import FileEditSource
@@ -283,6 +284,15 @@ class ActionExecutionClient(Runtime):
                 )
 
             assert action.timeout is not None
+
+            if isinstance(action, CreatePRAction): 
+                # TODO: track repo provider and call open PR
+                # We already have access to git provider tokens here
+                # Use GitService class and action args
+                # Instead of /execute_action we ping github api or gitlab api
+                # Return api response as observation
+                pass
+
 
             try:
                 execution_action_body: dict[str, Any] = {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This is exploratory in nature. With a create pr tool

1. We can assign a token with less permissions, one where the agent cannot open PRs
2. Agent can request to open a pr via a tool call
3. The BE will process the action request and use a higher permission token that is never given to the agent

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1fe7db0-nikolaik   --name openhands-app-1fe7db0   docker.all-hands.dev/all-hands-ai/openhands:1fe7db0
```