### PR TITLE
Fix flaky TestLocalFileStore tests

### DIFF
--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import shutil
 from abc import ABC
 from dataclasses import dataclass, field
@@ -108,11 +107,22 @@ class _StorageTest(ABC):
 
 class TestLocalFileStore(TestCase, _StorageTest):
     def setUp(self):
-        os.makedirs('./_test_files_tmp', exist_ok=True)
-        self.store = LocalFileStore('./_test_files_tmp')
+        # Create a unique temporary directory for each test instance
+        import tempfile
+
+        self.temp_dir = tempfile.mkdtemp(prefix='openhands_test_')
+        self.store = LocalFileStore(self.temp_dir)
 
     def tearDown(self):
-        shutil.rmtree('./_test_files_tmp')
+        try:
+            # Use ignore_errors=True to avoid failures if directory is not empty
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+        except Exception as e:
+            import logging
+
+            logging.warning(
+                f'Failed to remove temporary directory {self.temp_dir}: {e}'
+            )
 
 
 class TestInMemoryFileStore(TestCase, _StorageTest):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import shutil
 import tempfile
 from abc import ABC
@@ -117,8 +118,6 @@ class TestLocalFileStore(TestCase, _StorageTest):
             # Use ignore_errors=True to avoid failures if directory is not empty
             shutil.rmtree(self.temp_dir, ignore_errors=True)
         except Exception as e:
-            import logging
-
             logging.warning(
                 f'Failed to remove temporary directory {self.temp_dir}: {e}'
             )

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
 from abc import ABC
 from dataclasses import dataclass, field
 from io import BytesIO, StringIO
@@ -108,8 +109,6 @@ class _StorageTest(ABC):
 class TestLocalFileStore(TestCase, _StorageTest):
     def setUp(self):
         # Create a unique temporary directory for each test instance
-        import tempfile
-
         self.temp_dir = tempfile.mkdtemp(prefix='openhands_test_')
         self.store = LocalFileStore(self.temp_dir)
 


### PR DESCRIPTION
## Description

This PR fixes a flaky test in the TestLocalFileStore class that was failing in CI with the error:

```
OSError: [Errno 39] Directory not empty: "./_test_files_tmp"
```

The issue was occurring when running tests in parallel with `pytest -n auto`, where multiple tests were trying to use the same directory `./_test_files_tmp` at the same time. When one test was trying to clean up the directory in its `tearDown` method, another test might still be using it.

## Changes

- Modified the TestLocalFileStore class to use a unique temporary directory for each test instance using Python's tempfile module
- Added error handling in the tearDown method to avoid failures if the directory cannot be removed
- Used `ignore_errors=True` with shutil.rmtree to handle cases where files might still be in use

## Testing

Verified that the tests now pass consistently when run in parallel with `pytest -n auto`.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4d8a14c-nikolaik   --name openhands-app-4d8a14c   docker.all-hands.dev/all-hands-ai/openhands:4d8a14c
```