### PR TITLE
feat: Add dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,15 @@
 // For format details, see: https://aka.ms/devcontainer.json
-// For config options, see: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Python 3",
+	// Documentation for this image:
+	// - https://github.com/devcontainers/templates/tree/main/src/python
+	// - https://github.com/microsoft/vscode-remote-try-python
+	// - https://hub.docker.com/r/microsoft/devcontainers-python
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
-	"postCreateCommand": "sudo apt update && sudo apt install netcat -y",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers-extra/features/poetry:2": {},
+		"ghcr.io/devcontainers/features/node:1": {},
+	},
+	"postCreateCommand": ".devcontainer/setup.sh",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+// For format details, see: https://aka.ms/devcontainer.json
+// For config options, see: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"postCreateCommand": "sudo apt update && sudo apt install netcat -y",
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install `nc`
+sudo apt update && sudo apt install netcat -y
+
+# Do common setup tasks
+source .openhands/setup.sh

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+# force *nix line endings so files don't look modified in container run from Windows clone
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 *.ipynb linguist-vendored
+
+# force *nix line endings so files don't look modified in container run from Windows clone
+* text eol=lf
+# Git incorrectly thinks some media is text
+*.png -text
+*.mp4 -text

--- a/.gitignore
+++ b/.gitignore
@@ -161,8 +161,15 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
-.vscode/
 .cursorignore
+
+# VS Code: Ignore all but certain files that specify repo-specific settings.
+# https://stackoverflow.com/questions/32964920/should-i-commit-the-vscode-folder-to-source-control
+.vscode/**/*
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/settings.json
+!.vscode/tasks.json
 
 # evaluation
 evaluation/evaluation_outputs

--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -9,4 +9,5 @@ python -m pip install pre-commit
 if [ -d ".git" ]; then
     echo "Installing pre-commit hooks..."
     pre-commit install
+    make install-pre-commit-hooks
 fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    // force *nix line endings so files don't look modified in container run from Windows clone
+    "files.eol": "\n",
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+}


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below
Add dev container
**End-user friendly description of the problem this fixes or functionality this introduces.**

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Added a barebones dev container to avoid installing dependencies listed in [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md). I confirmed that this image has everything we need to `make build && make run`.

While I was at it, I told Git to force *nix line endings (LF), even when cloned from Windows (normally CRLF). This way, when you do a `git status` in the Linux image while looking at a repo cloned from Windows, you won't have the problem of _every_ file looking "modified" just because of line endings.

I also added configuration so the editor would enforce these line endings _and_ so we wouldn't have to wait until `pre-commit` to catch whitespace issues.

This is also being discussed in [this Slack thread](https://openhands-ai.slack.com/archives/C06U8UTKSAD/p1747680397285089).

---
**Link of any specific issues this addresses:**
