### PR TITLE
Fix: Remove strip() from parameter value extraction to preserve indentation

### DIFF
--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -582,7 +582,7 @@ def _extract_and_validate_params(
     found_params = set()
     for param_match in param_matches:
         param_name = param_match.group(1)
-        param_value = param_match.group(2).strip()
+        param_value = param_match.group(2)
 
         # Validate parameter is allowed
         if allowed_params and param_name not in allowed_params:

--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -654,6 +654,34 @@ NON_FNCALL_RESPONSE_MESSAGE = {
 <parameter=view_range>[1, 10]</parameter>
 </function>""",
         ),
+        # Test case with indented code block to verify indentation is preserved
+        (
+            [
+                {
+                    'index': 1,
+                    'function': {
+                        'arguments': '{"command": "str_replace", "path": "/test/file.py", "old_str": "def example():\\n    pass", "new_str": "def example():\\n    # This is indented\\n    print(\\"hello\\")\\n    return True"}',
+                        'name': 'str_replace_editor',
+                    },
+                    'id': 'test_id',
+                    'type': 'function',
+                }
+            ],
+            """<function=str_replace_editor>
+<parameter=command>str_replace</parameter>
+<parameter=path>/test/file.py</parameter>
+<parameter=old_str>
+def example():
+    pass
+</parameter>
+<parameter=new_str>
+def example():
+    # This is indented
+    print("hello")
+    return True
+</parameter>
+</function>""",
+        ),
     ],
 )
 def test_convert_tool_call_to_string(tool_calls, expected):


### PR DESCRIPTION
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Fixed an issue where the indentation in code blocks was being incorrectly modified when using the str_replace function. This was caused by the strip() function removing whitespace from parameter values, which affected the indentation of code blocks.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This PR removes the strip() function call from the parameter value extraction in the fn_call_converter.py file. This ensures that indentation in code blocks is preserved when using the str_replace function.

The issue was that when using str_replace, the indentation of the original and new code blocks could be different, leading to incorrect code formatting. By removing the strip() function, we ensure that the indentation is preserved exactly as provided by the user.

---
**Link of any specific issues this addresses:**
N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2789e31-nikolaik   --name openhands-app-2789e31   docker.all-hands.dev/all-hands-ai/openhands:2789e31
```