### PR TITLE
Regenerate openapi spec

### DIFF
--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -1,34 +1,23 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
-    "title": "OpenHands API",
+    "title": "OpenHands",
     "description": "OpenHands: Code Less, Make More",
-    "version": "1.0.0"
+    "version": "0.39.2"
   },
-  "servers": [
-    {
-      "url": "https://app.all-hands.dev",
-      "description": "Production server"
-    },
-    {
-      "url": "http://localhost:3000",
-      "description": "Local development server"
-    }
-  ],
   "paths": {
     "/health": {
       "get": {
-        "summary": "Health check",
-        "description": "Check if the API is running",
-        "operationId": "health",
+        "summary": "Health",
+        "operationId": "health_health_get",
         "responses": {
           "200": {
-            "description": "API is running",
+            "description": "Successful Response",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
                   "type": "string",
-                  "example": "OK"
+                  "title": "Response Health Health Get"
                 }
               }
             }
@@ -36,228 +25,89 @@
         }
       }
     },
-    "/api/conversations/{conversation_id}/config": {
+    "/api/options/models": {
       "get": {
-        "summary": "Get runtime configuration",
-        "description": "Retrieve the runtime configuration (session ID and runtime ID)",
-        "operationId": "getRemoteRuntimeConfig",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          }
-        ],
+        "summary": "Get Litellm Models",
+        "description": "Get all models supported by LiteLLM.\n\nThis function combines models from litellm and Bedrock, removing any\nerror-prone Bedrock models.\n\nTo get the models:\n```sh\ncurl http://localhost:3000/api/litellm-models\n```\n\nReturns:\n    list[str]: A sorted list of unique model names.",
+        "operationId": "get_litellm_models_api_options_models_get",
         "responses": {
           "200": {
-            "description": "Runtime configuration",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "runtime_id": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "session_id": {
-                      "type": "string",
-                      "nullable": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/conversations/{conversation_id}/vscode-url": {
-      "get": {
-        "summary": "Get VSCode URL",
-        "description": "Get the VSCode URL for the conversation",
-        "operationId": "getVscodeUrl",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "VSCode URL",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "vscode_url": {
-                      "type": "string",
-                      "nullable": true
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Error getting VSCode URL",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "vscode_url": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/conversations/{conversation_id}/web-hosts": {
-      "get": {
-        "summary": "Get runtime hosts",
-        "description": "Get the hosts used by the runtime",
-        "operationId": "getHosts",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Runtime hosts",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "hosts": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Error getting runtime hosts",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "hosts": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "nullable": true
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/conversations/{conversation_id}/submit-feedback": {
-      "post": {
-        "summary": "Submit feedback",
-        "description": "Submit user feedback for a conversation",
-        "operationId": "submitFeedback",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "email": {
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "version": {
+                  "items": {
                     "type": "string"
                   },
-                  "permissions": {
-                    "type": "string",
-                    "default": "private"
-                  },
-                  "polarity": {
-                    "type": "string"
-                  },
-                  "feedback": {
-                    "type": "string"
-                  }
+                  "type": "array",
+                  "title": "Response Get Litellm Models Api Options Models Get"
                 }
               }
             }
           }
-        },
+        }
+      }
+    },
+    "/api/options/agents": {
+      "get": {
+        "summary": "Get Agents",
+        "description": "Get all agents supported by LiteLLM.\n\nTo get the agents:\n```sh\ncurl http://localhost:3000/api/agents\n```\n\nReturns:\n    list[str]: A sorted list of agent names.",
+        "operationId": "get_agents_api_options_agents_get",
         "responses": {
           "200": {
-            "description": "Feedback submitted successfully",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response Get Agents Api Options Agents Get"
                 }
               }
             }
-          },
-          "500": {
-            "description": "Error submitting feedback",
+          }
+        }
+      }
+    },
+    "/api/options/security-analyzers": {
+      "get": {
+        "summary": "Get Security Analyzers",
+        "description": "Get all supported security analyzers.\n\nTo get the security analyzers:\n```sh\ncurl http://localhost:3000/api/security-analyzers\n```\n\nReturns:\n    list[str]: A sorted list of security analyzer names.",
+        "operationId": "get_security_analyzers_api_options_security_analyzers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response Get Security Analyzers Api Options Security Analyzers Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/options/config": {
+      "get": {
+        "summary": "Get Config",
+        "description": "Get current config.\n\nReturns:\n    dict[str, Any]: The current server configuration.",
+        "operationId": "get_config_api_options_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "title": "Response Get Config Api Options Config Get"
                 }
               }
             }
@@ -267,39 +117,38 @@
     },
     "/api/conversations/{conversation_id}/list-files": {
       "get": {
-        "summary": "List files",
-        "description": "List files in the specified path",
-        "operationId": "listFiles",
+        "summary": "List Files",
+        "description": "List files in the specified path.\n\nThis function retrieves a list of files from the agent's runtime file store,\nexcluding certain system and hidden files/directories.\n\nTo list files:\n```sh\ncurl http://localhost:3000/api/conversations/{conversation_id}/list-files\n```\n\nArgs:\n    request (Request): The incoming request object.\n    path (str, optional): The path to list files from. Defaults to None.\n\nReturns:\n    list: A list of file names in the specified path.\n\nRaises:\n    HTTPException: If there's an error listing the files.",
+        "operationId": "list_files_api_conversations__conversation_id__list_files_get",
         "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          },
           {
             "name": "path",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
-            },
-            "description": "Path to list files from"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Path"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of files",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "title": "Response List Files Api Conversations  Conversation Id  List Files Get"
                 }
               }
             }
