### PR TITLE
Limit size of browser events

### DIFF
--- a/openhands/runtime/browser/base64.py
+++ b/openhands/runtime/browser/base64.py
@@ -4,40 +4,15 @@ from PIL import Image
 import numpy as np
 
 def image_to_png_base64_url(
-    image: np.ndarray | Image.Image,
-    add_data_prefix: bool = False,
-    max_size_kb: int = 1024,
-    minimum_quality: int = 10,
+    image: np.ndarray | Image.Image, add_data_prefix: bool = False
 ) -> str:
-    """Convert a numpy array to a base64 encoded png image url.
-    
-    Will not guarantee the size of the image, but will attempt to compress it to below the specified maximum size.
-
-    Args:
-        image: The image to convert.
-        add_data_prefix: Whether to add the data prefix to the base64 string.
-        max_size_kb: Maximum size of the image in kilobytes.
-        minimum_quality: Minimum quality of the image.
-    """
+    """Convert a numpy array to a base64 encoded png image url."""
     if isinstance(image, np.ndarray):
         image = Image.fromarray(image)
     if image.mode in ('RGBA', 'LA'):
         image = image.convert('RGB')
-
-    max_size_bytes = max_size_kb * 1024
-    quality = 85
-
-    while True:
-        buffered = io.BytesIO()
-        image.save(buffered, format='PNG', quality=quality)
-
-        if len(buffered.getvalue()) <= max_size_bytes:
-            break
-
-        # If the buffer is too large, reduce the quality.
-        quality -= 5
-        if quality < minimum_quality:
-            break
+    buffered = io.BytesIO()
+    image.save(buffered, format='PNG')
 
     image_base64 = base64.b64encode(buffered.getvalue()).decode()
     return (

--- a/openhands/runtime/browser/base64.py
+++ b/openhands/runtime/browser/base64.py
@@ -4,15 +4,40 @@ from PIL import Image
 import numpy as np
 
 def image_to_png_base64_url(
-    image: np.ndarray | Image.Image, add_data_prefix: bool = False
+    image: np.ndarray | Image.Image,
+    add_data_prefix: bool = False,
+    max_size_kb: int = 1024,
+    minimum_quality: int = 10,
 ) -> str:
-    """Convert a numpy array to a base64 encoded png image url."""
+    """Convert a numpy array to a base64 encoded png image url.
+    
+    Will not guarantee the size of the image, but will attempt to compress it to below the specified maximum size.
+
+    Args:
+        image: The image to convert.
+        add_data_prefix: Whether to add the data prefix to the base64 string.
+        max_size_kb: Maximum size of the image in kilobytes.
+        minimum_quality: Minimum quality of the image.
+    """
     if isinstance(image, np.ndarray):
         image = Image.fromarray(image)
     if image.mode in ('RGBA', 'LA'):
         image = image.convert('RGB')
-    buffered = io.BytesIO()
-    image.save(buffered, format='PNG')
+
+    max_size_bytes = max_size_kb * 1024
+    quality = 85
+
+    while True:
+        buffered = io.BytesIO()
+        image.save(buffered, format='PNG', quality=quality)
+
+        if len(buffered.getvalue()) <= max_size_bytes:
+            break
+
+        # If the buffer is too large, reduce the quality.
+        quality -= 5
+        if quality < minimum_quality:
+            break
 
     image_base64 = base64.b64encode(buffered.getvalue()).decode()
     return (

--- a/openhands/runtime/browser/utils.py
+++ b/openhands/runtime/browser/utils.py
@@ -91,6 +91,7 @@ async def browse(
             active_page_index=obs.get(
                 'active_page_index', -1
             ),  # index of the active page
+            dom_object=obs.get('dom_object', {}),  # DOM object
             axtree_object=obs.get('axtree_object', {}),  # accessibility tree object
             extra_element_properties=obs.get('extra_element_properties', {}),
             focused_element_bid=obs.get(

--- a/openhands/runtime/browser/utils.py
+++ b/openhands/runtime/browser/utils.py
@@ -91,7 +91,6 @@ async def browse(
             active_page_index=obs.get(
                 'active_page_index', -1
             ),  # index of the active page
-            dom_object=obs.get('dom_object', {}),  # DOM object
             axtree_object=obs.get('axtree_object', {}),  # accessibility tree object
             extra_element_properties=obs.get('extra_element_properties', {}),
             focused_element_bid=obs.get(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

While browsing certain sites, the agent can produce events in the MBs. The majority of this data seems to come from storing the DOM object, although this is not referenced anywhere I can find.

This PR makes it so the default browser observations no longer store the DOM object (they just use the default `{}`). In addition, it also updates the screenshot serialization to place an upper-bound on the size (at 1 MB).

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3e5ff8a-nikolaik   --name openhands-app-3e5ff8a   docker.all-hands.dev/all-hands-ai/openhands:3e5ff8a
```