### PR TITLE
Fix openhands-resolver.yml

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -83,7 +83,7 @@ jobs:
         (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'MEMBER')
         )
       )
-    runs-on: "${{ inputs.runner }}"
+    runs-on: "${{ inputs.runner || 'ubuntu-latest' }}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Fix the resolver GitHub workflow to have a valid `inputs.runner` when invoked via comments on GitHub or such, different than another workflow.

I think after https://github.com/All-Hands-AI/OpenHands/pull/8216 the call to `openhands-agent` from comments fails. I just saw its failure in Actions on an @amanape comment, and it was because this was an empty string in `runs-on`.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:13d490c-nikolaik   --name openhands-app-13d490c   docker.all-hands.dev/all-hands-ai/openhands:13d490c
```