### PR TITLE
Fix for issue where initial env vars are not passed to runtime

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -237,7 +237,7 @@ class RemoteRuntime(ActionExecutionClient):
         environment: dict[str, str] = {}
         if self.config.debug or os.environ.get('DEBUG', 'false').lower() == 'true':
             environment['DEBUG'] = 'true'
-        environment.update(self.config.sandbox.runtime_startup_env_vars)
+        environment.update(self.initial_env_vars)
         start_request: dict[str, Any] = {
             'image': self.container_image,
             'command': command,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
The `initial_env_vars` include the `config.sandbox.runtime_startup_env_vars`, but may include additional  / overridden values. These should be passed in at startup.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
So currently we set up the remote runtime with incomplete / wrong initial variables, and then later fix it with a call to `setup_initial_env` later. This makes the environment variables correct from the beginning - so we could probably remove that later call.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:57a1b90-nikolaik   --name openhands-app-57a1b90   docker.all-hands.dev/all-hands-ai/openhands:57a1b90
```