### PR TITLE
chore(docker): update docker base images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,23 @@
+# NodeJS
 frontend/node_modules
-config.toml
-.envrc
-.env
-.git
+
+# Configuration (except pyproject.toml)
+*.ini
+*.toml
+!pyproject.toml
+*.yml
+
+# Documentation (except README.md)
+*.md
+!README.md
+
+# Hidden files and directories
+.*
+__pycache__
+
+# Unneded files and directories
+/dev_config/
+/docs/
+/evaluation/
+/tests/
+CITATION.cff

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,5 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - "containers/*"
-      - "evaluation/benchmarks/*"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "containers/*"
+      - "evaluation/benchmarks/*"
+    schedule:
+      interval: "weekly"

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -75,7 +75,6 @@ COPY --chown=openhands:app --chmod=770 --from=backend-builder ${VIRTUAL_ENV} ${V
 COPY --chown=openhands:app --chmod=770 ./microagents ./microagents
 COPY --chown=openhands:app --chmod=770 ./openhands ./openhands
 COPY --chown=openhands:app --chmod=777 ./openhands/runtime/plugins ./openhands/runtime/plugins
-COPY --chown=openhands:app --chmod=770 ./openhands/agenthub ./openhands/agenthub
 COPY --chown=openhands:app pyproject.toml poetry.lock README.md MANIFEST.in LICENSE ./
 
 # This is run as "openhands" user, and will create __pycache__ with openhands:openhands ownership

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -1,16 +1,16 @@
 ARG OPENHANDS_BUILD_VERSION=dev
-FROM node:21.7.2-bookworm-slim AS frontend-builder
+FROM node:22.16.0-bookworm-slim AS frontend-builder
 
 WORKDIR /app
 
-COPY ./frontend/package.json frontend/package-lock.json ./
-RUN npm install -g npm@10.5.1
+COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 
-COPY ./frontend ./
+COPY frontend ./
 RUN npm run build
 
-FROM python:3.12.3-slim AS backend-builder
+FROM python:3.12.10-slim AS base
+FROM base AS backend-builder
 
 WORKDIR /app
 ENV PYTHONPATH='/app'
@@ -22,17 +22,18 @@ ENV POETRY_NO_INTERACTION=1 \
 
 RUN apt-get update -y \
     && apt-get install -y curl make git build-essential \
-    && python3 -m pip install poetry==1.8.2  --break-system-packages
+    && python3 -m pip install poetry --break-system-packages
 
-COPY ./pyproject.toml ./poetry.lock ./
+COPY pyproject.toml poetry.lock ./
 RUN touch README.md
 RUN export POETRY_CACHE_DIR && poetry install --without evaluation --no-root && rm -rf $POETRY_CACHE_DIR
 
-FROM python:3.12.3-slim AS openhands-app
+FROM base AS openhands-app
 
 WORKDIR /app
 
-ARG OPENHANDS_BUILD_VERSION #re-declare for this section
+# re-declare for this section
+ARG OPENHANDS_BUILD_VERSION
 
 ENV RUN_AS_OPENHANDS=true
 # A random number--we need this to be different from the user's UID on the host machine
@@ -75,11 +76,7 @@ COPY --chown=openhands:app --chmod=770 ./microagents ./microagents
 COPY --chown=openhands:app --chmod=770 ./openhands ./openhands
 COPY --chown=openhands:app --chmod=777 ./openhands/runtime/plugins ./openhands/runtime/plugins
 COPY --chown=openhands:app --chmod=770 ./openhands/agenthub ./openhands/agenthub
-COPY --chown=openhands:app ./pyproject.toml ./pyproject.toml
-COPY --chown=openhands:app ./poetry.lock ./poetry.lock
-COPY --chown=openhands:app ./README.md ./README.md
-COPY --chown=openhands:app ./MANIFEST.in ./MANIFEST.in
-COPY --chown=openhands:app ./LICENSE ./LICENSE
+COPY --chown=openhands:app pyproject.toml poetry.lock README.md MANIFEST.in LICENSE ./
 
 # This is run as "openhands" user, and will create __pycache__ with openhands:openhands ownership
 RUN python openhands/core/download.py # No-op to download assets

--- a/evaluation/benchmarks/scienceagentbench/Dockerfile
+++ b/evaluation/benchmarks/scienceagentbench/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-bookworm
+FROM python:3.11-bookworm
 
 
 # For OpenHands agents to explore the dataset directories, please download the full benchmark [here](https://buckeyemailosu-my.sharepoint.com/:u:/g/personal/chen_8336_buckeyemail_osu_edu/EQuA6uJ3CtRHvRfZ2GiN1tYBRVJE4DSUD10MW61fr7HuSQ?e=sCBegG) and unzip it with password `scienceagentbench`.

--- a/evaluation/benchmarks/scienceagentbench/Dockerfile
+++ b/evaluation/benchmarks/scienceagentbench/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bookworm
+FROM python:3.12-bookworm
 
 
 # For OpenHands agents to explore the dataset directories, please download the full benchmark [here](https://buckeyemailosu-my.sharepoint.com/:u:/g/personal/chen_8336_buckeyemail_osu_edu/EQuA6uJ3CtRHvRfZ2GiN1tYBRVJE4DSUD10MW61fr7HuSQ?e=sCBegG) and unzip it with password `scienceagentbench`.


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Updated Docker base images

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Let Dependabot update Docker weekly
- Warning: pyproject.toml allows Python 3.13 but it wasn't possible to build containers/app on arm64
- dive: `Potential wasted space: 127 MB`
- Why are write permissions needed for 318 Python source files, 14 Markdown files and 1.5 GB .venv files?

---
**Link of any specific issues this addresses:**
