### PR TITLE
Add Export Trajectory Button to Conversation Card

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
@@ -10,6 +10,7 @@ interface ConversationCardContextMenuProps {
   onDisplayCost?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onShowAgentTools?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onDownloadViaVSCode?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onExportTrajectory?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   position?: "top" | "bottom";
 }
 
@@ -20,6 +21,7 @@ export function ConversationCardContextMenu({
   onDisplayCost,
   onShowAgentTools,
   onDownloadViaVSCode,
+  onExportTrajectory,
   position = "bottom",
 }: ConversationCardContextMenuProps) {
   const ref = useClickOutsideElement<HTMLUListElement>(onClose);
@@ -66,6 +68,14 @@ export function ConversationCardContextMenu({
           onClick={onShowAgentTools}
         >
           Show Agent Tools & Metadata
+        </ContextMenuListItem>
+      )}
+      {onExportTrajectory && (
+        <ContextMenuListItem
+          testId="export-trajectory-button"
+          onClick={onExportTrajectory}
+        >
+          Export Trajectory
         </ContextMenuListItem>
       )}
     </ContextMenu>


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Adds an "Export Trajectory" button to the conversation card context menu, allowing users to easily export conversation trajectory data as a JSON file.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Added an "Export Trajectory" button to the conversation card context menu
- Implemented the export functionality using the existing `useGetTrajectory` hook and `downloadTrajectory` utility
- Added error handling with toast notifications
- Added analytics tracking for the export action
- Added comprehensive tests for the new functionality

---
**Link of any specific issues this addresses:**

N/A