@@ -310,26 +159,30 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "additionalProperties": true,
+                  "title": "Response 404 List Files Api Conversations  Conversation Id  List Files Get"
                 }
               }
             }
           },
           "500": {
-            "description": "Error listing files",
+            "description": "Error listing or filtering files",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "additionalProperties": true,
+                  "title": "Response 500 List Files Api Conversations  Conversation Id  List Files Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -339,56 +192,31 @@
     },
     "/api/conversations/{conversation_id}/select-file": {
       "get": {
-        "summary": "Get file content",
-        "description": "Retrieve the content of a specified file",
-        "operationId": "selectFile",
+        "summary": "Select File",
+        "description": "Retrieve the content of a specified file.\n\nTo select a file:\n```sh\ncurl http://localhost:3000/api/conversations/{conversation_id}select-file?file=<file_path>\n```\n\nArgs:\n    file (str): The path of the file to be retrieved.\n        Expect path to be absolute inside the runtime.\n    request (Request): The incoming request object.\n\nReturns:\n    dict: A dictionary containing the file content.\n\nRaises:\n    HTTPException: If there's an error opening the file.",
+        "operationId": "select_file_api_conversations__conversation_id__select_file_get",
         "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          },
           {
             "name": "file",
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
-            },
-            "description": "Path of the file to be retrieved"
+              "type": "string",
+              "title": "File"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "File content",
+            "description": "File content returned as JSON",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "Unable to open binary file",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response 200 Select File Api Conversations  Conversation Id  Select File Get"
                 }
               }
             }
@@ -399,11 +227,30 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "additionalProperties": true,
+                  "title": "Response 500 Select File Api Conversations  Conversation Id  Select File Get"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported media type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response 415 Select File Api Conversations  Conversation Id  Select File Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -413,29 +260,14 @@
     },
     "/api/conversations/{conversation_id}/zip-directory": {
       "get": {
-        "summary": "Download workspace as zip",
-        "description": "Download the current workspace as a zip file",
-        "operationId": "zipCurrentWorkspace",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          }
-        ],
+        "summary": "Zip Current Workspace",
+        "operationId": "zip_current_workspace_api_conversations__conversation_id__zip_directory_get",
         "responses": {
           "200": {
-            "description": "Workspace zip file",
+            "description": "Zipped workspace returned as FileResponse",
             "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
+              "application/json": {
+                "schema": {}
               }
             }
           },
@@ -444,12 +276,9 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "title": "Response 500 Zip Current Workspace Api Conversations  Conversation Id  Zip Directory Get"
                 }
               }
             }
@@ -459,42 +288,67 @@
     },
     "/api/conversations/{conversation_id}/git/changes": {
       "get": {
-        "summary": "Get git changes",
-        "description": "Get git changes in the workspace",
-        "operationId": "gitChanges",
+        "summary": "Git Changes",
+        "operationId": "git_changes_api_conversations__conversation_id__git_changes_get",
         "parameters": [
           {
             "name": "conversation_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
+              "type": "string",
+              "title": "Conversation Id"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Git changes",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "title": "Response Git Changes Api Conversations  Conversation Id  Git Changes Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not a git repository",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response 404 Git Changes Api Conversations  Conversation Id  Git Changes Get"
                 }
               }
             }
           },
           "500": {
-            "description": "Error getting git changes",
+            "description": "Error getting changes",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "additionalProperties": true,
+                  "title": "Response 500 Git Changes Api Conversations  Conversation Id  Git Changes Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -504,51 +358,59 @@
     },
     "/api/conversations/{conversation_id}/git/diff": {
       "get": {
-        "summary": "Get git diff",
-        "description": "Get git diff for a specific file",
-        "operationId": "gitDiff",
+        "summary": "Git Diff",
+        "operationId": "git_diff_api_conversations__conversation_id__git_diff_get",
         "parameters": [
           {
             "name": "conversation_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
+              "type": "string",
+              "title": "Conversation Id"
+            }
           },
           {
             "name": "path",
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
-            },
-            "description": "Path of the file to get diff for"
+              "type": "string",
+              "title": "Path"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Git diff",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Git Diff Api Conversations  Conversation Id  Git Diff Get"
                 }
               }
             }
           },
           "500": {
-            "description": "Error getting git diff",
+            "description": "Error getting diff",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "additionalProperties": true,
+                  "title": "Response 500 Git Diff Api Conversations  Conversation Id  Git Diff Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -556,59 +418,37 @@
         }
       }
     },
-    "/api/conversations/{conversation_id}/trajectory": {
-      "get": {
-        "summary": "Get trajectory",
-        "description": "Get the conversation trajectory",
-        "operationId": "getTrajectory",
+    "/api/conversations/{conversation_id}/submit-feedback": {
+      "post": {
+        "summary": "Submit Feedback",
+        "description": "Submit user feedback.\n\nThis function stores the provided feedback data.\n\nTo submit feedback:\n```sh\ncurl -X POST -d '{\"email\": \"test@example.com\"}' -H \"Authorization:\"\n```\n\nArgs:\n    request (Request): The incoming request object.\n    feedback (FeedbackDataModel): The feedback data to be stored.\n\nReturns:\n    dict: The stored feedback data.\n\nRaises:\n    HTTPException: If there's an error submitting the feedback.",
+        "operationId": "submit_feedback_api_conversations__conversation_id__submit_feedback_post",
         "parameters": [
           {
             "name": "conversation_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
+              "type": "string",
+              "title": "Conversation Id"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Conversation trajectory",
+            "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "trajectory": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    }
-                  }
-                }
+                "schema": {}
               }
             }
           },
-          "500": {
-            "description": "Error getting trajectory",
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "trajectory": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      },
-                      "nullable": true
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -616,53 +456,142 @@
         }
       }
     },
