### PR TITLE
Fix #8510: Improve error messages for invalid microagent format

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -176,7 +176,22 @@ class Session:
         except Exception as e:
             self.logger.exception(f'Error creating agent_session: {e}')
             err_class = e.__class__.__name__
-            await self.send_error(f'Failed to create agent session: {err_class}')
+
+            # Get detailed error message
+            error_message = str(e)
+
+            # For microagent validation errors, provide more helpful information
+            if (
+                'MicroagentValidationError' in err_class
+                or 'ValueError' in err_class
+                and 'microagent' in error_message.lower()
+            ):
+                await self.send_error(
+                    f'Failed to create agent session: {error_message}'
+                )
+            else:
+                # For other errors, just show the error class to avoid exposing sensitive information
+                await self.send_error(f'Failed to create agent session: {err_class}')
             return
 
     def _create_llm(self, agent_cls: str | None) -> LLM:

--- a/tests/unit/test_microagent_utils.py
+++ b/tests/unit/test_microagent_utils.py
@@ -166,3 +166,37 @@ Testing loading with trailing slashes.
     assert isinstance(agent_t, KnowledgeMicroagent)
     assert agent_t.type == MicroagentType.KNOWLEDGE  # Check inferred type
     assert 'trailing' in agent_t.triggers
+
+
+def test_invalid_microagent_type(temp_microagents_dir):
+    """Test loading a microagent with an invalid type."""
+    # Create a microagent with an invalid type
+    invalid_agent = """---
+name: invalid_type_agent
+type: task
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+  - test
+---
+
+# Invalid Type Test
+
+This microagent has an invalid type.
+"""
+    invalid_file = temp_microagents_dir / 'invalid_type.md'
+    invalid_file.write_text(invalid_agent)
+
+    # Attempt to load the microagent should raise a MicroagentValidationError
+    from openhands.core.exceptions import MicroagentValidationError
+
+    with pytest.raises(MicroagentValidationError) as excinfo:
+        load_microagents_from_dir(temp_microagents_dir)
+
+    # Check that the error message contains helpful information
+    error_msg = str(excinfo.value)
+    assert 'invalid_type.md' in error_msg
+    assert 'Invalid "type" value: "task"' in error_msg
+    assert 'Valid types are:' in error_msg
+    assert '"knowledge"' in error_msg
+    assert '"repo"' in error_msg


### PR DESCRIPTION
This PR fixes issue #8510 by improving error messages for invalid microagent formats.

## Changes

1. Enhanced error handling in `microagent.py` to provide more detailed error messages when microagent validation fails
2. Updated the error handling in `session.py` to display the full error message for microagent validation errors instead of just the error class name
3. Added a new test case to verify that invalid microagent types produce helpful error messages

With these changes, when a microagent has an invalid format (like an unsupported `type` value), the UI will show a detailed error message that includes the name of the offending file and what went wrong, making it easier for users to fix the issue.

Closes #8510

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c6503d76275447a0acc71374595ca1d0)