### PR TITLE
[refactor]: Move setup_sandbox_config function

### DIFF
--- a/openhands/resolver/issue_resolver.py
+++ b/openhands/resolver/issue_resolver.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 from pydantic import SecretStr
 from termcolor import colored
 
-import openhands
 from openhands.controller.state.state import State
 from openhands.core.config import AgentConfig, AppConfig, LLMConfig, SandboxConfig
 from openhands.core.logger import openhands_logger as logger
@@ -37,7 +36,6 @@ from openhands.resolver.issue_handler_factory import IssueHandlerFactory
 from openhands.resolver.resolver_output import ResolverOutput
 from openhands.resolver.utils import (
     codeact_user_response,
-    get_unique_uid,
     identify_token,
     reset_logger_for_multiprocessing,
 )
@@ -51,7 +49,7 @@ AGENT_CLASS = 'CodeActAgent'
 class IssueResolver:
     GITLAB_CI = os.getenv('GITLAB_CI') == 'true'
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: Namespace, sandbox_config: SandboxConfig) -> None:
         """Initialize the IssueResolver with the given parameters.
         Params initialized:
             owner: Owner of the repo.
@@ -59,7 +57,6 @@ class IssueResolver:
             token: Token to access the repository.
             username: Username to access the repository.
             platform: Platform of the repository.
-            runtime_container_image: Container image to use.
             max_iterations: Maximum number of iterations to run.
             output_dir: Output directory to write the results.
             llm_config: Configuration for the language model.
@@ -70,13 +67,6 @@ class IssueResolver:
             comment_id: Optional ID of a specific comment to focus on.
             base_domain: The base domain for the git server.
         """
-
-        # Setup and validate container images
-        self.sandbox_config = self._setup_sandbox_config(
-            args.base_container_image,
-            args.runtime_container_image,
-            args.is_experimental,
-        )
 
         parts = args.selected_repo.rsplit('/', 1)
         if len(parts) < 2:
@@ -182,54 +172,7 @@ class IssueResolver:
             llm_config=self.llm_config,
         )
         self.issue_handler = factory.create()
-
-    @classmethod
-    def _setup_sandbox_config(
-        cls,
-        base_container_image: str | None,
-        runtime_container_image: str | None,
-        is_experimental: bool,
-    ) -> SandboxConfig:
-        if runtime_container_image is not None and base_container_image is not None:
-            raise ValueError('Cannot provide both runtime and base container images.')
-
-        if (
-            runtime_container_image is None
-            and base_container_image is None
-            and not is_experimental
-        ):
-            runtime_container_image = (
-                f'ghcr.io/all-hands-ai/runtime:{openhands.__version__}-nikolaik'
-            )
-
-        # Convert container image values to string or None
-        container_base = (
-            str(base_container_image) if base_container_image is not None else None
-        )
-        container_runtime = (
-            str(runtime_container_image)
-            if runtime_container_image is not None
-            else None
-        )
-
-        sandbox_config = SandboxConfig(
-            base_container_image=container_base,
-            runtime_container_image=container_runtime,
-            enable_auto_lint=False,
-            use_host_network=False,
-            timeout=300,
-        )
-
-        # Configure sandbox for GitLab CI environment
-        if cls.GITLAB_CI:
-            sandbox_config.local_runtime_url = os.getenv(
-                'LOCAL_RUNTIME_URL', 'http://localhost'
-            )
-            user_id = os.getuid() if hasattr(os, 'getuid') else 1000
-            if user_id == 0:
-                sandbox_config.user_id = get_unique_uid()
-
-        return sandbox_config
+        self.sandbox_config = sandbox_config
 
     def initialize_runtime(
         self,

--- a/openhands/resolver/resolve_issue.py
+++ b/openhands/resolver/resolve_issue.py
@@ -1,8 +1,59 @@
 # flake8: noqa: E501
 
 import asyncio
+import os
 
+import openhands
+from openhands.core.config import SandboxConfig
 from openhands.resolver.issue_resolver import IssueResolver
+from openhands.resolver.utils import (
+    get_unique_uid,
+)
+
+
+def setup_sandbox_config(
+    base_container_image: str | None,
+    runtime_container_image: str | None,
+    is_experimental: bool,
+) -> SandboxConfig:
+    if runtime_container_image is not None and base_container_image is not None:
+        raise ValueError('Cannot provide both runtime and base container images.')
+
+    if (
+        runtime_container_image is None
+        and base_container_image is None
+        and not is_experimental
+    ):
+        runtime_container_image = (
+            f'ghcr.io/all-hands-ai/runtime:{openhands.__version__}-nikolaik'
+        )
+
+    # Convert container image values to string or None
+    container_base = (
+        str(base_container_image) if base_container_image is not None else None
+    )
+    container_runtime = (
+        str(runtime_container_image) if runtime_container_image is not None else None
+    )
+
+    sandbox_config = SandboxConfig(
+        base_container_image=container_base,
+        runtime_container_image=container_runtime,
+        enable_auto_lint=False,
+        use_host_network=False,
+        timeout=300,
+    )
+
+    # Configure sandbox for GitLab CI environment
+    if os.getenv('GITLAB_CI') == 'true':
+        sandbox_config.local_runtime_url = os.getenv(
+            'LOCAL_RUNTIME_URL', 'http://localhost'
+        )
+        user_id = os.getuid() if hasattr(os, 'getuid') else 1000
+        if user_id == 0:
+            sandbox_config.user_id = get_unique_uid()
+
+    return sandbox_config
 
 
 def main() -> None:
@@ -121,7 +172,13 @@ def main() -> None:
 
     my_args = parser.parse_args()
 
-    issue_resolver = IssueResolver(my_args)
+    sandbox_config = setup_sandbox_config(
+        my_args.base_container_image,
+        my_args.runtime_container_image,
+        my_args.is_experimental,
+    )
+
+    issue_resolver = IssueResolver(my_args, sandbox_config)
     asyncio.run(issue_resolver.resolve_issue())
 
 

--- a/tests/unit/resolver/github/test_resolve_issues.py
+++ b/tests/unit/resolver/github/test_resolve_issues.py
@@ -20,6 +20,7 @@ from openhands.resolver.interfaces.issue_definitions import (
     ServiceContextPR,
 )
 from openhands.resolver.issue_resolver import IssueResolver
+from openhands.resolver.resolve_issue import setup_sandbox_config
 from openhands.resolver.resolver_output import ResolverOutput
 
 
@@ -124,7 +125,12 @@ def test_initialize_runtime(default_mock_args, mock_github_token):
     ]
 
     # Create resolver with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
 
     resolver.initialize_runtime(mock_runtime)
 
