### PR TITLE
Fix typo in issue_resolver.py: 'confgurable' -> 'configurable'

### DIFF
--- a/openhands/resolver/issue_resolver.py
+++ b/openhands/resolver/issue_resolver.py
@@ -44,7 +44,7 @@ from openhands.resolver.utils import (
 from openhands.runtime.base import Runtime
 from openhands.utils.async_utils import GENERAL_TIMEOUT, call_async_from_sync
 
-# Don't make this confgurable for now, unless we have other competitive agents
+# Don't make this configurable for now, unless we have other competitive agents
 AGENT_CLASS = 'CodeActAgent'
 
 


### PR DESCRIPTION
This PR fixes a typo in openhands/resolver/issue_resolver.py line 47. It changes 'confgurable' to 'configurable'.

Issue #8838