### PR TITLE
Add support for user/org level microagents

### DIFF
--- a/frontend/__tests__/services/observations.test.tsx
+++ b/frontend/__tests__/services/observations.test.tsx
@@ -32,7 +32,7 @@ describe("handleObservationMessage", () => {
         screenshot: "base64-screenshot-data",
       },
     };
-    
+
     handleObservationMessage(message);
 
     // Check that setScreenshotSrc and setUrl were called with the correct values
@@ -52,7 +52,7 @@ describe("handleObservationMessage", () => {
         screenshot: "base64-screenshot-data",
       },
     };
-    
+
     handleObservationMessage(message);
 
     // Check that setScreenshotSrc and setUrl were called with the correct values

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -534,7 +534,10 @@ fi
         if not files:
             return loaded_microagents
 
-        self.log('info', f'Found {len(files)} files in {source_description} microagents directory')
+        self.log(
+            'info',
+            f'Found {len(files)} files in {source_description} microagents directory',
+        )
         zip_path = self.copy_from(str(microagents_dir))
         microagent_folder = tempfile.mkdtemp()
 

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -522,15 +522,121 @@ fi
         """Load microagents from the selected repository.
         If selected_repository is None, load microagents from the current workspace.
         This is the main entry point for loading microagents.
+
+        This method also checks for user/org level microagents stored in a .openhands repository.
+        For example, if the repository is github.com/acme-co/api, it will also check for
+        github.com/acme-co/.openhands and load microagents from there if it exists.
         """
 
         loaded_microagents: list[BaseMicroagent] = []
         workspace_root = Path(self.config.workspace_mount_path_in_sandbox)
         microagents_dir = workspace_root / '.openhands' / 'microagents'
         repo_root = None
+
+        # Check for user/org level microagents if a repository is selected
         if selected_repository:
+            repo_parts = selected_repository.split('/')
+            if len(repo_parts) >= 2:
+                # Extract the domain and org/user name
+                domain = repo_parts[0] if len(repo_parts) > 2 else 'github.com'
+                org_name = repo_parts[-2]
+
+                # Construct the org-level .openhands repo path
+                org_openhands_repo = f'{domain}/{org_name}/.openhands'
+                if domain not in org_openhands_repo:
+                    org_openhands_repo = f'github.com/{org_openhands_repo}'
+
+                self.log(
+                    'info',
+                    f'Checking for org-level microagents at {org_openhands_repo}',
+                )
+
+                # Try to clone the org-level .openhands repo
+                try:
+                    # Create a temporary directory for the org-level repo
+                    org_repo_dir = workspace_root / f'org_openhands_{org_name}'
+
+                    # Use authenticated URL if tokens are available
+                    remote_url = f'https://{org_openhands_repo}.git'
+
+                    # Try to use token if available (similar to clone_or_init_repo method)
+                    provider = None
+                    if 'github.com' in org_openhands_repo:
+                        provider = ProviderType.GITHUB
+                    elif 'gitlab.com' in org_openhands_repo:
+                        provider = ProviderType.GITLAB
+
+                    if (
+                        provider
+                        and self.git_provider_tokens
+                        and provider in self.git_provider_tokens
+                    ):
+                        git_token = self.git_provider_tokens[provider].token
+                        if git_token:
+                            if provider == ProviderType.GITLAB:
+                                remote_url = f'https://oauth2:{git_token.get_secret_value()}@{org_openhands_repo.replace("gitlab.com/", "")}.git'
+                            else:
+                                remote_url = f'https://{git_token.get_secret_value()}@{org_openhands_repo.replace("github.com/", "")}.git'
+
+                    clone_cmd = f"git clone {remote_url} {org_repo_dir} 2>/dev/null || echo 'Org repo not found'"
+
+                    action = CmdRunAction(command=clone_cmd)
+                    obs = self.run_action(action)
+
+                    if (
+                        isinstance(obs, CmdOutputObservation)
+                        and obs.exit_code == 0
+                        and 'Org repo not found' not in obs.content
+                    ):
+                        self.log(
+                            'info',
+                            f'Successfully cloned org-level microagents from {org_openhands_repo}',
+                        )
+
+                        # Load microagents from the org-level repo
+                        org_microagents_dir = org_repo_dir / 'microagents'
+                        org_files = self.list_files(str(org_microagents_dir))
+
+                        if org_files:
+                            self.log(
+                                'info',
+                                f'Found {len(org_files)} files in org-level microagents directory',
+                            )
+                            org_zip_path = self.copy_from(str(org_microagents_dir))
+                            org_microagent_folder = tempfile.mkdtemp()
+
+                            with ZipFile(org_zip_path, 'r') as zip_file:
+                                zip_file.extractall(org_microagent_folder)
+
+                            org_zip_path.unlink()
+                            org_repo_agents, org_knowledge_agents = (
+                                load_microagents_from_dir(org_microagent_folder)
+                            )
+
+                            self.log(
+                                'info',
+                                f'Loaded {len(org_repo_agents)} repo agents and {len(org_knowledge_agents)} knowledge agents from org-level repo',
+                            )
+
+                            loaded_microagents.extend(org_repo_agents.values())
+                            loaded_microagents.extend(org_knowledge_agents.values())
+                            shutil.rmtree(org_microagent_folder)
+
+                        # Clean up the org repo directory
+                        shutil.rmtree(org_repo_dir)
+                    else:
+                        self.log(
+                            'info',
+                            f'No org-level microagents found at {org_openhands_repo}',
+                        )
+
+                except Exception as e:
+                    self.log('error', f'Error loading org-level microagents: {str(e)}')
+
+            # Continue with repository-specific microagents
             repo_root = workspace_root / selected_repository.split('/')[-1]
             microagents_dir = repo_root / '.openhands' / 'microagents'
