### PR TITLE
fix(frontend): Consider agent state errors

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -172,7 +172,7 @@ export function WsClientProvider({
       if (isAgentStateChangeObservation(event)) {
         if (event.extras.agent_state === "error") {
           trackError({
-            message: event.message,
+            message: event.extras.reason || "Unknown error",
             source: "chat",
             metadata: { msgId: event.id },
           });

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -169,16 +169,25 @@ export function WsClientProvider({
         setParsedEvents((prevEvents) => [...prevEvents, event]);
       }
 
-      if (isErrorObservation(event) || isAgentStateChangeObservation(event)) {
+      if (isAgentStateChangeObservation(event)) {
+        if (event.extras.agent_state === "error") {
+          trackError({
+            message: event.message,
+            source: "chat",
+            metadata: { msgId: event.id },
+          });
+          setErrorMessage(event.extras.reason || "Unknown error");
+        }
+
+        return;
+      }
+
+      if (isErrorObservation(event)) {
         trackError({
           message: event.message,
           source: "chat",
           metadata: { msgId: event.id },
         });
-
-        if (isAgentStateChangeObservation(event)) {
-          setErrorMessage(event.extras.reason || "Unknown error");
-        }
       } else {
         removeErrorMessage();
       }

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -19,6 +19,7 @@ import { useUserProviders } from "#/hooks/use-user-providers";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { OpenHandsObservation } from "#/types/core/observations";
 import {
+  isAgentStateChangeObservation,
   isErrorObservation,
   isOpenHandsAction,
   isOpenHandsObservation,
@@ -168,12 +169,16 @@ export function WsClientProvider({
         setParsedEvents((prevEvents) => [...prevEvents, event]);
       }
 
-      if (isErrorObservation(event)) {
+      if (isErrorObservation(event) || isAgentStateChangeObservation(event)) {
         trackError({
           message: event.message,
           source: "chat",
           metadata: { msgId: event.id },
         });
+
+        if (isAgentStateChangeObservation(event)) {
+          setErrorMessage(event.extras.reason || "Unknown error");
+        }
       } else {
         removeErrorMessage();
       }

--- a/frontend/src/types/core/guards.ts
+++ b/frontend/src/types/core/guards.ts
@@ -6,6 +6,7 @@ import {
   SystemMessageAction,
 } from "./actions";
 import {
+  AgentStateChangeObservation,
   CommandObservation,
   ErrorObservation,
   MCPObservation,
@@ -38,6 +39,11 @@ export const isErrorObservation = (
   event: OpenHandsParsedEvent,
 ): event is ErrorObservation =>
   isOpenHandsObservation(event) && event.observation === "error";
+
+export const isAgentStateChangeObservation = (
+  event: OpenHandsParsedEvent,
+): event is AgentStateChangeObservation =>
+  isOpenHandsObservation(event) && event.observation === "agent_state_changed";
 
 export const isCommandObservation = (
   event: OpenHandsParsedEvent,

--- a/frontend/src/types/core/guards.ts
+++ b/frontend/src/types/core/guards.ts
@@ -12,6 +12,7 @@ import {
   MCPObservation,
   OpenHandsObservation,
 } from "./observations";
+import { StatusUpdate } from "./variances";
 
 export const isOpenHandsAction = (
   event: OpenHandsParsedEvent,
@@ -69,3 +70,8 @@ export const isMcpObservation = (
   event: OpenHandsParsedEvent,
 ): event is MCPObservation =>
   isOpenHandsObservation(event) && event.observation === "mcp";
+
+export const isStatusUpdate = (
+  event: OpenHandsParsedEvent,
+): event is StatusUpdate =>
+  "status_update" in event && "type" in event && "id" in event;

--- a/frontend/src/types/core/observations.ts
+++ b/frontend/src/types/core/observations.ts
@@ -6,6 +6,7 @@ export interface AgentStateChangeObservation
   source: "agent";
   extras: {
     agent_state: AgentState;
+    reason?: string;
   };
 }
 

--- a/frontend/src/types/core/variances.ts
+++ b/frontend/src/types/core/variances.ts
@@ -33,7 +33,15 @@ interface LocalUserMessageAction {
   };
 }
 
+export interface StatusUpdate {
+  status_update: true;
+  type: "error";
+  id: string;
+  message: string;
+}
+
 export type OpenHandsVariance =
   | TokenConfig
   | InitConfig
-  | LocalUserMessageAction;
+  | LocalUserMessageAction
+  | StatusUpdate;


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Previously, only WebSocket errors, disconnects, and error events were taken into account

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Also take agent state change observation errors into account

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b023569-nikolaik   --name openhands-app-b023569   docker.all-hands.dev/all-hands-ai/openhands:b023569
```