### PR TITLE
Always enable logout button regardless of GitHub connection status

### DIFF
--- a/frontend/__tests__/components/context-menu/account-settings-context-menu.test.tsx
+++ b/frontend/__tests__/components/context-menu/account-settings-context-menu.test.tsx
@@ -20,7 +20,6 @@ describe("AccountSettingsContextMenu", () => {
       <AccountSettingsContextMenu
         onLogout={onLogoutMock}
         onClose={onCloseMock}
-        isLoggedIn
       />,
     );
 
@@ -35,7 +34,6 @@ describe("AccountSettingsContextMenu", () => {
       <AccountSettingsContextMenu
         onLogout={onLogoutMock}
         onClose={onCloseMock}
-        isLoggedIn
       />,
     );
 
@@ -45,12 +43,11 @@ describe("AccountSettingsContextMenu", () => {
     expect(onLogoutMock).toHaveBeenCalledOnce();
   });
 
-  test("onLogout should be enabled even if the user is not logged in", async () => {
+  test("logout button is always enabled", async () => {
     render(
       <AccountSettingsContextMenu
         onLogout={onLogoutMock}
         onClose={onCloseMock}
-        isLoggedIn={false}
       />,
     );
 
@@ -65,7 +62,6 @@ describe("AccountSettingsContextMenu", () => {
       <AccountSettingsContextMenu
         onLogout={onLogoutMock}
         onClose={onCloseMock}
-        isLoggedIn
       />,
     );
 

--- a/frontend/__tests__/components/context-menu/account-settings-context-menu.test.tsx
+++ b/frontend/__tests__/components/context-menu/account-settings-context-menu.test.tsx
@@ -45,7 +45,7 @@ describe("AccountSettingsContextMenu", () => {
     expect(onLogoutMock).toHaveBeenCalledOnce();
   });
 
-  test("onLogout should be disabled if the user is not logged in", async () => {
+  test("onLogout should be enabled even if the user is not logged in", async () => {
     render(
       <AccountSettingsContextMenu
         onLogout={onLogoutMock}
@@ -57,7 +57,7 @@ describe("AccountSettingsContextMenu", () => {
     const logoutOption = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
     await user.click(logoutOption);
 
-    expect(onLogoutMock).not.toHaveBeenCalled();
+    expect(onLogoutMock).toHaveBeenCalledOnce();
   });
 
   it("should call onClose when clicking outside of the element", async () => {

--- a/frontend/__tests__/components/user-actions.test.tsx
+++ b/frontend/__tests__/components/user-actions.test.tsx
@@ -57,7 +57,7 @@ describe("UserActions", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("onLogout should not be called when the user is not logged in", async () => {
+  test("logout button is always enabled", async () => {
     render(<UserActions onLogout={onLogoutMock} />);
 
     const userAvatar = screen.getByTestId("user-avatar");
@@ -66,6 +66,6 @@ describe("UserActions", () => {
     const logoutOption = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
     await user.click(logoutOption);
 
-    expect(onLogoutMock).not.toHaveBeenCalled();
+    expect(onLogoutMock).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/__tests__/i18n/translations.test.tsx
+++ b/frontend/__tests__/i18n/translations.test.tsx
@@ -11,7 +11,6 @@ describe("Translations", () => {
       <AccountSettingsContextMenu
         onLogout={() => {}}
         onClose={() => {}}
-        isLoggedIn
       />,
     );
     expect(

--- a/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
+++ b/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
@@ -7,8 +7,6 @@ import { I18nKey } from "#/i18n/declaration";
 interface AccountSettingsContextMenuProps {
   onLogout: () => void;
   onClose: () => void;
-  // eslint-disable-next-line react/no-unused-prop-types
-  isLoggedIn: boolean; // Kept for backward compatibility but no longer used
 }
 
 export function AccountSettingsContextMenu({

--- a/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
+++ b/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
@@ -7,13 +7,13 @@ import { I18nKey } from "#/i18n/declaration";
 interface AccountSettingsContextMenuProps {
   onLogout: () => void;
   onClose: () => void;
-  isLoggedIn: boolean;
+  // eslint-disable-next-line react/no-unused-prop-types
+  isLoggedIn: boolean; // Kept for backward compatibility but no longer used
 }
 
 export function AccountSettingsContextMenu({
   onLogout,
   onClose,
-  isLoggedIn,
 }: AccountSettingsContextMenuProps) {
   const ref = useClickOutsideElement<HTMLUListElement>(onClose);
   const { t } = useTranslation();
@@ -24,7 +24,7 @@ export function AccountSettingsContextMenu({
       ref={ref}
       className="absolute right-full md:left-full -top-1 z-10 w-fit"
     >
-      <ContextMenuListItem onClick={onLogout} isDisabled={!isLoggedIn}>
+      <ContextMenuListItem onClick={onLogout}>
         {t(I18nKey.ACCOUNT_SETTINGS$LOGOUT)}
       </ContextMenuListItem>
     </ContextMenu>

--- a/frontend/src/components/features/sidebar/user-actions.tsx
+++ b/frontend/src/components/features/sidebar/user-actions.tsx
@@ -35,7 +35,6 @@ export function UserActions({ onLogout, user, isLoading }: UserActionsProps) {
 
       {accountContextMenuIsVisible && (
         <AccountSettingsContextMenu
-          isLoggedIn={!!user}
           onLogout={handleLogout}
           onClose={closeAccountMenu}
         />

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -12,7 +12,8 @@
         "ar": "قيمة السر مطلوبة",
         "fr": "La valeur du secret est requise",
         "tr": "Gizli değer gereklidir",
-        "de": "Geheimer Wert ist erforderlich"
+        "de": "Geheimer Wert ist erforderlich",
+        "uk": "Значення секрету є обов'язковим"
     },
     "SECRETS$ADD_SECRET": {
         "en": "Add secret",
@@ -27,7 +28,8 @@
         "ar": "إضافة سر",
         "fr": "Ajouter un secret",
         "tr": "Gizli ekle",
-        "de": "Geheimnis hinzufügen"
+        "de": "Geheimnis hinzufügen",
+        "uk": "Додати секрет"
     },
     "SECRETS$EDIT_SECRET": {
         "en": "Edit secret",
@@ -42,7 +44,8 @@
         "ar": "تعديل السر",
         "fr": "Modifier le secret",
         "tr": "Gizliyi düzenle",
-        "de": "Geheimnis bearbeiten"
+        "de": "Geheimnis bearbeiten",
+        "uk": "Редагувати секрет"
     },
     "SECRETS$NO_SECRETS_FOUND": {
         "en": "No secrets found",
@@ -57,7 +60,8 @@
         "ar": "لم يتم العثور على أسرار",
         "fr": "Aucun secret trouvé",
         "tr": "Gizli bulunamadı",
-        "de": "Keine Geheimnisse gefunden"
+        "de": "Keine Geheimnisse gefunden",
+        "uk": "Секретів не знайдено"
     },
     "SECRETS$ADD_NEW_SECRET": {
         "en": "Add a new secret",
@@ -72,7 +76,8 @@
         "ar": "إضافة سر جديد",
         "fr": "Ajouter un nouveau secret",
         "tr": "Yeni bir gizli ekle",
-        "de": "Neues Geheimnis hinzufügen"
+        "de": "Neues Geheimnis hinzufügen",
+        "uk": "Додати новий секрет"
     },
     "SECRETS$CONFIRM_DELETE_KEY": {
         "en": "Are you sure you want to delete this key?",
@@ -87,7 +92,8 @@
         "ar": "هل أنت متأكد أنك تريد حذف هذا المفتاح؟",
         "fr": "Êtes-vous sûr de vouloir supprimer cette clé ?",
         "tr": "Bu anahtarı silmek istediğinizden emin misiniz?",
-        "de": "Sind Sie sicher, dass Sie diesen Schlüssel löschen möchten?"
+        "de": "Sind Sie sicher, dass Sie diesen Schlüssel löschen möchten?",
+        "uk": "Ви впевнені, що хочете видалити цей ключ?"
     },
     "SETTINGS$MCP_TITLE": {
         "en": "Model Context Protocol (MCP)",
@@ -1062,7 +1068,8 @@
         "ar": "أسرار",
         "fr": "Secrets",
         "tr": "Sırları",
-        "de": "Geheimnisse"
+        "de": "Geheimnisse",
+        "uk": "Секрети"
     },
     "SETTINGS$NAV_API_KEYS": {
         "en": "API Keys",


### PR DESCRIPTION
## Description
This PR ensures the logout button is always enabled, even when the user is not connected to GitHub.

## Changes
- Removed the `isDisabled={!isLoggedIn}` condition from the logout button in `AccountSettingsContextMenu`
- Completely removed the `isLoggedIn` prop from `AccountSettingsContextMenu` as it is no longer needed
- Updated the test to reflect the new behavior

## Testing
- All tests pass
- The logout button is now always enabled

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:12ffc6c-nikolaik   --name openhands-app-12ffc6c   docker.all-hands.dev/all-hands-ai/openhands:12ffc6c
```