### PR TITLE
Add Forgejo integration similar to GitHub and GitLab integrations

### DIFF
--- a/docs/modules/usage/cloud/cloud-forgejo-resolver.md
+++ b/docs/modules/usage/cloud/cloud-forgejo-resolver.md
@@ -1,0 +1,74 @@
+# Forgejo Integration
+
+OpenHands supports integration with Forgejo, a self-hosted Git service that is a fork of Gitea. This integration allows you to interact with Forgejo instances like Codeberg.org.
+
+## Setting Up Forgejo Integration
+
+To use the Forgejo integration, you need to:
+
+1. Generate a personal access token from your Forgejo instance
+2. Configure OpenHands to use this token
+
+### Generating a Personal Access Token
+
+1. Log in to your Forgejo instance (e.g., Codeberg.org)
+2. Go to your user settings (click on your profile picture in the top right corner, then "Settings")
+3. In the left sidebar, click on "Applications"
+4. Under "Generate New Token", enter a name for your token (e.g., "OpenHands")
+5. Select the appropriate scopes for your token (at minimum, you'll need "repo" access)
+6. Click "Generate Token"
+7. Copy the generated token (you won't be able to see it again)
+
+### Configuring OpenHands
+
+You can provide your Forgejo token to OpenHands in one of these ways:
+
+#### Environment Variable
+
+Set the `FORGEJO_TOKEN` environment variable:
+
+```bash
+export FORGEJO_TOKEN=your_token_here
+```
+
+#### Configuration File
+
+Add your token to the OpenHands configuration file:
+
+```yaml
+provider_tokens:
+  forgejo:
+    token: your_token_here
+```
+
+## Using the Forgejo Integration
+
+Once configured, you can use the Forgejo integration to:
+
+- Browse and search repositories
+- View issues and pull requests
+- Clone repositories
+- Create pull requests
+
+The Forgejo integration works similarly to the GitHub and GitLab integrations, with the same interface and functionality.
+
+## Customizing the Base URL
+
+By default, the Forgejo integration uses Codeberg.org as the base URL. If you're using a different Forgejo instance, you can customize the base URL:
+
+```python
+from openhands.integrations.forgejo.forgejo_service import ForgejoService
+from pydantic import SecretStr
+
+# Create a Forgejo service with a custom base URL
+forgejo_service = ForgejoService(
+    token=SecretStr("your_token_here"),
+    base_url="https://your-forgejo-instance.com/api/v1"
+)
+```
+
+## Limitations
+
+- The Forgejo API may have some differences from the GitHub API
+- Some advanced features like requesting reviewers work differently in Forgejo
+- API rate limits may vary depending on the Forgejo instance

--- a/microagents/knowledge/forgejo.md
+++ b/microagents/knowledge/forgejo.md
@@ -1,0 +1,79 @@
+# Forgejo Knowledge
+
+Forgejo is a self-hosted Git service that is a fork of Gitea. It provides a lightweight, open-source alternative to GitHub and GitLab. Codeberg.org is a popular instance of Forgejo.
+
+## API
+
+The Forgejo API is compatible with the Gitea API. It follows a RESTful design and uses JSON for data exchange. The base URL for the API is typically:
+
+```
+https://[forgejo-instance]/api/v1
+```
+
+For Codeberg, the base URL is:
+
+```
+https://codeberg.org/api/v1
+```
+
+### Authentication
+
+Forgejo supports several authentication methods:
+
+1. HTTP basic authentication
+2. `token=...` parameter in URL query string
+3. `access_token=...` parameter in URL query string
+4. `Authorization: token ...` header in HTTP headers
+
+### Common Endpoints
+
+- `/user` - Get authenticated user information
+- `/user/repos` - List repositories for the authenticated user
+- `/repos/search` - Search for repositories
+- `/repos/{owner}/{repo}` - Get repository information
+- `/repos/{owner}/{repo}/issues` - List issues for a repository
+- `/repos/{owner}/{repo}/pulls` - List pull requests for a repository
+
+### Pagination
+
+The API supports pagination with the `page` and `limit` parameters. The `Link` header is returned with next, previous, and last page links if there are more than one page.
+
+## Differences from GitHub/GitLab
+
+- Forgejo uses `limit` instead of `per_page` for pagination
+- Forgejo uses `stars_count` instead of `stargazers_count` for repository stars
+- Forgejo doesn't have a direct API for requesting reviewers on pull requests
+- Forgejo doesn't support replying to specific comments in the same way as GitHub
+
+## Codeberg Specifics
+
+Codeberg.org is a popular Forgejo instance hosted in the EU. It's a non-profit, community-driven platform focused on free and open source software.
+
+- Base URL: `https://codeberg.org/api/v1`
+- Authentication: Uses personal access tokens
+- Rate Limiting: Has rate limits to prevent abuse
+
+## Using the Forgejo Integration
+
+To use the Forgejo integration in OpenHands:
+
+1. Generate a personal access token from your Forgejo instance (e.g., Codeberg)
+2. Set the token as an environment variable: `FORGEJO_TOKEN`
+3. Use the Forgejo provider in your code
+
+Example:
+```python
+from openhands.integrations.service_types import ProviderType
+from openhands.integrations.provider import ProviderHandler
+
+# Create a provider handler with Forgejo token
+provider_handler = ProviderHandler({
+    ProviderType.FORGEJO: ProviderToken(token=SecretStr("your_token"))
+})
+
+# Get user information
+user = await provider_handler.get_user()
+
+# Search repositories
+repos = await provider_handler.search_repositories("query", 10, "updated", "desc")
+```

--- a/openhands/integrations/forgejo/forgejo_service.py
+++ b/openhands/integrations/forgejo/forgejo_service.py
@@ -1,0 +1,181 @@
+import os
+from typing import Any
+
+import httpx
+from pydantic import SecretStr
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.integrations.service_types import (
+    AuthenticationError,
+    GitService,
+    ProviderType,
+    Repository,
+    UnknownException,
+    User,
+)
+from openhands.server.types import AppMode
+from openhands.utils.import_utils import get_impl
+
+
+class ForgejoService(GitService):
+    BASE_URL = 'https://codeberg.org/api/v1'  # Default to Codeberg, can be overridden
+    token: SecretStr = SecretStr('')
+    refresh = False
+
+    def __init__(
+        self,
+        user_id: str | None = None,
+        external_auth_id: str | None = None,
+        external_auth_token: SecretStr | None = None,
+        token: SecretStr | None = None,
+        external_token_manager: bool = False,
+        base_url: str | None = None,
+    ):
+        self.user_id = user_id
+        self.external_token_manager = external_token_manager
+
+        if token:
+            self.token = token
+            
+        if base_url:
+            self.BASE_URL = base_url
+
+    async def _get_forgejo_headers(self) -> dict:
+        """
+        Retrieve the Forgejo Token to construct the headers
+        """
+        if self.user_id and not self.token:
+            self.token = await self.get_latest_token()
+
+        return {
+            'Authorization': f'token {self.token.get_secret_value()}',
+            'Accept': 'application/json',
+        }
+
+    def _has_token_expired(self, status_code: int) -> bool:
+        return status_code == 401
+
+    async def get_latest_token(self) -> SecretStr | None:
+        return self.token
+
+    async def _fetch_data(
+        self, url: str, params: dict | None = None
+    ) -> tuple[Any, dict]:
+        try:
+            async with httpx.AsyncClient() as client:
+                forgejo_headers = await self._get_forgejo_headers()
+                response = await client.get(url, headers=forgejo_headers, params=params)
+                if self.refresh and self._has_token_expired(response.status_code):
+                    await self.get_latest_token()
+                    forgejo_headers = await self._get_forgejo_headers()
+                    response = await client.get(
+                        url, headers=forgejo_headers, params=params
+                    )
+
+                response.raise_for_status()
+                headers = {}
+                if 'Link' in response.headers:
+                    headers['Link'] = response.headers['Link']
+
+                return response.json(), headers
+
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError('Invalid Forgejo token')
+            raise UnknownException(f'Unknown error: {e}')
+
+        except httpx.HTTPError as e:
+            raise UnknownException(f'HTTP error: {e}')
+
+    async def get_user(self) -> User:
+        url = f'{self.BASE_URL}/user'
+        response, _ = await self._fetch_data(url)
+
+        return User(
+            id=response.get('id'),
+            username=response.get('username'),
+            avatar_url=response.get('avatar_url'),
+            name=response.get('full_name'),
+            email=response.get('email'),
+            company=response.get('organization'),
+            login=response.get('username'),
+        )
+
+    async def search_repositories(
+        self, query: str, per_page: int = 30, sort: str = 'updated', order: str = 'desc'
+    ) -> list[Repository]:
+        url = f'{self.BASE_URL}/repos/search'
+        params = {
+            'q': query,
+            'limit': per_page,
+            'sort': sort,
+            'order': order,
+            'mode': 'source',  # Only return repositories that are not forks
+        }
+
+        response, _ = await self._fetch_data(url, params)
+        repos = [
+            Repository(
+                id=repo.get('id'),
+                full_name=repo.get('full_name'),
+                stargazers_count=repo.get('stars_count'),
+                git_provider=ProviderType.FORGEJO,
+            )
+            for repo in response.get('data', [])
+        ]
+
+        return repos
+
+    async def get_repositories(self, sort: str, app_mode: AppMode) -> list[Repository]:
+        MAX_REPOS = 1000
+        PER_PAGE = 100  # Maximum allowed by Forgejo API
+        all_repos: list[dict] = []
+        page = 1
+
+        url = f'{self.BASE_URL}/user/repos'
+        # Map GitHub's sort values to Forgejo's sort values
+        sort_map = {
+            'pushed': 'updated',
+            'updated': 'updated',
+            'created': 'created',
+            'full_name': 'name',
+        }
+        forgejo_sort = sort_map.get(sort, 'updated')
+
+        while len(all_repos) < MAX_REPOS:
+            params = {
+                'page': str(page),
+                'limit': str(PER_PAGE),
+                'sort': forgejo_sort,
+            }
+            response, headers = await self._fetch_data(url, params)
+
+            if not response:  # No more repositories
+                break
+
+            all_repos.extend(response)
+            page += 1
+
+            # Check if we've reached the last page
+            link_header = headers.get('Link', '')
+            if 'rel="next"' not in link_header:
+                break
+
+        # Trim to MAX_REPOS if needed and convert to Repository objects
+        all_repos = all_repos[:MAX_REPOS]
+        return [
+            Repository(
+                id=repo.get('id'),
+                full_name=repo.get('full_name'),
+                stargazers_count=repo.get('stars_count'),
+                git_provider=ProviderType.FORGEJO,
+            )
+            for repo in all_repos
+        ]
+
+
+forgejo_service_cls = os.environ.get(
+    'OPENHANDS_FORGEJO_SERVICE_CLS',
+    'openhands.integrations.forgejo.forgejo_service.ForgejoService',
+)
+ForgejoServiceImpl = get_impl(ForgejoService, forgejo_service_cls)

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -17,6 +17,7 @@ from pydantic.json import pydantic_encoder
 from openhands.events.action.action import Action
 from openhands.events.action.commands import CmdRunAction
 from openhands.events.stream import EventStream
+from openhands.integrations.forgejo.forgejo_service import ForgejoServiceImpl
 from openhands.integrations.github.github_service import GithubServiceImpl
 from openhands.integrations.gitlab.gitlab_service import GitLabServiceImpl
 from openhands.integrations.service_types import (
@@ -147,6 +148,7 @@ class ProviderHandler:
         self.service_class_map: dict[ProviderType, type[GitService]] = {
             ProviderType.GITHUB: GithubServiceImpl,
             ProviderType.GITLAB: GitLabServiceImpl,
+            ProviderType.FORGEJO: ForgejoServiceImpl,
         }
 
         self.external_auth_id = external_auth_id

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -9,6 +9,7 @@ from openhands.server.types import AppMode
 class ProviderType(Enum):
     GITHUB = 'github'
     GITLAB = 'gitlab'
+    FORGEJO = 'forgejo'
 
 
 class TaskType(str, Enum):

--- a/openhands/resolver/interfaces/forgejo.py
+++ b/openhands/resolver/interfaces/forgejo.py
@@ -1,0 +1,454 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.resolver.interfaces.issue import (
+    Issue,
+    IssueHandlerInterface,
+    ReviewThread,
+)
+from openhands.resolver.utils import extract_issue_references
+
+
+class ForgejoIssueHandler(IssueHandlerInterface):
+    def __init__(self, owner: str, repo: str, token: str, username: str | None = None):
+        self.owner = owner
+        self.repo = repo
+        self.token = token
+        self.username = username
+        self.base_url = self.get_base_url()
+        self.download_url = self.get_download_url()
+        self.clone_url = self.get_clone_url()
+        self.headers = self.get_headers()
+
+    def set_owner(self, owner: str) -> None:
+        self.owner = owner
+
+    def get_headers(self) -> dict[str, str]:
+        return {
+            'Authorization': f'token {self.token}',
+            'Accept': 'application/json',
+        }
+
+    def get_base_url(self) -> str:
+        return f'https://codeberg.org/api/v1/repos/{self.owner}/{self.repo}'
+
+    def get_authorize_url(self) -> str:
+        return f'https://{self.username}:{self.token}@codeberg.org/'
+
+    def get_branch_url(self, branch_name: str) -> str:
+        return self.get_base_url() + f'/branches/{branch_name}'
+
+    def get_download_url(self) -> str:
+        return f'{self.base_url}/issues'
+
+    def get_clone_url(self) -> str:
+        username_and_token = (
+            f'{self.username}:{self.token}'
+            if self.username
+            else f'x-auth-token:{self.token}'
+        )
+        return f'https://{username_and_token}@codeberg.org/{self.owner}/{self.repo}.git'
+
+    def get_compare_url(self, branch_name: str) -> str:
+        return f'https://codeberg.org/{self.owner}/{self.repo}/compare/{branch_name}?expand=1'
+
+    def get_converted_issues(
+        self, issue_numbers: list[int] | None = None, comment_id: int | None = None
+    ) -> list[Issue]:
+        """Download issues from Forgejo.
+
+        Args:
+            issue_numbers: The numbers of the issues to download
+            comment_id: The ID of a single comment, if provided, otherwise all comments
+
+        Returns:
+            List of Forgejo issues.
+        """
+
+        if not issue_numbers:
+            raise ValueError('Unspecified issue number')
+
+        all_issues = self.download_issues()
+        logger.info(f'Limiting resolving to issues {issue_numbers}.')
+        all_issues = [
+            issue
+            for issue in all_issues
+            if issue['number'] in issue_numbers and not issue.get('pull_request')
+        ]
+
+        if len(issue_numbers) == 1 and not all_issues:
+            raise ValueError(f'Issue {issue_numbers[0]} not found')
+
+        converted_issues = []
+        for issue in all_issues:
+            # Check for required fields (number and title)
+            if any([issue.get(key) is None for key in ['number', 'title']]):
+                logger.warning(
+                    f'Skipping issue {issue} as it is missing number or title.'
+                )
+                continue
+
+            # Handle empty body by using empty string
+            if issue.get('body') is None:
+                issue['body'] = ''
+
+            # Get issue thread comments
+            thread_comments = self.get_issue_comments(
+                issue['number'], comment_id=comment_id
+            )
+            # Convert empty lists to None for optional fields
+            issue_details = Issue(
+                owner=self.owner,
+                repo=self.repo,
+                number=issue['number'],
+                title=issue['title'],
+                body=issue['body'],
+                thread_comments=thread_comments,
+                review_comments=None,  # Initialize review comments as None for regular issues
+            )
+
+            converted_issues.append(issue_details)
+
+        return converted_issues
+
+    def download_issues(self) -> list[Any]:
+        params: dict[str, int | str] = {'state': 'open', 'page': 1, 'limit': 100}
+        all_issues = []
+
+        while True:
+            response = httpx.get(self.download_url, headers=self.headers, params=params)
+            response.raise_for_status()
+            issues = response.json()
+
+            if not issues:
+                break
+
+            if not isinstance(issues, list) or any(
+                [not isinstance(issue, dict) for issue in issues]
+            ):
+                raise ValueError(
+                    'Expected list of dictionaries from Service Forgejo API.'
+                )
+
+            all_issues.extend(issues)
+            assert isinstance(params['page'], int)
+            params['page'] += 1
+
+        return all_issues
+
+    def get_issue_comments(
+        self, issue_number: int, comment_id: int | None = None
+    ) -> list[str] | None:
+        """Download comments for a specific issue from Forgejo."""
+        url = f'{self.download_url}/{issue_number}/comments'
+        params = {'page': 1, 'limit': 100}
+        all_comments = []
+
+        while True:
+            response = httpx.get(url, headers=self.headers, params=params)
+            response.raise_for_status()
+            comments = response.json()
+
+            if not comments:
+                break
+
+            if comment_id:
+                matching_comment = next(
+                    (
+                        comment['body']
+                        for comment in comments
+                        if comment['id'] == comment_id
+                    ),
+                    None,
+                )
+                if matching_comment:
+                    return [matching_comment]
+            else:
+                all_comments.extend([comment['body'] for comment in comments])
+
+            params['page'] += 1
+
+        return all_comments if all_comments else None
+
+    def branch_exists(self, branch_name: str) -> bool:
+        logger.info(f'Checking if branch {branch_name} exists...')
+        response = httpx.get(
+            f'{self.base_url}/branches/{branch_name}', headers=self.headers
+        )
+        exists = response.status_code == 200
+        logger.info(f'Branch {branch_name} exists: {exists}')
+        return exists
+
+    def get_branch_name(self, base_branch_name: str) -> str:
+        branch_name = base_branch_name
+        attempt = 1
+        while self.branch_exists(branch_name):
+            attempt += 1
+            branch_name = f'{base_branch_name}-try{attempt}'
+        return branch_name
+
+    def reply_to_comment(self, pr_number: int, comment_id: str, reply: str) -> None:
+        # Forgejo doesn't support replying to specific comments in the same way as GitHub
+        # So we'll just add a new comment to the PR
+        self.send_comment_msg(pr_number, reply)
+
+    def get_pull_url(self, pr_number: int) -> str:
+        return f'https://codeberg.org/{self.owner}/{self.repo}/pulls/{pr_number}'
+
+    def get_default_branch_name(self) -> str:
+        response = httpx.get(f'{self.base_url}', headers=self.headers)
+        response.raise_for_status()
+        data = response.json()
+        return str(data['default_branch'])
+
+    def create_pull_request(self, data: dict[str, Any] | None = None) -> dict[str, Any]:
+        if data is None:
+            data = {}
+        response = httpx.post(f'{self.base_url}/pulls', headers=self.headers, json=data)
+        if response.status_code == 403:
+            raise RuntimeError(
+                'Failed to create pull request due to missing permissions. '
+                'Make sure that the provided token has push permissions for the repository.'
+            )
+        response.raise_for_status()
+        pr_data = response.json()
+        return dict(pr_data)
+
+    def request_reviewers(self, reviewer: str, pr_number: int) -> None:
+        # Forgejo doesn't have a direct API for requesting reviewers
+        # We'll add a comment mentioning the reviewer instead
+        msg = f"@{reviewer} Could you please review this pull request?"
+        self.send_comment_msg(pr_number, msg)
+
+    def send_comment_msg(self, issue_number: int, msg: str) -> None:
+        """Send a comment message to a Forgejo issue or pull request.
+
+        Args:
+            issue_number: The issue or pull request number
+            msg: The message content to post as a comment
+        """
+        # Post a comment on the PR
+        comment_url = f'{self.base_url}/issues/{issue_number}/comments'
+        comment_data = {'body': msg}
+        comment_response = httpx.post(
+            comment_url, headers=self.headers, json=comment_data
+        )
+        if comment_response.status_code != 201:
+            logger.error(
+                f'Failed to post comment: {comment_response.status_code} {comment_response.text}'
+            )
+        else:
+            logger.info(f'Comment added to the PR: {msg}')
+
+    def get_context_from_external_issues_references(
+        self,
+        closing_issues: list[str],
+        closing_issue_numbers: list[int],
+        issue_body: str,
+        review_comments: list[str] | None,
+        review_threads: list[ReviewThread],
+        thread_comments: list[str] | None,
+    ) -> list[str]:
+        return []
+
+
+class ForgejoPRHandler(ForgejoIssueHandler):
+    def __init__(self, owner: str, repo: str, token: str, username: str | None = None):
+        super().__init__(owner, repo, token, username)
+        self.download_url = f'https://codeberg.org/api/v1/repos/{self.owner}/{self.repo}/pulls'
+
+    def download_pr_metadata(
+        self, pull_number: int, comment_id: int | None = None
+    ) -> tuple[list[str], list[int], list[str], list[ReviewThread], list[str]]:
+        """Get metadata for a pull request.
+
+        Args:
+            pull_number: The number of the pull request to query.
+            comment_id: Optional ID of a specific comment to focus on.
+
+        Returns:
+            Tuple containing:
+            - List of closing issue bodies
+            - List of closing issue numbers
+            - List of review bodies
+            - List of review threads
+            - List of thread comments
+        """
+        # Get the PR details
+        pr_url = f'{self.base_url}/pulls/{pull_number}'
+        pr_response = httpx.get(pr_url, headers=self.headers)
+        pr_response.raise_for_status()
+        pr_data = pr_response.json()
+
+        # Get closing issues from PR body
+        closing_issues_bodies = []
+        closing_issue_numbers = []
+        if pr_data.get('body'):
+            # Extract issue references from PR body
+            issue_refs = extract_issue_references(pr_data['body'])
+            for issue_ref in issue_refs:
+                try:
+                    issue_url = f'{self.base_url}/issues/{issue_ref}'
+                    issue_response = httpx.get(issue_url, headers=self.headers)
+                    if issue_response.status_code == 200:
+                        issue_data = issue_response.json()
+                        closing_issues_bodies.append(issue_data.get('body', ''))
+                        closing_issue_numbers.append(issue_data.get('number'))
+                except Exception as e:
+                    logger.warning(f"Error fetching issue {issue_ref}: {e}")
+
+        # Get review comments
+        review_url = f'{self.base_url}/pulls/{pull_number}/comments'
+        review_params = {'page': 1, 'limit': 100}
+        review_comments = []
+        
+        while True:
+            review_response = httpx.get(review_url, headers=self.headers, params=review_params)
+            review_response.raise_for_status()
+            comments = review_response.json()
+            
+            if not comments:
+                break
+                
+            if comment_id:
+                matching_comments = [c for c in comments if c.get('id') == comment_id]
+                if matching_comments:
+                    review_comments.extend([c.get('body', '') for c in matching_comments])
+                    break
+            else:
+                review_comments.extend([c.get('body', '') for c in comments])
+                
+            review_params['page'] += 1
+
+        # Get PR comments (thread comments)
+        thread_url = f'{self.base_url}/issues/{pull_number}/comments'
+        thread_params = {'page': 1, 'limit': 100}
+        thread_comments = []
+        
+        while True:
+            thread_response = httpx.get(thread_url, headers=self.headers, params=thread_params)
+            thread_response.raise_for_status()
+            comments = thread_response.json()
+            
+            if not comments:
+                break
+                
+            if comment_id:
+                matching_comments = [c for c in comments if c.get('id') == comment_id]
+                if matching_comments:
+                    thread_comments.extend([c.get('body', '') for c in matching_comments])
+                    break
+            else:
+                thread_comments.extend([c.get('body', '') for c in comments])
+                
+            thread_params['page'] += 1
+
+        # Create review threads
+        review_threads = []
+        for comment in review_comments:
+            # In Forgejo, we don't have the same concept of review threads as in GitHub
+            # So we'll create a simple thread for each comment
+            thread = ReviewThread(
+                id=str(comment_id) if comment_id else "0",
+                message=comment,
+                files=[],
+            )
+            review_threads.append(thread)
+
+        return (
+            closing_issues_bodies,
+            closing_issue_numbers,
+            review_comments,
+            review_threads,
+            thread_comments,
+        )
+
+    def get_converted_issues(
+        self, issue_numbers: list[int] | None = None, comment_id: int | None = None
+    ) -> list[Issue]:
+        """Download pull requests from Forgejo.
+
+        Args:
+            issue_numbers: The numbers of the pull requests to download
+            comment_id: The ID of a single comment, if provided, otherwise all comments
+
+        Returns:
+            List of Forgejo pull requests as Issues.
+        """
+        if not issue_numbers:
+            raise ValueError('Unspecified pull request number')
+
+        all_prs = self.download_prs()
+        logger.info(f'Limiting resolving to pull requests {issue_numbers}.')
+        all_prs = [pr for pr in all_prs if pr['number'] in issue_numbers]
+
+        if len(issue_numbers) == 1 and not all_prs:
+            raise ValueError(f'Pull request {issue_numbers[0]} not found')
+
+        converted_issues = []
+        for pr in all_prs:
+            # Check for required fields (number and title)
+            if any([pr.get(key) is None for key in ['number', 'title']]):
+                logger.warning(
+                    f'Skipping pull request {pr} as it is missing number or title.'
+                )
+                continue
+
+            # Handle empty body by using empty string
+            if pr.get('body') is None:
+                pr['body'] = ''
+
+            # Get PR metadata
+            (
+                closing_issues,
+                closing_issue_numbers,
+                review_comments,
+                review_threads,
+                thread_comments,
+            ) = self.download_pr_metadata(pr['number'], comment_id)
+
+            # Convert empty lists to None for optional fields
+            issue_details = Issue(
+                owner=self.owner,
+                repo=self.repo,
+                number=pr['number'],
+                title=pr['title'],
+                body=pr['body'],
+                thread_comments=thread_comments if thread_comments else None,
+                review_comments=review_comments if review_comments else None,
+                review_threads=review_threads if review_threads else None,
+                closing_issues=closing_issues if closing_issues else None,
+                closing_issue_numbers=closing_issue_numbers if closing_issue_numbers else None,
+            )
+
+            converted_issues.append(issue_details)
+
+        return converted_issues
+
+    def download_prs(self) -> list[Any]:
+        params: dict[str, int | str] = {'state': 'open', 'page': 1, 'limit': 100}
+        all_prs = []
+
+        while True:
+            response = httpx.get(self.download_url, headers=self.headers, params=params)
+            response.raise_for_status()
+            prs = response.json()
+
+            if not prs:
+                break
+
+            if not isinstance(prs, list) or any(
+                [not isinstance(pr, dict) for pr in prs]
+            ):
+                raise ValueError(
+                    'Expected list of dictionaries from Service Forgejo API.'
+                )
+
+            all_prs.extend(prs)
+            assert isinstance(params['page'], int)
+            params['page'] += 1
+
+        return all_prs

--- a/tests/unit/test_forgejo_service.py
+++ b/tests/unit/test_forgejo_service.py
@@ -1,0 +1,222 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from openhands.integrations.forgejo.forgejo_service import ForgejoService
+from openhands.integrations.service_types import ProviderType, Repository, User
+from openhands.server.types import AppMode
+
+
+@pytest.fixture
+def forgejo_service():
+    return ForgejoService(token=SecretStr("test_token"))
+
+
+@pytest.mark.asyncio
+async def test_get_user(forgejo_service):
+    # Mock response data
+    mock_user_data = {
+        "id": 1,
+        "username": "test_user",
+        "avatar_url": "https://codeberg.org/avatar/test_user",
+        "full_name": "Test User",
+        "email": "test@example.com",
+        "organization": "Test Org",
+    }
+
+    # Mock the _fetch_data method
+    forgejo_service._fetch_data = AsyncMock(return_value=(mock_user_data, {}))
+
+    # Call the method
+    user = await forgejo_service.get_user()
+
+    # Verify the result
+    assert isinstance(user, User)
+    assert user.id == 1
+    assert user.login == "test_user"
+    assert user.avatar_url == "https://codeberg.org/avatar/test_user"
+    assert user.name == "Test User"
+    assert user.email == "test@example.com"
+    assert user.company == "Test Org"
+
+    # Verify the _fetch_data call
+    forgejo_service._fetch_data.assert_called_once_with(f"{forgejo_service.BASE_URL}/user")
+
+
+@pytest.mark.asyncio
+async def test_search_repositories(forgejo_service):
+    # Mock response data
+    mock_repos_data = {
+        "data": [
+            {
+                "id": 1,
+                "full_name": "test_user/repo1",
+                "stars_count": 10,
+            },
+            {
+                "id": 2,
+                "full_name": "test_user/repo2",
+                "stars_count": 20,
+            },
+        ]
+    }
+
+    # Mock the _fetch_data method
+    forgejo_service._fetch_data = AsyncMock(return_value=(mock_repos_data, {}))
+
+    # Call the method
+    repos = await forgejo_service.search_repositories("test", 10, "updated", "desc")
+
+    # Verify the result
+    assert len(repos) == 2
+    assert all(isinstance(repo, Repository) for repo in repos)
+    assert repos[0].id == 1
+    assert repos[0].full_name == "test_user/repo1"
+    assert repos[0].stargazers_count == 10
+    assert repos[0].git_provider == ProviderType.FORGEJO
+    assert repos[1].id == 2
+    assert repos[1].full_name == "test_user/repo2"
+    assert repos[1].stargazers_count == 20
+    assert repos[1].git_provider == ProviderType.FORGEJO
+
+    # Verify the _fetch_data call
+    forgejo_service._fetch_data.assert_called_once_with(
+        f"{forgejo_service.BASE_URL}/repos/search",
+        {
+            "q": "test",
+            "limit": 10,
+            "sort": "updated",
+            "order": "desc",
+            "mode": "source",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_repositories(forgejo_service):
+    # Mock response data for first page
+    mock_repos_data_page1 = [
+        {
+            "id": 1,
+            "full_name": "test_user/repo1",
+            "stars_count": 10,
+        },
+        {
+            "id": 2,
+            "full_name": "test_user/repo2",
+            "stars_count": 20,
+        },
+    ]
+
+    # Mock response data for second page
+    mock_repos_data_page2 = [
+        {
+            "id": 3,
+            "full_name": "test_user/repo3",
+            "stars_count": 30,
+        },
+    ]
+
+    # Mock the _fetch_data method to return different data for different pages
+    forgejo_service._fetch_data = AsyncMock()
+    forgejo_service._fetch_data.side_effect = [
+        (mock_repos_data_page1, {"Link": '<https://codeberg.org/api/v1/user/repos?page=2>; rel="next"'}),
+        (mock_repos_data_page2, {"Link": ""}),
+    ]
+
+    # Call the method
+    repos = await forgejo_service.get_repositories("updated", AppMode.OSS)
+
+    # Verify the result
+    assert len(repos) == 3
+    assert all(isinstance(repo, Repository) for repo in repos)
+    assert repos[0].id == 1
+    assert repos[0].full_name == "test_user/repo1"
+    assert repos[0].stargazers_count == 10
+    assert repos[0].git_provider == ProviderType.FORGEJO
+    assert repos[1].id == 2
+    assert repos[1].full_name == "test_user/repo2"
+    assert repos[1].stargazers_count == 20
+    assert repos[1].git_provider == ProviderType.FORGEJO
+    assert repos[2].id == 3
+    assert repos[2].full_name == "test_user/repo3"
+    assert repos[2].stargazers_count == 30
+    assert repos[2].git_provider == ProviderType.FORGEJO
+
+    # Verify the _fetch_data calls
+    assert forgejo_service._fetch_data.call_count == 2
+    forgejo_service._fetch_data.assert_any_call(
+        f"{forgejo_service.BASE_URL}/user/repos",
+        {"page": "1", "limit": "100", "sort": "updated"},
+    )
+    forgejo_service._fetch_data.assert_any_call(
+        f"{forgejo_service.BASE_URL}/user/repos",
+        {"page": "2", "limit": "100", "sort": "updated"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_success(forgejo_service):
+    # Mock httpx.AsyncClient
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"key": "value"}
+    mock_response.headers = {"Link": "next_link"}
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    # Patch httpx.AsyncClient
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        # Call the method
+        result, headers = await forgejo_service._fetch_data("https://test.url", {"param": "value"})
+
+    # Verify the result
+    assert result == {"key": "value"}
+    assert headers == {"Link": "next_link"}
+    mock_response.raise_for_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_auth_error(forgejo_service):
+    # Mock httpx.AsyncClient
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "401 Unauthorized", request=MagicMock(), response=mock_response
+    )
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    # Patch httpx.AsyncClient
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        # Call the method and expect an exception
+        with pytest.raises(Exception) as excinfo:
+            await forgejo_service._fetch_data("https://test.url", {"param": "value"})
+
+    # Verify the exception
+    assert "Invalid Forgejo token" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_other_error(forgejo_service):
+    # Mock httpx.AsyncClient
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500 Server Error", request=MagicMock(), response=mock_response
+    )
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    # Patch httpx.AsyncClient
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        # Call the method and expect an exception
+        with pytest.raises(Exception) as excinfo:
+            await forgejo_service._fetch_data("https://test.url", {"param": "value"})
+
+    # Verify the exception
+    assert "Unknown error" in str(excinfo.value)


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**

This PR adds support for Forgejo, a self-hosted Git service that is a fork of Gitea. With this integration, users can now interact with Forgejo instances like Codeberg.org in the same way they interact with GitHub and GitLab. This enables browsing repositories, viewing issues and pull requests, and creating pull requests on Forgejo platforms.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

This PR implements a Forgejo integration similar to the existing GitHub and GitLab integrations. It includes:

1. A new `ForgejoService` class that implements the `GitService` protocol
2. A new `ForgejoIssueHandler` and `ForgejoPRHandler` for the resolver interface
3. Updates to the `ProviderType` enum to include Forgejo
4. Updates to the `ProviderHandler` class to support the Forgejo service
5. A new microagent knowledge file for Forgejo
6. Comprehensive unit tests for the Forgejo service
7. Documentation for the Forgejo integration

The implementation follows the same patterns as the existing GitHub and GitLab integrations, making it easy to understand and maintain. The Forgejo API is similar to the GitHub API, but there are some differences in endpoint names and response formats that are handled in the implementation.

The integration has been tested against Codeberg.org, a popular Forgejo instance, and works correctly for browsing repositories, searching, and other operations.

---
**Link of any specific issues this addresses.**

N/A