### PR TITLE
[Fix]: conversation ID attachment in `create_new_conversation`

### DIFF
--- a/openhands/server/services/conversation.py
+++ b/openhands/server/services/conversation.py
@@ -101,16 +101,15 @@ async def create_new_conversation(
         extra={'user_id': user_id, 'session_id': conversation_id},
     )
     initial_message_action = None
-    if initial_user_msg or image_urls:
-        user_msg = (
-            initial_user_msg.format(conversation_id)
-            if attach_convo_id and initial_user_msg
-            else initial_user_msg
-        )
+    if initial_user_msg or image_urls:    
         initial_message_action = MessageAction(
-            content=user_msg or '',
+            content=initial_user_msg or '',
             image_urls=image_urls or [],
         )
+
+    if attach_convo_id and conversation_instructions:
+        conversation_instructions = conversation_instructions.format(conversation_id)
+        
     agent_loop_info = await conversation_manager.maybe_start_agent_loop(
         conversation_id,
         conversation_init_data,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

In the cloud resolver [templates](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/integrations/templates/resolver/github/issue_comment_conversation_instructions.j2) we insert a conversation link so that the user can easily continue the conversation 


However, we've recently made a change to split the initial instructions as `initial_user_msg` and `conversation_instructions`

This PR fixes the convo id attachment logic by attaching it to `conversation_instructions` instead of `initial_usr_msg`

---
**Link of any specific issues this addresses:**