-    "/api/conversations/{conversation_id}/security/{path}": {
+    "/api/conversations/{conversation_id}/config": {
       "get": {
-        "summary": "Security analyzer API (GET)",
-        "description": "Catch-all route for security analyzer API GET requests",
-        "operationId": "securityApiGet",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Security analyzer API path"
-          }
-        ],
+        "summary": "Get Remote Runtime Config",
+        "description": "Retrieve the runtime configuration.\n\nCurrently, this is the session ID and runtime ID (if available).",
+        "operationId": "get_remote_runtime_config_api_conversations__conversation_id__config_get",
         "responses": {
           "200": {
-            "description": "Security analyzer response",
+            "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object"
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/conversations/{conversation_id}/vscode-url": {
+      "get": {
+        "summary": "Get Vscode Url",
+        "description": "Get the VSCode URL.\n\nThis endpoint allows getting the VSCode URL.\n\nArgs:\n    request (Request): The incoming FastAPI request object.\n\nReturns:\n    JSONResponse: A JSON response indicating the success of the operation.",
+        "operationId": "get_vscode_url_api_conversations__conversation_id__vscode_url_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/conversations/{conversation_id}/web-hosts": {
+      "get": {
+        "summary": "Get Hosts",
+        "description": "Get the hosts used by the runtime.\n\nThis endpoint allows getting the hosts used by the runtime.\n\nArgs:\n    request (Request): The incoming FastAPI request object.\n\nReturns:\n    JSONResponse: A JSON response indicating the success of the operation.",
+        "operationId": "get_hosts_api_conversations__conversation_id__web_hosts_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/conversations/{conversation_id}/events": {
+      "get": {
+        "summary": "Search Events",
+        "description": "Search through the event stream with filtering and pagination.\nArgs:\n    request: The incoming request object\n    start_id: Starting ID in the event stream. Defaults to 0\n    end_id: Ending ID in the event stream\n    reverse: Whether to retrieve events in reverse order. Defaults to False.\n    filter: Filter for events\n    limit: Maximum number of events to return. Must be between 1 and 100. Defaults to 20\nReturns:\n    dict: Dictionary containing:\n        - events: List of matching events\n        - has_more: Whether there are more matching events after this batch\nRaises:\n    HTTPException: If conversation is not found\n    ValueError: If limit is less than 1 or greater than 100",
+        "operationId": "search_events_api_conversations__conversation_id__events_get",
+        "parameters": [
+          {
+            "name": "start_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Start Id"
+            }
+          },
+          {
+            "name": "end_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
                 }
+              ],
+              "title": "End Id"
+            }
+          },
+          {
+            "name": "reverse",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Reverse"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/EventFilter"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Filter"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           },
-          "404": {
-            "description": "Security analyzer not initialized",
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -670,176 +599,14 @@
         }
       },
       "post": {
-        "summary": "Security analyzer API (POST)",
-        "description": "Catch-all route for security analyzer API POST requests",
-        "operationId": "securityApiPost",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Security analyzer API path"
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object"
-              }
-            }
-          }
-        },
+        "summary": "Add Event",
+        "operationId": "add_event_api_conversations__conversation_id__events_post",
         "responses": {
           "200": {
-            "description": "Security analyzer response",
+            "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Security analyzer not initialized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Security analyzer API (PUT)",
-        "description": "Catch-all route for security analyzer API PUT requests",
-        "operationId": "securityApiPut",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Security analyzer API path"
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Security analyzer response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Security analyzer not initialized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Security analyzer API (DELETE)",
-        "description": "Catch-all route for security analyzer API DELETE requests",
-        "operationId": "securityApiDelete",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Security analyzer API path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Security analyzer response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Security analyzer not initialized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
-                }
+                "schema": {}
               }
             }
           }
@@ -848,93 +615,36 @@
     },
     "/api/conversations": {
       "post": {
-        "summary": "Create new conversation",
-        "description": "Initialize a new conversation",
-        "operationId": "newConversation",
+        "summary": "New Conversation",
+        "description": "Initialize a new session or join an existing one.\n\nAfter successful initialization, the client should connect to the WebSocket\nusing the returned conversation ID.",
+        "operationId": "new_conversation_api_conversations_post",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "repository": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "Full name of the repository (e.g., owner/repo)"
-                  },
-                  "git_provider": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "The Git provider (e.g., github or gitlab). If omitted, all configured providers are checked for the repository."
-                  },
-                  "selected_branch": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "initial_user_msg": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "conversation_instructions": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "Optional instructions the agent must follow throughout the conversation while addressing the user's initial task"
-                  },
-                  "image_urls": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true
-                  },
-                  "replay_json": {
-                    "type": "string",
-                    "nullable": true
-                  }
-                }
+                "$ref": "#/components/schemas/InitSessionRequest"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Conversation created successfully",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "status": {
-                      "type": "string",
-                      "example": "ok"
-                    },
-                    "conversation_id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/InitSessionResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Error creating conversation",
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "status": {
-                      "type": "string",
-                      "example": "error"
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "msg_id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -942,18 +652,24 @@
         }
       },
       "get": {
-        "summary": "Search conversations",
-        "description": "Search for conversations",
-        "operationId": "searchConversations",
+        "summary": "Search Conversations",
+        "operationId": "search_conversations_api_conversations_get",
         "parameters": [
           {
             "name": "page_id",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
-            },
-            "description": "Page ID for pagination"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Id"
+            }
           },
           {
             "name": "limit",
@@ -961,58 +677,28 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 20
-            },
-            "description": "Number of conversations to return"
+              "default": 20,
+              "title": "Limit"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Conversations",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "conversation_id": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "last_updated_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "created_at": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "selected_repository": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "status": {
-                            "type": "string",
-                            "enum": ["RUNNING", "STOPPED"]
-                          },
-                          "trigger": {
-                            "type": "string",
-                            "enum": ["GUI", "API"]
-                          }
-                        }
-                      }
-                    },
-                    "next_page_id": {
-                      "type": "string",
-                      "nullable": true
-                    }
-                  }
+                  "$ref": "#/components/schemas/ConversationInfoResultSet"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1022,109 +708,44 @@
     },
     "/api/conversations/{conversation_id}": {
       "get": {
-        "summary": "Get conversation",
-        "description": "Get conversation details",
-        "operationId": "getConversation",
+        "summary": "Get Conversation",
+        "operationId": "get_conversation_api_conversations__conversation_id__get",
         "parameters": [
           {
             "name": "conversation_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
+              "type": "string",
+              "title": "Conversation Id"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Conversation details",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "conversation_id": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ConversationInfo"
                     },
-                    "title": {
-                      "type": "string"
-                    },
-                    "last_updated_at": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "selected_repository": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "status": {
-                      "type": "string",
-                      "enum": ["RUNNING", "STOPPED"]
-                    },
-                    "trigger": {
-                      "type": "string",
-                      "enum": ["GUI", "API"]
+                    {
+                      "type": "null"
                     }
-                  }
+                  ],
+                  "title": "Response Get Conversation Api Conversations  Conversation Id  Get"
                 }
               }
             }
           },
