### PR TITLE
Fix ExceededBudgetError not being properly displayed in frontend

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -284,10 +284,7 @@ class AgentController:
                 err_id = 'STATUS$ERROR_LLM_OUT_OF_CREDITS'
                 self.state.last_error = err_id
                 # Create an ErrorObservation with the specific error_id
-                error_observation = ErrorObservation(
-                    content=str(e),
-                    error_id=err_id
-                )
+                error_observation = ErrorObservation(content=str(e), error_id=err_id)
                 # Add the ErrorObservation to the event stream
                 self.event_stream.add_event(error_observation, EventSource.AGENT)
             elif isinstance(e, ContentPolicyViolationError) or (

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -283,6 +283,13 @@ class AgentController:
             elif isinstance(e, BadRequestError) and 'ExceededBudget' in str(e):
                 err_id = 'STATUS$ERROR_LLM_OUT_OF_CREDITS'
                 self.state.last_error = err_id
+                # Create an ErrorObservation with the specific error_id
+                error_observation = ErrorObservation(
+                    content=str(e),
+                    error_id=err_id
+                )
+                # Add the ErrorObservation to the event stream
+                self.event_stream.add_event(error_observation, EventSource.AGENT)
             elif isinstance(e, ContentPolicyViolationError) or (
                 isinstance(e, BadRequestError)
                 and 'ContentPolicyViolationError' in str(e)

--- a/tests/unit/test_budget_error_fix.py
+++ b/tests/unit/test_budget_error_fix.py
@@ -1,79 +1,77 @@
-import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from litellm import BadRequestError
+
 from openhands.controller.agent_controller import AgentController
 from openhands.events.observation.error import ErrorObservation
-from openhands.events import EventStream, EventSource
-from openhands.core.schema import AgentState
-from openhands.storage.memory import InMemoryFileStore
 
 
 @pytest.mark.asyncio
 async def test_budget_error_fix_fails_without_fix():
     """
     Test that demonstrates the issue with ExceededBudgetError not being properly displayed in the frontend.
-    
+
     This test should FAIL with the current implementation and PASS after the fix is applied.
-    
+
     The issue is that when a BadRequestError with 'ExceededBudget' occurs:
     1. The agent_controller correctly identifies it and sets error_id to 'STATUS$ERROR_LLM_OUT_OF_CREDITS'
     2. It calls status_callback with this error_id
     3. But it doesn't create an ErrorObservation with this error_id
     4. So the frontend doesn't receive the specific error_id and shows a generic error message
-    
+
     The fix is to create an ErrorObservation with the specific error_id and add it to the event stream.
     """
     # Create a BadRequestError with ExceededBudget message
     budget_error = BadRequestError(
-        message="Litellm_proxyException - ExceededBudget: User=20d03f52-abb6-4414-b024-67cc89d53e12 over budget. Spend=750.0430599000048, Budget=750.0.",
-        model="gpt-4o",
-        llm_provider="openai",
+        message='Litellm_proxyException - ExceededBudget: User=20d03f52-abb6-4414-b024-67cc89d53e12 over budget. Spend=750.0430599000048, Budget=750.0.',
+        model='gpt-4o',
+        llm_provider='openai',
     )
-    
+
     # Create a properly mocked controller that can work with the real _react_to_exception method
     controller = MagicMock()
     controller.state = MagicMock()
-    controller.state.last_error = ""
+    controller.state.last_error = ''
     controller.status_callback = MagicMock()
     controller.set_agent_state_to = AsyncMock()  # Mock the async method
-    
+
     # Create a spy for event_stream.add_event
     event_stream = MagicMock()
     added_events = []
-    
+
     def spy_add_event(event, source):
         added_events.append((event, source))
         return None
-    
+
     event_stream.add_event = spy_add_event
     controller.event_stream = event_stream
-    
+
     # Get the actual _react_to_exception method from AgentController
     real_react_to_exception = AgentController._react_to_exception
-    
+
     # Call the real _react_to_exception method with our mocked controller
     await real_react_to_exception(controller, budget_error)
-    
+
     # Check that status_callback was called with the correct error_id
     controller.status_callback.assert_called_once_with(
-        'error', 
-        'STATUS$ERROR_LLM_OUT_OF_CREDITS', 
-        'STATUS$ERROR_LLM_OUT_OF_CREDITS'
+        'error', 'STATUS$ERROR_LLM_OUT_OF_CREDITS', 'STATUS$ERROR_LLM_OUT_OF_CREDITS'
     )
-    
+
     # Check if any ErrorObservation was added to the event stream
     error_observations = [
-        event for event, source in added_events 
-        if isinstance(event, ErrorObservation)
+        event for event, source in added_events if isinstance(event, ErrorObservation)
     ]
-    
+
     # This assertion should FAIL with the current implementation and PASS after the fix
     # The test is expected to fail here because the current implementation doesn't create an ErrorObservation
-    assert len(error_observations) > 0, "No ErrorObservation was added to the event stream"
-    
+    assert len(error_observations) > 0, (
+        'No ErrorObservation was added to the event stream'
+    )
+
     # The following assertions will only run if the above assertion passes (which it shouldn't with the current implementation)
     if error_observations:
         error_observation = error_observations[0]
-        assert error_observation.error_id == 'STATUS$ERROR_LLM_OUT_OF_CREDITS', \
+        assert error_observation.error_id == 'STATUS$ERROR_LLM_OUT_OF_CREDITS', (
             f"Expected error_id 'STATUS$ERROR_LLM_OUT_OF_CREDITS', got '{error_observation.error_id}'"
+        )

--- a/tests/unit/test_budget_error_fix.py
+++ b/tests/unit/test_budget_error_fix.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from litellm import BadRequestError
+from openhands.controller.agent_controller import AgentController
+from openhands.events.observation.error import ErrorObservation
+from openhands.events import EventStream, EventSource
+from openhands.core.schema import AgentState
+from openhands.storage.memory import InMemoryFileStore
+
+
+@pytest.mark.asyncio
+async def test_budget_error_fix_fails_without_fix():
+    """
+    Test that demonstrates the issue with ExceededBudgetError not being properly displayed in the frontend.
+    
+    This test should FAIL with the current implementation and PASS after the fix is applied.
+    
+    The issue is that when a BadRequestError with 'ExceededBudget' occurs:
+    1. The agent_controller correctly identifies it and sets error_id to 'STATUS$ERROR_LLM_OUT_OF_CREDITS'
+    2. It calls status_callback with this error_id
+    3. But it doesn't create an ErrorObservation with this error_id
+    4. So the frontend doesn't receive the specific error_id and shows a generic error message
+    
+    The fix is to create an ErrorObservation with the specific error_id and add it to the event stream.
+    """
+    # Create a BadRequestError with ExceededBudget message
+    budget_error = BadRequestError(
+        message="Litellm_proxyException - ExceededBudget: User=20d03f52-abb6-4414-b024-67cc89d53e12 over budget. Spend=750.0430599000048, Budget=750.0.",
+        model="gpt-4o",
+        llm_provider="openai",
+    )
+    
+    # Create a properly mocked controller that can work with the real _react_to_exception method
+    controller = MagicMock()
+    controller.state = MagicMock()
+    controller.state.last_error = ""
+    controller.status_callback = MagicMock()
+    controller.set_agent_state_to = AsyncMock()  # Mock the async method
+    
+    # Create a spy for event_stream.add_event
+    event_stream = MagicMock()
+    added_events = []
+    
+    def spy_add_event(event, source):
+        added_events.append((event, source))
+        return None
+    
+    event_stream.add_event = spy_add_event
+    controller.event_stream = event_stream
+    
+    # Get the actual _react_to_exception method from AgentController
+    real_react_to_exception = AgentController._react_to_exception
+    
+    # Call the real _react_to_exception method with our mocked controller
+    await real_react_to_exception(controller, budget_error)
+    
+    # Check that status_callback was called with the correct error_id
+    controller.status_callback.assert_called_once_with(
+        'error', 
+        'STATUS$ERROR_LLM_OUT_OF_CREDITS', 
+        'STATUS$ERROR_LLM_OUT_OF_CREDITS'
+    )
+    
+    # Check if any ErrorObservation was added to the event stream
+    error_observations = [
+        event for event, source in added_events 
+        if isinstance(event, ErrorObservation)
+    ]
+    
+    # This assertion should FAIL with the current implementation and PASS after the fix
+    # The test is expected to fail here because the current implementation doesn't create an ErrorObservation
+    assert len(error_observations) > 0, "No ErrorObservation was added to the event stream"
+    
+    # The following assertions will only run if the above assertion passes (which it shouldn't with the current implementation)
+    if error_observations:
+        error_observation = error_observations[0]
+        assert error_observation.error_id == 'STATUS$ERROR_LLM_OUT_OF_CREDITS', \
+            f"Expected error_id 'STATUS$ERROR_LLM_OUT_OF_CREDITS', got '{error_observation.error_id}'"


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Fixes an issue where users would see a generic "Agent Encountered an Error" message when they ran out of OpenHands credits, instead of the more specific "You're out of OpenHands Credits" message.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
When a BadRequestError with "ExceededBudget" occurs, the agent_controller correctly identifies it and sets the error_id to "STATUS$ERROR_LLM_OUT_OF_CREDITS", but it wasn't creating an ErrorObservation with this specific error_id. As a result, the frontend would display a generic error message instead of the specific "You're out of OpenHands Credits" message.

This PR adds code to create an ErrorObservation with the specific error_id and adds it to the event stream, ensuring that the frontend receives the proper error message. A test has been added that demonstrates the issue and verifies the fix.

---
**Link of any specific issues this addresses:**
N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bc554cc-nikolaik   --name openhands-app-bc554cc   docker.all-hands.dev/all-hands-ai/openhands:bc554cc
```