### PR TITLE
[Fix]: Don't start conversations without user instructions for remote api key conversations

### DIFF
--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -209,6 +209,17 @@ async def new_conversation(
     if auth_type == AuthType.BEARER:
         conversation_trigger = ConversationTrigger.REMOTE_API_KEY
 
+
+    if conversation_trigger == ConversationTrigger.REMOTE_API_KEY and not initial_user_msg:
+        return JSONResponse(
+            content={
+                'status': 'error',
+                'message': 'Missing initial user message',
+                'msg_id': 'CONFIGURATION$MISSING_USER_MESSAGE',
+            },
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
     try:
         if repository:
             provider_handler = ProviderHandler(provider_tokens)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Conversations will not start using OpenHands API Key unless initial user message is provided  

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Conversations will not start using OpenHands API Key unless initial user message is provided

This is to prevent users from repeatedly starting new conversations with no messages. These conversations reserve compute for around 30 minutes, but aren't utilized. 

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:86a6a31-nikolaik   --name openhands-app-86a6a31   docker.all-hands.dev/all-hands-ai/openhands:86a6a31
```