### PR TITLE
fix(frontend): fix mobile view of SettingsModal

### DIFF
--- a/frontend/src/components/shared/modals/settings/model-selector.tsx
+++ b/frontend/src/components/shared/modals/settings/model-selector.tsx
@@ -68,7 +68,7 @@ export function ModelSelector({
   const { t } = useTranslation();
 
   return (
-    <div className="flex w-[680px] justify-between gap-[46px]">
+    <div className="flex flex-col md:flex-row w-[full] md:w-[680px] justify-between gap-4 md:gap-[46px]">
       <fieldset className="flex flex-col gap-2.5 w-full">
         <label className="text-sm">{t(I18nKey.LLM$PROVIDER)}</label>
         <Autocomplete

--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -87,7 +87,7 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
             name="llm-api-key-input"
             label={t(I18nKey.SETTINGS_FORM$API_KEY)}
             type="password"
-            className="w-[680px]"
+            className="w-full"
             placeholder={isLLMKeySet ? "<hidden>" : ""}
             startContent={isLLMKeySet && <KeyStatusIcon isSet={isLLMKeySet} />}
           />

--- a/frontend/src/components/shared/modals/settings/settings-modal.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-modal.tsx
@@ -21,7 +21,7 @@ export function SettingsModal({ onClose, settings }: SettingsModalProps) {
     <ModalBackdrop>
       <div
         data-testid="ai-config-modal"
-        className="bg-base-secondary min-w-[384px] p-6 rounded-xl flex flex-col gap-2 border border-tertiary"
+        className="bg-base-secondary m-4 min-w-[384px] p-6 rounded-xl flex flex-col gap-2 border border-tertiary"
       >
         {aiConfigOptions.error && (
           <p className="text-danger text-xs">{aiConfigOptions.error.message}</p>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

I tweaked some tailwind styles in order to fix the SettingsModal mobile view. The desktop view is unchanged.
Please let me know if you have any suggestions on this matter.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/c51fbcc4-9c3c-41e7-bb66-411701f60614) | ![After](https://github.com/user-attachments/assets/205e68c8-f91e-45ac-8faa-483e8aaeec5e)


---
**How to run the changes locally**
Go to OpenHands/frontend directory
Use `npm run dev:mock` to run the frontend project
You should see the modal open in the home page. If not, go to [Line 30 of /frontend/src/components/features/sidebar/sidebar.tsx](https://github.com/KianoshArian/OpenHands/blob/main/frontend/src/components/features/sidebar/sidebar.tsx#L30) and set the initial state value of `settingsModalIsOpen` to `true`:

```typescript
const [settingsModalIsOpen, setSettingsModalIsOpen] = React.useState(false);
```
Change to:
```typescript
const [settingsModalIsOpen, setSettingsModalIsOpen] = React.useState(true);
```
