### PR TITLE
chore: log stack trace when failed to connect in mcp

### DIFF
--- a/openhands/mcp/utils.py
+++ b/openhands/mcp/utils.py
@@ -69,7 +69,9 @@ async def create_mcp_clients(
                 mcp_clients.append(client)
                 logger.info(f'Connected to MCP server {server_url} via SSE')
             except Exception as e:
-                logger.error(f'Failed to connect to {server_url}: {str(e)}')
+                logger.error(
+                    f'Failed to connect to {server_url}: {str(e)}', exc_info=True
+                )
                 try:
                     await client.disconnect()
                 except Exception as disconnect_error:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1f002ef-nikolaik   --name openhands-app-1f002ef   docker.all-hands.dev/all-hands-ai/openhands:1f002ef
```