@@ -146,7 +152,12 @@ async def test_resolve_issue_no_issues_found(default_mock_args, mock_github_toke
     default_mock_args.issue_number = 5432
 
     # Create a resolver instance with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
 
     # Mock the issue handler
     resolver.issue_handler = mock_handler
@@ -355,7 +366,12 @@ async def test_complete_runtime(default_mock_args, mock_github_token):
     ]
 
     # Create resolver with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
 
     result = await resolver.complete_runtime(mock_runtime, 'base_commit_hash')
 
@@ -448,7 +464,12 @@ async def test_process_issue(
     default_mock_args.issue_type = 'pr' if test_case.get('is_pr', False) else 'issue'
 
     # Create a resolver instance with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
     resolver.user_instructions_prompt_template = mock_user_instructions_template
 
     # Mock the handler with LLM config

--- a/tests/unit/resolver/gitlab/test_gitlab_resolve_issues.py
+++ b/tests/unit/resolver/gitlab/test_gitlab_resolve_issues.py
@@ -19,9 +19,8 @@ from openhands.resolver.interfaces.issue_definitions import (
     ServiceContextIssue,
     ServiceContextPR,
 )
-from openhands.resolver.issue_resolver import (
-    IssueResolver,
-)
+from openhands.resolver.issue_resolver import IssueResolver
+from openhands.resolver.resolve_issue import setup_sandbox_config
 from openhands.resolver.resolver_output import ResolverOutput
 
 
@@ -136,7 +135,12 @@ def test_initialize_runtime(default_mock_args, mock_gitlab_token):
         ]
 
     # Create resolver with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
 
     resolver.initialize_runtime(mock_runtime)
 
@@ -166,7 +170,12 @@ async def test_resolve_issue_no_issues_found(default_mock_args, mock_gitlab_toke
     default_mock_args.issue_number = 5432
 
     # Create a resolver instance with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
 
     # Mock the issue handler
     resolver.issue_handler = mock_handler
@@ -396,7 +405,12 @@ async def test_complete_runtime(default_mock_args, mock_gitlab_token):
     ]
 
     # Create a resolver instance with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
 
     result = await resolver.complete_runtime(mock_runtime, 'base_commit_hash')
 
