### PR TITLE
fix(frontend): Don't show terminal commands in chat interface that are from the user

### DIFF
--- a/frontend/src/components/features/chat/event-content-helpers/should-render-event.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/should-render-event.ts
@@ -1,6 +1,11 @@
 import { OpenHandsAction } from "#/types/core/actions";
 import { OpenHandsEventType } from "#/types/core/base";
-import { isOpenHandsAction, isOpenHandsObservation } from "#/types/core/guards";
+import {
+  isCommandAction,
+  isCommandObservation,
+  isOpenHandsAction,
+  isOpenHandsObservation,
+} from "#/types/core/guards";
 import { OpenHandsObservation } from "#/types/core/observations";
 
 const COMMON_NO_RENDER_LIST: OpenHandsEventType[] = [
@@ -15,11 +20,21 @@ export const shouldRenderEvent = (
   event: OpenHandsAction | OpenHandsObservation,
 ) => {
   if (isOpenHandsAction(event)) {
+    if (isCommandAction(event) && event.source === "user") {
+      // For user commands, we always hide them from the chat interface
+      return false;
+    }
+
     const noRenderList = COMMON_NO_RENDER_LIST.concat(ACTION_NO_RENDER_LIST);
     return !noRenderList.includes(event.action);
   }
 
   if (isOpenHandsObservation(event)) {
+    if (isCommandObservation(event) && event.source === "user") {
+      // For user commands, we always hide them from the chat interface
+      return false;
+    }
+
     return !COMMON_NO_RENDER_LIST.includes(event.observation);
   }
 

--- a/frontend/src/components/features/chat/messages.tsx
+++ b/frontend/src/components/features/chat/messages.tsx
@@ -2,31 +2,9 @@ import React from "react";
 import { OpenHandsAction } from "#/types/core/actions";
 import { OpenHandsObservation } from "#/types/core/observations";
 import { isOpenHandsAction, isOpenHandsObservation } from "#/types/core/guards";
-import { OpenHandsEventType } from "#/types/core/base";
 import { EventMessage } from "./event-message";
 import { ChatMessage } from "./chat-message";
 import { useOptimisticUserMessage } from "#/hooks/use-optimistic-user-message";
-
-const COMMON_NO_RENDER_LIST: OpenHandsEventType[] = [
-  "system",
-  "agent_state_changed",
-  "change_agent_state",
-];
-
-const ACTION_NO_RENDER_LIST: OpenHandsEventType[] = ["recall"];
-
-const shouldRenderEvent = (event: OpenHandsAction | OpenHandsObservation) => {
-  if (isOpenHandsAction(event)) {
-    const noRenderList = COMMON_NO_RENDER_LIST.concat(ACTION_NO_RENDER_LIST);
-    return !noRenderList.includes(event.action);
-  }
-
-  if (isOpenHandsObservation(event)) {
-    return !COMMON_NO_RENDER_LIST.includes(event.observation);
-  }
-
-  return true;
-};
 
 interface MessagesProps {
   messages: (OpenHandsAction | OpenHandsObservation)[];
@@ -54,7 +32,7 @@ export const Messages: React.FC<MessagesProps> = React.memo(
 
     return (
       <>
-        {messages.filter(shouldRenderEvent).map((message, index) => (
+        {messages.map((message, index) => (
           <EventMessage
             key={index}
             event={message}

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -20,7 +20,7 @@ export interface SystemMessageAction extends OpenHandsActionEvent<"system"> {
 }
 
 export interface CommandAction extends OpenHandsActionEvent<"run"> {
-  source: "agent";
+  source: "agent" | "user";
   args: {
     command: string;
     security_risk: ActionSecurityRisk;

--- a/frontend/src/types/core/guards.ts
+++ b/frontend/src/types/core/guards.ts
@@ -4,6 +4,7 @@ import {
   AssistantMessageAction,
   OpenHandsAction,
   SystemMessageAction,
+  CommandAction,
 } from "./actions";
 import {
   AgentStateChangeObservation,
@@ -40,6 +41,10 @@ export const isErrorObservation = (
   event: OpenHandsParsedEvent,
 ): event is ErrorObservation =>
   isOpenHandsObservation(event) && event.observation === "error";
+
+export const isCommandAction = (
+  event: OpenHandsParsedEvent,
+): event is CommandAction => isOpenHandsAction(event) && event.action === "run";
 
 export const isAgentStateChangeObservation = (
   event: OpenHandsParsedEvent,

--- a/frontend/src/types/core/observations.ts
+++ b/frontend/src/types/core/observations.ts
@@ -11,7 +11,7 @@ export interface AgentStateChangeObservation
 }
 
 export interface CommandObservation extends OpenHandsObservationEvent<"run"> {
-  source: "agent";
+  source: "agent" | "user";
   extras: {
     command: string;
     hidden?: boolean;


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
If the user entered terminal commands from the "Terminal" tab, we'd see it on the chat interface as well

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Filter out user terminal commands from chat interface
- Remove duplicate `shouldRenderEvent` function

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:16af667-nikolaik   --name openhands-app-16af667   docker.all-hands.dev/all-hands-ai/openhands:16af667
```