### PR TITLE
Fix for docker-compose on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 
 services:
   openhands:
+    network_mode: host
     build:
       context: ./
       dockerfile: ./containers/app/Dockerfile
@@ -10,10 +11,7 @@ services:
       - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-docker.all-hands.dev/all-hands-ai/runtime:0.38-nikolaik}
       #- SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234} # enable this only if you want a specific non-root sandbox user but you will have to manually adjust permissions of openhands-state for this user
       - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
-    ports:
-      - "3000:3000"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - DOCKER_HOST_ADDR=127.0.0.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ~/.openhands-state:/.openhands-state


### PR DESCRIPTION
# Summary
Added network_mode: host for Linux compatibility in docker-compose.yml
Removed explicit port mappings and host.docker.internal configuration
Added DOCKER_HOST_ADDR environment variable for Linux networking

# Test plan
Verify Docker Compose works correctly on Linux environments
Ensure proper connection between containers

Fixes https://github.com/All-Hands-AI/OpenHands/issues/5968
