### PR TITLE
Enhance pause button visibility with gray circle background

### DIFF
--- a/frontend/src/components/features/controls/agent-control-bar.tsx
+++ b/frontend/src/components/features/controls/agent-control-bar.tsx
@@ -40,7 +40,13 @@ export function AgentControlBar() {
         }
         handleAction={handleAction}
       >
-        {curAgentState === AgentState.PAUSED ? <PlayIcon /> : <PauseIcon />}
+        {curAgentState === AgentState.PAUSED ? (
+          <PlayIcon />
+        ) : (
+          <div className="bg-gray-200 p-2 rounded-full">
+            <PauseIcon />
+          </div>
+        )}
       </ActionButton>
     </div>
   );

--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -23,7 +23,7 @@ export function ActionButton({
         className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out"
         type="button"
       >
-        <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">
+        <span className="relative flex items-center justify-center group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">
           {children}
         </span>
         <span className="absolute -inset-[5px] border-2 border-red-400/40 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out" />


### PR DESCRIPTION
This PR adds a gray circle background to the pause button to make it more prominent and easier to identify. The circle is only shown when the agent is running (not when it is paused).

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:054adcf-nikolaik   --name openhands-app-054adcf   docker.all-hands.dev/all-hands-ai/openhands:054adcf
```