### PR TITLE
Add ability to customize configuration model on per-agent basis

### DIFF
--- a/openhands/controller/agent.py
+++ b/openhands/controller/agent.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from openhands.controller.state.state import State
-    from openhands.core.config import AgentConfig
     from openhands.events.action import Action
     from openhands.events.action.message import SystemMessageAction
     from openhands.utils.prompt import PromptManager
 from litellm import ChatCompletionToolParam
 
+from openhands.core.config import AgentConfig
 from openhands.core.exceptions import (
     AgentAlreadyRegisteredError,
     AgentNotRegisteredError,
@@ -33,10 +33,13 @@ class Agent(ABC):
     _registry: dict[str, type['Agent']] = {}
     sandbox_plugins: list[PluginRequirement] = []
 
+    config_model: type[AgentConfig] = AgentConfig
+    """Class field that specifies the config model to use for the agent. Subclasses may override with a derived config model if needed."""
+
     def __init__(
         self,
         llm: LLM,
-        config: 'AgentConfig',
+        config: AgentConfig,
     ):
         self.llm = llm
         self.config = config

--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field, ValidationError
 from openhands.core.config.condenser_config import CondenserConfig, NoOpCondenserConfig
 from openhands.core.config.extended_config import ExtendedConfig
 from openhands.core.logger import openhands_logger as logger
+from openhands.utils.import_utils import get_impl
 
 
 class AgentConfig(BaseModel):
@@ -94,7 +95,27 @@ class AgentConfig(BaseModel):
             try:
                 # Merge base config with overrides
                 merged = {**base_config.model_dump(), **overrides}
-                custom_config = cls.model_validate(merged)
+                if merged.get('classpath'):
+                    # if an explicit classpath is given, try to load it and look up its config model class
+                    from openhands.controller.agent import Agent
+
+                    try:
+                        agent_cls = get_impl(Agent, merged.get('classpath'))
+                        custom_config = agent_cls.config_model.model_validate(merged)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to load custom agent class [{merged.get('classpath')}]: {e}. Using default config model."
+                        )
+                        custom_config = cls.model_validate(merged)
+                else:
+                    # otherwise, try to look up the agent class by name (i.e. if it's a built-in)
+                    # if that fails, just use the default AgentConfig class.
+                    try:
+                        agent_cls = Agent.get_cls(name)
+                        custom_config = agent_cls.config_model.model_validate(merged)
+                    except Exception as e:
+                        # otherwise, just fall back to the default config model
+                        custom_config = cls.model_validate(merged)
                 agent_mapping[name] = custom_config
             except ValidationError as e:
                 logger.warning(


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Allows implementors of custom/derived Agents to provide a custom config model for the agent. This is done by overriding the new class attribute `Agent.config_model` with a subtype of `AgentConfig`:

Example usage:

```python
class MyAgentConfig(AgentConfig):
  foo: str = "bar"

class MyAgent(Agent):
  config_model = MyAgentConfig
```

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This is a follow-up to #8283, where I mentioned it would be good to have custom/derived agents be able to specify their own config models.

This commit adds a new class attribute, `Agent.config_model`. When the mapping of agent configurations is loaded in `AgentConfig.from_toml_section()`, the function attempts to load the appropriate agent class either from the `classpath` attribute, or the agent's name from the toml header (i.e. `[agent.AgentName]`). If the agent class is found, the config is parsed using `resolved_agent_class.config_model`, otherwise it falls back to the default `AgentConfig` model.

---
**Link of any specific issues this addresses:**
#8283
