### PR TITLE
[Refactor]: separate args setup logic for restarting conversations

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -48,6 +48,35 @@ def create_provider_tokens_object(
     return MappingProxyType(provider_information)
 
 
+async def setup_init_convo_settings(
+    user_id: str | None, providers_set: list[ProviderType]
+):
+    settings_store = await SettingsStoreImpl.get_instance(config, user_id)
+    settings = await settings_store.load()
+
+    secrets_store = await SecretsStoreImpl.get_instance(config, user_id)
+    user_secrets: UserSecrets | None = await secrets_store.load()
+
+    if not settings:
+        raise ConnectionRefusedError(
+            'Settings not found', {'msg_id': 'CONFIGURATION$SETTINGS_NOT_FOUND'}
+        )
+
+    session_init_args: dict = {}
+    if settings:
+        session_init_args = {**settings.__dict__, **session_init_args}
+
+    git_provider_tokens = create_provider_tokens_object(providers_set)
+    if server_config.app_mode != AppMode.SAAS and user_secrets:
+        git_provider_tokens = user_secrets.provider_tokens
+
+    session_init_args['git_provider_tokens'] = git_provider_tokens
+    if user_secrets:
+        session_init_args['custom_secrets'] = user_secrets.custom_secrets
+
+    return session_init_args
+
+
 @sio.event
 async def connect(connection_id: str, environ: dict) -> None:
     try:
@@ -85,28 +114,7 @@ async def connect(connection_id: str, environ: dict) -> None:
             conversation_id, cookies_str, authorization_header
         )
 
-        settings_store = await SettingsStoreImpl.get_instance(config, user_id)
-        settings = await settings_store.load()
-
-        secrets_store = await SecretsStoreImpl.get_instance(config, user_id)
-        user_secrets: UserSecrets | None = await secrets_store.load()
-
-        if not settings:
-            raise ConnectionRefusedError(
-                'Settings not found', {'msg_id': 'CONFIGURATION$SETTINGS_NOT_FOUND'}
-            )
-        session_init_args: dict = {}
-        if settings:
-            session_init_args = {**settings.__dict__, **session_init_args}
-
-        git_provider_tokens = create_provider_tokens_object(providers_set)
-        if server_config.app_mode != AppMode.SAAS and user_secrets:
-            git_provider_tokens = user_secrets.provider_tokens
-
-        session_init_args['git_provider_tokens'] = git_provider_tokens
-        if user_secrets:
-            session_init_args['custom_secrets'] = user_secrets.custom_secrets
-
+        session_init_args = await setup_init_convo_settings(user_id, providers_set)
         conversation_init_data = ConversationInitData(**session_init_args)
 
         agent_loop_info = await conversation_manager.join_conversation(

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -50,7 +50,7 @@ def create_provider_tokens_object(
 
 async def setup_init_convo_settings(
     user_id: str | None, providers_set: list[ProviderType]
-):
+) -> ConversationInitData:
     settings_store = await SettingsStoreImpl.get_instance(config, user_id)
     settings = await settings_store.load()
 
@@ -74,7 +74,7 @@ async def setup_init_convo_settings(
     if user_secrets:
         session_init_args['custom_secrets'] = user_secrets.custom_secrets
 
-    return session_init_args
+    return ConversationInitData(**session_init_args)
 
 
 @sio.event
@@ -114,9 +114,7 @@ async def connect(connection_id: str, environ: dict) -> None:
             conversation_id, cookies_str, authorization_header
         )
 
-        session_init_args = await setup_init_convo_settings(user_id, providers_set)
-        conversation_init_data = ConversationInitData(**session_init_args)
-
+        conversation_init_data = await setup_init_convo_settings(user_id, providers_set)
         agent_loop_info = await conversation_manager.join_conversation(
             conversation_id,
             connection_id,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR makes the logic for setting up convo args a helper function. This way it can be reused elsewhere.



---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0c4b600-nikolaik   --name openhands-app-0c4b600   docker.all-hands.dev/all-hands-ai/openhands:0c4b600
```