### PR TITLE
Fix OpenAPI schema generation (again)

### DIFF
--- a/openhands/storage/data_models/user_secrets.py
+++ b/openhands/storage/data_models/user_secrets.py
@@ -14,6 +14,7 @@ from pydantic.json import pydantic_encoder
 
 from openhands.integrations.provider import (
     CUSTOM_SECRETS_TYPE,
+    CUSTOM_SECRETS_TYPE_WITH_JSON_SCHEMA,
     PROVIDER_TOKEN_TYPE,
     PROVIDER_TOKEN_TYPE_WITH_JSON_SCHEMA,
     ProviderToken,
@@ -26,7 +27,7 @@ class UserSecrets(BaseModel):
         default_factory=lambda: MappingProxyType({})
     )
 
-    custom_secrets: CUSTOM_SECRETS_TYPE = Field(
+    custom_secrets: CUSTOM_SECRETS_TYPE_WITH_JSON_SCHEMA = Field(
         default_factory=lambda: MappingProxyType({})
     )
 

--- a/tests/unit/test_openapi_schema_generation.py
+++ b/tests/unit/test_openapi_schema_generation.py
@@ -1,0 +1,96 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from openhands.integrations.provider import ProviderToken, ProviderType
+from openhands.server.app import app
+from openhands.server.user_auth.user_auth import UserAuth
+from openhands.storage.data_models.user_secrets import UserSecrets
+from openhands.storage.memory import InMemoryFileStore
+from openhands.storage.secrets.secrets_store import SecretsStore
+from openhands.storage.settings.file_settings_store import FileSettingsStore
+from openhands.storage.settings.settings_store import SettingsStore
+
+
+class MockUserAuth(UserAuth):
+    """Mock implementation of UserAuth for testing"""
+
+    def __init__(self):
+        self._settings = None
+        self._settings_store = MagicMock()
+        self._settings_store.load = AsyncMock(return_value=None)
+        self._settings_store.store = AsyncMock()
+
+    async def get_user_id(self) -> str | None:
+        return 'test-user'
+
+    async def get_access_token(self) -> SecretStr | None:
+        return SecretStr('test-token')
+
+    async def get_provider_tokens(self) -> dict[ProviderType, ProviderToken] | None:
+        return None
+
+    async def get_user_settings_store(self) -> SettingsStore | None:
+        return self._settings_store
+
+    async def get_secrets_store(self) -> SecretsStore | None:
+        return None
+
+    async def get_user_secrets(self) -> UserSecrets | None:
+        return None
+
+    @classmethod
+    async def get_instance(cls, request: Request) -> UserAuth:
+        return MockUserAuth()
+
+
+@pytest.fixture
+def test_client():
+    # Create a test client
+    with (
+        patch(
+            'openhands.server.user_auth.user_auth.UserAuth.get_instance',
+            return_value=MockUserAuth(),
+        ),
+        patch(
+            'openhands.storage.settings.file_settings_store.FileSettingsStore.get_instance',
+            AsyncMock(return_value=FileSettingsStore(InMemoryFileStore())),
+        ),
+    ):
+        client = TestClient(app)
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_openapi_schema_generation(test_client):
+    """Test that the OpenAPI schema can be generated without errors.
+    
+    This test ensures that the FastAPI app can generate a valid OpenAPI schema,
+    which is important for API documentation and client generation.
+    """
+    # Get the OpenAPI schema from the /openapi.json endpoint
+    response = test_client.get("/openapi.json")
+    
+    # Check that the response is successful
+    assert response.status_code == 200
+    
+    # Verify that the response is valid JSON
+    schema = response.json()
+    
+    # Basic validation of the schema structure
+    assert "openapi" in schema
+    assert "info" in schema
+    assert "paths" in schema
+    
+    # Verify that the schema can be serialized to JSON without errors
+    # This is a good test for ensuring all types can be properly converted to JSON Schema
+    json_str = json.dumps(schema)
+    assert json_str is not None
+    
+    # Optionally, you can check for specific endpoints if needed
+    assert "/api/settings" in schema["paths"]
+    assert "/health" in schema["paths"]

--- a/tests/unit/test_openapi_schema_generation.py
+++ b/tests/unit/test_openapi_schema_generation.py
@@ -68,29 +68,29 @@ def test_client():
 @pytest.mark.asyncio
 async def test_openapi_schema_generation(test_client):
     """Test that the OpenAPI schema can be generated without errors.
-    
+
     This test ensures that the FastAPI app can generate a valid OpenAPI schema,
     which is important for API documentation and client generation.
     """
     # Get the OpenAPI schema from the /openapi.json endpoint
-    response = test_client.get("/openapi.json")
-    
+    response = test_client.get('/openapi.json')
+
     # Check that the response is successful
     assert response.status_code == 200
-    
+
     # Verify that the response is valid JSON
     schema = response.json()
-    
+
     # Basic validation of the schema structure
-    assert "openapi" in schema
-    assert "info" in schema
-    assert "paths" in schema
-    
+    assert 'openapi' in schema
+    assert 'info' in schema
+    assert 'paths' in schema
+
     # Verify that the schema can be serialized to JSON without errors
     # This is a good test for ensuring all types can be properly converted to JSON Schema
     json_str = json.dumps(schema)
     assert json_str is not None
-    
+
     # Optionally, you can check for specific endpoints if needed
-    assert "/api/settings" in schema["paths"]
-    assert "/health" in schema["paths"]
+    assert '/api/settings' in schema['paths']
+    assert '/health' in schema['paths']


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR fixes an error with OpenAPI schema generation that was causing the following error:

```
pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.IsInstanceSchema (<class "mappingproxy">)
```

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


### Changes
- Fixed the issue with OpenAPI schema generation for mappingproxy objects
- Added a unit test to ensure OpenAPI schema generation works correctly
- Test verifies that the /openapi.json endpoint returns a valid schema

### Testing
- Added test_openapi_schema_generation that verifies:
  - Status code 200 from /openapi.json endpoint
  - Valid JSON structure with expected fields
  - Proper serialization of the schema
  - Presence of expected endpoints in the schema

The test ensures that the OpenAPI schema can be generated without errors, which is important for API documentation and client generation.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3b5d141-nikolaik   --name openhands-app-3b5d141   docker.all-hands.dev/all-hands-ai/openhands:3b5d141
```