### PR TITLE
Refactor: Move startup command generation to DockerRuntime method

### DIFF
--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -1,3 +1,5 @@
+import warnings
+
 from openhands.core.config import AppConfig
 from openhands.runtime.plugins import PluginRequirement
 
@@ -19,6 +21,18 @@ def get_action_execution_server_startup_command(
     override_user_id: int | None = None,
     override_username: str | None = None,
 ) -> list[str]:
+    """
+    DEPRECATED: This function has been moved to a method on the DockerRuntime class.
+    Use DockerRuntime.get_action_execution_server_startup_command() instead.
+
+    This function will be removed in a future release.
+    """
+    warnings.warn(
+        'get_action_execution_server_startup_command is deprecated. '
+        'Use DockerRuntime.get_action_execution_server_startup_command() instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
     sandbox_config = app_config.sandbox
 
     # Plugin args


### PR DESCRIPTION
## Description
This PR refactors the Docker runtime to make the function which generates the startup command a method on the runtime rather than a static function. This makes it easier to create subclasses with custom startup commands.

## Changes
- Move `get_action_execution_server_startup_command` from static function to instance method on `DockerRuntime`
- Mark original function as deprecated with warning
- Update call in `_init_container` to use instance method
- Add proper type annotations and docstrings

## Testing
- All existing tests pass
- Linting checks pass

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d0466a4-nikolaik   --name openhands-app-d0466a4   docker.all-hands.dev/all-hands-ai/openhands:d0466a4
```