### PR TITLE
[Fix]: Loaded provider token should always be string

### DIFF
--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.7.5'
+const PACKAGE_VERSION = '2.7.6'
 const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -43,7 +43,11 @@ class ProviderToken(BaseModel):
         if isinstance(token_value, ProviderToken):
             return token_value
         elif isinstance(token_value, dict):
-            token_str = token_value.get('token')
+            token_str = token_value.get('token', '')
+            # Override with emtpy string if it was set to None
+            # Cannot pass None to SecretStr
+            if token_str is None:
+                token_str = ''
             user_id = token_value.get('user_id')
             return cls(token=SecretStr(token_str), user_id=user_id)
 

--- a/openhands/server/routes/secrets.py
+++ b/openhands/server/routes/secrets.py
@@ -52,7 +52,6 @@ async def invalidate_legacy_secrets_store(
 
 
 async def check_provider_tokens(provider_info: POSTProviderModel) -> str:
-    print(provider_info)
     if provider_info.provider_tokens:
         # Determine whether tokens are valid
         for token_type, token_value in provider_info.provider_tokens.items():
@@ -154,10 +153,10 @@ async def load_custom_secrets_names(
         return GETCustomSecrets(custom_secrets=custom_secrets)
 
     except Exception as e:
-        logger.warning(f'Invalid token: {e}')
+        logger.warning(f'Failed to load secret names: {e}')
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={'error': 'Invalid token'},
+            content={'error': 'Failed to get secret names'},
         )
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

During development I ended up in a state where the token value as `None`. When loading it back from the file it gets passed into a `SecretStr` object. This breaks the application for all the routes which check if a provider token is set via `if provider_token.token` conditionals (the error being `object of type 'NoneType' has no len()`)

This PR makes sure that if we accidentally wrote `None` for the value, we load it back as an empty string

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:eaa8924-nikolaik   --name openhands-app-eaa8924   docker.all-hands.dev/all-hands-ai/openhands:eaa8924
```