### PR TITLE
Resolve warnings of logger library

### DIFF
--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -101,7 +101,7 @@ async def _create_new_conversation(
             )
 
     else:
-        logger.warn('Settings not present, not starting conversation')
+        logger.warning('Settings not present, not starting conversation')
         raise MissingSettingsError('Settings not found')
 
     session_init_args['git_provider_tokens'] = git_provider_tokens


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```