### PR TITLE
Fix setup.sh error logging

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -431,7 +431,7 @@ class Runtime(FileEditRuntimeMixin):
         )
         action.set_hard_timeout(600)
         obs = self.run_action(action)
-        if isinstance(obs, CmdOutputObservation) and obs.exit_code != 0:
+        if not isinstance(obs, CmdOutputObservation) or obs.exit_code != 0:
             self.log('error', f'Setup script failed: {obs.content}')
 
     @property


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Better logging for setup.sh failures.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Currently when setup.sh is run it will only log an error if it's CmdOutputObservation w/o an error, but we should also log errors if the return is not CmdOutputObservation

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:75a2642-nikolaik   --name openhands-app-75a2642   docker.all-hands.dev/all-hands-ai/openhands:75a2642
```