### PR TITLE
Fix log for clearing pending action to be at the same level

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -772,7 +772,7 @@ class AgentController:
         """Executes a single step of the parent or delegate agent. Detects stuck agents and limits on the number of iterations and the task budget."""
         if self.get_agent_state() != AgentState.RUNNING:
             self.log(
-                'info',
+                'debug',
                 f'Agent not stepping because state is {self.get_agent_state()} (not RUNNING)',
                 extra={'msg_type': 'STEP_BLOCKED_STATE'},
             )
@@ -782,7 +782,7 @@ class AgentController:
             action_id = getattr(self._pending_action, 'id', 'unknown')
             action_type = type(self._pending_action).__name__
             self.log(
-                'info',
+                'debug',
                 f'Agent not stepping because of pending action: {action_type} (id={action_id})',
                 extra={'msg_type': 'STEP_BLOCKED_PENDING_ACTION'},
             )


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The logging message for set pending action is at `INFO`, while the message for clearing pending action is at `DEBUG` level. This leads to reports that the action is set and never cleared, when it's not the case.

This PR proposes to fix that by setting both at DEBUG.

Addresses
- https://github.com/All-Hands-AI/OpenHands/issues/8107
- https://github.com/All-Hands-AI/OpenHands/issues/8429 