### PR TITLE
Fix double-wrapped github token

### DIFF
--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -101,15 +101,11 @@ def initialize_repository_for_runtime(
     provider_tokens = {}
     if 'GITHUB_TOKEN' in os.environ:
         github_token = SecretStr(os.environ['GITHUB_TOKEN'])
-        provider_tokens[ProviderType.GITHUB] = ProviderToken(
-            token=SecretStr(github_token)
-        )
+        provider_tokens[ProviderType.GITHUB] = ProviderToken(token=github_token)
 
     if 'GITLAB_TOKEN' in os.environ:
         gitlab_token = SecretStr(os.environ['GITLAB_TOKEN'])
-        provider_tokens[ProviderType.GITLAB] = ProviderToken(
-            token=SecretStr(gitlab_token)
-        )
+        provider_tokens[ProviderType.GITLAB] = ProviderToken(token=gitlab_token)
 
     secret_store = (
         UserSecrets(provider_tokens=provider_tokens) if provider_tokens else None


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

I got AuthenticationError with cli mode, with a GITHUB_TOKEN in env. Turns out we were double-wrapping the token in a `SecretStr` so we were sending *** to GitHub. 😓 

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b516313-nikolaik   --name openhands-app-b516313   docker.all-hands.dev/all-hands-ai/openhands:b516313
```