### PR TITLE
add more logging to debug runtime restarts

### DIFF
--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -90,6 +90,9 @@ async def connect(connection_id: str, environ: dict) -> None:
             )
             latest_event_id = -1
         conversation_id = query_params.get('conversation_id', [None])[0]
+        logger.info(
+            f'Socket request for conversation {conversation_id} with connection_id {connection_id}'
+        )
         raw_list = query_params.get('providers_set', [])
         providers_list = []
         for item in raw_list:
@@ -111,6 +114,9 @@ async def connect(connection_id: str, environ: dict) -> None:
         conversation_validator = create_conversation_validator()
         user_id = await conversation_validator.validate(
             conversation_id, cookies_str, authorization_header
+        )
+        logger.info(
+            f'User {user_id} is allowed to connect to conversation {conversation_id}'
         )
 
         conversation_init_data = await setup_init_convo_settings(user_id, providers_set)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:329eb08-nikolaik   --name openhands-app-329eb08   docker.all-hands.dev/all-hands-ai/openhands:329eb08
```