### PR TITLE
fix: url repo encode

### DIFF
--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -84,7 +84,7 @@ export function RepositorySelectionForm({
   const allRepositories = repositories?.concat(searchedRepos || []);
   const repositoriesItems = allRepositories?.map((repo) => ({
     key: repo.id,
-    label: repo.full_name,
+    label: decodeURIComponent(repo.full_name),
   }));
 
   const branchesItems = branches?.map((branch) => ({

--- a/frontend/src/components/features/home/tasks/task-suggestions.tsx
+++ b/frontend/src/components/features/home/tasks/task-suggestions.tsx
@@ -28,7 +28,7 @@ export function TaskSuggestions({ filterFor }: TaskSuggestionsProps) {
         {suggestedTasks?.map((taskGroup, index) => (
           <TaskGroup
             key={index}
-            title={taskGroup.title}
+            title={decodeURIComponent(taskGroup.title)}
             tasks={taskGroup.tasks}
           />
         ))}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Claro! Aqui está um exemplo de texto em inglês para o Pull Request (PR):

---

### 🛠️ Decode Encoded Task Group Titles

**What was changed:**

* Updated the `title` prop from:
![image](https://github.com/user-attachments/assets/9a972c00-ac30-4d98-9df9-9718f25c14a5)


  ```tsx
  title={taskGroup.title}
  ```

  to:
![image](https://github.com/user-attachments/assets/5b2955cb-7ff4-4c0f-9354-0afb53cd0dae)

  ```tsx
  title={decodeURIComponent(taskGroup.title)}
  ```

**Why:**

* Task group titles were being passed as URL-encoded strings, causing display issues (e.g., `%20` instead of spaces).
* `decodeURIComponent` ensures the title is properly rendered for the user.

**Impact:**

* UI improvement for task group titles.
* No breaking changes expected.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
