### PR TITLE
Revert "Fix for issue where initial env vars are not passed to runtime"

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -239,7 +239,7 @@ class RemoteRuntime(ActionExecutionClient):
         environment: dict[str, str] = {}
         if self.config.debug or os.environ.get('DEBUG', 'false').lower() == 'true':
             environment['DEBUG'] = 'true'
-        environment.update(self.initial_env_vars)
+        environment.update(self.config.sandbox.runtime_startup_env_vars)
         start_request: dict[str, Any] = {
             'image': self.container_image,
             'command': command,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Revert "Fix for issue where initial env vars are not passed to runtime (#8597)"

This reverts commit 3873d9f0027f0211e464bf0ec104578fea935b8f.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e6b88e4-nikolaik   --name openhands-app-e6b88e4   docker.all-hands.dev/all-hands-ai/openhands:e6b88e4
```