### PR TITLE
fix(frontend): Prevent making too many calls to `/git/changes` on conversation load

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -131,7 +131,6 @@ export function WsClientProvider({
   const { providers } = useUserProviders();
 
   const messageRateHandler = useRate({ threshold: 250 });
-  const [messagesHaveLoaded, setMessagesHaveLoaded] = React.useState(false);
 
   function send(event: Record<string, unknown>) {
     if (!sioRef.current) {
@@ -153,12 +152,11 @@ export function WsClientProvider({
 
       // Invalidate diffs cache when a file is edited or written
       if (
-        messagesHaveLoaded &&
-        (isFileEditAction(event) ||
-          isFileWriteAction(event) ||
-          isCommandAction(event))
+        isFileEditAction(event) ||
+        isFileWriteAction(event) ||
+        isCommandAction(event)
       ) {
-        queryClient.invalidateQueries({
+        queryClient.removeQueries({
           queryKey: ["file_changes", conversationId],
         });
 
@@ -252,15 +250,6 @@ export function WsClientProvider({
       sio.off("disconnect", handleDisconnect);
     };
   }, [conversationId]);
-
-  React.useEffect(() => {
-    if (
-      status === WsClientProviderStatus.CONNECTED &&
-      !messageRateHandler.isUnderThreshold
-    ) {
-      setMessagesHaveLoaded(true);
-    }
-  }, [messageRateHandler.isUnderThreshold, status]);
 
   React.useEffect(
     () => () => {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

# Problem
In order to show the latest changes under the "Changes" tab, we refetch data from `/git/changes` everytime there is a file edit/write or command action. We do this in the `handleMessage` handler of the WS provider.

Because of this, everytime we load a conversation, there is a rush of events that mass through this handler, invalidating the query every time one of those actions show up, resulting in making multiple calls

## Reproduction Steps

1. In a new conversation, ask OH to make many file edit/write or command actions
2. Go back to home
3. Navigate back to conversation
4. [In Network tab] observe `n` calls to `/git/changes` where `n` are the total number of file edit/write + command actions


# Solution
Instead of invalidating queries (which makes a follow-up request), we remove the query (`.removeQueries`, which does not make a follow-up request)

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6dd54ec-nikolaik   --name openhands-app-6dd54ec   docker.all-hands.dev/all-hands-ai/openhands:6dd54ec
```