### PR TITLE
bug: fix fn_call error during API response

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -707,6 +707,10 @@ def convert_non_fncall_messages_to_fncall_messages(
                     TOOL_RESULT_REGEX_PATTERN, content, re.DOTALL
                 )
             elif isinstance(content, list):
+                if len(content) > 1:
+                    text_concatenated = "".join(item.get("text", "") for item in content if item.get('type') == 'text')
+                    content = [{"type": "text", "text": text_concatenated}]
+
                 tool_result_match = next(
                     (
                         _match

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -536,8 +536,8 @@ def convert_fncall_messages_to_non_fncall_messages(
             if isinstance(content, str):
                 content = prefix + content
             elif isinstance(content, list):
-                if content and content[-1]['type'] == 'text':
-                    content[-1]['text'] = prefix + content[-1]['text']
+                if content and (first_text_content := next((c for c in content if c['type'] == 'text'), None)):
+                    first_text_content['text'] = prefix + content[-1]['text']
                 else:
                     content = [{'type': 'text', 'text': prefix}] + content
             else:
@@ -707,14 +707,6 @@ def convert_non_fncall_messages_to_fncall_messages(
                     TOOL_RESULT_REGEX_PATTERN, content, re.DOTALL
                 )
             elif isinstance(content, list):
-                if len(content) > 1:
-                    text_concatenated = ''.join(
-                        item.get('text', '')
-                        for item in content
-                        if item.get('type') == 'text'
-                    )
-                    content = [{'type': 'text', 'text': text_concatenated}]
-
                 tool_result_match = next(
                     (
                         _match

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -708,8 +708,12 @@ def convert_non_fncall_messages_to_fncall_messages(
                 )
             elif isinstance(content, list):
                 if len(content) > 1:
-                    text_concatenated = "".join(item.get("text", "") for item in content if item.get('type') == 'text')
-                    content = [{"type": "text", "text": text_concatenated}]
+                    text_concatenated = ''.join(
+                        item.get('text', '')
+                        for item in content
+                        if item.get('type') == 'text'
+                    )
+                    content = [{'type': 'text', 'text': text_concatenated}]
 
                 tool_result_match = next(
                     (

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -541,7 +541,7 @@ def convert_fncall_messages_to_non_fncall_messages(
                         (c for c in content if c['type'] == 'text'), None
                     )
                 ):
-                    first_text_content['text'] = prefix + content[-1]['text']
+                    first_text_content['text'] = prefix + first_text_content['text']
                 else:
                     content = [{'type': 'text', 'text': prefix}] + content
             else:

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -536,7 +536,11 @@ def convert_fncall_messages_to_non_fncall_messages(
             if isinstance(content, str):
                 content = prefix + content
             elif isinstance(content, list):
-                if content and (first_text_content := next((c for c in content if c['type'] == 'text'), None)):
+                if content and (
+                    first_text_content := next(
+                        (c for c in content if c['type'] == 'text'), None
+                    )
+                ):
                     first_text_content['text'] = prefix + content[-1]['text']
                 else:
                     content = [{'type': 'text', 'text': prefix}] + content

--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -944,3 +944,31 @@ def test_convert_from_multiple_tool_calls_no_tool_calls():
         input_messages
     )
     assert result == input_messages
+
+
+def test_convert_fncall_messages_with_image_url():
+    """Test that convert_fncall_messages_to_non_fncall_messages handles image URLs correctly."""
+    messages = [
+        {
+            'role': 'tool',
+            'name': 'browser',
+            'content': [
+                {
+                    'type': 'text',
+                    'text': 'some browser tool results',
+                },
+                {
+                    'type': 'image_url',
+                    'image_url': {'url': 'data:image/gif;base64,R0lGODlhAQABAAAAACw='},
+                },
+            ],
+        }
+    ]
+    converted_messages = convert_fncall_messages_to_non_fncall_messages(messages, [])
+    assert len(converted_messages) == 1
+    assert converted_messages[0]['role'] == 'user'
+    assert len(converted_messages[0]['content']) == len(messages[0]['content'])
+    assert (
+        next(c for c in converted_messages[0]['content'] if c['type'] == 'text')['text']
+        == f'EXECUTION RESULT of [{messages[0]["name"]}]:\n{messages[0]["content"][0]["text"]}'
+    )


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This is a bug I found when receiving simulated fncall response, here's the original code snippet: https://github.com/All-Hands-AI/OpenHands/blob/77cd05c33b1eb292c336db772b973920f5b9daf4/openhands/llm/fn_call_converter.py#L728-L739

You can see line 733, the method is based on the assumption that response of simulated-fncalls should always end up with a content that `len(content)==1`, however this is **not true** for provider openrouter/anthropic。 Here's an response example a got:

```json
[
    {
        "type": "text",
        "text": "EXECUTION RESULT of [browser]:\n"
    },
    {
        "type": "text",
        "text": "LARGE CONTENT HERE......[Current URL: http://localhost:53782/]\n[Focused element bid: 8]\n\n[Action executed successfully.]\n============== BEGIN accessibility tree ==============\nRootWebArea 'VSCode......Note that only visible portion of webpage is present in the screenshot. You may need to scroll to view the remaining portion of the web-page.)\n"
    },
    {
        "type": "image_url",
        "image_url": {
            "url": "..LARGE IMAGE BASE64 CONTENT HERE...... data:image/png;base64,iVBORw0......kSuQmCC"
        },
        "cache_control": {
            "type": "ephemeral"
        }
    }
]
```

And of course such response will lead to a raised error. The main issue with such response is that, it separates the response of fn_call into 2 contents(I don't know why), and apparently fn_call_converter didn't include such case. So I made this change to concatenate all `text` content into one.

As for result, it functions pretty well.

---
**Link of any specific issues this addresses:**

Not checked yet, but I'm pretty sure whoever is using openrouter/anthropic as a provider would encounter it.