### PR TITLE
Fix frontend tests to reflect new branch selection logic

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,8 +1,3 @@
----
-name: repo
-type: repo
-agent: CodeActAgent
----
 This repository contains the code for OpenHands, an automated AI software engineer. It has a Python backend
 (in the `openhands` directory) and React frontend (in the `frontend` directory).
 

--- a/docs/modules/usage/llms/azure-llms.md
+++ b/docs/modules/usage/llms/azure-llms.md
@@ -1,6 +1,7 @@
 # Azure
 
-OpenHands uses LiteLLM to make calls to Azure's chat models. You can find their documentation on using Azure as a provider [here](https://docs.litellm.ai/docs/providers/azure).
+OpenHands uses LiteLLM to make calls to Azure's chat models. You can find their documentation on using Azure as a 
+provider [here](https://docs.litellm.ai/docs/providers/azure).
 
 ## Azure OpenAI Configuration
 
@@ -18,7 +19,7 @@ docker run -it --pull=always \
     ...
 ```
 
-Then in the OpenHands UI Settings:
+Then in the OpenHands UI Settings under the `LLM` tab:
 
 :::note
 You will need your ChatGPT deployment name which can be found on the deployments page in Azure. This is referenced as

--- a/docs/modules/usage/llms/google-llms.md
+++ b/docs/modules/usage/llms/google-llms.md
@@ -7,10 +7,11 @@ OpenHands uses LiteLLM to make calls to Google's chat models. You can find their
 
 ## Gemini - Google AI Studio Configs
 
-When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings:
+When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
 - `LLM Provider` to `Gemini`
 - `LLM Model` to the model you will be using.
-If the model is not in the list, toggle `Advanced` options, and enter it in `Custom Model` (e.g. gemini/&lt;model-name&gt; like `gemini/gemini-2.0-flash`).
+If the model is not in the list, enable `Advanced` options, and enter it in `Custom Model` 
+(e.g. gemini/&lt;model-name&gt; like `gemini/gemini-2.0-flash`).
 - `API Key` to your Gemini API key
 
 ## VertexAI - Google Cloud Platform Configs
@@ -24,7 +25,8 @@ VERTEXAI_PROJECT="<your-gcp-project-id>"
 VERTEXAI_LOCATION="<your-gcp-location>"
 ```
 
-Then set the following in the OpenHands UI through the Settings:
+Then set the following in the OpenHands UI through the Settings under the `LLM` tab:
 - `LLM Provider` to `VertexAI`
 - `LLM Model` to the model you will be using.
-If the model is not in the list, toggle `Advanced` options, and enter it in `Custom Model` (e.g. vertex_ai/&lt;model-name&gt;).
+If the model is not in the list, enable `Advanced` options, and enter it in `Custom Model` 
+(e.g. vertex_ai/&lt;model-name&gt;).

--- a/docs/modules/usage/llms/groq.md
+++ b/docs/modules/usage/llms/groq.md
@@ -1,22 +1,21 @@
 # Groq
 
-OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their documentation on using Groq as a provider [here](https://docs.litellm.ai/docs/providers/groq).
+OpenHands uses LiteLLM to make calls to chat models on Groq. You can find their documentation on using Groq as a 
+provider [here](https://docs.litellm.ai/docs/providers/groq).
 
 ## Configuration
 
-When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings:
+When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
 - `LLM Provider` to `Groq`
 - `LLM Model` to the model you will be using. [Visit here to see the list of
-models that Groq hosts](https://console.groq.com/docs/models). If the model is not in the list, toggle
-`Advanced` options, and enter it in `Custom Model` (e.g. groq/&lt;model-name&gt; like `groq/llama3-70b-8192`).
+models that Groq hosts](https://console.groq.com/docs/models). If the model is not in the list, 
+enable `Advanced` options, and enter it in `Custom Model` (e.g. groq/&lt;model-name&gt; like `groq/llama3-70b-8192`).
 - `API key` to your Groq API key. To find or create your Groq API Key, [see here](https://console.groq.com/keys).
-
-
 
 ## Using Groq as an OpenAI-Compatible Endpoint
 
 The Groq endpoint for chat completion is [mostly OpenAI-compatible](https://console.groq.com/docs/openai). Therefore, you can access Groq models as you
-would access any OpenAI-compatible endpoint. In the OpenHands UI through the Settings:
+would access any OpenAI-compatible endpoint. In the OpenHands UI through the Settings under the `LLM` tab:
 1. Enable `Advanced` options
 2. Set the following:
    - `Custom Model` to the prefix `openai/` + the model you will be using (e.g. `openai/llama3-70b-8192`)

--- a/docs/modules/usage/llms/litellm-proxy.md
+++ b/docs/modules/usage/llms/litellm-proxy.md
@@ -7,7 +7,7 @@ OpenHands supports using the [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/
 To use LiteLLM proxy with OpenHands, you need to:
 
 1. Set up a LiteLLM proxy server (see [LiteLLM documentation](https://docs.litellm.ai/docs/proxy/quick_start))
-2. When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings:
+2. When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
   * Enable `Advanced` options
   * `Custom Model` to the prefix `litellm_proxy/` + the model you will be using (e.g. `litellm_proxy/anthropic.claude-3-5-sonnet-20241022-v2:0`)
   * `Base URL` to your LiteLLM proxy URL (e.g. `https://your-litellm-proxy.com`)
@@ -15,6 +15,7 @@ To use LiteLLM proxy with OpenHands, you need to:
 
 ## Supported Models
 
-The supported models depend on your LiteLLM proxy configuration. OpenHands supports any model that your LiteLLM proxy is configured to handle.
+The supported models depend on your LiteLLM proxy configuration. OpenHands supports any model that your LiteLLM proxy 
+is configured to handle.
 
 Refer to your LiteLLM proxy configuration for the list of available models and their names.

--- a/docs/modules/usage/llms/local-llms.md
+++ b/docs/modules/usage/llms/local-llms.md
@@ -75,7 +75,7 @@ Start OpenHands using `make run`.
 
 ### Configure OpenHands
 
-Once OpenHands is running, you'll need to set the following in the OpenHands UI through the Settings:
+Once OpenHands is running, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab: 
 1. Enable `Advanced` options.
 2. Set the following:
 - `Custom Model` to `openai/<served-model-name>` (e.g. `openai/openhands-lm-32b-v0.1`)

--- a/docs/modules/usage/llms/openai-llms.md
+++ b/docs/modules/usage/llms/openai-llms.md
@@ -1,14 +1,15 @@
 # OpenAI
 
-OpenHands uses LiteLLM to make calls to OpenAI's chat models. You can find their documentation on using OpenAI as a provider [here](https://docs.litellm.ai/docs/providers/openai).
+OpenHands uses LiteLLM to make calls to OpenAI's chat models. You can find their documentation on using OpenAI as a 
+provider [here](https://docs.litellm.ai/docs/providers/openai).
 
 ## Configuration
 
-When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings:
+When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
 * `LLM Provider` to `OpenAI`
 * `LLM Model` to the model you will be using.
 [Visit here to see a full list of OpenAI models that LiteLLM supports.](https://docs.litellm.ai/docs/providers/openai#openai-chat-completion-models)
-If the model is not in the list, toggle `Advanced` options, and enter it in `Custom Model` (e.g. openai/&lt;model-name&gt; like `openai/gpt-4o`).
+If the model is not in the list, enable `Advanced` options, and enter it in `Custom Model` (e.g. openai/&lt;model-name&gt; like `openai/gpt-4o`).
 * `API Key` to your OpenAI API key. To find or create your OpenAI Project API Key, [see here](https://platform.openai.com/api-keys).
 
 ## Using OpenAI-Compatible Endpoints
@@ -17,7 +18,7 @@ Just as for OpenAI Chat completions, we use LiteLLM for OpenAI-compatible endpoi
 
 ## Using an OpenAI Proxy
 
-If you're using an OpenAI proxy, in the OpenHands UI through the Settings:
+If you're using an OpenAI proxy, in the OpenHands UI through the Settings under the `LLM` tab:
 1. Enable `Advanced` options
 2. Set the following:
    - `Custom Model` to openai/&lt;model-name&gt; (e.g. `openai/gpt-4o` or openai/&lt;proxy-prefix&gt;/&lt;model-name&gt;)

--- a/docs/modules/usage/llms/openrouter.md
+++ b/docs/modules/usage/llms/openrouter.md
@@ -1,12 +1,14 @@
 # OpenRouter
 
-OpenHands uses LiteLLM to make calls to chat models on OpenRouter. You can find their documentation on using OpenRouter as a provider [here](https://docs.litellm.ai/docs/providers/openrouter).
+OpenHands uses LiteLLM to make calls to chat models on OpenRouter. You can find their documentation on using 
+OpenRouter as a provider [here](https://docs.litellm.ai/docs/providers/openrouter).
 
 ## Configuration
 
-When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings:
+When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
 * `LLM Provider` to `OpenRouter`
 * `LLM Model` to the model you will be using.
 [Visit here to see a full list of OpenRouter models](https://openrouter.ai/models).
-If the model is not in the list, toggle `Advanced` options, and enter it in `Custom Model` (e.g. openrouter/&lt;model-name&gt; like `openrouter/anthropic/claude-3.5-sonnet`).
+If the model is not in the list, enable `Advanced` options, and enter it in 
+`Custom Model` (e.g. openrouter/&lt;model-name&gt; like `openrouter/anthropic/claude-3.5-sonnet`).
 * `API Key` to your OpenRouter API key.

--- a/docs/modules/usage/mcp.md
+++ b/docs/modules/usage/mcp.md
@@ -13,9 +13,11 @@ or custom tools. MCP is based on the open standard defined at [modelcontextproto
 
 ## Configuration
 
-MCP configuration is defined in the `[mcp]` section of your `config.toml` file.
+MCP configuration can be defined in:
+* The OpenHands UI through the Settings under the `MCP` tab.
+* The `config.toml` file under the `[mcp]` section if not using the UI.
 
-### Configuration Example
+### Configuration Example via config.toml
 
 ```toml
 [mcp]
@@ -82,7 +84,7 @@ Stdio servers are configured using an object with the following properties:
 
 When OpenHands starts, it:
 
-1. Reads the MCP configuration from `config.toml`.
+1. Reads the MCP configuration.
 2. Connects to any configured SSE servers.
 3. Starts any configured stdio servers.
 4. Registers the tools provided by these servers with the agent.

--- a/frontend/__tests__/components/features/home/home-header.test.tsx
+++ b/frontend/__tests__/components/features/home/home-header.test.tsx
@@ -43,7 +43,6 @@ describe("HomeHeader", () => {
     await userEvent.click(launchButton);
 
     expect(createConversationSpy).toHaveBeenCalledExactlyOnceWith(
-      "gui",
       undefined,
       undefined,
       undefined,

--- a/frontend/__tests__/components/features/home/repo-connector.test.tsx
+++ b/frontend/__tests__/components/features/home/repo-connector.test.tsx
@@ -173,7 +173,6 @@ describe("RepoConnector", () => {
     await userEvent.click(launchButton);
 
     expect(createConversationSpy).toHaveBeenCalledExactlyOnceWith(
-      "gui",
       "rbren/polaris",
       "github",
       undefined,

--- a/frontend/__tests__/components/features/home/task-card.test.tsx
+++ b/frontend/__tests__/components/features/home/task-card.test.tsx
@@ -85,7 +85,6 @@ describe("TaskCard", () => {
       await userEvent.click(launchButton);
 
       expect(createConversationSpy).toHaveBeenCalledWith(
-        "suggested_task",
         MOCK_RESPOSITORIES[0].full_name,
         MOCK_RESPOSITORIES[0].git_provider,
         undefined,

--- a/frontend/__tests__/routes/home-screen.test.tsx
+++ b/frontend/__tests__/routes/home-screen.test.tsx
@@ -174,6 +174,16 @@ describe("HomeScreen", () => {
 
   describe("launch buttons", () => {
     const setupLaunchButtons = async () => {
+      // Mock the branch retrieval to return branches including main
+      const getRepositoryBranchesSpy = vi.spyOn(
+        OpenHands,
+        "getRepositoryBranches",
+      );
+      getRepositoryBranchesSpy.mockResolvedValue([
+        { name: "main" },
+        { name: "develop" }
+      ]);
+      
       let headerLaunchButton = screen.getByTestId("header-launch-button");
       let repoLaunchButton = await screen.findByTestId("repo-launch-button");
       let tasksLaunchButtons =
@@ -185,11 +195,17 @@ describe("HomeScreen", () => {
       await userEvent.click(dropdown);
       const repoOption = screen.getAllByText("octocat/hello-world")[1];
       await userEvent.click(repoOption);
+      
+      // Wait for the branch to be auto-selected
+      await waitFor(() => {
+        expect(repoLaunchButton).toBeEnabled();
+      });
 
-      expect(headerLaunchButton).not.toBeDisabled();
-      expect(repoLaunchButton).not.toBeDisabled();
+      // With the new branch selection logic, main branch should be auto-selected
+      expect(headerLaunchButton).toBeEnabled();
+      expect(repoLaunchButton).toBeEnabled();
       tasksLaunchButtons.forEach((button) => {
-        expect(button).not.toBeDisabled();
+        expect(button).toBeEnabled();
       });
 
       headerLaunchButton = screen.getByTestId("header-launch-button");

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -10,7 +10,6 @@ import {
   GetTrajectoryResponse,
   GitChangeDiff,
   GitChange,
-  ConversationTrigger,
 } from "./open-hands.types";
 import { openHands } from "./open-hands-axios";
 import { ApiSettings, PostApiSettings, Provider } from "#/types/settings";
@@ -144,7 +143,6 @@ class OpenHands {
   }
 
   static async createConversation(
-    conversation_trigger: ConversationTrigger = "gui",
     selectedRepository?: string,
     git_provider?: Provider,
     initialUserMsg?: string,
@@ -154,7 +152,6 @@ class OpenHands {
     selected_branch?: string,
   ): Promise<Conversation> {
     const body = {
-      conversation_trigger,
       repository: selectedRepository,
       git_provider,
       selected_branch,

--- a/frontend/src/components/features/home/home-header.tsx
+++ b/frontend/src/components/features/home/home-header.tsx
@@ -28,7 +28,7 @@ export function HomeHeader() {
           testId="header-launch-button"
           variant="primary"
           type="button"
-          onClick={() => createConversation({ conversation_trigger: "gui" })}
+          onClick={() => createConversation({})}
           isDisabled={isCreatingConversation}
         >
           {!isCreatingConversation && "Launch from Scratch"}

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -200,7 +200,6 @@ export function RepositorySelectionForm({
         onClick={() =>
           createConversation({
             selectedRepository,
-            conversation_trigger: "gui",
             selected_branch: selectedBranch?.name,
           })
         }

--- a/frontend/src/components/features/home/tasks/task-card.tsx
+++ b/frontend/src/components/features/home/tasks/task-card.tsx
@@ -40,7 +40,6 @@ export function TaskCard({ task }: TaskCardProps) {
     const repo = getRepo(task.repo, task.git_provider);
 
     return createConversation({
-      conversation_trigger: "suggested_task",
       selectedRepository: repo,
       suggested_task: task,
     });

--- a/frontend/src/components/features/settings/git-settings/github-token-input.tsx
+++ b/frontend/src/components/features/settings/git-settings/github-token-input.tsx
@@ -51,10 +51,9 @@ export function GitHubTokenInput({
         placeholder="github.com"
         defaultValue={githubHostSet || undefined}
         startContent={
-          githubHostSet && githubHostSet.trim() !== "" ? (
+          githubHostSet &&
+          githubHostSet.trim() !== "" && (
             <KeyStatusIcon testId="gh-set-host-indicator" isSet />
-          ) : (
-            <KeyStatusIcon testId="gh-set-host-indicator" isSet={false} />
           )
         }
       />

--- a/frontend/src/components/features/settings/git-settings/gitlab-token-input.tsx
+++ b/frontend/src/components/features/settings/git-settings/gitlab-token-input.tsx
@@ -51,10 +51,9 @@ export function GitLabTokenInput({
         placeholder="gitlab.com"
         defaultValue={gitlabHostSet || undefined}
         startContent={
-          gitlabHostSet && gitlabHostSet.trim() !== "" ? (
+          gitlabHostSet &&
+          gitlabHostSet.trim() !== "" && (
             <KeyStatusIcon testId="gl-set-host-indicator" isSet />
-          ) : (
-            <KeyStatusIcon testId="gl-set-host-indicator" isSet={false} />
           )
         }
       />

--- a/frontend/src/components/shared/task-form.tsx
+++ b/frontend/src/components/shared/task-form.tsx
@@ -52,7 +52,7 @@ export function TaskForm({ ref }: TaskFormProps) {
     const formData = new FormData(event.currentTarget);
 
     const q = formData.get("q")?.toString();
-    createConversation({ q, conversation_trigger: "gui" });
+    createConversation({ q });
   };
 
   return (

--- a/frontend/src/hooks/mutation/use-create-conversation.ts
+++ b/frontend/src/hooks/mutation/use-create-conversation.ts
@@ -6,7 +6,6 @@ import OpenHands from "#/api/open-hands";
 import { setInitialPrompt } from "#/state/initial-query-slice";
 import { RootState } from "#/store";
 import { GitRepository } from "#/types/git";
-import { ConversationTrigger } from "#/api/open-hands.types";
 import { SuggestedTask } from "#/components/features/home/tasks/task.types";
 
 export const useCreateConversation = () => {
@@ -21,7 +20,6 @@ export const useCreateConversation = () => {
   return useMutation({
     mutationKey: ["create-conversation"],
     mutationFn: async (variables: {
-      conversation_trigger: ConversationTrigger;
       q?: string;
       selectedRepository?: GitRepository | null;
       selected_branch?: string;
@@ -30,7 +28,6 @@ export const useCreateConversation = () => {
       if (variables.q) dispatch(setInitialPrompt(variables.q));
 
       return OpenHands.createConversation(
-        variables.conversation_trigger,
         variables.selectedRepository
           ? variables.selectedRepository.full_name
           : undefined,

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -2156,7 +2156,8 @@
         "ar": "مضيف GitHub (اختياري)",
         "fr": "Hôte GitHub (optionnel)",
         "tr": "GitHub Sunucusu (isteğe bağlı)",
-        "de": "GitHub-Host (optional)"
+        "de": "GitHub-Host (optional)",
+        "uk": "Хост GitHub (необов'язково)"
     },
     "GITHUB$TOKEN_OPTIONAL": {
         "en": "GitHub Token (Optional)",
@@ -2754,13 +2755,33 @@
         "en": "Settings not found. Please check your API key",
         "es": "Configuraciones no encontradas. Por favor revisa tu API key",
         "zh-TW": "找不到設定。請檢查您的 API 金鑰",
-        "uk": "Налаштування не знайдено. Будь ласка, перевірте свій ключ API."
+        "uk": "Налаштування не знайдено. Будь ласка, перевірте свій ключ API.",
+        "ja": "設定が見つかりません。APIキーを確認してください",
+        "zh-CN": "未找到设置。请检查您的API密钥",
+        "ko-KR": "설정을 찾을 수 없습니다. API 키를 확인하세요",
+        "no": "Innstillinger ikke funnet. Vennligst sjekk API-nøkkelen din",
+        "ar": "لم يتم العثور على الإعدادات. يرجى التحقق من مفتاح API الخاص بك",
+        "de": "Einstellungen nicht gefunden. Bitte überprüfen Sie Ihren API-Schlüssel",
+        "fr": "Paramètres non trouvés. Veuillez vérifier votre clé API",
+        "it": "Impostazioni non trovate. Controlla la tua chiave API",
+        "pt": "Configurações não encontradas. Por favor, verifique sua chave API",
+        "tr": "Ayarlar bulunamadı. Lütfen API anahtarınızı kontrol edin"
     },
     "CONNECT_TO_GITHUB_BY_TOKEN_MODAL$TERMS_OF_SERVICE": {
         "en": "terms of service",
         "es": "términos de servicio",
         "zh-TW": "服務條款",
-        "uk": "умови обслуговування"
+        "uk": "умови обслуговування",
+        "ja": "利用規約",
+        "zh-CN": "服务条款",
+        "ko-KR": "서비스 약관",
+        "no": "tjenestevilkår",
+        "ar": "شروط الخدمة",
+        "de": "Nutzungsbedingungen",
+        "fr": "conditions d'utilisation",
+        "it": "termini di servizio",
+        "pt": "termos de serviço",
+        "tr": "hizmet şartları"
     },
     "SESSION$SERVER_CONNECTED_MESSAGE": {
         "en": "Connected to server",
@@ -2775,7 +2796,8 @@
         "ar": "تم الاتصال بالخادم",
         "tr": "Sunucuya bağlandı",
         "no": "Koblet til server",
-        "uk": "Підключено до сервера"
+        "uk": "Підключено до сервера",
+        "ja": "サーバーに接続しました"
     },
     "SESSION$SESSION_HANDLING_ERROR_MESSAGE": {
         "en": "Error handling message",
@@ -3732,7 +3754,10 @@
         "de": "Keine Ergebnisse gefunden.",
         "it": "Nessun risultato trovato.",
         "pt": "Nenhum resultado encontrado.",
-        "uk": "Результатів не знайдено."
+        "uk": "Результатів не знайдено.",
+        "no": "Ingen resultater funnet.",
+        "ar": "لم يتم العثور على نتائج.",
+        "tr": "Sonuç bulunamadı."
     },
     "GITHUB$LOADING_REPOSITORIES": {
         "en": "Loading repositories...",
@@ -4115,7 +4140,8 @@
         "ar": "Upload a .json",
         "no": "Upload a .json",
         "tr": "Upload a .json",
-        "uk": "Завантажити .json"
+        "uk": "Завантажити .json",
+        "ja": ".jsonをアップロード"
     },
     "LANDING$RECENT_CONVERSATION": {
         "en": "jump back to your most recent conversation",
@@ -4935,83 +4961,323 @@
     },
     "SETTINGS$API_KEYS": {
         "en": "API Keys",
-        "uk": "API ключі"
+        "uk": "API ключі",
+        "ja": "APIキー",
+        "zh-CN": "API密钥",
+        "zh-TW": "API金鑰",
+        "ko-KR": "API 키",
+        "no": "API-nøkler",
+        "ar": "مفاتيح API",
+        "de": "API-Schlüssel",
+        "fr": "Clés API",
+        "it": "Chiavi API",
+        "pt": "Chaves API",
+        "es": "Claves API",
+        "tr": "API Anahtarları"
     },
     "SETTINGS$API_KEYS_DESCRIPTION": {
         "en": "API keys allow you to authenticate with the OpenHands API programmatically. Keep your API keys secure; anyone with your API key can access your account.",
-        "uk": "Ключі API дозволяють вам програмно автентифікуватися за допомогою API OpenHands. Зберігайте свої ключі API в безпеці; будь-хто, хто має ваш ключ API, може отримати доступ до вашого облікового запису."
+        "uk": "Ключі API дозволяють вам програмно автентифікуватися за допомогою API OpenHands. Зберігайте свої ключі API в безпеці; будь-хто, хто має ваш ключ API, може отримати доступ до вашого облікового запису.",
+        "ja": "APIキーを使用すると、OpenHands APIにプログラムで認証できます。APIキーは安全に保管してください。APIキーを持っている人は誰でもあなたのアカウントにアクセスできます。",
+        "zh-CN": "API密钥允许您以编程方式与OpenHands API进行身份验证。请确保您的API密钥安全；任何拥有您API密钥的人都可以访问您的账户。",
+        "zh-TW": "API金鑰允許您以程式化方式與OpenHands API進行身份驗證。請確保您的API金鑰安全；任何擁有您API金鑰的人都可以訪問您的帳戶。",
+        "ko-KR": "API 키를 사용하면 OpenHands API에 프로그래밍 방식으로 인증할 수 있습니다. API 키를 안전하게 보관하세요. API 키가 있는 사람은 누구나 귀하의 계정에 접근할 수 있습니다.",
+        "no": "API-nøkler lar deg autentisere med OpenHands API programmatisk. Hold API-nøklene dine sikre; alle med API-nøkkelen din kan få tilgang til kontoen din.",
+        "ar": "تتيح لك مفاتيح API المصادقة مع واجهة برمجة تطبيقات OpenHands برمجيًا. حافظ على أمان مفاتيح API الخاصة بك؛ يمكن لأي شخص لديه مفتاح API الخاص بك الوصول إلى حسابك.",
+        "de": "API-Schlüssel ermöglichen Ihnen die programmatische Authentifizierung mit der OpenHands-API. Halten Sie Ihre API-Schlüssel sicher; jeder mit Ihrem API-Schlüssel kann auf Ihr Konto zugreifen.",
+        "fr": "Les clés API vous permettent de vous authentifier auprès de l'API OpenHands par programmation. Gardez vos clés API en sécurité ; toute personne disposant de votre clé API peut accéder à votre compte.",
+        "it": "Le chiavi API ti consentono di autenticarti con l'API OpenHands in modo programmatico. Mantieni le tue chiavi API al sicuro; chiunque abbia la tua chiave API può accedere al tuo account.",
+        "pt": "As chaves API permitem que você se autentique com a API OpenHands programaticamente. Mantenha suas chaves API seguras; qualquer pessoa com sua chave API pode acessar sua conta.",
+        "es": "Las claves API le permiten autenticarse con la API de OpenHands de forma programática. Mantenga sus claves API seguras; cualquier persona con su clave API puede acceder a su cuenta.",
+        "tr": "API anahtarları, OpenHands API ile programlı olarak kimlik doğrulamanıza olanak tanır. API anahtarlarınızı güvende tutun; API anahtarınıza sahip olan herkes hesabınıza erişebilir."
     },
     "SETTINGS$CREATE_API_KEY": {
         "en": "Create API Key",
-        "uk": "Створити API ключ"
+        "uk": "Створити API ключ",
+        "ja": "APIキーを作成",
+        "zh-CN": "创建API密钥",
+        "zh-TW": "創建API金鑰",
+        "ko-KR": "API 키 생성",
+        "no": "Opprett API-nøkkel",
+        "ar": "إنشاء مفتاح API",
+        "de": "API-Schlüssel erstellen",
+        "fr": "Créer une clé API",
+        "it": "Crea chiave API",
+        "pt": "Criar chave API",
+        "es": "Crear clave API",
+        "tr": "API Anahtarı Oluştur"
     },
     "SETTINGS$CREATE_API_KEY_DESCRIPTION": {
         "en": "Give your API key a descriptive name to help you identify it later.",
-        "uk": "Дайте своєму ключу API змістовну назву, щоб ви могли його пізніше ідентифікувати."
+        "uk": "Дайте своєму ключу API змістовну назву, щоб ви могли його пізніше ідентифікувати.",
+        "ja": "後で識別しやすいように、APIキーにわかりやすい名前を付けてください。",
+        "zh-CN": "为您的API密钥提供一个描述性名称，以便您以后能够识别它。",
+        "zh-TW": "為您的API金鑰提供一個描述性名稱，以便您以後能夠識別它。",
+        "ko-KR": "나중에 식별하는 데 도움이 되도록 API 키에 설명적인 이름을 지정하세요.",
+        "no": "Gi API-nøkkelen din et beskrivende navn for å hjelpe deg med å identifisere den senere.",
+        "ar": "أعط مفتاح API الخاص بك اسمًا وصفيًا لمساعدتك في التعرف عليه لاحقًا.",
+        "de": "Geben Sie Ihrem API-Schlüssel einen beschreibenden Namen, um ihn später leichter identifizieren zu können.",
+        "fr": "Donnez à votre clé API un nom descriptif pour vous aider à l'identifier ultérieurement.",
+        "it": "Dai alla tua chiave API un nome descrittivo per aiutarti a identificarla in seguito.",
+        "pt": "Dê à sua chave API um nome descritivo para ajudá-lo a identificá-la posteriormente.",
+        "es": "Asigne a su clave API un nombre descriptivo para ayudarle a identificarla más adelante.",
+        "tr": "API anahtarınıza, daha sonra tanımlamanıza yardımcı olacak açıklayıcı bir isim verin."
     },
     "SETTINGS$DELETE_API_KEY": {
         "en": "Delete API Key",
-        "uk": "Видалити API ключ"
+        "uk": "Видалити API ключ",
+        "ja": "APIキーを削除",
+        "zh-CN": "删除API密钥",
+        "zh-TW": "刪除API金鑰",
+        "ko-KR": "API 키 삭제",
+        "no": "Slett API-nøkkel",
+        "ar": "حذف مفتاح API",
+        "de": "API-Schlüssel löschen",
+        "fr": "Supprimer la clé API",
+        "it": "Elimina chiave API",
+        "pt": "Excluir chave API",
+        "es": "Eliminar clave API",
+        "tr": "API Anahtarını Sil"
     },
     "SETTINGS$DELETE_API_KEY_CONFIRMATION": {
         "en": "Are you sure you want to delete the API key \"{{name}}\"? This action cannot be undone.",
-        "uk": "Ви впевнені, що хочете видалити ключ API \"{{name}}\"? Цю дію не можна скасувати."
+        "uk": "Ви впевнені, що хочете видалити ключ API \"{{name}}\"? Цю дію не можна скасувати.",
+        "ja": "APIキー\"{{name}}\"を削除してもよろしいですか？この操作は元に戻せません。",
+        "zh-CN": "您确定要删除API密钥\"{{name}}\"吗？此操作无法撤消。",
+        "zh-TW": "您確定要刪除API金鑰\"{{name}}\"嗎？此操作無法撤消。",
+        "ko-KR": "API 키 \"{{name}}\"을(를) 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",
+        "no": "Er du sikker på at du vil slette API-nøkkelen \"{{name}}\"? Denne handlingen kan ikke angres.",
+        "ar": "هل أنت متأكد أنك تريد حذف مفتاح API \"{{name}}\"؟ لا يمكن التراجع عن هذا الإجراء.",
+        "de": "Sind Sie sicher, dass Sie den API-Schlüssel \"{{name}}\" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "fr": "Êtes-vous sûr de vouloir supprimer la clé API \"{{name}}\" ? Cette action ne peut pas être annulée.",
+        "it": "Sei sicuro di voler eliminare la chiave API \"{{name}}\"? Questa azione non può essere annullata.",
+        "pt": "Tem certeza de que deseja excluir a chave API \"{{name}}\"? Esta ação não pode ser desfeita.",
+        "es": "¿Está seguro de que desea eliminar la clave API \"{{name}}\"? Esta acción no se puede deshacer.",
+        "tr": "\"{{name}}\" API anahtarını silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
     },
     "SETTINGS$NO_API_KEYS": {
         "en": "You don't have any API keys yet. Create one to get started.",
-        "uk": "У вас ще немає API-ключів. Створіть один, щоб почати."
+        "uk": "У вас ще немає API-ключів. Створіть один, щоб почати.",
+        "ja": "まだAPIキーがありません。作成して始めましょう。",
+        "zh-CN": "您还没有任何API密钥。创建一个以开始使用。",
+        "zh-TW": "您還沒有任何API金鑰。創建一個以開始使用。",
+        "ko-KR": "아직 API 키가 없습니다. 시작하려면 하나를 생성하세요.",
+        "no": "Du har ingen API-nøkler ennå. Opprett en for å komme i gang.",
+        "ar": "ليس لديك أي مفاتيح API حتى الآن. قم بإنشاء واحد للبدء.",
+        "de": "Sie haben noch keine API-Schlüssel. Erstellen Sie einen, um zu beginnen.",
+        "fr": "Vous n'avez pas encore de clés API. Créez-en une pour commencer.",
+        "it": "Non hai ancora chiavi API. Creane una per iniziare.",
+        "pt": "Você ainda não tem nenhuma chave API. Crie uma para começar.",
+        "es": "Aún no tiene ninguna clave API. Cree una para comenzar.",
+        "tr": "Henüz API anahtarınız yok. Başlamak için bir tane oluşturun."
     },
     "SETTINGS$NAME": {
         "en": "Name",
-        "uk": "Назва"
+        "uk": "Назва",
+        "ja": "名前",
+        "zh-CN": "名称",
+        "zh-TW": "名稱",
+        "ko-KR": "이름",
+        "no": "Navn",
+        "ar": "الاسم",
+        "de": "Name",
+        "fr": "Nom",
+        "it": "Nome",
+        "pt": "Nome",
+        "es": "Nombre",
+        "tr": "İsim"
     },
     "SETTINGS$KEY_PREFIX": {
         "en": "Key Prefix",
-        "uk": "Префікс ключа"
+        "uk": "Префікс ключа",
+        "ja": "キーのプレフィックス",
+        "zh-CN": "密钥前缀",
+        "zh-TW": "金鑰前綴",
+        "ko-KR": "키 접두사",
+        "no": "Nøkkelprefix",
+        "ar": "بادئة المفتاح",
+        "de": "Schlüsselpräfix",
+        "fr": "Préfixe de clé",
+        "it": "Prefisso chiave",
+        "pt": "Prefixo da chave",
+        "es": "Prefijo de clave",
+        "tr": "Anahtar Öneki"
     },
     "SETTINGS$CREATED_AT": {
         "en": "Created",
-        "uk": "Створено"
+        "uk": "Створено",
+        "ja": "作成日時",
+        "zh-CN": "创建时间",
+        "zh-TW": "創建時間",
+        "ko-KR": "생성됨",
+        "no": "Opprettet",
+        "ar": "تم الإنشاء",
+        "de": "Erstellt",
+        "fr": "Créé",
+        "it": "Creato",
+        "pt": "Criado",
+        "es": "Creado",
+        "tr": "Oluşturuldu"
     },
     "SETTINGS$LAST_USED": {
         "en": "Last Used",
-        "uk": "Останнє використання"
+        "uk": "Останнє використання",
+        "ja": "最終使用日時",
+        "zh-CN": "最后使用时间",
+        "zh-TW": "最後使用時間",
+        "ko-KR": "마지막 사용",
+        "no": "Sist brukt",
+        "ar": "آخر استخدام",
+        "de": "Zuletzt verwendet",
+        "fr": "Dernière utilisation",
+        "it": "Ultimo utilizzo",
+        "pt": "Último uso",
+        "es": "Último uso",
+        "tr": "Son Kullanım"
     },
     "SETTINGS$ACTIONS": {
         "en": "Actions",
-        "uk": "Дії"
+        "uk": "Дії",
+        "ja": "アクション",
+        "zh-CN": "操作",
+        "zh-TW": "操作",
+        "ko-KR": "작업",
+        "no": "Handlinger",
+        "ar": "إجراءات",
+        "de": "Aktionen",
+        "fr": "Actions",
+        "it": "Azioni",
+        "pt": "Ações",
+        "es": "Acciones",
+        "tr": "İşlemler"
     },
     "SETTINGS$API_KEY_CREATED": {
         "en": "API Key Created",
-        "uk": "API-ключ створено"
+        "uk": "API-ключ створено",
+        "ja": "APIキーが作成されました",
+        "zh-CN": "API密钥已创建",
+        "zh-TW": "API金鑰已創建",
+        "ko-KR": "API 키 생성됨",
+        "no": "API-nøkkel opprettet",
+        "ar": "تم إنشاء مفتاح API",
+        "de": "API-Schlüssel erstellt",
+        "fr": "Clé API créée",
+        "it": "Chiave API creata",
+        "pt": "Chave API criada",
+        "es": "Clave API creada",
+        "tr": "API Anahtarı Oluşturuldu"
     },
     "SETTINGS$API_KEY_DELETED": {
         "en": "API key deleted successfully",
-        "uk": "API-ключ видалено"
+        "uk": "API-ключ видалено",
+        "ja": "APIキーが正常に削除されました",
+        "zh-CN": "API密钥已成功删除",
+        "zh-TW": "API金鑰已成功刪除",
+        "ko-KR": "API 키가 성공적으로 삭제되었습니다",
+        "no": "API-nøkkel slettet",
+        "ar": "تم حذف مفتاح API بنجاح",
+        "de": "API-Schlüssel erfolgreich gelöscht",
+        "fr": "Clé API supprimée avec succès",
+        "it": "Chiave API eliminata con successo",
+        "pt": "Chave API excluída com sucesso",
+        "es": "Clave API eliminada con éxito",
+        "tr": "API anahtarı başarıyla silindi"
     },
     "SETTINGS$API_KEY_WARNING": {
         "en": "This is the only time your API key will be displayed. Please copy it now and store it securely.",
-        "uk": "Це єдиний раз, коли буде відображено ваш ключ API. Будь ласка, скопіюйте його зараз і збережіть у безпеці.."
+        "uk": "Це єдиний раз, коли буде відображено ваш ключ API. Будь ласка, скопіюйте його зараз і збережіть у безпеці.",
+        "ja": "これはAPIキーが表示される唯一の機会です。今すぐコピーして安全に保管してください。",
+        "zh-CN": "这是您的API密钥唯一显示的时间。请立即复制并安全存储。",
+        "zh-TW": "這是您的API金鑰唯一顯示的時間。請立即複製並安全存儲。",
+        "ko-KR": "이것은 API 키가 표시되는 유일한 시간입니다. 지금 복사하여 안전하게 보관하세요.",
+        "no": "Dette er den eneste gangen API-nøkkelen din vil bli vist. Vennligst kopier den nå og lagre den sikkert.",
+        "ar": "هذه هي المرة الوحيدة التي سيتم فيها عرض مفتاح API الخاص بك. يرجى نسخه الآن وتخزينه بشكل آمن.",
+        "de": "Dies ist das einzige Mal, dass Ihr API-Schlüssel angezeigt wird. Bitte kopieren Sie ihn jetzt und speichern Sie ihn sicher.",
+        "fr": "C'est la seule fois que votre clé API sera affichée. Veuillez la copier maintenant et la stocker en toute sécurité.",
+        "it": "Questa è l'unica volta che la tua chiave API verrà visualizzata. Copiala ora e conservala in modo sicuro.",
+        "pt": "Esta é a única vez que sua chave API será exibida. Por favor, copie-a agora e armazene-a com segurança.",
+        "es": "Esta es la única vez que se mostrará su clave API. Por favor, cópiela ahora y guárdela de forma segura.",
+        "tr": "API anahtarınız yalnızca bu kez görüntülenecektir. Lütfen şimdi kopyalayın ve güvenli bir şekilde saklayın."
     },
     "SETTINGS$API_KEY_COPIED": {
         "en": "API key copied to clipboard",
-        "uk": "Ключ API скопійовано в буфер обміну"
+        "uk": "Ключ API скопійовано в буфер обміну",
+        "ja": "APIキーがクリップボードにコピーされました",
+        "zh-CN": "API密钥已复制到剪贴板",
+        "zh-TW": "API金鑰已複製到剪貼板",
+        "ko-KR": "API 키가 클립보드에 복사되었습니다",
+        "no": "API-nøkkel kopiert til utklippstavlen",
+        "ar": "تم نسخ مفتاح API إلى الحافظة",
+        "de": "API-Schlüssel in die Zwischenablage kopiert",
+        "fr": "Clé API copiée dans le presse-papiers",
+        "it": "Chiave API copiata negli appunti",
+        "pt": "Chave API copiada para a área de transferência",
+        "es": "Clave API copiada al portapapeles",
+        "tr": "API anahtarı panoya kopyalandı"
     },
     "SETTINGS$API_KEY_NAME_PLACEHOLDER": {
         "en": "My API Key",
-        "uk": "Мій ключ API"
+        "uk": "Мій ключ API",
+        "ja": "私のAPIキー",
+        "zh-CN": "我的API密钥",
+        "zh-TW": "我的API金鑰",
+        "ko-KR": "내 API 키",
+        "no": "Min API-nøkkel",
+        "ar": "مفتاح API الخاص بي",
+        "de": "Mein API-Schlüssel",
+        "fr": "Ma clé API",
+        "it": "La mia chiave API",
+        "pt": "Minha chave API",
+        "es": "Mi clave API",
+        "tr": "API Anahtarım"
     },
     "BUTTON$CREATE": {
         "en": "Create",
-        "uk": "Створити"
+        "uk": "Створити",
+        "ja": "作成",
+        "zh-CN": "创建",
+        "zh-TW": "創建",
+        "ko-KR": "생성",
+        "no": "Opprett",
+        "ar": "إنشاء",
+        "de": "Erstellen",
+        "fr": "Créer",
+        "it": "Crea",
+        "pt": "Criar",
+        "es": "Crear",
+        "tr": "Oluştur"
     },
     "BUTTON$DELETE": {
         "en": "Delete",
-        "uk": "Видалити"
+        "uk": "Видалити",
+        "ja": "削除",
+        "zh-CN": "删除",
+        "zh-TW": "刪除",
+        "ko-KR": "삭제",
+        "no": "Slett",
+        "ar": "حذف",
+        "de": "Löschen",
+        "fr": "Supprimer",
+        "it": "Elimina",
+        "pt": "Excluir",
+        "es": "Eliminar",
+        "tr": "Sil"
     },
     "BUTTON$COPY_TO_CLIPBOARD": {
         "en": "Copy to Clipboard",
-        "uk": "Копіювати в буфер обміну"
+        "uk": "Копіювати в буфер обміну",
+        "ja": "クリップボードにコピー",
+        "zh-CN": "复制到剪贴板",
+        "zh-TW": "複製到剪貼板",
+        "ko-KR": "클립보드에 복사",
+        "no": "Kopier til utklippstavlen",
+        "ar": "نسخ إلى الحافظة",
+        "de": "In die Zwischenablage kopieren",
+        "fr": "Copier dans le presse-papiers",
+        "it": "Copia negli appunti",
+        "pt": "Copiar para a área de transferência",
+        "es": "Copiar al portapapeles",
+        "tr": "Panoya Kopyala"
     },
     "BUTTON$REFRESH": {
         "en": "Refresh",
@@ -5031,7 +5297,19 @@
     },
     "ERROR$REQUIRED_FIELD": {
         "en": "This field is required",
-        "uk": "Це поле обов'язкове"
+        "uk": "Це поле обов'язкове",
+        "ja": "この項目は必須です",
+        "zh-CN": "此字段为必填项",
+        "zh-TW": "此欄位為必填項",
+        "ko-KR": "이 필드는 필수입니다",
+        "no": "Dette feltet er påkrevd",
+        "ar": "هذا الحقل مطلوب",
+        "de": "Dieses Feld ist erforderlich",
+        "fr": "Ce champ est obligatoire",
+        "it": "Questo campo è obbligatorio",
+        "pt": "Este campo é obrigatório",
+        "es": "Este campo es obligatorio",
+        "tr": "Bu alan zorunludur"
     },
     "PLANNER$EMPTY_MESSAGE": {
         "en": "No plan created.",
@@ -5835,7 +6113,19 @@
     },
     "AGENT_ERROR$TOO_MANY_CONVERSATIONS": {
         "en": "Too many conversations at once.",
-        "uk": "Занадто багато розмов одночасно."
+        "uk": "Занадто багато розмов одночасно.",
+        "ja": "一度に多すぎる会話があります。",
+        "zh-CN": "同时进行的对话过多。",
+        "zh-TW": "同時進行的對話過多。",
+        "ko-KR": "한 번에 너무 많은 대화가 있습니다.",
+        "no": "For mange samtaler på en gang.",
+        "ar": "الكثير من المحادثات في وقت واحد.",
+        "de": "Zu viele Gespräche auf einmal.",
+        "fr": "Trop de conversations à la fois.",
+        "it": "Troppe conversazioni contemporaneamente.",
+        "pt": "Muitas conversas ao mesmo tempo.",
+        "es": "Demasiadas conversaciones a la vez.",
+        "tr": "Aynı anda çok fazla konuşma var."
     },
     "PROJECT_MENU_CARD_CONTEXT_MENU$CONNECT_TO_GITHUB_LABEL": {
         "en": "Connect to GitHub",
@@ -6592,7 +6882,18 @@
     "SETTINGS_FORM$ENABLE_DEFAULT_CONDENSER_SWITCH_LABEL": {
         "en": "Enable Memory Condenser",
         "zh-TW": "啟用記憶體壓縮器",
-        "uk": "Увімкнути конденсатор пам'яті"
+        "uk": "Увімкнути конденсатор пам'яті",
+        "ja": "メモリコンデンサーを有効にする",
+        "zh-CN": "启用内存压缩器",
+        "ko-KR": "메모리 컨덴서 활성화",
+        "no": "Aktiver minnekondensator",
+        "ar": "تمكين مكثف الذاكرة",
+        "de": "Speicherkondensator aktivieren",
+        "fr": "Activer le condensateur de mémoire",
+        "it": "Abilita condensatore di memoria",
+        "pt": "Ativar condensador de memória",
+        "es": "Habilitar condensador de memoria",
+        "tr": "Bellek Yoğunlaştırıcıyı Etkinleştir"
     },
     "BUTTON$MARK_HELPFUL": {
         "en": "Mark this solution as helpful",
@@ -7103,7 +7404,8 @@
         "es": "Ventana de contexto",
         "ar": "نافذة السياق",
         "fr": "Fenêtre de contexte",
-        "tr": "Bağlam Penceresi"
+        "tr": "Bağlam Penceresi",
+        "uk": "Вікно контексту"
     },
     "CONVERSATION$USED": {
         "en": "used",
@@ -7118,7 +7420,8 @@
         "es": "usado",
         "ar": "مستخدم",
         "fr": "utilisé",
-        "tr": "kullanıldı"
+        "tr": "kullanıldı",
+        "uk": "використано"
     },
     "SETTINGS$RUNTIME_SETTINGS": {
         "en": "Runtime Settings (",
@@ -7469,7 +7772,8 @@
         "ar": "مضيف GitLab (اختياري)",
         "fr": "Hôte GitLab (optionnel)",
         "tr": "GitLab Sunucusu (isteğe bağlı)",
-        "de": "GitLab-Host (optional)"
+        "de": "GitLab-Host (optional)",
+        "uk": "Хост GitLab (необов'язково)"
     },
     "GITLAB$GET_TOKEN": {
         "en": "Generate a token on",
@@ -7802,7 +8106,10 @@
         "de": "Nutzungsbedingungen akzeptieren",
         "it": "Accetta i termini di servizio",
         "pt": "Aceitar termos de serviço",
-        "uk": "Прийняти Умови надання послуг"
+        "uk": "Прийняти Умови надання послуг",
+        "no": "Godta vilkår for tjenesten",
+        "ar": "قبول شروط الخدمة",
+        "tr": "Hizmet Şartlarını Kabul Et"
     },
     "TOS$ACCEPT_TERMS_DESCRIPTION": {
         "en": "Please review and accept our terms of service before continuing",
@@ -7815,7 +8122,10 @@
         "de": "Bitte überprüfen und akzeptieren Sie unsere Nutzungsbedingungen, bevor Sie fortfahren",
         "it": "Si prega di rivedere e accettare i nostri termini di servizio prima di continuare",
         "pt": "Por favor, revise e aceite nossos termos de serviço antes de continuar",
-        "uk": "Будь ласка, ознайомтеся та прийміть наші умови надання послуг, перш ніж продовжити"
+        "uk": "Будь ласка, ознайомтеся та прийміть наші умови надання послуг, перш ніж продовжити",
+        "no": "Vennligst gjennomgå og godta våre vilkår for tjenesten før du fortsetter",
+        "ar": "يرجى مراجعة وقبول شروط الخدمة الخاصة بنا قبل المتابعة",
+        "tr": "Devam etmeden önce lütfen hizmet şartlarımızı gözden geçirin ve kabul edin"
     },
     "TOS$CONTINUE": {
         "en": "Continue",
@@ -7828,7 +8138,10 @@
         "de": "Fortfahren",
         "it": "Continua",
         "pt": "Continuar",
-        "uk": "Продовжити"
+        "uk": "Продовжити",
+        "no": "Fortsett",
+        "ar": "متابعة",
+        "tr": "Devam Et"
     },
     "TOS$ERROR_ACCEPTING": {
         "en": "Error accepting Terms of Service",
@@ -7841,7 +8154,10 @@
         "de": "Fehler beim Akzeptieren der Nutzungsbedingungen",
         "it": "Errore nell'accettazione dei Termini di Servizio",
         "pt": "Erro ao aceitar os Termos de Serviço",
-        "uk": "Помилка прийняття Умов обслуговування"
+        "uk": "Помилка прийняття Умов обслуговування",
+        "no": "Feil ved godkjenning av vilkår for tjenesten",
+        "ar": "خطأ في قبول شروط الخدمة",
+        "tr": "Hizmet Şartlarını kabul ederken hata oluştu"
     },
     "TIPS$CUSTOMIZE_MICROAGENT": {
         "en": "You can customize OpenHands for your repo using a microagent. Ask OpenHands to put a description of the repo, including how to run the code, into .openhands/microagents/repo.md.",

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -50,7 +50,6 @@ app = APIRouter(prefix='/api')
 
 
 class InitSessionRequest(BaseModel):
-    conversation_trigger: ConversationTrigger = ConversationTrigger.GUI
     repository: str | None = None
     git_provider: ProviderType | None = None
     selected_branch: str | None = None
@@ -181,8 +180,9 @@ async def new_conversation(
     image_urls = data.image_urls or []
     replay_json = data.replay_json
     suggested_task = data.suggested_task
-    conversation_trigger = data.conversation_trigger
     git_provider = data.git_provider
+
+    conversation_trigger = ConversationTrigger.GUI
 
     if suggested_task:
         initial_user_msg = suggested_task.get_prompt_for_task()

--- a/openhands/storage/data_models/conversation_metadata.py
+++ b/openhands/storage/data_models/conversation_metadata.py
@@ -8,6 +8,7 @@ class ConversationTrigger(Enum):
     GUI = 'gui'
     SUGGESTED_TASK = 'suggested_task'
     REMOTE_API_KEY = 'openhands_api'
+    SLACK = 'slack'
 
 
 @dataclass

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -240,7 +240,6 @@ async def test_new_conversation_success(provider_handler_mock):
             mock_create_conversation.return_value = 'test_conversation_id'
 
             test_request = InitSessionRequest(
-                conversation_trigger=ConversationTrigger.GUI,
                 repository='test/repo',
                 selected_branch='main',
                 initial_user_msg='Hello, agent!',
@@ -297,7 +296,6 @@ async def test_new_conversation_with_suggested_task(provider_handler_mock):
                 )
 
                 test_request = InitSessionRequest(
-                    conversation_trigger=ConversationTrigger.SUGGESTED_TASK,
                     repository='test/repo',
                     selected_branch='main',
                     suggested_task=test_task,
@@ -347,7 +345,6 @@ async def test_new_conversation_missing_settings(provider_handler_mock):
             )
 
             test_request = InitSessionRequest(
-                conversation_trigger=ConversationTrigger.GUI,
                 repository='test/repo',
                 selected_branch='main',
                 initial_user_msg='Hello, agent!',
@@ -377,7 +374,6 @@ async def test_new_conversation_invalid_api_key(provider_handler_mock):
             )
 
             test_request = InitSessionRequest(
-                conversation_trigger=ConversationTrigger.GUI,
                 repository='test/repo',
                 selected_branch='main',
                 initial_user_msg='Hello, agent!',
@@ -469,7 +465,6 @@ async def test_new_conversation_with_bearer_auth(provider_handler_mock):
 
             # Create the request object
             test_request = InitSessionRequest(
-                conversation_trigger=ConversationTrigger.GUI,  # This should be overridden
                 repository='test/repo',
                 selected_branch='main',
                 initial_user_msg='Hello, agent!',
@@ -503,7 +498,6 @@ async def test_new_conversation_with_null_repository():
 
             # Create the request object with null repository
             test_request = InitSessionRequest(
-                conversation_trigger=ConversationTrigger.GUI,
                 repository=None,  # Explicitly set to None
                 selected_branch=None,
                 initial_user_msg='Hello, agent!',
@@ -541,7 +535,6 @@ async def test_new_conversation_with_provider_authentication_error(
 
             # Create the request object
             test_request = InitSessionRequest(
-                conversation_trigger=ConversationTrigger.GUI,
                 repository='test/repo',
                 selected_branch='main',
                 initial_user_msg='Hello, agent!',
@@ -571,7 +564,6 @@ async def test_new_conversation_with_provider_authentication_error(
 @pytest.mark.asyncio
 async def test_new_conversation_with_unsupported_params(test_client):
     test_request_data = {
-        'conversation_trigger': 'GUI',  # This is a valid parameter
         'repository': 'test/repo',  # This is valid
         'selected_branch': 'main',  # This is valid
         'initial_user_msg': 'Hello, agent!',  # Valid parameter


### PR DESCRIPTION
This PR fixes the failing frontend tests in PR #8490 by updating the test files to reflect the new branch selection logic. The changes include:

1. Updated tests to account for auto-selection of main/master branch
2. Fixed test assertions to match the actual API signature for createConversation
3. Added proper mocking for getRepositoryBranches function

All tests are now passing.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:db5c97e-nikolaik   --name openhands-app-db5c97e   docker.all-hands.dev/all-hands-ai/openhands:db5c97e
```