### PR TITLE
Make chat auto-scroll functionality more explicit

### DIFF
--- a/frontend/src/hooks/use-scroll-to-bottom.ts
+++ b/frontend/src/hooks/use-scroll-to-bottom.ts
@@ -9,7 +9,13 @@ export function useScrollToBottom(scrollRef: RefObject<HTMLDivElement | null>) {
 
   // Check if the scroll position is at the bottom
   const isAtBottom = useCallback((element: HTMLElement): boolean => {
-    const bottomThreshold = 10; // Pixels from bottom to consider "at bottom"
+    // Use a percentage of the container height as threshold (10%)
+    // This makes it "fuzzier" - user needs to scroll up more to break auto-scroll
+    const bottomThresholdPercentage = 0.1; // 10% of container height
+    const bottomThreshold = Math.max(
+      element.clientHeight * bottomThresholdPercentage,
+      20, // Minimum threshold of 20px
+    );
     const bottomPosition = element.scrollTop + element.clientHeight;
     return bottomPosition >= element.scrollHeight - bottomThreshold;
   }, []);

--- a/frontend/src/hooks/use-scroll-to-bottom.ts
+++ b/frontend/src/hooks/use-scroll-to-bottom.ts
@@ -1,21 +1,19 @@
-import { RefObject, useEffect, useState, useCallback } from "react";
+import { RefObject, useEffect, useState, useCallback, useRef } from "react";
 
 export function useScrollToBottom(scrollRef: RefObject<HTMLDivElement | null>) {
   // Track whether we should auto-scroll to the bottom when content changes
-  const [shouldScrollToBottom, setShouldScrollToBottom] = useState(true);
+  const [autoscroll, setAutoscroll] = useState(true);
 
   // Track whether the user is currently at the bottom of the scroll area
   const [hitBottom, setHitBottom] = useState(true);
 
+  // Store previous scroll position to detect scroll direction
+  const prevScrollTopRef = useRef<number>(0);
+
   // Check if the scroll position is at the bottom
   const isAtBottom = useCallback((element: HTMLElement): boolean => {
-    // Use a percentage of the container height as threshold (10%)
-    // This makes it "fuzzier" - user needs to scroll up more to break auto-scroll
-    const bottomThresholdPercentage = 0.1; // 10% of container height
-    const bottomThreshold = Math.max(
-      element.clientHeight * bottomThresholdPercentage,
-      20, // Minimum threshold of 20px
-    );
+    // Use a fixed 20px buffer
+    const bottomThreshold = 20;
     const bottomPosition = element.scrollTop + element.clientHeight;
     return bottomPosition >= element.scrollHeight - bottomThreshold;
   }, []);
@@ -26,9 +24,24 @@ export function useScrollToBottom(scrollRef: RefObject<HTMLDivElement | null>) {
       const isCurrentlyAtBottom = isAtBottom(e);
       setHitBottom(isCurrentlyAtBottom);
 
-      // Only update shouldScrollToBottom when user manually scrolls
-      // This prevents content changes from affecting our scroll behavior decision
-      setShouldScrollToBottom(isCurrentlyAtBottom);
+      // Get current scroll position
+      const currentScrollTop = e.scrollTop;
+
+      // Detect scroll direction
+      const isScrollingUp = currentScrollTop < prevScrollTopRef.current;
+
+      // Update previous scroll position for next comparison
+      prevScrollTopRef.current = currentScrollTop;
+
+      // Turn off autoscroll only when scrolling up
+      if (isScrollingUp) {
+        setAutoscroll(false);
+      }
+
+      // Turn on autoscroll when scrolled to the bottom
+      if (isCurrentlyAtBottom) {
+        setAutoscroll(true);
+      }
     },
     [isAtBottom],
   );
@@ -38,8 +51,8 @@ export function useScrollToBottom(scrollRef: RefObject<HTMLDivElement | null>) {
     const dom = scrollRef.current;
     if (dom) {
       requestAnimationFrame(() => {
-        // Set shouldScrollToBottom to true when manually scrolling to bottom
-        setShouldScrollToBottom(true);
+        // Set autoscroll to true when manually scrolling to bottom
+        setAutoscroll(true);
         setHitBottom(true);
 
         // Use smooth scrolling but with a fast duration
@@ -53,8 +66,8 @@ export function useScrollToBottom(scrollRef: RefObject<HTMLDivElement | null>) {
 
   // Auto-scroll effect that runs when content changes
   useEffect(() => {
-    // Only auto-scroll if the user was already at the bottom
-    if (shouldScrollToBottom) {
+    // Only auto-scroll if autoscroll is enabled
+    if (autoscroll) {
       const dom = scrollRef.current;
       if (dom) {
         requestAnimationFrame(() => {
@@ -69,8 +82,8 @@ export function useScrollToBottom(scrollRef: RefObject<HTMLDivElement | null>) {
 
   return {
     scrollRef,
-    autoScroll: shouldScrollToBottom,
-    setAutoScroll: setShouldScrollToBottom,
+    autoScroll: autoscroll,
+    setAutoScroll: setAutoscroll,
     scrollDomToBottom,
     hitBottom,
     setHitBottom,


### PR DESCRIPTION
## Description
This PR modifies the auto-scroll functionality in the chat window to make it "fuzzier" by increasing the scroll threshold. 

## Changes
- Changed the fixed 10px threshold to a percentage-based threshold (10% of container height)
- Set a minimum threshold of 20px to ensure it works well on smaller screens
- This ensures users need to scroll up more significantly to break the auto-scroll functionality

## Problem Solved
Sometimes the chat window would not auto-scroll when new messages arrived if the user had scrolled up just slightly. This change makes the auto-scroll behavior more forgiving, requiring users to be scrolled up more significantly before auto-scroll is disabled.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8cc8f6d-nikolaik   --name openhands-app-8cc8f6d   docker.all-hands.dev/all-hands-ai/openhands:8cc8f6d
```