### PR TITLE
Add 10px bottom padding to paragraph tags in markdown rendering

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -6,6 +6,7 @@ import { cn } from "#/utils/utils";
 import { ul, ol } from "../markdown/list";
 import { CopyToClipboardButton } from "#/components/shared/buttons/copy-to-clipboard-button";
 import { anchor } from "../markdown/anchor";
+import { paragraph } from "../markdown/paragraph";
 
 interface ChatMessageProps {
   type: "user" | "assistant";
@@ -64,6 +65,7 @@ export function ChatMessage({
             ul,
             ol,
             a: anchor,
+            p: paragraph,
           }}
           remarkPlugins={[remarkGfm]}
         >

--- a/frontend/src/components/features/chat/expandable-message.tsx
+++ b/frontend/src/components/features/chat/expandable-message.tsx
@@ -15,6 +15,7 @@ import { OpenHandsObservation } from "#/types/core/observations";
 import { cn } from "#/utils/utils";
 import { code } from "../markdown/code";
 import { ol, ul } from "../markdown/list";
+import { paragraph } from "../markdown/paragraph";
 import { MonoComponent } from "./mono-component";
 import { PathComponent } from "./path-component";
 
@@ -196,6 +197,7 @@ export function ExpandableMessage({
                 code,
                 ul,
                 ol,
+                p: paragraph,
               }}
               remarkPlugins={[remarkGfm]}
             >

--- a/frontend/src/components/features/jupyter/jupyter-cell-output.tsx
+++ b/frontend/src/components/features/jupyter/jupyter-cell-output.tsx
@@ -4,6 +4,7 @@ import { atomOneDark } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import { JupyterLine } from "#/utils/parse-cell-content";
+import { paragraph } from "../markdown/paragraph";
 
 interface JupyterCellOutputProps {
   lines: JupyterLine[];
@@ -25,7 +26,12 @@ export function JupyterCellOutput({ lines }: JupyterCellOutputProps) {
           if (line.type === "image") {
             return (
               <div key={index}>
-                <Markdown urlTransform={(value: string) => value}>
+                <Markdown
+                  components={{
+                    p: paragraph,
+                  }}
+                  urlTransform={(value: string) => value}
+                >
                   {line.content}
                 </Markdown>
               </div>

--- a/frontend/src/components/features/markdown/paragraph.tsx
+++ b/frontend/src/components/features/markdown/paragraph.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { ExtraProps } from "react-markdown";
+
+// Custom component to render <p> in markdown with bottom padding
+export function paragraph({
+  children,
+}: React.ClassAttributes<HTMLParagraphElement> &
+  React.HTMLAttributes<HTMLParagraphElement> &
+  ExtraProps) {
+  return <p className="pb-[10px]">{children}</p>;
+}


### PR DESCRIPTION
This PR adds 10px of bottom padding to paragraph tags rendered by markdown in the chat window. This improves readability by preventing paragraphs from being squished together.

### Changes:
- Created a new custom paragraph component in `frontend/src/components/features/markdown/paragraph.tsx`
- Added the custom paragraph component to all markdown renderers in the application
- Applied consistent padding of 10px to the bottom of each paragraph

This change affects all markdown rendering in the chat interface, expandable messages, and Jupyter cell outputs.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b8f3c71-nikolaik   --name openhands-app-b8f3c71   docker.all-hands.dev/all-hands-ai/openhands:b8f3c71
```