### PR TITLE
Fix gitlab header error in console

### DIFF
--- a/openhands/storage/data_models/user_secrets.py
+++ b/openhands/storage/data_models/user_secrets.py
@@ -45,7 +45,7 @@ class UserSecrets(BaseModel):
         expose_secrets = info.context and info.context.get('expose_secrets', False)
 
         for token_type, provider_token in provider_tokens.items():
-            if not provider_token:
+            if not provider_token or not provider_token.token:
                 continue
 
             token_type_str = (

--- a/openhands/storage/secrets/file_secrets_store.py
+++ b/openhands/storage/secrets/file_secrets_store.py
@@ -20,6 +20,12 @@ class FileSecretsStore(SecretsStore):
         try:
             json_str = await call_sync_from_async(self.file_store.read, self.path)
             kwargs = json.loads(json_str)
+            provider_tokens = {
+                k: v
+                for k, v in (kwargs.get('provider_tokens') or {}).items()
+                if v.get('token')
+            }
+            kwargs['provider_tokens'] = provider_tokens
             secrets = UserSecrets(**kwargs)
             return secrets
         except FileNotFoundError:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
This error occurs because we do not filter blank strings when creating secrets.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Fix for error in console:
```
Error:
service_types.py:173 - HTTP error on gitlab API: LocalProtocolError : Illegal header value b'Bearer '
```

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:af663ee-nikolaik   --name openhands-app-af663ee   docker.all-hands.dev/all-hands-ai/openhands:af663ee
```