### PR TITLE
Add MCP log passing mechanism to expose error logs

### DIFF
--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -366,10 +366,20 @@ class ActionExecutionClient(Runtime):
                 'POST',
                 f'{self.action_execution_server_url}/update_mcp_server',
                 json=stdio_tools,
-                timeout=10,
+                timeout=15,  # Increased timeout to account for log collection
             )
             if response.status_code != 200:
                 self.log('warning', f'Failed to update MCP server: {response.text}')
+            else:
+                # Process and log the captured logs from the response
+                try:
+                    response_data = response.json()
+                    if 'logs' in response_data and response_data['logs']:
+                        self.log('info', 'MCP server logs:')
+                        for log_entry in response_data['logs']:
+                            self.log('info', f'MCP: {log_entry}')
+                except Exception as e:
+                    self.log('warning', f'Failed to process MCP server logs: {str(e)}')
 
             # No API key by default. Child runtime can override this when appropriate
             updated_mcp_config.sse_servers.append(

--- a/tests/unit/test_mcp_log_passing.py
+++ b/tests/unit/test_mcp_log_passing.py
@@ -1,0 +1,115 @@
+import logging
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openhands.runtime.action_execution_server import QueueHandler
+
+
+class TestMCPLogPassing(unittest.TestCase):
+    """Test the MCP log passing mechanism."""
+
+    def test_queue_handler(self):
+        """Test that the QueueHandler correctly captures logs."""
+        from queue import Queue
+
+        # Create a queue and handler
+        log_queue = Queue()
+        handler = QueueHandler(log_queue)
+        handler.setFormatter(logging.Formatter('%(levelname)s:%(name)s:%(message)s'))
+
+        # Create a logger and add the handler
+        logger = logging.getLogger('test_logger')
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+
+        # Log some messages
+        logger.debug('Debug message')
+        logger.info('Info message')
+        logger.warning('Warning message')
+        logger.error('Error message')
+
+        # Check that the messages were captured
+        self.assertEqual(log_queue.qsize(), 4)
+        self.assertEqual(log_queue.get(), 'DEBUG:test_logger:Debug message')
+        self.assertEqual(log_queue.get(), 'INFO:test_logger:Info message')
+        self.assertEqual(log_queue.get(), 'WARNING:test_logger:Warning message')
+        self.assertEqual(log_queue.get(), 'ERROR:test_logger:Error message')
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_server_log_capture(self):
+        """Test that the update_mcp_server endpoint captures logs."""
+        with patch(
+            'openhands.runtime.action_execution_server.mcp_router'
+        ) as mock_router:
+            # Mock the router and its methods
+            mock_router.profile_manager = MagicMock()
+            mock_router.get_unique_servers = MagicMock(
+                return_value=['server1', 'server2']
+            )
+            mock_router.update_servers = AsyncMock()
+
+            # Mock the mcp_router_logger to simulate log messages
+            with patch(
+                'openhands.runtime.action_execution_server.mcp_router_logger'
+            ) as mock_logger:
+                # Set up the mock logger to emit a log message when addHandler is called
+                def add_handler_side_effect(handler):
+                    record = logging.LogRecord(
+                        'mcpm.router.router',
+                        logging.INFO,
+                        '',
+                        0,
+                        'Connected to server jetbrains with capabilities',
+                        (),
+                        None,
+                    )
+                    handler.emit(record)
+
+                    error_record = logging.LogRecord(
+                        'mcpm.router.router',
+                        logging.ERROR,
+                        '',
+                        0,
+                        'Failed to add server jetbrains: No working IDE endpoint available',
+                        (),
+                        None,
+                    )
+                    handler.emit(error_record)
+
+                mock_logger.addHandler.side_effect = add_handler_side_effect
+
+                # Mock the request
+                mock_request = MagicMock()
+                mock_request.json = AsyncMock(return_value=[{'name': 'test_server'}])
+
+                # Mock file operations
+                with patch('builtins.open', MagicMock()):
+                    with patch('json.load', MagicMock(return_value={'default': []})):
+                        with patch('json.dump', MagicMock()):
+                            with patch('os.path.exists', MagicMock(return_value=True)):
+                                # Import the function to test
+                                from openhands.runtime.action_execution_server import (
+                                    update_mcp_server,
+                                )
+
+                                # Call the function
+                                result = await update_mcp_server(mock_request)
+
+                                # Check the result
+                                self.assertEqual(result['status'], 'success')
+                                self.assertEqual(
+                                    result['servers_updated'], ['server1', 'server2']
+                                )
+                                self.assertEqual(len(result['logs']), 2)
+                                self.assertIn(
+                                    'Connected to server jetbrains', result['logs'][0]
+                                )
+                                self.assertIn(
+                                    'Failed to add server jetbrains', result['logs'][1]
+                                )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #8514

Implements a log passing mechanism for the MCP router to help users debug configuration issues. The `/update_mcp_config` endpoint now captures and returns error logs from the MCP router for 2 seconds after the update is initiated.

Changes:
- Added a QueueHandler class to capture logs from the MCP router
- Modified the update_mcp_server endpoint to capture logs for 2 seconds
- Updated the action execution client to process and display logs
- Added unit tests to verify the implementation

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/48963ffce5e14e45929f0f0387fe9ef3)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0d00d37-nikolaik   --name openhands-app-0d00d37   docker.all-hands.dev/all-hands-ai/openhands:0d00d37
```