### PR TITLE
bug: fix cache_control missing during convertion

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -544,6 +544,8 @@ def convert_fncall_messages_to_non_fncall_messages(
                 raise FunctionCallConversionError(
                     f'Unexpected content type {type(content)}. Expected str or list. Content: {content}'
                 )
+            if "cache_control" in message:
+                content[-1]["cache_control"] = {'type': 'ephemeral'}
             converted_messages.append({'role': 'user', 'content': content})
         else:
             raise FunctionCallConversionError(

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -544,8 +544,8 @@ def convert_fncall_messages_to_non_fncall_messages(
                 raise FunctionCallConversionError(
                     f'Unexpected content type {type(content)}. Expected str or list. Content: {content}'
                 )
-            if "cache_control" in message:
-                content[-1]["cache_control"] = {'type': 'ephemeral'}
+            if 'cache_control' in message:
+                content[-1]['cache_control'] = {'type': 'ephemeral'}
             converted_messages.append({'role': 'user', 'content': content})
         else:
             raise FunctionCallConversionError(

--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -944,3 +944,53 @@ def test_convert_from_multiple_tool_calls_no_tool_calls():
         input_messages
     )
     assert result == input_messages
+
+
+def test_convert_fncall_messages_with_cache_control():
+    """Test that cache_control is properly handled in tool messages."""
+    # Prepare test data
+    messages = [
+        {
+            'role': 'tool',
+            'name': 'test_tool',
+            'content': [{'type': 'text', 'text': 'test content'}],
+            'cache_control': {'type': 'ephemeral'},
+        }
+    ]
+
+    # Call the function
+    result = convert_fncall_messages_to_non_fncall_messages(messages, [])
+
+    # Verify the result
+    assert len(result) == 1
+    assert result[0]['role'] == 'user'
+    assert 'cache_control' in result[0]['content'][-1]
+    assert result[0]['content'][-1]['cache_control'] == {'type': 'ephemeral'}
+    assert (
+        result[0]['content'][0]['text']
+        == 'EXECUTION RESULT of [test_tool]:\ntest content'
+    )
+
+
+def test_convert_fncall_messages_without_cache_control():
+    """Test that tool messages without cache_control work as expected."""
+    # Prepare test data
+    messages = [
+        {
+            'role': 'tool',
+            'name': 'test_tool',
+            'content': [{'type': 'text', 'text': 'test content'}],
+        }
+    ]
+
+    # Call the function
+    result = convert_fncall_messages_to_non_fncall_messages(messages, [])
+
+    # Verify the result
+    assert len(result) == 1
+    assert result[0]['role'] == 'user'
+    assert 'cache_control' not in result[0]['content'][-1]
+    assert (
+        result[0]['content'][0]['text']
+        == 'EXECUTION RESULT of [test_tool]:\ntest content'
+    )


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Original code introduces a bug that it drops `"{cache_control" : {'type': 'ephemeral'}}`  during conversion of `fncall` to `non_fncall`. So I added it here. The reason for this is that claude from provider openrouter is not supporting `fncall` using the api of anthropic, but a openai-commpatiable api(I'll also submit a patch to litellm to fix this btw).

A typical example of this is using APIs from `Openrouter/anthropic/` models. (direct API call to anthropic is banned in my region, so have to use Openrouter as a workaround.

**non-trivial design**:

1. `cache control` is only added whenever message parameter has such key inside
2. It only affects messages with role `tool`
3. This is actually a design fault of anthropic, there's actually a thorough discussion about it [here](https://github.com/BerriAI/litellm/issues/6422#issuecomment-2438765472) and within the code comments
https://github.com/All-Hands-AI/OpenHands/blob/77cd05c33b1eb292c336db772b973920f5b9daf4/openhands/core/message.py#L102-L126
They are mainly about how we should extract `cache_control` out to a higher level when it comes to function calls, it's just that `fn_calls conversion` didn't make the changes accordingly.

---
**Link of any specific issues this addresses:**

I haven't have the time to find any existing issues yet, but it is what happening on me. With this patch, prompt cache is working again. I can show some scrrenshot from my openrouter to see  if cache hits with the same exact prompt request:

Before patch(only 5128 tokens because only system prompt is working):

![image](https://github.com/user-attachments/assets/25f629c9-4921-425d-921d-fd9b72d830b1)

After patch(fully operational):

![image](https://github.com/user-attachments/assets/88655e6d-f97d-419e-9bd1-80865192fc66)