### PR TITLE
[Fix]: make mcp config optional in settings

### DIFF
--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -116,7 +116,7 @@ class Session:
             or settings.sandbox_runtime_container_image
             else self.config.sandbox.runtime_container_image
         )
-        self.config.mcp = settings.mcp_config if settings.mcp_config else MCPConfig(sse_servers=[], stdio_servers=[])
+        self.config.mcp = settings.mcp_config or MCPConfig(sse_servers=[], stdio_servers=[])
         # Add OpenHands' MCP server by default
         openhands_mcp_server = OpenHandsMCPConfigImpl.create_default_mcp_server_config(self.config.mcp_host, self.user_id)
         if openhands_mcp_server:

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -12,7 +12,7 @@ from openhands.core.config.condenser_config import (
     CondenserPipelineConfig,
     LLMSummarizingCondenserConfig,
 )
-from openhands.core.config.mcp_config import OpenHandsMCPConfigImpl
+from openhands.core.config.mcp_config import MCPConfig, OpenHandsMCPConfigImpl
 from openhands.core.exceptions import MicroagentValidationError
 from openhands.core.logger import OpenHandsLoggerAdapter
 from openhands.core.schema import AgentState
@@ -116,7 +116,7 @@ class Session:
             or settings.sandbox_runtime_container_image
             else self.config.sandbox.runtime_container_image
         )
-        self.config.mcp = settings.mcp_config
+        self.config.mcp = settings.mcp_config if settings.mcp_config else MCPConfig(sse_servers=[], stdio_servers=[])
         # Add OpenHands' MCP server by default
         openhands_mcp_server = OpenHandsMCPConfigImpl.create_default_mcp_server_config(self.config.mcp_host, self.user_id)
         if openhands_mcp_server:

--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -38,7 +38,7 @@ class Settings(BaseModel):
     user_consents_to_analytics: bool | None = None
     sandbox_base_container_image: str | None = None
     sandbox_runtime_container_image: str | None = None
-    mcp_config: MCPConfig = Field(default_factory=MCPConfig)
+    mcp_config: MCPConfig | None = None
 
 
     model_config = {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

If a user doesn't have `MCPConfig` in their settings, loading it causes as error. The `Settings` basemodel  always expects MCPConfig to exist in user settings (the change was made in #8348)

We fix this by making the field optional again



---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e4b6e05-nikolaik   --name openhands-app-e4b6e05   docker.all-hands.dev/all-hands-ai/openhands:e4b6e05
```