### PR TITLE
hotfix(frontend): Prevent merging conversation events when switching between conversations

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -261,6 +261,11 @@ export function WsClientProvider({
   }, [conversationId]);
 
   React.useEffect(() => {
+    // reset events when conversationId changes
+    setEvents([]);
+    setParsedEvents([]);
+    setStatus(WsClientProviderStatus.DISCONNECTED);
+
     if (!conversationId) {
       throw new Error("No conversation ID provided");
     }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
If you're viewing Conversation A and then switch to Conversation B via the conversations panel, the UI will show messages from both Conversation A and B

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Clear events when switching between conversation

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:630190a-nikolaik   --name openhands-app-630190a   docker.all-hands.dev/all-hands-ai/openhands:630190a
```