### PR TITLE
Fix unsupported MCP tools param

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from openhands.events.action import Action
     from openhands.llm.llm import ModelResponse
 
-from openhands.llm.llm_utils import check_tools_for_llm_compatibility
+from openhands.llm.llm_utils import check_tools
 import openhands.agenthub.codeact_agent.function_calling as codeact_function_calling
 from openhands.agenthub.codeact_agent.tools.bash import create_cmd_run_tool
 from openhands.agenthub.codeact_agent.tools.browser import BrowserTool
@@ -186,7 +186,7 @@ class CodeActAgent(Agent):
         params: dict = {
             'messages': self.llm.format_messages_for_llm(messages),
         }
-        params['tools'] = check_tools_for_llm_compatibility(self.tools, self.llm.config)
+        params['tools'] = check_tools(self.tools, self.llm.config)
         params['extra_body'] = {'metadata': state.to_llm_metadata(agent_name=self.name)}
         response = self.llm.completion(**params)
         logger.debug(f'Response from LLM: {response}')
@@ -264,7 +264,7 @@ class CodeActAgent(Agent):
             self.conversation_memory.apply_prompt_caching(messages)
 
         return messages
-    
+
     def response_to_actions(self, response: 'ModelResponse') -> list['Action']:
         return codeact_function_calling.response_to_actions(
             response, mcp_tool_names=list(self.mcp_tools.keys())

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -279,9 +279,6 @@ class LLM(RetryMixin, DebugMixin):
             # Record start time for latency measurement
             start_time = time.time()
             # we don't support streaming here, thus we get a ModelResponse
-            logger.debug(
-                f'LLM: calling litellm completion with model: {self.config.model}, base_url: {self.config.base_url}, args: {args}, kwargs: {kwargs}'
-            )
             resp: ModelResponse = self._completion_unwrapped(*args, **kwargs)
 
             # Calculate and record latency

--- a/openhands/llm/llm_utils.py
+++ b/openhands/llm/llm_utils.py
@@ -1,0 +1,44 @@
+import copy
+from typing import TYPE_CHECKING
+
+from openhands.core.config import LLMConfig
+from openhands.core.logger import openhands_logger as logger
+
+if TYPE_CHECKING:
+    from litellm import ChatCompletionToolParam
+
+
+def check_tools_for_llm_compatibility(
+    tools: list['ChatCompletionToolParam'], llm_config: LLMConfig
+) -> list['ChatCompletionToolParam']:
+    """Checks and modifies tools for compatibility with the current LLM."""
+    # Special handling for Gemini models which don't support default fields and have limited format support
+    if 'gemini' in llm_config.model.lower():
+        logger.info(
+            f'Removing default fields and unsupported formats from tools for Gemini model {llm_config.model} '
+            "since Gemini models have limited format support (only 'enum' and 'date-time' for STRING types)."
+        )
+        # prevent mutation of input tools
+        checked_tools = copy.deepcopy(tools)
+        # Strip off default fields and unsupported formats that cause errors with gemini-preview
+        for tool in checked_tools:
+            if 'function' in tool and 'parameters' in tool['function']:
+                if 'properties' in tool['function']['parameters']:
+                    for prop_name, prop in tool['function']['parameters'][
+                        'properties'
+                    ].items():
+                        # Remove default fields
+                        if 'default' in prop:
+                            del prop['default']
+
+                        # Remove format fields for STRING type parameters if the format is unsupported
+                        # Gemini only supports 'enum' and 'date-time' formats for STRING type
+                        if prop.get('type') == 'string' and 'format' in prop:
+                            supported_formats = ['enum', 'date-time']
+                            if prop['format'] not in supported_formats:
+                                logger.info(
+                                    f'Removing unsupported format "{prop["format"]}" for STRING parameter "{prop_name}"'
+                                )
+                                del prop['format']
+        return checked_tools
+    return tools

--- a/openhands/llm/llm_utils.py
+++ b/openhands/llm/llm_utils.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from litellm import ChatCompletionToolParam
 
 
-def check_tools_for_llm_compatibility(
+def check_tools(
     tools: list['ChatCompletionToolParam'], llm_config: LLMConfig
 ) -> list['ChatCompletionToolParam']:
     """Checks and modifies tools for compatibility with the current LLM."""


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR proposes a fix unsupported parameter `format` property.

I see this on Gemini latest versions, and it's reported in issues too. I think actually it might not be only Gemini. This is a quick fix, I made a small refactoring of the method out of agent's `step`, maybe we should move this in tools serialization code in a follow up... 🤔 or elsewhere, that code doesn't know the LLM and maybe it's for the best.

I haven't yet verified if it was reported to litellm, will do.

---
**Link of any specific issues this addresses:**
Fix #8595 

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a0d7f2c-nikolaik   --name openhands-app-a0d7f2c   docker.all-hands.dev/all-hands-ai/openhands:a0d7f2c
```