### PR TITLE
Fix provider tokens in SAAS

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -89,9 +89,9 @@ async def connect(connection_id: str, environ):
     if settings:
         session_init_args = {**settings.__dict__, **session_init_args}
 
-    git_provider_tokens = user_secrets.provider_tokens
-    if server_config.app_mode == AppMode.SAAS:
-        git_provider_tokens = create_provider_tokens_object(providers_set)
+    git_provider_tokens = create_provider_tokens_object(providers_set)
+    if server_config.app_mode != AppMode.SAAS:
+        git_provider_tokens = user_secrets.provider_tokens
 
     session_init_args['git_provider_tokens'] = git_provider_tokens
 


### PR DESCRIPTION
Fix so that in SAAS mode, the user secrets are not used to set provider tokens.  This caused an exception when no user secrets exist.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1747240-nikolaik   --name openhands-app-1747240   docker.all-hands.dev/all-hands-ai/openhands:1747240
```