### PR TITLE
fix(frontend): Only clear UI messages on cid change

### DIFF
--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -289,14 +289,14 @@ export function WsClientProvider({
 
   React.useEffect(() => {
     lastEventRef.current = null;
-  }, [conversationId]);
 
-  React.useEffect(() => {
     // reset events when conversationId changes
     setEvents([]);
     setParsedEvents([]);
     setStatus(WsClientProviderStatus.DISCONNECTED);
+  }, [conversationId]);
 
+  React.useEffect(() => {
     if (!conversationId) {
       throw new Error("No conversation ID provided");
     }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Sometimes, we'd clear the messages from the chat interface on other triggers, possible due to a change in `conversation.status`

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Only clear on cid change

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b567c57-nikolaik   --name openhands-app-b567c57   docker.all-hands.dev/all-hands-ai/openhands:b567c57
```