### PR TITLE
Clarify API rate limit behavior

### DIFF
--- a/docs/modules/usage/cloud/cloud-api.md
+++ b/docs/modules/usage/cloud/cloud-api.md
@@ -172,6 +172,5 @@ The response is formatted as follows:
 
 ## Rate Limits
 
-The API has a limit of 10 simultaneous conversations per account. If you need a higher limit for your use case, please contact us at [contact@all-hands.dev](mailto:contact@all-hands.dev).
-
-If you exceed this limit, the API will return a 429 Too Many Requests response.
+If you have too many conversations running at once, older conversations will be paused to limit the number of concurrent conversations.
+If you're running into issues and need a higher limit for your use case, please contact us at [contact@all-hands.dev](mailto:contact@all-hands.dev).


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Clarifies API rate limit behavior.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
The previous description that you'd get a 429 rate limited error when you exceed a limit was inaccurate, fixed to accurately describe the behavior.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1fdb3fb-nikolaik   --name openhands-app-1fdb3fb   docker.all-hands.dev/all-hands-ai/openhands:1fdb3fb
```