@@ -483,7 +497,12 @@ async def test_process_issue(
     default_mock_args.issue_type = 'pr' if test_case.get('is_pr', False) else 'issue'
 
     # Create a resolver instance with mocked token identification
-    resolver = IssueResolver(default_mock_args)
+    sandbox_config = setup_sandbox_config(
+        default_mock_args.base_container_image,
+        default_mock_args.runtime_container_image,
+        default_mock_args.is_experimental
+    )
+    resolver = IssueResolver(default_mock_args,sandbox_config)
     resolver.user_instructions_prompt_template = mock_user_instructions_template
 
     # Mock the handler with LLM config

--- a/tests/unit/resolver/test_resolve_issue.py
+++ b/tests/unit/resolver/test_resolve_issue.py
@@ -5,7 +5,7 @@ import pytest
 from openhands.core.config import SandboxConfig
 from openhands.events.action import CmdRunAction
 from openhands.resolver.issue_resolver import IssueResolver
-
+from openhands.resolver.resolve_issue import setup_sandbox_config
 
 def assert_sandbox_config(
     config: SandboxConfig,
@@ -26,7 +26,7 @@ def assert_sandbox_config(
 def test_setup_sandbox_config_default():
     """Test default configuration when no images provided and not experimental"""
     with mock.patch('openhands.__version__', 'mock'):
-        config = IssueResolver._setup_sandbox_config(
+        config = setup_sandbox_config(
             base_container_image=None,
             runtime_container_image=None,
             is_experimental=False,
@@ -42,7 +42,7 @@ def test_setup_sandbox_config_both_images():
     with pytest.raises(
         ValueError, match='Cannot provide both runtime and base container images.'
     ):
-        IssueResolver._setup_sandbox_config(
+        setup_sandbox_config(
             base_container_image='base-image',
             runtime_container_image='runtime-image',
             is_experimental=False,
@@ -52,7 +52,7 @@ def test_setup_sandbox_config_both_images():
 def test_setup_sandbox_config_base_only():
     """Test configuration when only base_container_image is provided"""
     base_image = 'custom-base-image'
-    config = IssueResolver._setup_sandbox_config(
+    config = setup_sandbox_config(
         base_container_image=base_image,
         runtime_container_image=None,
         is_experimental=False,
@@ -66,7 +66,7 @@ def test_setup_sandbox_config_base_only():
 def test_setup_sandbox_config_runtime_only():
     """Test configuration when only runtime_container_image is provided"""
     runtime_image = 'custom-runtime-image'
-    config = IssueResolver._setup_sandbox_config(
+    config = setup_sandbox_config(
         base_container_image=None,
         runtime_container_image=runtime_image,
         is_experimental=False,
@@ -78,7 +78,7 @@ def test_setup_sandbox_config_runtime_only():
 def test_setup_sandbox_config_experimental():
     """Test configuration when experimental mode is enabled"""
     with mock.patch('openhands.__version__', 'mock'):
-        config = IssueResolver._setup_sandbox_config(
+        config = setup_sandbox_config(
             base_container_image=None,
             runtime_container_image=None,
             is_experimental=True,
@@ -88,12 +88,12 @@ def test_setup_sandbox_config_experimental():
 
 
 @mock.patch('openhands.resolver.issue_resolver.os.getuid', return_value=0)
-@mock.patch('openhands.resolver.issue_resolver.get_unique_uid', return_value=1001)
+@mock.patch('openhands.resolver.resolve_issue.get_unique_uid', return_value=1001)
 def test_setup_sandbox_config_gitlab_ci(mock_get_unique_uid, mock_getuid):
     """Test GitLab CI specific configuration when running as root"""
     with mock.patch('openhands.__version__', 'mock'):
         with mock.patch.object(IssueResolver, 'GITLAB_CI', True):
-            config = IssueResolver._setup_sandbox_config(
+            config = setup_sandbox_config(
                 base_container_image=None,
                 runtime_container_image=None,
                 is_experimental=False,
@@ -107,7 +107,7 @@ def test_setup_sandbox_config_gitlab_ci_non_root(mock_getuid):
     """Test GitLab CI configuration when not running as root"""
     with mock.patch('openhands.__version__', 'mock'):
         with mock.patch.object(IssueResolver, 'GITLAB_CI', True):
-            config = IssueResolver._setup_sandbox_config(
+            config = setup_sandbox_config(
                 base_container_image=None,
                 runtime_container_image=None,
                 is_experimental=False,


### PR DESCRIPTION
…r and move sandbox setup to a dedicated function

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

To decouple the command-line parsing logic from the processing logic, I’ve refactored `setup_sandbox_config` from a class method into a standalone function.

To keep the diff manageable, I’m temporarily passing both `args` and `sandbox_config` to the `IssueResolver` constructor. In a future update, the constructor will no longer depend on `args`, and the necessary values will be passed as individual variables instead.

---
**Link of any specific issues this addresses:**
