### PR TITLE
Fix all broken docs links across the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We have a separate doc [Development.md](https://github.com/All-Hands-AI/OpenHand
 There are many ways that you can contribute:
 
 1. **Download and use** OpenHands, and send [issues](https://github.com/All-Hands-AI/OpenHands/issues) when you encounter something that isn't working or a feature that you'd like to see.
-2. **Send feedback** after each session by [clicking the thumbs-up thumbs-down buttons](https://docs.all-hands.dev/modules/usage/feedback), so we can see where things are working and failing, and also build an open dataset for training code agents.
+2. **Send feedback** after each session by [clicking the thumbs-up thumbs-down buttons](https://docs.all-hands.dev/usage/feedback), so we can see where things are working and failing, and also build an open dataset for training code agents.
 3. **Improve the Codebase** by sending [PRs](#sending-pull-requests-to-openhands) (see details below). In particular, we have some [good first issues](https://github.com/All-Hands-AI/OpenHands/labels/good%20first%20issue) that may be ones to start on.
 
 ## What Can I Build?

--- a/Development.md
+++ b/Development.md
@@ -76,7 +76,7 @@ variables in your terminal. The final configurations are set from highest to low
 Environment variables > config.toml variables > default variables
 
 **Note on Alternative Models:**
-See [our documentation](https://docs.all-hands.dev/modules/usage/llms) for recommended models.
+See [our documentation](https://docs.all-hands.dev/usage/llms) for recommended models.
 
 ### 4. Running the application
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
@@ -47,5 +47,5 @@ Les options de personnalisation que vous pouvez définir sont :
 | `LLM_MODEL`                      | Variable | Définir le LLM à utiliser avec OpenHands                                                             | `LLM_MODEL="anthropic/claude-3-5-sonnet-20241022"` |
 | `OPENHANDS_MAX_ITER`             | Variable | Définir la limite maximale d'itérations de l'agent                                                   | `OPENHANDS_MAX_ITER=10`                            |
 | `OPENHANDS_MACRO`                | Variable | Personnaliser la macro par défaut pour invoquer le résolveur                                         | `OPENHANDS_MACRO=@resolveit`                       |
-| `OPENHANDS_BASE_CONTAINER_IMAGE` | Variable | Sandbox personnalisé ([en savoir plus](https://docs.all-hands.dev/modules/usage/how-to/custom-sandbox-guide)) | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
+| `OPENHANDS_BASE_CONTAINER_IMAGE` | Variable | Sandbox personnalisé ([en savoir plus](https://docs.all-hands.dev/usage/how-to/custom-sandbox-guide)) | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
 | `TARGET_BRANCH`                  | Variable | Fusionner vers une branche autre que `main`                                                          | `TARGET_BRANCH="dev"`                              |

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/installation.mdx
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/installation.mdx
@@ -73,10 +73,10 @@ docker run -it --rm --pull=always \
 
 Vous trouverez OpenHands en cours d'exécution à l'adresse http://localhost:3000 !
 
-Vous pouvez également [connecter OpenHands à votre système de fichiers local](https://docs.all-hands.dev/modules/usage/runtimes/docker#connecting-to-your-filesystem),
-exécuter OpenHands en [mode headless](https://docs.all-hands.dev/modules/usage/how-to/headless-mode) scriptable,
-interagir avec lui via une [CLI conviviale](https://docs.all-hands.dev/modules/usage/how-to/cli-mode),
-ou l'exécuter sur des problèmes étiquetés avec [une action GitHub](https://docs.all-hands.dev/modules/usage/how-to/github-action).
+Vous pouvez également [connecter OpenHands à votre système de fichiers local](https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem),
+exécuter OpenHands en [mode headless](https://docs.all-hands.dev/usage/how-to/headless-mode) scriptable,
+interagir avec lui via une [CLI conviviale](https://docs.all-hands.dev/usage/how-to/cli-mode),
+ou l'exécuter sur des problèmes étiquetés avec [une action GitHub](https://docs.all-hands.dev/usage/how-to/github-action).
 
 ## Configuration
 
@@ -118,4 +118,4 @@ Cette version est instable et est recommandée uniquement à des fins de test ou
 
 Pour le flux de travail de développement, consultez [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
 
-Vous rencontrez des problèmes ? Consultez notre [Guide de dépannage](https://docs.all-hands.dev/modules/usage/troubleshooting).
+Vous rencontrez des problèmes ? Consultez notre [Guide de dépannage](https://docs.all-hands.dev/usage/troubleshooting).

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/intro.mdx
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/usage/intro.mdx
@@ -91,7 +91,7 @@ Si vous souhaitez utiliser la version **(instable !)** la plus récente, vous po
 
 Pour le workflow de développement, consultez [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
 
-Avez-vous des problèmes ? Consultez notre [Guide de dépannage](https://docs.all-hands.dev/modules/usage/troubleshooting).
+Avez-vous des problèmes ? Consultez notre [Guide de dépannage](https://docs.all-hands.dev/usage/troubleshooting).
 
 :::warning
 OpenHands est actuellement en cours de développement, mais vous pouvez déjà exécuter la version alpha pour voir le système de bout en bout en action.

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
@@ -47,5 +47,5 @@ GitHub resolverは、動作をカスタマイズするために有効な[リポ�
 | `LLM_MODEL`                      | 変数       | OpenHandsで使用するLLMを設定                                                                      | `LLM_MODEL="anthropic/claude-3-5-sonnet-20241022"` |
 | `OPENHANDS_MAX_ITER`             | 変数       | エージェントの反復回数の最大制限を設定                                                            | `OPENHANDS_MAX_ITER=10`                            |
 | `OPENHANDS_MACRO`                | 変数       | リゾルバーを呼び出すためのデフォルトマクロをカスタマイズ                                          | `OPENHANDS_MACRO=@resolveit`                       |
-| `OPENHANDS_BASE_CONTAINER_IMAGE` | 変数       | カスタムサンドボックス（[詳細](https://docs.all-hands.dev/modules/usage/how-to/custom-sandbox-guide)） | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
+| `OPENHANDS_BASE_CONTAINER_IMAGE` | 変数       | カスタムサンドボックス（[詳細](https://docs.all-hands.dev/usage/how-to/custom-sandbox-guide)） | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
 | `TARGET_BRANCH`                  | 変数       | `main`以外のブランチにマージ                                                                      | `TARGET_BRANCH="dev"`                              |

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/installation.mdx
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/installation.mdx
@@ -73,10 +73,10 @@ docker run -it --rm --pull=always \
 
 OpenHandsは http://localhost:3000 で実行されています！
 
-また、[OpenHandsをローカルファイルシステムに接続](https://docs.all-hands.dev/modules/usage/runtimes/docker#connecting-to-your-filesystem)したり、
-OpenHandsを[ヘッドレスモード](https://docs.all-hands.dev/modules/usage/how-to/headless-mode)でスクリプト実行したり、
-[使いやすいCLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode)を介して操作したり、
-[GitHubアクション](https://docs.all-hands.dev/modules/usage/how-to/github-action)でタグ付けされた課題に対して実行したりすることもできます。
+また、[OpenHandsをローカルファイルシステムに接続](https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem)したり、
+OpenHandsを[ヘッドレスモード](https://docs.all-hands.dev/usage/how-to/headless-mode)でスクリプト実行したり、
+[使いやすいCLI](https://docs.all-hands.dev/usage/how-to/cli-mode)を介して操作したり、
+[GitHubアクション](https://docs.all-hands.dev/usage/how-to/github-action)でタグ付けされた課題に対して実行したりすることもできます。
 
 ## セットアップ
 
@@ -117,4 +117,4 @@ SemVerを使用しているため、`0.9`は自動的に最新の`0.9.x`リリ�
 
 開発ワークフローについては、[Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)を参照してください。
 
-問題がありますか？[トラブルシューティングガイド](https://docs.all-hands.dev/modules/usage/troubleshooting)をご確認ください。
+問題がありますか？[トラブルシューティングガイド](https://docs.all-hands.dev/usage/troubleshooting)をご確認ください。

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/intro.mdx
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/usage/intro.mdx
@@ -91,7 +91,7 @@ OpenHandsはこのワークスペースフォルダにのみアクセスでき�
 
 開発ワークフローについては、[Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)を参照してください。
 
-問題がありますか？[トラブルシューティングガイド](https://docs.all-hands.dev/modules/usage/troubleshooting)をご確認ください。
+問題がありますか？[トラブルシューティングガイド](https://docs.all-hands.dev/usage/troubleshooting)をご確認ください。
 
 :::warning
 OpenHandsは現在開発中ですが、アルファ版を実行してエンドツーエンドのシステムを動作させることができます。

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
@@ -47,5 +47,5 @@ As opções de personalização que você pode definir são:
 | `LLM_MODEL`                      | Variável  | Define o LLM a ser usado com OpenHands                                                              | `LLM_MODEL="anthropic/claude-3-5-sonnet-20241022"` |
 | `OPENHANDS_MAX_ITER`             | Variável  | Define o limite máximo para iterações do agente                                                     | `OPENHANDS_MAX_ITER=10`                            |
 | `OPENHANDS_MACRO`                | Variável  | Personaliza a macro padrão para invocar o resolver                                                  | `OPENHANDS_MACRO=@resolveit`                       |
-| `OPENHANDS_BASE_CONTAINER_IMAGE` | Variável  | Sandbox personalizado ([saiba mais](https://docs.all-hands.dev/modules/usage/how-to/custom-sandbox-guide)) | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
+| `OPENHANDS_BASE_CONTAINER_IMAGE` | Variável  | Sandbox personalizado ([saiba mais](https://docs.all-hands.dev/usage/how-to/custom-sandbox-guide)) | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
 | `TARGET_BRANCH`                  | Variável  | Mesclar para uma branch diferente de `main`                                                         | `TARGET_BRANCH="dev"`                              |

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/installation.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/usage/installation.mdx
@@ -73,10 +73,10 @@ docker run -it --rm --pull=always \
 
 Você encontrará o OpenHands rodando em http://localhost:3000!
 
-Você também pode [conectar o OpenHands ao seu sistema de arquivos local](https://docs.all-hands.dev/modules/usage/runtimes/docker#connecting-to-your-filesystem),
-executar o OpenHands em um [modo headless](https://docs.all-hands.dev/modules/usage/how-to/headless-mode) programável,
-interagir com ele através de uma [CLI amigável](https://docs.all-hands.dev/modules/usage/how-to/cli-mode),
-ou executá-lo em issues marcadas com [uma ação do GitHub](https://docs.all-hands.dev/modules/usage/how-to/github-action).
+Você também pode [conectar o OpenHands ao seu sistema de arquivos local](https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem),
+executar o OpenHands em um [modo headless](https://docs.all-hands.dev/usage/how-to/headless-mode) programável,
+interagir com ele através de uma [CLI amigável](https://docs.all-hands.dev/usage/how-to/cli-mode),
+ou executá-lo em issues marcadas com [uma ação do GitHub](https://docs.all-hands.dev/usage/how-to/github-action).
 
 ## Configuração
 
@@ -118,4 +118,4 @@ Esta versão é instável e é recomendada apenas para fins de teste ou desenvol
 
 Para o fluxo de trabalho de desenvolvimento, consulte [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
 
-Está tendo problemas? Confira nosso [Guia de Solução de Problemas](https://docs.all-hands.dev/modules/usage/troubleshooting).
+Está tendo problemas? Confira nosso [Guia de Solução de Problemas](https://docs.all-hands.dev/usage/troubleshooting).

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/custom_sandbox_guide.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/custom_sandbox_guide.md
@@ -78,7 +78,7 @@ base_container_image="custom_image"
 
 ## 技术解释
 
-请参考[运行时文档中自定义 Docker 镜像的章节](https://docs.all-hands.dev/modules/usage/architecture/runtime#advanced-how-openhands-builds-and-maintains-od-runtime-images)获取更详细的解释。
+请参考[运行时文档中自定义 Docker 镜像的章节](https://docs.all-hands.dev/usage/architecture/runtime#advanced-how-openhands-builds-and-maintains-od-runtime-images)获取更详细的解释。
 
 ## 故障排除 / 错误
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/how-to/github-action.md
@@ -47,5 +47,5 @@ GitHub resolver 将自动检查有效的[仓库密钥](https://docs.github.com/e
 | `LLM_MODEL`                      | 变量     | 设置与 OpenHands 一起使用的 LLM                                                         | `LLM_MODEL="anthropic/claude-3-5-sonnet-20241022"` |
 | `OPENHANDS_MAX_ITER`             | 变量     | 设置代理迭代的最大限制                                                                  | `OPENHANDS_MAX_ITER=10`                            |
 | `OPENHANDS_MACRO`                | 变量     | 自定义用于调用 resolver 的默认宏                                                        | `OPENHANDS_MACRO=@resolveit`                       |
-| `OPENHANDS_BASE_CONTAINER_IMAGE` | 变量     | 自定义沙箱（[了解更多](https://docs.all-hands.dev/modules/usage/how-to/custom-sandbox-guide)） | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
+| `OPENHANDS_BASE_CONTAINER_IMAGE` | 变量     | 自定义沙箱（[了解更多](https://docs.all-hands.dev/usage/how-to/custom-sandbox-guide)） | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
 | `TARGET_BRANCH`                  | 变量     | 合并到 `main` 以外的分支                                                                | `TARGET_BRANCH="dev"`                              |

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/installation.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/installation.mdx
@@ -73,10 +73,10 @@ docker run -it --rm --pull=always \
 
 OpenHands 将在 http://localhost:3000 运行！
 
-你还可以[将 OpenHands 连接到本地文件系统](https://docs.all-hands.dev/modules/usage/runtimes/docker#connecting-to-your-filesystem)，
-以[无头模式](https://docs.all-hands.dev/modules/usage/how-to/headless-mode)运行 OpenHands，
-通过[友好的 CLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode)与其交互，
-或者使用 [GitHub action](https://docs.all-hands.dev/modules/usage/how-to/github-action) 在标记的问题上运行它。
+你还可以[将 OpenHands 连接到本地文件系统](https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem)，
+以[无头模式](https://docs.all-hands.dev/usage/how-to/headless-mode)运行 OpenHands，
+通过[友好的 CLI](https://docs.all-hands.dev/usage/how-to/cli-mode)与其交互，
+或者使用 [GitHub action](https://docs.all-hands.dev/usage/how-to/github-action) 在标记的问题上运行它。
 
 ## 设置
 
@@ -116,4 +116,4 @@ OpenHands 需要 API 密钥才能访问大多数语言模型。以下是从推�
 
 有关开发工作流程，请参阅 [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)。
 
-遇到问题？请查看我们的[故障排除指南](https://docs.all-hands.dev/modules/usage/troubleshooting)。
+遇到问题？请查看我们的[故障排除指南](https://docs.all-hands.dev/usage/troubleshooting)。

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/intro.mdx
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/usage/intro.mdx
@@ -91,7 +91,7 @@ OpenHands 只会访问这个工作区文件夹。它在一个安全的 docker �
 
 有关开发工作流程，请参阅 [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)。
 
-遇到问题了吗？查看我们的 [故障排除指南](https://docs.all-hands.dev/modules/usage/troubleshooting)。
+遇到问题了吗？查看我们的 [故障排除指南](https://docs.all-hands.dev/usage/troubleshooting)。
 
 :::warning
 OpenHands 目前正在开发中，但你已经可以运行 alpha 版本来查看端到端系统的运作情况。

--- a/docs/modules/usage/how-to/github-action.md
+++ b/docs/modules/usage/how-to/github-action.md
@@ -47,6 +47,6 @@ The customization options you can set are:
 | `LLM_MODEL`                      | Variable | Set the LLM to use with OpenHands                                                                   | `LLM_MODEL="anthropic/claude-3-5-sonnet-20241022"` |
 | `OPENHANDS_MAX_ITER`             | Variable | Set max limit for agent iterations                                                                  | `OPENHANDS_MAX_ITER=10`                            |
 | `OPENHANDS_MACRO`                | Variable | Customize default macro for invoking the resolver                                                   | `OPENHANDS_MACRO=@resolveit`                       |
-| `OPENHANDS_BASE_CONTAINER_IMAGE` | Variable | Custom Sandbox ([learn more](https://docs.all-hands.dev/modules/usage/how-to/custom-sandbox-guide)) | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
+| `OPENHANDS_BASE_CONTAINER_IMAGE` | Variable | Custom Sandbox ([learn more](https://docs.all-hands.dev/usage/how-to/custom-sandbox-guide)) | `OPENHANDS_BASE_CONTAINER_IMAGE="custom_image"`    |
 | `TARGET_BRANCH`                  | Variable | Merge to branch other than `main`                                                                   | `TARGET_BRANCH="dev"`                              |
 | `TARGET_RUNNER`                  | Variable | Target runner to execute the agent workflow (default ubuntu-latest)                                 | `TARGET_RUNNER="custom-runner"`                    |

--- a/docs/modules/usage/installation.mdx
+++ b/docs/modules/usage/installation.mdx
@@ -78,10 +78,10 @@ docker run -it --rm --pull=always \
 
 You'll find OpenHands running at http://localhost:3000!
 
-You can also [connect OpenHands to your local filesystem](https://docs.all-hands.dev/modules/usage/runtimes/docker#connecting-to-your-filesystem),
-run OpenHands in a scriptable [headless mode](https://docs.all-hands.dev/modules/usage/how-to/headless-mode),
-interact with it via a [friendly CLI](https://docs.all-hands.dev/modules/usage/how-to/cli-mode),
-or run it on tagged issues with [a GitHub action](https://docs.all-hands.dev/modules/usage/how-to/github-action).
+You can also [connect OpenHands to your local filesystem](https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem),
+run OpenHands in a scriptable [headless mode](https://docs.all-hands.dev/usage/how-to/headless-mode),
+interact with it via a [friendly CLI](https://docs.all-hands.dev/usage/how-to/cli-mode),
+or run it on tagged issues with [a GitHub action](https://docs.all-hands.dev/usage/how-to/github-action).
 
 ## Setup
 
@@ -123,4 +123,4 @@ This version is unstable and is recommended for testing or development purposes 
 
 For the development workflow, see [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
 
-Are you having trouble? Check out our [Troubleshooting Guide](https://docs.all-hands.dev/modules/usage/troubleshooting).
+Are you having trouble? Check out our [Troubleshooting Guide](https://docs.all-hands.dev/usage/troubleshooting).

--- a/docs/modules/usage/llms/local-llms.md
+++ b/docs/modules/usage/llms/local-llms.md
@@ -50,7 +50,7 @@ We recommend using [LMStudio](https://lmstudio.ai/) for serving these models loc
 
 ### Start OpenHands with locally served model
 
-Check [the installation guide](https://docs.all-hands.dev/modules/usage/installation) to make sure you have all the prerequisites for running OpenHands.
+Check [the installation guide](https://docs.all-hands.dev/usage/installation) to make sure you have all the prerequisites for running OpenHands.
 
 ```bash
 export LMSTUDIO_MODEL_NAME="imported-models/uncategorized/devstralq4_k_m.gguf" # <- Replace this with the model name you copied from LMStudio

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -120,7 +120,7 @@ You can start your own fork of [our huggingface evaluation outputs](https://hugg
 
 ## For Benchmark Developers
 
-To learn more about how to integrate your benchmark into OpenHands, check out [tutorial here](https://docs.all-hands.dev/modules/usage/how-to/evaluation-harness). Briefly,
+To learn more about how to integrate your benchmark into OpenHands, check out [tutorial here](https://docs.all-hands.dev/usage/how-to/evaluation-harness). Briefly,
 
 - Each subfolder contains a specific benchmark or experiment. For example, [`evaluation/benchmarks/swe_bench`](./benchmarks/swe_bench) should contain
 all the preprocessing/evaluation/analysis scripts.

--- a/frontend/__tests__/components/features/settings/api-keys-manager.test.tsx
+++ b/frontend/__tests__/components/features/settings/api-keys-manager.test.tsx
@@ -52,7 +52,7 @@ describe("ApiKeysManager", () => {
     // Find the link to the API documentation
     const link = screen.getByRole("link");
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "https://docs.all-hands.dev/modules/usage/cloud/cloud-api");
+    expect(link).toHaveAttribute("href", "https://docs.all-hands.dev/usage/cloud/cloud-api");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });

--- a/frontend/src/components/features/home/home-header.tsx
+++ b/frontend/src/components/features/home/home-header.tsx
@@ -43,7 +43,7 @@ export function HomeHeader() {
         <p className="text-sm">
           {t("HOME$NOT_SURE_HOW_TO_START")}{" "}
           <a
-            href="https://docs.all-hands.dev/modules/usage/getting-started"
+            href="https://docs.all-hands.dev/usage/getting-started"
             target="_blank"
             rel="noopener noreferrer"
             className="underline underline-offset-2"

--- a/frontend/src/components/features/settings/api-keys-manager.tsx
+++ b/frontend/src/components/features/settings/api-keys-manager.tsx
@@ -69,7 +69,7 @@ export function ApiKeysManager() {
             components={{
               a: (
                 <a
-                  href="https://docs.all-hands.dev/modules/usage/cloud/cloud-api"
+                  href="https://docs.all-hands.dev/usage/cloud/cloud-api"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-blue-400 hover:underline"

--- a/frontend/src/components/features/settings/mcp-settings/mcp-config-editor.tsx
+++ b/frontend/src/components/features/settings/mcp-settings/mcp-config-editor.tsx
@@ -35,7 +35,7 @@ export function MCPConfigEditor({ mcpConfig, onChange }: MCPConfigEditorProps) {
       <div className="flex justify-between items-center mb-4">
         <div className="flex items-center">
           <a
-            href="https://docs.all-hands.dev/modules/usage/mcp"
+            href="https://docs.all-hands.dev/usage/mcp"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-blue-400 hover:underline mr-3"

--- a/frontend/src/components/features/settings/mcp-settings/mcp-config-viewer.tsx
+++ b/frontend/src/components/features/settings/mcp-settings/mcp-config-viewer.tsx
@@ -95,7 +95,7 @@ export function MCPConfigViewer({ mcpConfig }: MCPConfigViewerProps) {
           {t(I18nKey.SETTINGS$MCP_CONFIGURATION)}
         </h3>
         <a
-          href="https://docs.all-hands.dev/modules/usage/mcp"
+          href="https://docs.all-hands.dev/usage/mcp"
           target="_blank"
           rel="noopener noreferrer"
           className="text-xs text-blue-400 hover:underline"

--- a/frontend/src/components/shared/hero-heading.tsx
+++ b/frontend/src/components/shared/hero-heading.tsx
@@ -17,7 +17,7 @@ export function HeroHeading() {
           <a
             rel="noopener noreferrer"
             target="_blank"
-            href="https://docs.all-hands.dev/modules/usage/getting-started"
+            href="https://docs.all-hands.dev/usage/getting-started"
             className="text-white underline underline-offset-[3px]"
           >
             {t(I18nKey.LANDING$START_HELP_LINK)}

--- a/frontend/src/components/shared/inputs/api-key-input.tsx
+++ b/frontend/src/components/shared/inputs/api-key-input.tsx
@@ -39,7 +39,7 @@ export function APIKeyInput({ isDisabled, isSet }: APIKeyInputProps) {
       <p className="text-sm text-[#A3A3A3]">
         {t(I18nKey.API$DONT_KNOW_KEY)}{" "}
         <a
-          href="https://docs.all-hands.dev/modules/usage/llms"
+          href="https://docs.all-hands.dev/usage/llms"
           rel="noreferrer noopener"
           target="_blank"
           className="underline underline-offset-2"

--- a/frontend/src/components/shared/modals/settings/settings-form.tsx
+++ b/frontend/src/components/shared/modals/settings/settings-form.tsx
@@ -96,7 +96,7 @@ export function SettingsForm({ settings, models, onClose }: SettingsFormProps) {
             testId="llm-api-key-help-anchor"
             text={t(I18nKey.SETTINGS$DONT_KNOW_API_KEY)}
             linkText={t(I18nKey.SETTINGS$CLICK_FOR_INSTRUCTIONS)}
-            href="https://docs.all-hands.dev/modules/usage/installation#getting-an-api-key"
+            href="https://docs.all-hands.dev/usage/installation#getting-an-api-key"
           />
         </div>
 

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -304,7 +304,7 @@ function LlmSettingsScreen() {
                 testId="llm-api-key-help-anchor"
                 text={t(I18nKey.SETTINGS$DONT_KNOW_API_KEY)}
                 linkText={t(I18nKey.SETTINGS$CLICK_FOR_INSTRUCTIONS)}
-                href="https://docs.all-hands.dev/modules/usage/installation#getting-an-api-key"
+                href="https://docs.all-hands.dev/usage/installation#getting-an-api-key"
               />
 
               <SettingsInput
@@ -379,7 +379,7 @@ function LlmSettingsScreen() {
                 testId="llm-api-key-help-anchor-advanced"
                 text={t(I18nKey.SETTINGS$DONT_KNOW_API_KEY)}
                 linkText={t(I18nKey.SETTINGS$CLICK_FOR_INSTRUCTIONS)}
-                href="https://docs.all-hands.dev/modules/usage/installation#getting-an-api-key"
+                href="https://docs.all-hands.dev/usage/installation#getting-an-api-key"
               />
 
               <SettingsInput

--- a/frontend/src/utils/tips.ts
+++ b/frontend/src/utils/tips.ts
@@ -8,29 +8,29 @@ export interface Tip {
 export const TIPS: Tip[] = [
   {
     key: I18nKey.TIPS$CUSTOMIZE_MICROAGENT,
-    link: "https://docs.all-hands.dev/modules/usage/prompting/microagents-repo",
+    link: "https://docs.all-hands.dev/usage/prompting/microagents-repo",
   },
   {
     key: I18nKey.TIPS$SETUP_SCRIPT,
-    link: "https://docs.all-hands.dev/modules/usage/customization/repository",
+    link: "https://docs.all-hands.dev/usage/customization/repository",
   },
   { key: I18nKey.TIPS$VSCODE_INSTANCE },
   { key: I18nKey.TIPS$SAVE_WORK },
   {
     key: I18nKey.TIPS$SPECIFY_FILES,
-    link: "https://docs.all-hands.dev/modules/usage/prompting/prompting-best-practices",
+    link: "https://docs.all-hands.dev/usage/prompting/prompting-best-practices",
   },
   {
     key: I18nKey.TIPS$HEADLESS_MODE,
-    link: "https://docs.all-hands.dev/modules/usage/how-to/headless-mode",
+    link: "https://docs.all-hands.dev/usage/how-to/headless-mode",
   },
   {
     key: I18nKey.TIPS$CLI_MODE,
-    link: "https://docs.all-hands.dev/modules/usage/how-to/cli-mode",
+    link: "https://docs.all-hands.dev/usage/how-to/cli-mode",
   },
   {
     key: I18nKey.TIPS$GITHUB_HOOK,
-    link: "https://docs.all-hands.dev/modules/usage/cloud/cloud-issue-resolver",
+    link: "https://docs.all-hands.dev/usage/cloud/cloud-issue-resolver",
   },
   {
     key: I18nKey.TIPS$BLOG_SIGNUP,

--- a/microagents/add_agent.md
+++ b/microagents/add_agent.md
@@ -36,6 +36,6 @@ When creating a new microagent:
 
 For detailed information, see:
 
-- [Microagents Overview](https://docs.all-hands.dev/modules/usage/prompting/microagents-overview)
-- [Microagents Syntax](https://docs.all-hands.dev/modules/usage/prompting/microagents-syntax)
+- [Microagents Overview](https://docs.all-hands.dev/usage/prompting/microagents-overview)
+- [Microagents Syntax](https://docs.all-hands.dev/usage/prompting/microagents-syntax)
 - [Example GitHub Microagent](https://github.com/All-Hands-AI/OpenHands/blob/main/microagents/github.md)

--- a/openhands/README.md
+++ b/openhands/README.md
@@ -52,4 +52,4 @@ flowchart LR
 
 ## Runtime
 
-Please refer to the [documentation](https://docs.all-hands.dev/modules/usage/architecture/runtime) to learn more about `Runtime`.
+Please refer to the [documentation](https://docs.all-hands.dev/usage/architecture/runtime) to learn more about `Runtime`.

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -376,7 +376,7 @@ def display_help() -> None:
     # Footer
     print_formatted_text(
         HTML(
-            '<grey>Learn more at: https://docs.all-hands.dev/modules/usage/getting-started</grey>'
+            '<grey>Learn more at: https://docs.all-hands.dev/usage/getting-started</grey>'
         )
     )
 

--- a/openhands/core/const/guide_url.py
+++ b/openhands/core/const/guide_url.py
@@ -1,1 +1,1 @@
-TROUBLESHOOTING_URL = 'https://docs.all-hands.dev/modules/usage/troubleshooting'
+TROUBLESHOOTING_URL = 'https://docs.all-hands.dev/usage/troubleshooting'

--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -40,7 +40,7 @@ Follow these steps to use this workflow in your own repository:
 
    Note: You can set these secrets at the organization level to use across multiple repositories.
 
-6. Set up any [custom configurations required](https://docs.all-hands.dev/modules/usage/how-to/github-action#custom-configurations)
+6. Set up any [custom configurations required](https://docs.all-hands.dev/usage/how-to/github-action#custom-configurations)
 
 7. Usage:
    There are two ways to trigger the OpenHands agent:

--- a/openhands/runtime/README.md
+++ b/openhands/runtime/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 The OpenHands Runtime folder contains the core components responsible for executing actions and managing the runtime environment for the OpenHands project. This README provides an overview of the main components and their interactions.
-You can learn more about how the runtime works in the [Docker Runtime](https://docs.all-hands.dev/modules/usage/architecture/runtime) documentation.
+You can learn more about how the runtime works in the [Docker Runtime](https://docs.all-hands.dev/usage/architecture/runtime) documentation.
 
 ## Main Components
 

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -129,7 +129,7 @@ def build_runtime_image(
     Returns:
     - str: <image_repo>:<MD5 hash>. Where MD5 hash is the hash of the docker build folder
 
-    See https://docs.all-hands.dev/modules/usage/architecture/runtime for more details.
+    See https://docs.all-hands.dev/usage/architecture/runtime for more details.
     """
     if build_folder is None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes all remaining broken links across the codebase that still pointed to outdated https://docs.all-hands.dev/modules/ URLs after the docs site was changed.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR updates every reference to the old https://docs.all-hands.dev/modules/ URLs across the entire project (README files, docs, etc.). Each instance was replaced with the new path https://docs.all-hands.dev/, removing /modules.

**Please verify that this change doesn’t break anything.**

---
**Link of any specific issues this addresses:**
