### PR TITLE
Fix KeyError on router error logging

### DIFF
--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -404,7 +404,7 @@ class ActionExecutionClient(Runtime):
             if response.status_code != 200:
                 self.log('warning', f'Failed to update MCP server: {response.text}')
             else:
-                if result['router_error_log']:
+                if result.get('router_error_log'):
                     self.log(
                         'warning',
                         f'Some MCP servers failed to be added: {result["router_error_log"]}',


### PR DESCRIPTION

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

We were seeing this error in logs:

```
  File "/app/openhands/runtime/impl/action_execution/action_execution_client.py", line 407, in get_mcp_config
    if result['router_error_log']:
       ~~~~~~^^^^^^^^^^^^^^^^^^^^
```

This patch should fix it.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d1c1eee-nikolaik   --name openhands-app-d1c1eee   docker.all-hands.dev/all-hands-ai/openhands:d1c1eee
```