### PR TITLE
Fix for nested event store

### DIFF
--- a/openhands/events/nested_event_store.py
+++ b/openhands/events/nested_event_store.py
@@ -43,7 +43,7 @@ class NestedEventStore(EventStoreABC):
                 headers['X-Session-API-Key'] = self.session_api_key
             response = httpx.get(url, headers=headers)
             result_set = response.json()
-            for result in result_set['results']:
+            for result in result_set['events']:
                 event = event_from_dict(result)
                 start_id = max(start_id, event.id + 1)
                 if end_id == event.id:

--- a/tests/unit/test_nested_event_store.py
+++ b/tests/unit/test_nested_event_store.py
@@ -37,11 +37,11 @@ def create_mock_event(
 
 
 def create_mock_response(
-    results: list[dict[str, Any]], has_more: bool = False
+    events: list[dict[str, Any]], has_more: bool = False
 ) -> MagicMock:
     """Helper function to create a mock HTTP response."""
     mock_response = MagicMock()
-    mock_response.json.return_value = {'results': results, 'has_more': has_more}
+    mock_response.json.return_value = {'events': events, 'has_more': has_more}
     return mock_response
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes an issue with the nested event store where events could not be properly retrieved from the API, which could cause failures in event retrieval, filtering, and pagination functionality.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes a bug in the `NestedEventStore` class where it was trying to access events using the key `results` in the response JSON, but the actual API returns events under the key `events`. The fix changes the key from `results` to `events` in both the `NestedEventStore` class and the corresponding test file.

Specifically:
1. Updated `openhands/events/nested_event_store.py` to use `result_set["events"]` instead of `result_set["results"]`
2. Updated `tests/unit/test_nested_event_store.py` to reflect this change in the mock response creation

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:41cd7cf-nikolaik   --name openhands-app-41cd7cf   docker.all-hands.dev/all-hands-ai/openhands:41cd7cf
```