### PR TITLE
Add force_refresh parameter to get_latest_token

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -70,7 +70,7 @@ class GitHubService(BaseGitService, GitService):
     def _has_token_expired(self, status_code: int) -> bool:
         return status_code == 401
 
-    async def get_latest_token(self) -> SecretStr | None:
+    async def get_latest_token(self, force_refresh: bool = False) -> SecretStr | None:
         return self.token
 
     async def _make_request(
@@ -94,7 +94,7 @@ class GitHubService(BaseGitService, GitService):
 
                 # Handle token refresh if needed
                 if self.refresh and self._has_token_expired(response.status_code):
-                    await self.get_latest_token()
+                    await self.get_latest_token(force_refresh=True)
                     github_headers = await self._get_github_headers()
                     response = await self.execute_request(
                         client=client,

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -63,7 +63,7 @@ class GitLabService(BaseGitService, GitService):
     def _has_token_expired(self, status_code: int) -> bool:
         return status_code == 401
 
-    async def get_latest_token(self) -> SecretStr | None:
+    async def get_latest_token(self, force_refresh: bool = False) -> SecretStr | None:
         return self.token
 
     async def _make_request(
@@ -87,7 +87,7 @@ class GitLabService(BaseGitService, GitService):
 
                 # Handle token refresh if needed
                 if self.refresh and self._has_token_expired(response.status_code):
-                    await self.get_latest_token()
+                    await self.get_latest_token(force_refresh=True)
                     gitlab_headers = await self._get_gitlab_headers()
                     response = await self.execute_request(
                         client=client,
@@ -140,7 +140,7 @@ class GitLabService(BaseGitService, GitService):
                 )
 
                 if self.refresh and self._has_token_expired(response.status_code):
-                    await self.get_latest_token()
+                    await self.get_latest_token(force_refresh=True)
                     gitlab_headers = await self._get_gitlab_headers()
                     gitlab_headers['Content-Type'] = 'application/json'
                     response = await client.post(
@@ -196,7 +196,7 @@ class GitLabService(BaseGitService, GitService):
                 full_name=repo.get('path_with_namespace'),
                 stargazers_count=repo.get('star_count'),
                 git_provider=ProviderType.GITLAB,
-                is_public=True
+                is_public=True,
             )
             for repo in response
         ]

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -120,11 +120,11 @@ class ProviderHandler:
         raise AuthenticationError('Need valid provider token')
 
     async def _get_latest_provider_token(
-        self, provider: ProviderType
+        self, provider: ProviderType, force_refresh: bool = False
     ) -> SecretStr | None:
         """Get latest token from service"""
         service = self._get_service(provider)
-        return await service.get_latest_token()
+        return await service.get_latest_token(force_refresh=force_refresh)
 
     async def get_repositories(self, sort: str, app_mode: AppMode) -> list[Repository]:
         """
@@ -259,7 +259,9 @@ class ProviderHandler:
                 )
 
                 if get_latest:
-                    token = await self._get_latest_provider_token(provider)
+                    token = await self._get_latest_provider_token(
+                        provider, force_refresh=get_latest
+                    )
 
                 if token:
                     env_vars[provider] = token

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -188,8 +188,12 @@ class GitService(Protocol):
         """Initialize the service with authentication details"""
         ...
 
-    async def get_latest_token(self) -> SecretStr | None:
-        """Get latest working token of the user"""
+    async def get_latest_token(self, force_refresh: bool = False) -> SecretStr | None:
+        """Get latest working token of the user
+
+        Args:
+            force_refresh: If True, force a refresh of the token even if it's already cached
+        """
         ...
 
     async def get_user(self) -> User:


### PR DESCRIPTION
This PR adds a `force_refresh` parameter to the `get_latest_token` function that defaults to False. This parameter allows forcing a token refresh even if the token is already cached.

Changes:
- Updated `get_latest_token` method signature in `service_types.py` to include `force_refresh` parameter with default value of False
- Updated `get_latest_token` implementations in both `github_service.py` and `gitlab_service.py` to match the new signature
- Modified token refresh logic in both services to pass `force_refresh=True` when token expiration is detected
- Updated `_get_latest_provider_token` method in `provider.py` to accept and pass the `force_refresh` parameter

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c0bf386-nikolaik   --name openhands-app-c0bf386   docker.all-hands.dev/all-hands-ai/openhands:c0bf386
```