### PR TITLE
Auth URL fix of on-prem

### DIFF
--- a/frontend/src/utils/generate-auth-url.ts
+++ b/frontend/src/utils/generate-auth-url.ts
@@ -6,10 +6,15 @@
  */
 export const generateAuthUrl = (identityProvider: string, requestUrl: URL) => {
   const redirectUri = `${requestUrl.origin}/oauth/keycloak/callback`;
-  const authUrl = requestUrl.hostname
+  let authUrl = requestUrl.hostname
     .replace(/(^|\.)staging\.all-hands\.dev$/, "$1auth.staging.all-hands.dev")
     .replace(/(^|\.)app\.all-hands\.dev$/, "auth.app.all-hands.dev")
     .replace(/(^|\.)localhost$/, "auth.staging.all-hands.dev");
+
+  // If no replacements matched, prepend "auth." (excluding localhost)
+  if (authUrl === requestUrl.hostname && requestUrl.hostname !== "localhost") {
+    authUrl = `auth.${requestUrl.hostname}`;
+  }
   const scope = "openid email profile"; // OAuth scope - not user-facing
   return `https://${authUrl}/realms/allhands/protocol/openid-connect/auth?client_id=allhands&kc_idp_hint=${identityProvider}&response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}`;
 };


### PR DESCRIPTION
SAAS only change for the auth URL when deployed outside of AH.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fe8659a-nikolaik   --name openhands-app-fe8659a   docker.all-hands.dev/all-hands-ai/openhands:fe8659a
```