### PR TITLE
docs: remove api_key section from MCP doc

### DIFF
--- a/docs/modules/usage/mcp.md
+++ b/docs/modules/usage/mcp.md
@@ -53,11 +53,6 @@ SSE servers are configured using either a string URL or an object with the follo
   - Type: `str`
   - Description: The URL of the SSE server
 
-- `api_key` (optional)
-  - Type: `str`
-  - Default: `None`
-  - Description: API key for authentication with the SSE server
-
 ### Stdio Servers
 
 Stdio servers are configured using an object with the following properties:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

`api_key` is not properly supported/tested in our CI

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:553f5d7-nikolaik   --name openhands-app-553f5d7   docker.all-hands.dev/all-hands-ai/openhands:553f5d7
```