### PR TITLE
Allow websocket connection to pass in Authorization header to conversation validator

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -72,6 +72,8 @@ async def connect(connection_id: str, environ):
             raise ConnectionRefusedError('No conversation_id in query params')
 
         cookies_str = environ.get('HTTP_COOKIE', '')
+        # Get Authorization header from the environment
+        # Headers in WSGI/ASGI are prefixed with 'HTTP_' and have dashes replaced with underscores
         authorization_header = environ.get('HTTP_AUTHORIZATION', None)
         conversation_validator = create_conversation_validator()
         user_id, github_user_id = await conversation_validator.validate(

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -72,9 +72,10 @@ async def connect(connection_id: str, environ):
             raise ConnectionRefusedError('No conversation_id in query params')
 
         cookies_str = environ.get('HTTP_COOKIE', '')
+        authorization_header = environ.get('HTTP_AUTHORIZATION', None)
         conversation_validator = create_conversation_validator()
         user_id, github_user_id = await conversation_validator.validate(
-            conversation_id, cookies_str
+            conversation_id, cookies_str, authorization_header
         )
 
         settings_store = await SettingsStoreImpl.get_instance(config, user_id)

--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from openhands.utils.import_utils import get_impl
 
@@ -7,7 +8,10 @@ class ConversationValidator:
     """Storage for conversation metadata. May or may not support multiple users depending on the environment."""
 
     async def validate(
-        self, conversation_id: str, cookies_str: str
+        self,
+        conversation_id: str,
+        cookies_str: str,
+        authorization_header: Optional[str] = None,
     ) -> tuple[None, None]:
         return None, None
 

--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 from openhands.utils.import_utils import get_impl
 
@@ -11,7 +10,7 @@ class ConversationValidator:
         self,
         conversation_id: str,
         cookies_str: str,
-        authorization_header: Optional[str] = None,
+        authorization_header: str | None = None,
     ) -> tuple[None, None]:
         return None, None
 


### PR DESCRIPTION
This PR allows the websocket connection to pass in an Authorization header which gets passed into the conversation validator. This enables API key authentication for websocket connections.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a7cec86-nikolaik   --name openhands-app-a7cec86   docker.all-hands.dev/all-hands-ai/openhands:a7cec86
```