### PR TITLE
Change default user filestore

### DIFF
--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -63,7 +63,7 @@ class OpenHandsConfig(BaseModel):
     extended: ExtendedConfig = Field(default_factory=lambda: ExtendedConfig({}))
     runtime: str = Field(default='docker')
     file_store: str = Field(default='local')
-    file_store_path: str = Field(default='/tmp/openhands_file_store')
+    file_store_path: str = Field(default='~/.openhands')
     file_store_web_hook_url: str | None = Field(default=None)
     file_store_web_hook_headers: dict | None = Field(default=None)
     save_trajectory_path: str | None = Field(default=None)

--- a/openhands/storage/local.py
+++ b/openhands/storage/local.py
@@ -9,7 +9,7 @@ class LocalFileStore(FileStore):
     root: str
 
     def __init__(self, root: str):
-        self.root = root
+        self.root = os.path.expanduser(root)
         os.makedirs(self.root, exist_ok=True)
 
     def get_full_path(self, path: str) -> str:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR proposes to switch the default user file store to a more expected one, and which is inline with other settings: user's home `.openhands` directory

---
**Link of any specific issues this addresses:**
