### PR TITLE
Fix VS Code tab and other runtime-dependent features showing null

### DIFF
--- a/frontend/src/hooks/query/use-active-host.ts
+++ b/frontend/src/hooks/query/use-active-host.ts
@@ -1,21 +1,14 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import React from "react";
-import { useSelector } from "react-redux";
 import OpenHands from "#/api/open-hands";
-import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
-import { RootState } from "#/store";
 import { useConversationId } from "#/hooks/use-conversation-id";
-import { useActiveConversation } from "./use-active-conversation";
+import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 
 export const useActiveHost = () => {
-  const { curAgentState } = useSelector((state: RootState) => state.agent);
   const [activeHost, setActiveHost] = React.useState<string | null>(null);
   const { conversationId } = useConversationId();
-  const { data: conversation } = useActiveConversation();
-  const enabled =
-    conversation?.status === "RUNNING" &&
-    !RUNTIME_INACTIVE_STATES.includes(curAgentState);
+  const runtimeIsReady = useRuntimeIsReady();
 
   const { data } = useQuery({
     queryKey: [conversationId, "hosts"],
@@ -23,7 +16,7 @@ export const useActiveHost = () => {
       const hosts = await OpenHands.getWebHosts(conversationId);
       return { hosts };
     },
-    enabled,
+    enabled: runtimeIsReady && !!conversationId,
     initialData: { hosts: [] },
     meta: {
       disableToast: true,

--- a/frontend/src/hooks/query/use-active-host.ts
+++ b/frontend/src/hooks/query/use-active-host.ts
@@ -15,7 +15,7 @@ export const useActiveHost = () => {
   const { data: conversation } = useActiveConversation();
   const enabled =
     conversation?.status === "RUNNING" &&
-    RUNTIME_INACTIVE_STATES.includes(curAgentState);
+    !RUNTIME_INACTIVE_STATES.includes(curAgentState);
 
   const { data } = useQuery({
     queryKey: [conversationId, "hosts"],

--- a/frontend/src/hooks/query/use-get-git-changes.ts
+++ b/frontend/src/hooks/query/use-get-git-changes.ts
@@ -1,23 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import React from "react";
-import { useSelector } from "react-redux";
 import OpenHands from "#/api/open-hands";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { GitChange } from "#/api/open-hands.types";
-import { RootState } from "#/store";
-import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
-import { useActiveConversation } from "./use-active-conversation";
+import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 
 export const useGetGitChanges = () => {
   const { conversationId } = useConversationId();
-  const { data: conversation } = useActiveConversation();
   const [orderedChanges, setOrderedChanges] = React.useState<GitChange[]>([]);
   const previousDataRef = React.useRef<GitChange[]>(null);
-
-  const { curAgentState } = useSelector((state: RootState) => state.agent);
-  const enabled =
-    conversation?.status === "RUNNING" &&
-    !RUNTIME_INACTIVE_STATES.includes(curAgentState);
+  const runtimeIsReady = useRuntimeIsReady();
 
   const result = useQuery({
     queryKey: ["file_changes", conversationId],
@@ -25,7 +17,7 @@ export const useGetGitChanges = () => {
     retry: false,
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 15, // 15 minutes
-    enabled,
+    enabled: runtimeIsReady && !!conversationId,
     meta: {
       disableToast: true,
     },

--- a/frontend/src/hooks/query/use-get-git-changes.ts
+++ b/frontend/src/hooks/query/use-get-git-changes.ts
@@ -17,7 +17,7 @@ export const useGetGitChanges = () => {
   const { curAgentState } = useSelector((state: RootState) => state.agent);
   const enabled =
     conversation?.status === "RUNNING" &&
-    RUNTIME_INACTIVE_STATES.includes(curAgentState);
+    !RUNTIME_INACTIVE_STATES.includes(curAgentState);
 
   const result = useQuery({
     queryKey: ["file_changes", conversationId],

--- a/frontend/src/hooks/query/use-vscode-url.ts
+++ b/frontend/src/hooks/query/use-vscode-url.ts
@@ -1,13 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { useSelector } from "react-redux";
 import OpenHands from "#/api/open-hands";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { I18nKey } from "#/i18n/declaration";
-import { RootState } from "#/store";
-import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
 import { transformVSCodeUrl } from "#/utils/vscode-url-helper";
-import { useActiveConversation } from "./use-active-conversation";
+import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 
 // Define the return type for the VS Code URL query
 interface VSCodeUrlResult {
@@ -18,11 +15,7 @@ interface VSCodeUrlResult {
 export const useVSCodeUrl = () => {
   const { t } = useTranslation();
   const { conversationId } = useConversationId();
-  const { data: conversation } = useActiveConversation();
-  const { curAgentState } = useSelector((state: RootState) => state.agent);
-  const enabled =
-    conversation?.status === "RUNNING" &&
-    !RUNTIME_INACTIVE_STATES.includes(curAgentState);
+  const runtimeIsReady = useRuntimeIsReady();
 
   return useQuery<VSCodeUrlResult>({
     queryKey: ["vscode_url", conversationId],
@@ -40,7 +33,7 @@ export const useVSCodeUrl = () => {
         error: t(I18nKey.VSCODE$URL_NOT_AVAILABLE),
       };
     },
-    enabled,
+    enabled: runtimeIsReady && !!conversationId,
     refetchOnMount: true,
     retry: 3,
   });

--- a/frontend/src/hooks/query/use-vscode-url.ts
+++ b/frontend/src/hooks/query/use-vscode-url.ts
@@ -22,7 +22,7 @@ export const useVSCodeUrl = () => {
   const { curAgentState } = useSelector((state: RootState) => state.agent);
   const enabled =
     conversation?.status === "RUNNING" &&
-    RUNTIME_INACTIVE_STATES.includes(curAgentState);
+    !RUNTIME_INACTIVE_STATES.includes(curAgentState);
 
   return useQuery<VSCodeUrlResult>({
     queryKey: ["vscode_url", conversationId],

--- a/frontend/src/hooks/use-runtime-is-ready.ts
+++ b/frontend/src/hooks/use-runtime-is-ready.ts
@@ -5,13 +5,13 @@ import { useActiveConversation } from "./query/use-active-conversation";
 
 /**
  * Hook to determine if the runtime is ready for operations
- * 
+ *
  * @returns boolean indicating if the runtime is ready
  */
 export const useRuntimeIsReady = (): boolean => {
   const { data: conversation } = useActiveConversation();
   const { curAgentState } = useSelector((state: RootState) => state.agent);
-  
+
   return (
     conversation?.status === "RUNNING" &&
     !RUNTIME_INACTIVE_STATES.includes(curAgentState)

--- a/frontend/src/hooks/use-runtime-is-ready.ts
+++ b/frontend/src/hooks/use-runtime-is-ready.ts
@@ -1,0 +1,19 @@
+import { useSelector } from "react-redux";
+import { RootState } from "#/store";
+import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
+import { useActiveConversation } from "./query/use-active-conversation";
+
+/**
+ * Hook to determine if the runtime is ready for operations
+ * 
+ * @returns boolean indicating if the runtime is ready
+ */
+export const useRuntimeIsReady = (): boolean => {
+  const { data: conversation } = useActiveConversation();
+  const { curAgentState } = useSelector((state: RootState) => state.agent);
+  
+  return (
+    conversation?.status === "RUNNING" &&
+    !RUNTIME_INACTIVE_STATES.includes(curAgentState)
+  );
+};


### PR DESCRIPTION
## Description
This PR fixes an issue where the VS Code tab and other runtime-dependent features (web hosts, git changes) were showing "null" instead of loading properly when the runtime was active.

## Root Cause
The issue was in several hooks in the frontend code. The `enabled` condition was incorrectly checking if the agent state is in `RUNTIME_INACTIVE_STATES` instead of checking if it is NOT in those states.

The condition was:
```typescript
const enabled =
  conversation?.status === "RUNNING" &&
  RUNTIME_INACTIVE_STATES.includes(curAgentState);
```

This is incorrect because `RUNTIME_INACTIVE_STATES` includes states like `LOADING`, `STOPPED`, and `ERROR`. The hooks should only be enabled when the agent state is NOT in these inactive states.

## Fix
1. Changed the condition to use the logical NOT operator in the following hooks:
   - `useVSCodeUrl`
   - `useActiveHost`
   - `useGetGitChanges`

2. Created a new `useRuntimeIsReady` hook to centralize this logic:
```typescript
export const useRuntimeIsReady = (): boolean => {
  const { data: conversation } = useActiveConversation();
  const { curAgentState } = useSelector((state: RootState) => state.agent);

  return (
    conversation?.status === "RUNNING" &&
    !RUNTIME_INACTIVE_STATES.includes(curAgentState)
  );
};
```

3. Updated all three hooks to use this new centralized hook.

This ensures that these features are only fetched when the agent is in an active state, which resolves the issue of showing "null".

## Testing
Manually verified that the VS Code tab, web hosts, and git changes now properly load when the runtime is active.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:337858a-nikolaik   --name openhands-app-337858a   docker.all-hands.dev/all-hands-ai/openhands:337858a
```