### PR TITLE
fix(frontend): Fix Mistral AI provider mapping from display name to key(#8689)

### DIFF
--- a/frontend/__tests__/components/modals/settings/model-selector.test.tsx
+++ b/frontend/__tests__/components/modals/settings/model-selector.test.tsx
@@ -12,6 +12,8 @@ vi.mock("react-i18next", () => ({
         LLM$MODEL: "LLM Model",
         LLM$SELECT_PROVIDER_PLACEHOLDER: "Select a provider",
         LLM$SELECT_MODEL_PLACEHOLDER: "Select a model",
+        MODEL_SELECTOR$VERIFIED: "Verified",
+        MODEL_SELECTOR$OTHERS: "Others",
       };
       return translations[key] || key;
     },
@@ -36,6 +38,10 @@ describe("ModelSelector", () => {
       separator: ".",
       models: ["command-r-v1:0"],
     },
+    mistral: {
+      separator: "/",
+      models: ["devstral-small-2505", "mistral-7b"],
+    },
   };
 
   it("should display the provider selector", async () => {
@@ -51,6 +57,7 @@ describe("ModelSelector", () => {
     expect(screen.getByText("Azure")).toBeInTheDocument();
     expect(screen.getByText("VertexAI")).toBeInTheDocument();
     expect(screen.getByText("cohere")).toBeInTheDocument();
+    expect(screen.getByText("Mistral AI")).toBeInTheDocument();
   });
 
   it("should disable the model selector if the provider is not selected", async () => {
@@ -132,5 +139,25 @@ describe("ModelSelector", () => {
 
     expect(screen.getByLabelText("LLM Provider")).toHaveValue("Azure");
     expect(screen.getByLabelText("LLM Model")).toHaveValue("ada");
+  });
+
+  it("should construct correct model names for mistral provider", async () => {
+    const mockOnChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ModelSelector models={models} onChange={mockOnChange} />);
+
+    const providerSelector = screen.getByLabelText("LLM Provider");
+    const modelSelector = screen.getByLabelText("LLM Model");
+
+    // Select Mistral AI provider
+    await user.click(providerSelector);
+    await user.click(screen.getByText("Mistral AI"));
+
+    // Select a model
+    await user.click(modelSelector);
+    await user.click(screen.getByText("devstral-small-2505"));
+
+    // Verify the correct model format is passed to onChange
+    expect(mockOnChange).toHaveBeenCalledWith("mistral/devstral-small-2505");
   });
 });

--- a/frontend/__tests__/utils/map-provider.test.ts
+++ b/frontend/__tests__/utils/map-provider.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { mapProvider } from "../../src/utils/map-provider";
+import { mapProvider, getProviderKey } from "../../src/utils/map-provider";
 
 test("mapProvider", () => {
   expect(mapProvider("azure")).toBe("Azure");
@@ -24,4 +24,54 @@ test("mapProvider", () => {
   expect(mapProvider("replicate")).toBe("Replicate");
   expect(mapProvider("voyage")).toBe("Voyage AI");
   expect(mapProvider("openrouter")).toBe("OpenRouter");
+});
+
+test("getProviderKey - reverse mapping from display name to provider key", () => {
+  // Test all known providers
+  expect(getProviderKey("OpenAI")).toBe("openai");
+  expect(getProviderKey("Azure")).toBe("azure");
+  expect(getProviderKey("Azure AI Studio")).toBe("azure_ai");
+  expect(getProviderKey("VertexAI")).toBe("vertex_ai");
+  expect(getProviderKey("PaLM")).toBe("palm");
+  expect(getProviderKey("Gemini")).toBe("gemini");
+  expect(getProviderKey("Anthropic")).toBe("anthropic");
+  expect(getProviderKey("AWS SageMaker")).toBe("sagemaker");
+  expect(getProviderKey("AWS Bedrock")).toBe("bedrock");
+  expect(getProviderKey("Mistral AI")).toBe("mistral");  // Our main fix
+  expect(getProviderKey("Anyscale")).toBe("anyscale");
+  expect(getProviderKey("Databricks")).toBe("databricks");
+  expect(getProviderKey("Ollama")).toBe("ollama");
+  expect(getProviderKey("Perplexity AI")).toBe("perlexity");
+  expect(getProviderKey("FriendliAI")).toBe("friendliai");
+  expect(getProviderKey("Groq")).toBe("groq");
+  expect(getProviderKey("Fireworks AI")).toBe("fireworks_ai");
+  expect(getProviderKey("Cloudflare Workers AI")).toBe("cloudflare");
+  expect(getProviderKey("DeepInfra")).toBe("deepinfra");
+  expect(getProviderKey("AI21")).toBe("ai21");
+  expect(getProviderKey("Replicate")).toBe("replicate");
+  expect(getProviderKey("Voyage AI")).toBe("voyage");
+  expect(getProviderKey("OpenRouter")).toBe("openrouter");
+});
+
+test("getProviderKey - handles unknown providers gracefully", () => {
+  // Should return the input as-is for unknown providers
+  expect(getProviderKey("Unknown Provider")).toBe("Unknown Provider");
+  expect(getProviderKey("custom-provider")).toBe("custom-provider");
+  expect(getProviderKey("")).toBe("");
+});
+
+test("getProviderKey - case sensitivity", () => {
+  expect(getProviderKey("mistral ai")).toBe("mistral ai");
+  expect(getProviderKey("MISTRAL AI")).toBe("MISTRAL AI");
+  expect(getProviderKey("Mistral AI")).toBe("mistral");
+});
+
+test("mapProvider and getProviderKey are inverse operations", () => {
+  const testProviders = ["openai", "mistral", "anthropic", "azure", "vertex_ai"];
+  
+  testProviders.forEach(providerKey => {
+    const displayName = mapProvider(providerKey);
+    const reversedKey = getProviderKey(displayName);
+    expect(reversedKey).toBe(providerKey);
+  });
 });

--- a/frontend/__tests__/utils/settings-utils.test.ts
+++ b/frontend/__tests__/utils/settings-utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { extractSettings } from "../../src/utils/settings-utils";
+
+describe("extractSettings - Provider Mapping Integration", () => {
+  it("should correctly convert Mistral AI display name to mistral provider key", () => {
+    const formData = new FormData();
+    formData.set("llm-provider-input", "Mistral AI");
+    formData.set("llm-model-input", "devstral-small-2505");
+    formData.set("llm-api-key-input", "test-api-key");
+
+    const result = extractSettings(formData);
+
+    expect(result.LLM_MODEL).toBe("mistral/devstral-small-2505");
+    expect(result.llm_api_key).toBe("test-api-key");
+    expect(result.LLM_API_KEY_SET).toBe(true);
+  });
+
+  it("should handle other providers correctly", () => {
+    const testCases = [
+      { display: "OpenAI", expected: "openai" },
+      { display: "Anthropic", expected: "anthropic" },
+      { display: "Azure", expected: "azure" },
+      { display: "VertexAI", expected: "vertex_ai" },
+    ];
+
+    testCases.forEach(({ display, expected }) => {
+      const formData = new FormData();
+      formData.set("llm-provider-input", display);
+      formData.set("llm-model-input", "test-model");
+
+      const result = extractSettings(formData);
+
+      expect(result.LLM_MODEL).toBe(`${expected}/test-model`);
+    });
+  });
+
+  it("should handle missing provider gracefully", () => {
+    const formData = new FormData();
+    formData.set("llm-model-input", "test-model");
+
+    const result = extractSettings(formData);
+
+    expect(result.LLM_MODEL).toBeUndefined();
+  });
+
+  it("should handle missing model gracefully", () => {
+    const formData = new FormData();
+    formData.set("llm-provider-input", "Mistral AI");
+    // No model set
+
+    const result = extractSettings(formData);
+
+    expect(result.LLM_MODEL).toBeUndefined();
+  });
+
+  it("should handle unknown provider by returning as-is", () => {
+    const formData = new FormData();
+    formData.set("llm-provider-input", "CustomProvider");
+    formData.set("llm-model-input", "custom-model");
+
+    const result = extractSettings(formData);
+
+    expect(result.LLM_MODEL).toBe("customprovider/custom-model");
+  });
+
+  it("should preserve other settings while fixing provider mapping", () => {
+    const formData = new FormData();
+    formData.set("llm-provider-input", "Mistral AI");
+    formData.set("llm-model-input", "devstral-small-2505");
+    formData.set("agent", "CodeActAgent");
+    formData.set("language", "en");
+    formData.set("use-advanced-options", "true");
+    formData.set("confirmation-mode", "true");
+    formData.set("security-analyzer", "test-analyzer");
+
+    const result = extractSettings(formData);
+
+    expect(result.LLM_MODEL).toBe("mistral/devstral-small-2505");
+    expect(result.AGENT).toBe("CodeActAgent");
+    expect(result.LANGUAGE).toBe("en");
+    expect(result.CONFIRMATION_MODE).toBe(true);
+    expect(result.SECURITY_ANALYZER).toBe("test-analyzer");
+  });
+});

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -101,6 +101,9 @@ const openHandsHandlers = [
       "gpt-4o-mini",
       "anthropic/claude-3.5",
       "anthropic/claude-sonnet-4-20250514",
+      "mistral/devstral-small-2505",
+      "mistral/mistral-large-2407",
+      "mistral/mistral-small-2409",
     ]),
   ),
 

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -9,6 +9,7 @@ import { hasAdvancedSettingsSet } from "#/utils/has-advanced-settings-set";
 import { useSaveSettings } from "#/hooks/mutation/use-save-settings";
 import { SettingsSwitch } from "#/components/features/settings/settings-switch";
 import { I18nKey } from "#/i18n/declaration";
+import { getProviderKey } from "#/utils/map-provider";
 import { SettingsInput } from "#/components/features/settings/settings-input";
 import { HelpLink } from "#/components/features/settings/help-link";
 import { BrandButton } from "#/components/features/settings/brand-button";
@@ -93,10 +94,15 @@ function LlmSettingsScreen() {
   };
 
   const basicFormAction = (formData: FormData) => {
-    const provider = formData.get("llm-provider-input")?.toString();
+    const providerDisplayName = formData.get("llm-provider-input")?.toString();
     const model = formData.get("llm-model-input")?.toString();
     const apiKey = formData.get("llm-api-key-input")?.toString();
     const searchApiKey = formData.get("search-api-key-input")?.toString();
+
+    // Convert display name to provider key
+    const provider = providerDisplayName
+      ? getProviderKey(providerDisplayName)
+      : undefined;
 
     const fullLlmModel =
       provider && model && `${provider}/${model}`.toLowerCase();

--- a/frontend/src/utils/map-provider.ts
+++ b/frontend/src/utils/map-provider.ts
@@ -29,3 +29,13 @@ export const mapProvider = (provider: string) =>
   Object.keys(MAP_PROVIDER).includes(provider)
     ? MAP_PROVIDER[provider as keyof typeof MAP_PROVIDER]
     : provider;
+
+// Reverse mapping: Convert display name back to provider key
+export const getProviderKey = (displayName: string): string => {
+  for (const [key, value] of Object.entries(MAP_PROVIDER)) {
+    if (value === displayName) {
+      return key;
+    }
+  }
+  return displayName; // Return as-is if no mapping found
+};

--- a/frontend/src/utils/organize-models-and-providers.ts
+++ b/frontend/src/utils/organize-models-and-providers.ts
@@ -40,7 +40,10 @@ export const organizeModelsAndProviders = (models: string[]) => {
       return;
     }
 
-    const key = provider || "other";
+    // Normalize mistralai to mistral to prevent duplicate providers
+    const normalizedProvider = provider === "mistralai" ? "mistral" : provider;
+    const key = normalizedProvider || "other";
+
     if (!object[key]) {
       object[key] = { separator, models: [] };
     }

--- a/frontend/src/utils/settings-utils.ts
+++ b/frontend/src/utils/settings-utils.ts
@@ -1,10 +1,17 @@
 import { Settings } from "#/types/settings";
+import { getProviderKey } from "#/utils/map-provider";
 
 const extractBasicFormData = (formData: FormData) => {
-  const provider = formData.get("llm-provider-input")?.toString();
+  const providerDisplayName = formData.get("llm-provider-input")?.toString();
   const model = formData.get("llm-model-input")?.toString();
 
-  const LLM_MODEL = `${provider}/${model}`.toLowerCase();
+  // Convert display name to provider key
+  const provider = providerDisplayName
+    ? getProviderKey(providerDisplayName)
+    : undefined;
+
+  const LLM_MODEL =
+    provider && model ? `${provider}/${model}`.toLowerCase() : undefined;
   const LLM_API_KEY = formData.get("llm-api-key-input")?.toString();
   const AGENT = formData.get("agent")?.toString();
   const LANGUAGE = formData.get("language")?.toString();


### PR DESCRIPTION
## Summary

Fixes the Mistral AI provider mapping issue where "Mistral AI" display name was being converted to "mistral ai" instead of "mistral", breaking LiteLLM compatibility in the backend.

## Changes Made

- **Add `getProviderKey()` function** to map display names back to provider keys in `map-provider.ts`
- **Fix `settings-utils.ts`** to use `getProviderKey()` for proper provider mapping
- **Update `llm-settings.tsx`** to use consistent provider mapping logic
- **Add comprehensive test coverage** for provider mapping functionality in both new and existing test files
- **Ensure "Mistral AI" display name** correctly maps to "mistral" provider key

## Problem Solved

Previously, when users selected "Mistral AI" in simple mode, the model name became `mistral ai/devstral-small-2505` (lowercase with space) instead of the correct `mistral/devstral-small-2505` format. This broke LiteLLM integration in the backend.

## Technical Details

- Added reverse mapping function that converts display names back to provider keys
- Updated form processing logic to use proper provider key mapping
- Maintained backward compatibility with existing functionality
- Added edge case handling for unknown providers

## Testing

- ✅ All existing tests pass
- ✅ Added new tests covering provider mapping scenarios
- ✅ Tested edge cases: unknown providers, missing data, case sensitivity

Fixes #8689