+
         self.log(
             'info',
             f'Selected repo: {selected_repository}, loading microagents from {microagents_dir} (inside runtime)',

--- a/openhands/server/routes/secrets.py
+++ b/openhands/server/routes/secrets.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
 
 from openhands.core.logger import openhands_logger as logger
-from openhands.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderToken
+from openhands.integrations.provider import PROVIDER_TOKEN_TYPE
 from openhands.integrations.service_types import ProviderType
 from openhands.integrations.utils import validate_provider_token
 from openhands.server.settings import (
@@ -55,31 +55,47 @@ async def invalidate_legacy_secrets_store(
 
 
 def process_token_validation_result(
-        confirmed_token_type: ProviderType | None, 
-        token_type: ProviderType):
-    
+    confirmed_token_type: ProviderType | None, token_type: ProviderType
+):
     if not confirmed_token_type or confirmed_token_type != token_type:
-        return f'Invalid token. Please make sure it is a valid {token_type.value} token.'
-    
+        return (
+            f'Invalid token. Please make sure it is a valid {token_type.value} token.'
+        )
+
     return ''
+
 
 async def check_provider_tokens(
     incoming_provider_tokens: POSTProviderModel,
-    existing_provider_tokens: PROVIDER_TOKEN_TYPE | None) -> str:
-
+    existing_provider_tokens: PROVIDER_TOKEN_TYPE | None,
+) -> str:
     msg = ''
     if incoming_provider_tokens.provider_tokens:
         # Determine whether tokens are valid
         for token_type, token_value in incoming_provider_tokens.provider_tokens.items():
             if token_value.token:
-                confirmed_token_type = await validate_provider_token(token_value.token, token_value.host) # FE always sends latest host
+                confirmed_token_type = await validate_provider_token(
+                    token_value.token, token_value.host
+                )  # FE always sends latest host
                 msg = process_token_validation_result(confirmed_token_type, token_type)
 
-            existing_token = existing_provider_tokens.get(token_type, None) if existing_provider_tokens else None
-            if existing_token and (existing_token.host != token_value.host) and existing_token.token:
-                confirmed_token_type = await validate_provider_token(existing_token.token, token_value.host) # Host has changed, check it against existing token
+            existing_token = (
+                existing_provider_tokens.get(token_type, None)
+                if existing_provider_tokens
+                else None
+            )
+            if (
+                existing_token
+                and (existing_token.host != token_value.host)
+                and existing_token.token
+            ):
+                confirmed_token_type = await validate_provider_token(
+                    existing_token.token, token_value.host
+                )  # Host has changed, check it against existing token
                 if not confirmed_token_type or confirmed_token_type != token_type:
-                    msg = process_token_validation_result(confirmed_token_type, token_type)
+                    msg = process_token_validation_result(
+                        confirmed_token_type, token_type
+                    )
 
     return msg
 
@@ -88,9 +104,8 @@ async def check_provider_tokens(
 async def store_provider_tokens(
     provider_info: POSTProviderModel,
     secrets_store: SecretsStore = Depends(get_secrets_store),
-    provider_tokens: PROVIDER_TOKEN_TYPE | None = Depends(get_provider_tokens)
+    provider_tokens: PROVIDER_TOKEN_TYPE | None = Depends(get_provider_tokens),
 ) -> JSONResponse:
-
     provider_err_msg = await check_provider_tokens(provider_info, provider_tokens)
     if provider_err_msg:
         return JSONResponse(
@@ -113,7 +128,9 @@ async def store_provider_tokens(
                     if existing_token and existing_token.token:
                         provider_info.provider_tokens[provider] = existing_token
 
-                provider_info.provider_tokens[provider] = provider_info.provider_tokens[provider].model_copy(update={'host': token_value.host})
+                provider_info.provider_tokens[provider] = provider_info.provider_tokens[
+                    provider
+                ].model_copy(update={'host': token_value.host})
 
         updated_secrets = user_secrets.model_copy(
             update={'provider_tokens': provider_info.provider_tokens}

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -11,7 +11,6 @@ from openhands.server.settings import (
     GETSettingsModel,
 )
 from openhands.server.shared import config
-from openhands.server.types import AppMode
 from openhands.server.user_auth import (
     get_provider_tokens,
     get_secrets_store,
@@ -20,7 +19,6 @@ from openhands.server.user_auth import (
 from openhands.storage.data_models.settings import Settings
 from openhands.storage.secrets.secrets_store import SecretsStore
 from openhands.storage.settings.settings_store import SettingsStore
-from openhands.server.shared import server_config
 
 app = APIRouter(prefix='/api')
 
@@ -47,13 +45,11 @@ async def load_settings(
                 content={'error': 'Settings not found'},
             )
 
-
         # On initial load, user secrets may not be populated with values migrated from settings store
         user_secrets = await invalidate_legacy_secrets_store(
             settings, settings_store, secrets_store
         )
 
-        
         # If invalidation is successful, then the returned user secrets holds the most recent values
         git_providers = (
             user_secrets.provider_tokens if user_secrets else provider_tokens
@@ -64,7 +60,6 @@ async def load_settings(
             for provider_type, provider_token in git_providers.items():
                 if provider_token.token or provider_token.user_id:
                     provider_tokens_set[provider_type] = provider_token.host
-
 
         settings_with_token_data = GETSettingsModel(
             **settings.model_dump(exclude='secrets_store'),

--- a/openhands/storage/data_models/user_secrets.py
+++ b/openhands/storage/data_models/user_secrets.py
@@ -56,13 +56,16 @@ class UserSecrets(BaseModel):
 
             token = None
             if provider_token.token:
-                token = provider_token.token.get_secret_value() if expose_secrets else pydantic_encoder(provider_token.token)
+                token = (
+                    provider_token.token.get_secret_value()
+                    if expose_secrets
+                    else pydantic_encoder(provider_token.token)
+                )
 
             tokens[token_type_str] = {
                 'token': token,
                 'host': provider_token.host,
                 'user_id': provider_token.user_id,
-                
             }
 
         return tokens


### PR DESCRIPTION
This PR adds support for user/org level microagents. When a repository is selected (e.g., github.com/acme-co/api), the system will now also check if a .openhands repository exists at the organization level (e.g., github.com/acme-co/.openhands). If it exists, it will clone it and load the microagents from the ./microagents/ folder.

This allows organizations to define microagents that apply to all of their repositories without having to duplicate them in each repository.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6b0fc11-nikolaik   --name openhands-app-6b0fc11   docker.all-hands.dev/all-hands-ai/openhands:6b0fc11
```