### PR TITLE
Fix openhands CLI command entry point

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -327,7 +327,7 @@ async def run_session(
     return new_session_requested
 
 
-async def main(loop: asyncio.AbstractEventLoop) -> None:
+async def main_async(loop: asyncio.AbstractEventLoop) -> None:
     """Runs the agent in CLI mode."""
     args = parse_arguments()
 
@@ -419,11 +419,12 @@ async def main(loop: asyncio.AbstractEventLoop) -> None:
         )
 
 
-if __name__ == '__main__':
+def main():
+    """Entry point for the CLI command."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        loop.run_until_complete(main(loop))
+        loop.run_until_complete(main_async(loop))
     except KeyboardInterrupt:
         print('Received keyboard interrupt, shutting down...')
     except ConnectionRefusedError as e:
@@ -445,3 +446,7 @@ if __name__ == '__main__':
         except Exception as e:
             print(f'Error during cleanup: {e}')
             sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -1,0 +1,57 @@
+"""Tests for the CLI main module."""
+
+import importlib
+import sys
+from unittest.mock import patch
+
+
+def test_main_function_exists():
+    """Test that the main function exists and can be imported."""
+    # Import the module
+    from openhands.cli import main
+
+    # Check that the main function exists
+    assert hasattr(main, 'main'), 'main function should exist in openhands.cli.main'
+
+    # Check that it's callable
+    assert callable(main.main), 'main should be a callable function'
+
+
+def test_main_function_can_be_called_without_arguments():
+    """Test that the main function can be called without arguments."""
+    # This test verifies that the main function can be called as an entry point
+    # without requiring any arguments
+
+    # Import the module
+    from openhands.cli import main
+
+    # Mock sys.argv to simulate command line arguments
+    with patch.object(sys, 'argv', ['openhands', '--help']):
+        # Mock the parse_arguments function to avoid actual argument parsing
+        with patch('openhands.cli.main.parse_arguments'):
+            # Mock the main_async function to avoid actual execution
+            with patch('openhands.cli.main.main_async') as mock_main_async:
+                # Call the main function - this should not raise any exceptions
+                try:
+                    # We expect this to exit with SystemExit due to --help
+                    main.main()
+                except SystemExit:
+                    pass
+
+                # Verify that main_async was called
+                mock_main_async.assert_called_once()
+
+
+def test_entry_point_in_pyproject():
+    """Test that the entry point in pyproject.toml points to the correct function."""
+    # This test verifies that the entry point in pyproject.toml points to a function
+    # that exists and can be called
+
+    # Import the module that would be called by the entry point
+    module = importlib.import_module('openhands.cli.main')
+
+    # Get the function that would be called by the entry point
+    function = getattr(module, 'main')
+
+    # Check that it's callable
+    assert callable(function), 'Entry point function should be callable'


### PR DESCRIPTION
## Description

This PR fixes the openhands CLI command entry point in pyproject.toml to ensure it works correctly. The issue was that the main function in openhands/cli/main.py was an async function that required a loop argument, which was not being provided by the entry point.

## Changes

1. Renamed the existing async main function to main_async
2. Added a new non-async main function that:
   - Sets up the event loop
   - Calls the async main_async function
   - Handles exceptions and cleanup
3. Updated the if __name__ == "__main__": block to call the new main function
4. Added tests to ensure the CLI command works correctly and to prevent this from breaking in the future

## Testing

- Added unit tests to verify that the main function exists and can be called without arguments
- Manually tested the command with "poetry run openhands --help" to confirm it works correctly

You can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/{})