-          "404": {
-            "description": "Conversation not found",
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "nullable": true
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "summary": "Update conversation",
-        "description": "Update conversation details",
-        "operationId": "updateConversation",
-        "parameters": [
-          {
-            "name": "conversation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Conversation updated successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1132,324 +753,37 @@
         }
       },
       "delete": {
-        "summary": "Delete conversation",
-        "description": "Delete a conversation",
-        "operationId": "deleteConversation",
+        "summary": "Delete Conversation",
+        "operationId": "delete_conversation_api_conversations__conversation_id__delete",
         "parameters": [
           {
             "name": "conversation_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
-            },
-            "description": "Conversation ID"
+              "type": "string",
+              "title": "Conversation Id"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Conversation deleted successfully",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/user/repositories": {
-      "get": {
-        "summary": "Get user repositories",
-        "description": "Get repositories for the authenticated user",
-        "operationId": "getUserRepositories",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "pushed"
-            },
-            "description": "Sort order for repositories"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User repositories",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "full_name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "html_url": {
-                        "type": "string"
-                      },
-                      "private": {
-                        "type": "boolean"
-                      },
-                      "fork": {
-                        "type": "boolean"
-                      },
-                      "updated_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      }
-                    }
-                  }
+                  "type": "boolean",
+                  "title": "Response Delete Conversation Api Conversations  Conversation Id  Delete"
                 }
               }
             }
           },
-          "401": {
-            "description": "Authentication error",
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Unknown error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/user/info": {
-      "get": {
-        "summary": "Get user info",
-        "description": "Get information about the authenticated user",
-        "operationId": "getUser",
-        "responses": {
-          "200": {
-            "description": "User information",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "login": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "email": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "avatar_url": {
-                      "type": "string",
-                      "nullable": true
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Unknown error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/user/search/repositories": {
-      "get": {
-        "summary": "Search repositories",
-        "description": "Search for repositories",
-        "operationId": "searchRepositories",
-        "parameters": [
-          {
-            "name": "query",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Search query"
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 5
-            },
-            "description": "Number of repositories to return per page"
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "stars"
-            },
-            "description": "Sort order for repositories"
-          },
-          {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "desc"
-            },
-            "description": "Sort direction"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Search results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "full_name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "html_url": {
-                        "type": "string"
-                      },
-                      "private": {
-                        "type": "boolean"
-                      },
-                      "fork": {
-                        "type": "boolean"
-                      },
-                      "updated_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Unknown error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/user/suggested-tasks": {
-      "get": {
-        "summary": "Get suggested tasks",
-        "description": "Get suggested tasks for the authenticated user across their most recently pushed repositories",
-        "operationId": "getSuggestedTasks",
-        "responses": {
-          "200": {
-            "description": "Suggested tasks",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string"
-                      },
-                      "url": {
-                        "type": "string"
-                      },
-                      "repository": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "created_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Unknown error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1459,73 +793,15 @@
     },
     "/api/settings": {
       "get": {
-        "summary": "Get settings",
-        "description": "Get user settings",
-        "operationId": "loadSettings",
+        "summary": "Load Settings",
+        "operationId": "load_settings_api_settings_get",
         "responses": {
           "200": {
-            "description": "User settings",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "language": {
-                      "type": "string"
-                    },
-                    "agent": {
-                      "type": "string"
-                    },
-                    "security_analyzer": {
-                      "type": "string"
-                    },
-                    "confirmation_mode": {
-                      "type": "boolean"
-                    },
-                    "llm_model": {
-                      "type": "string"
-                    },
-                    "llm_api_key_set": {
-                      "type": "boolean"
-                    },
-                    "llm_base_url": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "remote_runtime_resource_factor": {
-                      "type": "number"
-                    },
-                    "enable_default_condenser": {
-                      "type": "boolean"
-                    },
-                    "enable_sound_notifications": {
-                      "type": "boolean"
-                    },
-                    "user_consents_to_analytics": {
-                      "type": "boolean"
-                    },
-                    "provider_tokens_set": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "boolean"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/GETSettingsModel"
                 }
               }
             }
@@ -1535,86 +811,9 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Store settings",
-        "description": "Store user settings",
-        "operationId": "storeSettings",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "language": {
-                    "type": "string"
-                  },
-                  "agent": {
-                    "type": "string"
-                  },
-                  "security_analyzer": {
-                    "type": "string"
-                  },
-                  "confirmation_mode": {
-                    "type": "boolean"
-                  },
-                  "llm_model": {
-                    "type": "string"
-                  },
-                  "llm_api_key": {
-                    "type": "string"
-                  },
-                  "llm_base_url": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "remote_runtime_resource_factor": {
-                    "type": "number"
-                  },
-                  "enable_default_condenser": {
-                    "type": "boolean"
-                  },
-                  "enable_sound_notifications": {
-                    "type": "boolean"
-                  },
-                  "user_consents_to_analytics": {
-                    "type": "boolean"
-                  },
-                  "provider_tokens": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Settings stored successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "title": "Response 404 Load Settings Api Settings Get"
                 }
               }
             }
@@ -1624,12 +823,37 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "title": "Response 401 Load Settings Api Settings Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Store Settings",
+        "operationId": "store_settings_api_settings_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Settings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Settings stored successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response 200 Store Settings Api Settings Post"
                 }
               }
             }
@@ -1639,12 +863,19 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "title": "Response 500 Store Settings Api Settings Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1654,23 +885,26 @@
     },
     "/api/reset-settings": {
       "post": {
-        "summary": "Reset settings (Deprecated)",
-        "description": "This endpoint is deprecated and will return a 410 Gone error. Reset functionality has been removed.",
-        "operationId": "resetSettings",
-        "deprecated": true,
+        "summary": "Reset Settings",
+        "description": "Resets user settings. (Deprecated)",
+        "operationId": "reset_settings_api_reset_settings_post",
         "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
           "410": {
-            "description": "Feature removed",
+            "description": "Reset settings functionality has been removed",
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "example": "Reset settings functionality has been removed."
-                    }
-                  }
+                  "title": "Response 410 Reset Settings Api Reset Settings Post"
                 }
               }
             }
