### PR TITLE
Fix: Make error messages collapsed by default

### DIFF
--- a/frontend/src/components/features/chat/expandable-message.tsx
+++ b/frontend/src/components/features/chat/expandable-message.tsx
@@ -42,7 +42,8 @@ export function ExpandableMessage({
 }: ExpandableMessageProps) {
   const { data: config } = useConfig();
   const { t, i18n } = useTranslation();
-  const [showDetails, setShowDetails] = useState(true);
+  // Initialize showDetails to false for error messages, true for other types
+  const [showDetails, setShowDetails] = useState(type !== "error");
   const [details, setDetails] = useState(message);
   const [translationId, setTranslationId] = useState<string | undefined>(id);
   const [translationParams, setTranslationParams] = useState<


### PR DESCRIPTION
This PR fixes the issue where error messages are expanded by default. Now error messages will be collapsed by default, consistent with other message types.

The fix is simple - we initialize the `showDetails` state based on the message type, setting it to `false` for error messages.