### PR TITLE
Update sidebar titles to make parallels between cloud and local usage more clear

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -31,7 +31,7 @@
             "pages": [
               "usage/cloud/openhands-cloud",
               {
-                "group": "Installation",
+                "group": "Install in your Repos",
                 "pages": [
                   "usage/cloud/github-installation",
                   "usage/cloud/gitlab-installation"
@@ -43,7 +43,7 @@
             ]
           },
           {
-            "group": "Usage Methods",
+            "group": "OpenHands Local",
             "pages": [
               "usage/how-to/gui-mode",
               "usage/how-to/cli-mode",

--- a/docs/usage/cloud/cloud-api.mdx
+++ b/docs/usage/cloud/cloud-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud API
+title: API Usage
 description: OpenHands Cloud provides a REST API that allows you to programmatically interact with the service. This guide explains how to obtain an API key and use the API to start conversations.
 ---
 

--- a/docs/usage/cloud/cloud-issue-resolver.mdx
+++ b/docs/usage/cloud/cloud-issue-resolver.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud Issue Resolver
+title: GitHub/GitLab Integration
 description: The Cloud Issue Resolver automates code fixes and provides intelligent assistance for your repositories on GitHub.
 ---
 

--- a/docs/usage/cloud/cloud-ui.mdx
+++ b/docs/usage/cloud/cloud-ui.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud UI
+title: GUI Usage
 description: The Cloud UI provides a web interface for interacting with OpenHands AI. This page explains how to access and use the OpenHands Cloud UI.
 ---
 

--- a/docs/usage/cloud/openhands-cloud.mdx
+++ b/docs/usage/cloud/openhands-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: Sign Up
 description: Getting started with OpenHands Cloud
 ---
 

--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI Mode
+title: CLI Usage
 description: CLI mode provides a powerful interactive Command-Line Interface (CLI) that lets you engage with OpenHands directly from your terminal.
 ---
 

--- a/docs/usage/how-to/github-action.mdx
+++ b/docs/usage/how-to/github-action.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenHands GitHub Action
+title: GitHub Actions
 description: This guide explains how to use the OpenHands GitHub Action in your own projects.
 ---
 

--- a/docs/usage/how-to/gui-mode.mdx
+++ b/docs/usage/how-to/gui-mode.mdx
@@ -1,5 +1,5 @@
 ---
-title: GUI Mode
+title: GUI Usage
 description: OpenHands provides a Graphical User Interface (GUI) mode for interacting with the AI assistant.
 ---
 


### PR DESCRIPTION
This PR addresses issue #8871 by updating the sidebar titles to make the parallels between cloud and local usage more clear.

Changes made:

1. Renamed "Usage Methods" to "OpenHands Local" in the sidebar structure
2. Updated page titles to match the requested structure:
   - For OpenHands Cloud:
     - "Getting Started" → "Sign Up"
     - "Cloud UI" → "GUI Usage"
     - "Cloud Issue Resolver" → "GitHub/GitLab Integration"
     - "Cloud API" → "API Usage"
     - "Installation" → "Install in your Repos"
   - For OpenHands Local:
     - "GUI Mode" → "GUI Usage"
     - "CLI Mode" → "CLI Usage"
     - "OpenHands GitHub Action" → "GitHub Actions"

These changes maintain the existing sidebar structure while making the parallels between cloud and local usage more clear.

Closes #8871

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/564805562c2d4d68a7d8402dc0f30e8e)