### PR TITLE
fix(frontend): Use uppercase event type for generic events without translation keys

### DIFF
--- a/frontend/src/components/features/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/features/chat/event-content-helpers/get-event-content.tsx
@@ -28,41 +28,58 @@ export const getEventContent = (
   let details: string = "";
 
   if (isOpenHandsAction(event)) {
-    title = (
-      <Trans
-        i18nKey={`ACTION_MESSAGE$${event.action.toUpperCase()}`}
-        values={{
-          path: hasPathProperty(event.args) && event.args.path,
-          command:
-            hasCommandProperty(event.args) && trimText(event.args.command, 80),
-          mcp_tool_name: event.action === "call_tool_mcp" && event.args.name,
-        }}
-        components={{
-          path: <PathComponent />,
-          cmd: <MonoComponent />,
-        }}
-      />
-    );
+    const actionKey = `ACTION_MESSAGE$${event.action.toUpperCase()}`;
+
+    // If translation key exists, use Trans component
+    if (i18n.exists(actionKey)) {
+      title = (
+        <Trans
+          i18nKey={actionKey}
+          values={{
+            path: hasPathProperty(event.args) && event.args.path,
+            command:
+              hasCommandProperty(event.args) &&
+              trimText(event.args.command, 80),
+            mcp_tool_name: event.action === "call_tool_mcp" && event.args.name,
+          }}
+          components={{
+            path: <PathComponent />,
+            cmd: <MonoComponent />,
+          }}
+        />
+      );
+    } else {
+      // For generic actions, just use the uppercase type
+      title = event.action.toUpperCase();
+    }
     details = getActionContent(event);
   }
 
   if (isOpenHandsObservation(event)) {
-    title = (
-      <Trans
-        i18nKey={`OBSERVATION_MESSAGE$${event.observation.toUpperCase()}`}
-        values={{
-          path: hasPathProperty(event.extras) && event.extras.path,
-          command:
-            hasCommandProperty(event.extras) &&
-            trimText(event.extras.command, 80),
-          mcp_tool_name: event.observation === "mcp" && event.extras.name,
-        }}
-        components={{
-          path: <PathComponent />,
-          cmd: <MonoComponent />,
-        }}
-      />
-    );
+    const observationKey = `OBSERVATION_MESSAGE$${event.observation.toUpperCase()}`;
+
+    // If translation key exists, use Trans component
+    if (i18n.exists(observationKey)) {
+      title = (
+        <Trans
+          i18nKey={observationKey}
+          values={{
+            path: hasPathProperty(event.extras) && event.extras.path,
+            command:
+              hasCommandProperty(event.extras) &&
+              trimText(event.extras.command, 80),
+            mcp_tool_name: event.observation === "mcp" && event.extras.name,
+          }}
+          components={{
+            path: <PathComponent />,
+            cmd: <MonoComponent />,
+          }}
+        />
+      );
+    } else {
+      // For generic observations, just use the uppercase type
+      title = event.observation.toUpperCase();
+    }
     details = getObservationContent(event);
   }
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This renders better titles for new or unaccounted events instead of a non-existent translation key

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f8e8305-nikolaik   --name openhands-app-f8e8305   docker.all-hands.dev/all-hands-ai/openhands:f8e8305
```