@@ -1678,38 +912,203 @@
         }
       }
     },
-    "/api/unset-settings-tokens": {
+    "/api/add-git-providers": {
       "post": {
-        "summary": "Unset settings tokens",
-        "description": "Unset provider tokens in settings",
-        "operationId": "unsetSettingsTokens",
+        "summary": "Store Provider Tokens",
+        "operationId": "store_provider_tokens_api_add_git_providers_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/POSTProviderModel"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
-            "description": "Tokens unset successfully",
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/unset-provider-tokens": {
+      "post": {
+        "summary": "Unset Provider Tokens",
+        "operationId": "unset_provider_tokens_api_unset_provider_tokens_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "title": "Response Unset Provider Tokens Api Unset Provider Tokens Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/secrets": {
+      "get": {
+        "summary": "Load Custom Secrets Names",
+        "operationId": "load_custom_secrets_names_api_secrets_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GETCustomSecrets"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Custom Secret",
+        "operationId": "create_custom_secret_api_secrets_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomSecretModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Create Custom Secret Api Secrets Post"
                 }
               }
             }
           },
-          "500": {
-            "description": "Error unsetting tokens",
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/secrets/{secret_id}": {
+      "put": {
+        "summary": "Update Custom Secret",
+        "operationId": "update_custom_secret_api_secrets__secret_id__put",
+        "parameters": [
+          {
+            "name": "secret_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Secret Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomSecretWithoutValueModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Update Custom Secret Api Secrets  Secret Id  Put"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Custom Secret",
+        "operationId": "delete_custom_secret_api_secrets__secret_id__delete",
+        "parameters": [
+          {
+            "name": "secret_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Secret Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1717,21 +1116,43 @@
         }
       }
     },
-    "/api/options/models": {
+    "/api/user/repositories": {
       "get": {
-        "summary": "Get models",
-        "description": "Get all models supported by LiteLLM",
-        "operationId": "getLitellmModels",
+        "summary": "Get User Repositories",
+        "operationId": "get_user_repositories_api_user_repositories_get",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "pushed",
+              "title": "Sort"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "List of models",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "string"
-                  }
+                    "$ref": "#/components/schemas/Repository"
+                  },
+                  "title": "Response Get User Repositories Api User Repositories Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1739,21 +1160,90 @@
         }
       }
     },
-    "/api/options/agents": {
+    "/api/user/info": {
       "get": {
-        "summary": "Get agents",
-        "description": "Get all agents supported by OpenHands",
-        "operationId": "getAgents",
+        "summary": "Get User",
+        "operationId": "get_user_api_user_info_get",
         "responses": {
           "200": {
-            "description": "List of agents",
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/search/repositories": {
+      "get": {
+        "summary": "Search Repositories",
+        "operationId": "search_repositories_api_user_search_repositories_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 5,
+              "title": "Per Page"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "stars",
+              "title": "Sort"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "title": "Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "string"
-                  }
+                    "$ref": "#/components/schemas/Repository"
+                  },
+                  "title": "Response Search Repositories Api User Search Repositories Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1761,21 +1251,66 @@
         }
       }
     },
-    "/api/options/security-analyzers": {
+    "/api/user/suggested-tasks": {
       "get": {
-        "summary": "Get security analyzers",
-        "description": "Get all supported security analyzers",
-        "operationId": "getSecurityAnalyzers",
+        "summary": "Get Suggested Tasks",
+        "description": "Get suggested tasks for the authenticated user across their most recently pushed repositories.\n\nReturns:\n- PRs owned by the user\n- Issues assigned to the user.",
+        "operationId": "get_suggested_tasks_api_user_suggested_tasks_get",
         "responses": {
           "200": {
-            "description": "List of security analyzers",
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SuggestedTask"
+                  },
+                  "type": "array",
+                  "title": "Response Get Suggested Tasks Api User Suggested Tasks Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/repository/branches": {
+      "get": {
+        "summary": "Get Repository Branches",
+        "description": "Get branches for a repository.\n\nArgs:\n    repository: The repository name in the format 'owner/repo'\n\nReturns:\n    A list of branches for the repository",
+        "operationId": "get_repository_branches_api_user_repository_branches_get",
+        "parameters": [
+          {
+            "name": "repository",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Repository"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "string"
-                  }
+                    "$ref": "#/components/schemas/Branch"
+                  },
+                  "title": "Response Get Repository Branches Api User Repository Branches Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1783,19 +1318,17 @@
         }
       }
     },
-    "/api/options/config": {
+    "/api/conversations/{conversation_id}/trajectory": {
       "get": {
-        "summary": "Get config",
-        "description": "Get current server configuration",
-        "operationId": "getConfig",
+        "summary": "Get Trajectory",
+        "description": "Get trajectory.\n\nThis function retrieves the current trajectory and returns it.\n\nArgs:\n    request (Request): The incoming request object.\n\nReturns:\n    JSONResponse: A JSON response containing the trajectory as a list of\n    events.",
+        "operationId": "get_trajectory_api_conversations__conversation_id__trajectory_get",
         "responses": {
           "200": {
-            "description": "Server configuration",
+            "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object"
-                }
+                "schema": {}
               }
             }
           }
@@ -1805,287 +1338,1247 @@
   },
   "components": {
     "schemas": {
-      "Repository": {
-        "type": "object",
+      "Branch": {
         "properties": {
-          "full_name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "html_url": {
-            "type": "string"
-          },
-          "private": {
-            "type": "boolean"
-          },
-          "fork": {
-            "type": "boolean"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "User": {
-        "type": "object",
-        "properties": {
-          "login": {
-            "type": "string"
-          },
           "name": {
             "type": "string",
-            "nullable": true
+            "title": "Name"
           },
-          "email": {
+          "commit_sha": {
             "type": "string",
-            "nullable": true
+            "title": "Commit Sha"
+          },
+          "protected": {
+            "type": "boolean",
+            "title": "Protected"
+          },
+          "last_push_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Push Date"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "commit_sha",
+          "protected"
+        ],
+        "title": "Branch"
+      },
+      "ConversationInfo": {
+        "properties": {
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "last_updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Updated At"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ConversationStatus",
+            "default": "STOPPED"
+          },
+          "selected_repository": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected Repository"
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConversationTrigger"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "num_connections": {
+            "type": "integer",
+            "title": "Num Connections",
+            "default": 0
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "session_api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Api Key"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "conversation_id",
+          "title"
+        ],
+        "title": "ConversationInfo"
+      },
+      "ConversationInfoResultSet": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationInfo"
+            },
+            "type": "array",
+            "title": "Results"
+          },
+          "next_page_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Page Id"
+          }
+        },
+        "type": "object",
+        "title": "ConversationInfoResultSet"
+      },
+      "ConversationStatus": {
+        "type": "string",
+        "enum": [
+          "RUNNING",
+          "STOPPED"
+        ],
+        "title": "ConversationStatus"
+      },
+      "ConversationTrigger": {
+        "type": "string",
+        "enum": [
+          "resolver",
+          "gui",
+          "suggested_task",
+          "openhands_api",
+          "slack"
+        ],
+        "title": "ConversationTrigger"
+      },
+      "CustomSecretModel": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "value": {
+            "type": "string",
+            "format": "password",
+            "title": "Value",
+            "writeOnly": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "value"
+        ],
+        "title": "CustomSecretModel",
+        "description": "Custom secret model with value"
+      },
+      "CustomSecretWithoutValueModel": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CustomSecretWithoutValueModel",
+        "description": "Custom secret model without value"
+      },
+      "EventFilter": {
+        "properties": {
+          "exclude_hidden": {
+            "type": "boolean",
+            "title": "Exclude Hidden",
+            "default": false
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Query"
+          },
+          "include_types": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Types"
+          },
+          "exclude_types": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exclude Types"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          }
+        },
+        "type": "object",
+        "title": "EventFilter"
+      },
+      "GETCustomSecrets": {
+        "properties": {
+          "custom_secrets": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CustomSecretWithoutValueModel"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Secrets"
+          }
+        },
+        "type": "object",
+        "title": "GETCustomSecrets",
+        "description": "Custom secrets names"
+      },
+      "GETSettingsModel": {
+        "properties": {
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent"
+          },
+          "max_iterations": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Iterations"
+          },
+          "security_analyzer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Security Analyzer"
+          },
+          "confirmation_mode": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmation Mode"
+          },
+          "llm_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Model"
+          },
+          "llm_api_key": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Api Key"
+          },
+          "llm_base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Base Url"
+          },
+          "remote_runtime_resource_factor": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remote Runtime Resource Factor"
+          },
+          "secrets_store": {
+            "$ref": "#/components/schemas/UserSecrets-Output"
+          },
+          "enable_default_condenser": {
+            "type": "boolean",
+            "title": "Enable Default Condenser",
+            "default": true
+          },
+          "enable_sound_notifications": {
+            "type": "boolean",
+            "title": "Enable Sound Notifications",
+            "default": false
+          },
+          "enable_proactive_conversation_starters": {
+            "type": "boolean",
+            "title": "Enable Proactive Conversation Starters",
+            "default": true
+          },
+          "user_consents_to_analytics": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Consents To Analytics"
+          },
+          "sandbox_base_container_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Base Container Image"
+          },
+          "sandbox_runtime_container_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Runtime Container Image"
+          },
+          "mcp_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MCPConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provider_tokens_set": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "propertyNames": {
+                  "$ref": "#/components/schemas/ProviderType"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Tokens Set"
+          },
+          "llm_api_key_set": {
+            "type": "boolean",
+            "title": "Llm Api Key Set"
+          }
+        },
+        "type": "object",
+        "required": [
+          "llm_api_key_set"
+        ],
+        "title": "GETSettingsModel",
+        "description": "Settings with additional token data for the frontend"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "InitSessionRequest": {
+        "properties": {
+          "repository": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repository"
+          },
+          "git_provider": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProviderType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "selected_branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected Branch"
+          },
+          "initial_user_msg": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Initial User Msg"
+          },
+          "image_urls": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Urls"
+          },
+          "replay_json": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replay Json"
+          },
+          "suggested_task": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SuggestedTask"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "conversation_instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Instructions"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "InitSessionRequest"
+      },
+      "InitSessionResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "conversation_url": {
+            "type": "string",
+            "title": "Conversation Url"
+          },
+          "session_api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Api Key"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "conversation_id",
+          "conversation_url",
+          "session_api_key"
+        ],
+        "title": "InitSessionResponse"
+      },
+      "MCPConfig": {
+        "properties": {
+          "sse_servers": {
+            "items": {
+              "$ref": "#/components/schemas/MCPSSEServerConfig"
+            },
+            "type": "array",
+            "title": "Sse Servers"
+          },
+          "stdio_servers": {
+            "items": {
+              "$ref": "#/components/schemas/MCPStdioServerConfig"
+            },
+            "type": "array",
+            "title": "Stdio Servers"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "MCPConfig",
+        "description": "Configuration for MCP (Message Control Protocol) settings.\n\nAttributes:\n    sse_servers: List of MCP SSE server configs\n    stdio_servers: List of MCP stdio server configs. These servers will be added to the MCP Router running inside runtime container."
+      },
+      "MCPSSEServerConfig": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "MCPSSEServerConfig",
+        "description": "Configuration for a single MCP server.\n\nAttributes:\n    url: The server URL\n    api_key: Optional API key for authentication"
+      },
+      "MCPStdioServerConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "command": {
+            "type": "string",
+            "title": "Command"
+          },
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Args"
+          },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Env"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "command"
+        ],
+        "title": "MCPStdioServerConfig",
+        "description": "Configuration for a MCP server that uses stdio.\n\nAttributes:\n    name: The name of the server\n    command: The command to run the server\n    args: The arguments to pass to the server\n    env: The environment variables to set for the server"
+      },
+      "POSTProviderModel": {
+        "properties": {
+          "mcp_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MCPConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provider_tokens": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderToken"
+            },
+            "propertyNames": {
+              "$ref": "#/components/schemas/ProviderType"
+            },
+            "type": "object",
+            "title": "Provider Tokens",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "title": "POSTProviderModel",
+        "description": "Settings for POST requests"
+      },
+      "ProviderToken": {
+        "properties": {
+          "token": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
+          "host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host"
+          }
+        },
+        "type": "object",
+        "title": "ProviderToken"
+      },
+      "ProviderType": {
+        "type": "string",
+        "enum": [
+          "github",
+          "gitlab"
+        ],
+        "title": "ProviderType"
+      },
+      "Repository": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "full_name": {
+            "type": "string",
+            "title": "Full Name"
+          },
+          "git_provider": {
+            "$ref": "#/components/schemas/ProviderType"
+          },
+          "is_public": {
+            "type": "boolean",
+            "title": "Is Public"
+          },
+          "stargazers_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stargazers Count"
+          },
+          "link_header": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link Header"
+          },
+          "pushed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pushed At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "full_name",
+          "git_provider",
+          "is_public"
+        ],
+        "title": "Repository"
+      },
+      "Settings": {
+        "properties": {
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent"
+          },
+          "max_iterations": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Iterations"
+          },
+          "security_analyzer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Security Analyzer"
+          },
+          "confirmation_mode": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmation Mode"
+          },
+          "llm_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Model"
+          },
+          "llm_api_key": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Api Key"
+          },
+          "llm_base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Base Url"
+          },
+          "remote_runtime_resource_factor": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remote Runtime Resource Factor"
+          },
+          "secrets_store": {
+            "$ref": "#/components/schemas/UserSecrets-Input"
+          },
+          "enable_default_condenser": {
+            "type": "boolean",
+            "title": "Enable Default Condenser",
+            "default": true
+          },
+          "enable_sound_notifications": {
+            "type": "boolean",
+            "title": "Enable Sound Notifications",
+            "default": false
+          },
+          "enable_proactive_conversation_starters": {
+            "type": "boolean",
+            "title": "Enable Proactive Conversation Starters",
+            "default": true
+          },
+          "user_consents_to_analytics": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Consents To Analytics"
+          },
+          "sandbox_base_container_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Base Container Image"
+          },
+          "sandbox_runtime_container_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Runtime Container Image"
+          },
+          "mcp_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MCPConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "Settings",
+        "description": "Persisted settings for OpenHands sessions"
+      },
+      "SuggestedTask": {
+        "properties": {
+          "git_provider": {
+            "$ref": "#/components/schemas/ProviderType"
+          },
+          "task_type": {
+            "$ref": "#/components/schemas/TaskType"
+          },
+          "repo": {
+            "type": "string",
+            "title": "Repo"
+          },
+          "issue_number": {
+            "type": "integer",
+            "title": "Issue Number"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "required": [
+          "git_provider",
+          "task_type",
+          "repo",
+          "issue_number",
+          "title"
+        ],
+        "title": "SuggestedTask"
+      },
+      "TaskType": {
+        "type": "string",
+        "enum": [
+          "MERGE_CONFLICTS",
+          "FAILING_CHECKS",
+          "UNRESOLVED_COMMENTS",
+          "OPEN_ISSUE",
+          "OPEN_PR"
+        ],
+        "title": "TaskType"
+      },
+      "User": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "login": {
+            "type": "string",
+            "title": "Login"
           },
           "avatar_url": {
             "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "SuggestedTask": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string"
+            "title": "Avatar Url"
           },
-          "url": {
-            "type": "string"
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
           },
-          "repository": {
-            "type": "string"
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
           },
-          "type": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "ConversationInfo": {
-        "type": "object",
-        "properties": {
-          "conversation_id": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "last_updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "selected_repository": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": ["RUNNING", "STOPPED"]
-          },
-          "trigger": {
-            "type": "string",
-            "enum": ["GUI", "API"]
-          }
-        }
-      },
-      "ConversationInfoResultSet": {
-        "type": "object",
-        "properties": {
-          "results": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConversationInfo"
-            }
-          },
-          "next_page_id": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "FeedbackDataModel": {
-        "type": "object",
-        "properties": {
           "email": {
-            "type": "string",
-            "format": "email"
-          },
-          "version": {
-            "type": "string"
-          },
-          "permissions": {
-            "type": "string",
-            "default": "private"
-          },
-          "polarity": {
-            "type": "string"
-          },
-          "feedback": {
-            "type": "string"
-          },
-          "trajectory": {
-            "type": "array",
-            "items": {
-              "type": "object"
-            }
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
           }
-        }
-      },
-      "Settings": {
+        },
         "type": "object",
-        "properties": {
-          "language": {
-            "type": "string"
-          },
-          "agent": {
-            "type": "string"
-          },
-          "security_analyzer": {
-            "type": "string"
-          },
-          "confirmation_mode": {
-            "type": "boolean"
-          },
-          "llm_model": {
-            "type": "string"
-          },
-          "llm_api_key": {
-            "type": "string"
-          },
-          "llm_base_url": {
-            "type": "string",
-            "nullable": true
-          },
-          "remote_runtime_resource_factor": {
-            "type": "number"
-          },
-          "enable_default_condenser": {
-            "type": "boolean"
-          },
-          "enable_sound_notifications": {
-            "type": "boolean"
-          },
-          "user_consents_to_analytics": {
-            "type": "boolean"
-          }
-        }
+        "required": [
+          "id",
+          "login",
+          "avatar_url"
+        ],
+        "title": "User"
       },
