### PR TITLE
Fix Bug #8425 - Enable prompt cache for OpenRouter model of calude-3.7-sonnet

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -50,6 +50,7 @@ LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
 CACHE_PROMPT_SUPPORTED_MODELS = [
     'claude-3-7-sonnet-20250219',
     'claude-sonnet-3-7-latest',
+    'claude-3.7-sonnet',
     'claude-3-5-sonnet-20241022',
     'claude-3-5-sonnet-20240620',
     'claude-3-5-haiku-20241022',


### PR DESCRIPTION
Enable prompt cache for OpenRouter claude-3.7-sonnet

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


### Describe the bug and reproduction steps

### Bug Description (https://github.com/All-Hands-AI/OpenHands/issues/8425)

The model of OpenRouter Claude-3.7-sonnet supports prompt cache (ref https://openrouter.ai/docs/features/prompt-caching), while the prompt cache is disabled by OpenHands due to the model is not included in `CACHE_PROMPT_SUPPORTED_MODELS` (`llm.py` line 50-58).
```python
CACHE_PROMPT_SUPPORTED_MODELS = [
    'claude-3-7-sonnet-20250219',
    'claude-3-5-sonnet-20241022',
    'claude-3-5-sonnet-20240620',
    'claude-3-5-haiku-20241022',
    'claude-3-haiku-20240307',
    'claude-3-opus-20240229',
]
```

### Root Cause Analysis
The model name in OpenRouter is `calude-3.7-sonnet`, while OpenHands's `CACHE_PROMPT_SUPPORTED_MODELS` only contains `claude-3-7-sonnet-20250219`.

### Change
- Add OpenRouter Model (`claude-3.7-sonnet`) into `CACHE_PROMPT_SUPPORTED_MODELS` in `llm.py`.

### Result Example
- Before fix
<img width="465" alt="Image" src="https://github.com/user-attachments/assets/6acf1db6-7e7b-44b0-aadb-ada6bfe1d1fc" />

- After fix
  - Prompt Cache Write
  <img width="466" alt="image" src="https://github.com/user-attachments/assets/84c56b40-14de-46bc-bf2e-2f32f5405913" />

  - Prompt Cache Read
  <img width="463" alt="image" src="https://github.com/user-attachments/assets/c3e35a11-7d78-4cb5-a40f-4f49cb171691" />

