### PR TITLE
Fix finish tool in-context example to include required parameters

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -217,8 +217,11 @@ USER: EXECUTION RESULT of [execute_bash]:
 [1] 126
 
 ASSISTANT:
-The server is running on port 5000 with PID 126. You can access the list of numbers in a table format by visiting http://127.0.0.1:5000. Let me know if you have any further requests!
 <function=finish>
+<parameter=message>
+The server is running on port 5000 with PID 126. You can access the list of numbers in a table format by visiting http://127.0.0.1:5000. Let me know if you have any further requests!
+</parameter>
+<parameter=task_completed>true</parameter>
 </function>
 
 --------------------- END OF EXAMPLE ---------------------


### PR DESCRIPTION
This PR fixes issue #8476 by updating the in-context example for the finish tool to include the required parameters (`message` and `task_completed`). The finish tool requires these parameters as specified in its definition, but they were missing from the example in `fn_call_converter.py`.

Fixes #8476

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/13c69b4847e54714a8b8113cd490e432)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5f8514c-nikolaik   --name openhands-app-5f8514c   docker.all-hands.dev/all-hands-ai/openhands:5f8514c
```