### PR TITLE
Fix git changes endpoint response model

### DIFF
--- a/openhands/server/routes/files.py
+++ b/openhands/server/routes/files.py
@@ -226,7 +226,7 @@ def zip_current_workspace(request: Request) -> FileResponse | JSONResponse:
 
 @app.get(
     '/git/changes',
-    response_model=dict[str, Any],
+    response_model=dict[str, list[dict[str, str]]],
     responses={
         404: {'description': 'Not a git repository', 'model': dict},
         500: {'description': 'Error getting changes', 'model': dict},
@@ -236,7 +236,7 @@ async def git_changes(
     request: Request,
     conversation_id: str,
     user_id: str = Depends(get_user_id),
-) -> dict[str, Any] | JSONResponse:
+) -> dict[str, list[dict[str, str]]] | JSONResponse:
     runtime: Runtime = request.state.conversation.runtime
     conversation_store = await ConversationStoreImpl.get_instance(
         config,
@@ -257,7 +257,8 @@ async def git_changes(
                 status_code=404,
                 content={'error': 'Not a git repository'},
             )
-        return changes
+        # Wrap the list in a dictionary to match the response_model
+        return {'changes': changes}
     except AgentRuntimeUnavailableError as e:
         logger.error(f'Runtime unavailable: {e}')
         return JSONResponse(


### PR DESCRIPTION
This PR fixes a ResponseValidationError in the git changes endpoint. The endpoint was defined with response_model=dict[str, Any], but the get_git_changes method returns a list[dict[str, str]] | None. This PR updates the response_model to match the actual return type and wraps the list in a dictionary to ensure the response is valid.