### PR TITLE
fix: remove duplicate rendering of tab components

### DIFF
--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@heroui/react";
 import React from "react";
-import { Outlet, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import { useDispatch, useSelector } from "react-redux";
 import { FaServer, FaExternalLinkAlt } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
@@ -200,11 +200,6 @@ function AppContent() {
           >
             {/* Use both Outlet and TabContent */}
             <div className="h-full w-full">
-              {/* Keep the Outlet for React Router to work properly */}
-              <div className="hidden">
-                <Outlet />
-              </div>
-              {/* Use TabContent to keep all tabs loaded but only show the active one */}
               <TabContent conversationPath={basePath} />
             </div>
           </Container>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

In #8243, after introducing `TabContent` component, we use both it and react-router's `Outlet`, which renders two versions of the same components and causes conflicts in shared state processing.

In fact it seems we can remove the `Outlet` component without affecting the behavior of `react-router`. I tested manually and this seems to help resolve the bash commands run by the agent not shown in "Terminal" tab.

---
**Link of any specific issues this addresses:**
