### PR TITLE
fix: validation error when saving SSE MCP server url on the UI

### DIFF
--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -43,22 +43,25 @@ class MCPConfig(BaseModel):
     stdio_servers: list[MCPStdioServerConfig] = Field(default_factory=list)
 
     model_config = {'extra': 'forbid'}
-
+    
+    @staticmethod
+    def _normalize_sse_servers(servers_data: list[dict | str]) -> list[dict]:
+        """Helper method to normalize SSE server configurations."""
+        normalized = []
+        for server in servers_data:
+            if isinstance(server, str):
+                normalized.append({'url': server})
+            else:
+                normalized.append(server)
+        return normalized
+    
     @model_validator(mode='before')
     def convert_string_urls(cls, data):
         """Convert string URLs to MCPSSEServerConfig objects."""
         if isinstance(data, dict) and 'sse_servers' in data:
-            servers = []
-            for server in data['sse_servers']:
-                if isinstance(server, dict):
-                    servers.append(server)
-                elif isinstance(server, str):
-                    servers.append({'url': server})
-                else:
-                    servers.append(server)  # Pass through any other type for validation to catch
-            data['sse_servers'] = servers
+            data['sse_servers'] = cls._normalize_sse_servers(data['sse_servers'])
         return data
-
+    
     def validate_servers(self) -> None:
         """Validate that server URLs are valid and unique."""
         urls = [server.url for server in self.sse_servers]
@@ -75,7 +78,7 @@ class MCPConfig(BaseModel):
                     raise ValueError(f'Invalid URL format: {url}')
             except Exception as e:
                 raise ValueError(f'Invalid URL {url}: {str(e)}')
-
+    
     @classmethod
     def from_toml_section(cls, data: dict) -> dict[str, 'MCPConfig']:
         """
@@ -92,25 +95,23 @@ class MCPConfig(BaseModel):
         try:
             # Convert all entries in sse_servers to MCPSSEServerConfig objects
             if 'sse_servers' in data:
+                data['sse_servers'] = cls._normalize_sse_servers(data['sse_servers'])
                 servers = []
                 for server in data['sse_servers']:
-                    if isinstance(server, dict):
-                        servers.append(MCPSSEServerConfig(**server))
-                    else:
-                        # Convert string URLs to MCPSSEServerConfig objects with no API key
-                        servers.append(MCPSSEServerConfig(url=server))
+                    servers.append(MCPSSEServerConfig(**server))
                 data['sse_servers'] = servers
-
+            
             # Convert all entries in stdio_servers to MCPStdioServerConfig objects
             if 'stdio_servers' in data:
                 servers = []
                 for server in data['stdio_servers']:
                     servers.append(MCPStdioServerConfig(**server))
                 data['stdio_servers'] = servers
-
+            
             # Create SSE config if present
             mcp_config = MCPConfig.model_validate(data)
             mcp_config.validate_servers()
+            
             # Create the main MCP config
             mcp_mapping['mcp'] = cls(
                 sse_servers=mcp_config.sse_servers,
@@ -118,5 +119,4 @@ class MCPConfig(BaseModel):
             )
         except ValidationError as e:
             raise ValueError(f'Invalid MCP configuration: {e}')
-
         return mcp_mapping

--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -43,7 +43,7 @@ class MCPConfig(BaseModel):
     stdio_servers: list[MCPStdioServerConfig] = Field(default_factory=list)
 
     model_config = {'extra': 'forbid'}
-    
+
     @staticmethod
     def _normalize_sse_servers(servers_data: list[dict | str]) -> list[dict]:
         """Helper method to normalize SSE server configurations."""
@@ -54,14 +54,14 @@ class MCPConfig(BaseModel):
             else:
                 normalized.append(server)
         return normalized
-    
+
     @model_validator(mode='before')
     def convert_string_urls(cls, data):
         """Convert string URLs to MCPSSEServerConfig objects."""
         if isinstance(data, dict) and 'sse_servers' in data:
             data['sse_servers'] = cls._normalize_sse_servers(data['sse_servers'])
         return data
-    
+
     def validate_servers(self) -> None:
         """Validate that server URLs are valid and unique."""
         urls = [server.url for server in self.sse_servers]
@@ -78,7 +78,7 @@ class MCPConfig(BaseModel):
                     raise ValueError(f'Invalid URL format: {url}')
             except Exception as e:
                 raise ValueError(f'Invalid URL {url}: {str(e)}')
-    
+
     @classmethod
     def from_toml_section(cls, data: dict) -> dict[str, 'MCPConfig']:
         """
@@ -100,18 +100,18 @@ class MCPConfig(BaseModel):
                 for server in data['sse_servers']:
                     servers.append(MCPSSEServerConfig(**server))
                 data['sse_servers'] = servers
-            
+
             # Convert all entries in stdio_servers to MCPStdioServerConfig objects
             if 'stdio_servers' in data:
                 servers = []
                 for server in data['stdio_servers']:
                     servers.append(MCPStdioServerConfig(**server))
                 data['stdio_servers'] = servers
-            
+
             # Create SSE config if present
             mcp_config = MCPConfig.model_validate(data)
             mcp_config.validate_servers()
-            
+
             # Create the main MCP config
             mcp_mapping['mcp'] = cls(
                 sse_servers=mcp_config.sse_servers,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

For SSE server configs, we allow both plain string and an object to be passed to the "sse_servers" array, but currently this only works when loading from `config.toml` because we handle both types separately in `from_toml_section`. When passing something like `"sse_servers": ["https://example-mcp-server.com/sse"]` and saving on the UI, it throws 422 error.

Instruction on the UI:
```
Example: { "sse_servers": ["https://example-mcp-server.com/sse"], "stdio_servers": [{ "name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"] }] }
```

---
**Link of any specific issues this addresses:**