-      "GETSettingsModel": {
-        "type": "object",
+      "UserSecrets-Input": {
         "properties": {
-          "language": {
-            "type": "string"
-          },
-          "agent": {
-            "type": "string"
-          },
-          "security_analyzer": {
-            "type": "string"
-          },
-          "confirmation_mode": {
-            "type": "boolean"
-          },
-          "llm_model": {
-            "type": "string"
-          },
-          "llm_api_key_set": {
-            "type": "boolean"
-          },
-          "llm_base_url": {
-            "type": "string",
-            "nullable": true
-          },
-          "remote_runtime_resource_factor": {
-            "type": "number"
-          },
-          "enable_default_condenser": {
-            "type": "boolean"
-          },
-          "enable_sound_notifications": {
-            "type": "boolean"
-          },
-          "user_consents_to_analytics": {
-            "type": "boolean"
-          },
-          "provider_tokens_set": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "boolean"
-            }
-          }
-        }
-      },
-      "POSTSettingsModel": {
-        "type": "object",
-        "properties": {
-          "language": {
-            "type": "string"
-          },
-          "agent": {
-            "type": "string"
-          },
-          "security_analyzer": {
-            "type": "string"
-          },
-          "confirmation_mode": {
-            "type": "boolean"
-          },
-          "llm_model": {
-            "type": "string"
-          },
-          "llm_api_key": {
-            "type": "string"
-          },
-          "llm_base_url": {
-            "type": "string",
-            "nullable": true
-          },
-          "remote_runtime_resource_factor": {
-            "type": "number"
-          },
-          "enable_default_condenser": {
-            "type": "boolean"
-          },
-          "enable_sound_notifications": {
-            "type": "boolean"
-          },
-          "user_consents_to_analytics": {
-            "type": "boolean"
-          },
           "provider_tokens": {
-            "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "type": "object",
+            "title": "Provider Tokens"
+          },
+          "custom_secrets": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Custom Secrets"
           }
-        }
-      }
-    },
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+        },
+        "type": "object",
+        "title": "UserSecrets"
+      },
+      "UserSecrets-Output": {
+        "properties": {
+          "provider_tokens": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {}
+                ]
+              },
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Provider Tokens"
+          },
+          "custom_secrets": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Custom Secrets"
+          }
+        },
+        "type": "object",
+        "title": "UserSecrets"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
       }
     }
-  },
-  "security": [
-    {
-      "bearerAuth": []
-    }
-  ]
+  }
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below




---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Regenerate the openapi.json using the following command while running the backend:
```bash
 curl -s http://127.0.0.1:3000/openapi.json | jq . > docs/static/openapi.json
```
---
When generating the API client I got a lot of errors and realised that the spec was totally wrong. We should probably add a build step to do this automatically. 

The website is also all wrong as it is built from the openapi spec. As can be easily seen here [api-reference/get-conversation](https://docs.all-hands.dev/api-reference/get-conversation) where the trigger is listed as "GUI" but the actual value has now changed to 
```json
"enum": [
  "resolver",
  "gui",
  "suggested_task",
  "openhands_api",
  "slack"
],
```
