### PR TITLE
Fix action suggestions to use git_provider from conversation metadata

### DIFF
--- a/frontend/__tests__/components/chat/action-suggestions.test.tsx
+++ b/frontend/__tests__/components/chat/action-suggestions.test.tsx
@@ -70,11 +70,12 @@ describe("ActionSuggestions", () => {
     });
   });
 
-  it("should render both GitHub buttons when GitHub token is set and repository is selected", async () => {
+  it("should render both GitHub buttons when GitHub token is set and repository is selected with GitHub provider", async () => {
     const getConversationSpy = vi.spyOn(OpenHands, "getConversation");
     // @ts-expect-error - only required for testing
     getConversationSpy.mockResolvedValue({
       selected_repository: "test-repo",
+      git_provider: "github"
     });
     renderActionSuggestions();
 
@@ -110,6 +111,42 @@ describe("ActionSuggestions", () => {
     renderActionSuggestions();
 
     expect(screen.queryByTestId("suggestion")).not.toBeInTheDocument();
+  });
+
+  it("should render GitLab buttons when GitLab token is set and repository is selected with GitLab provider", async () => {
+    const getSettingsSpy = vi.spyOn(OpenHands, "getSettings");
+    getSettingsSpy.mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      provider_tokens_set: {
+        github: "some-token",
+        gitlab: "some-gitlab-token",
+      },
+    });
+    
+    const getConversationSpy = vi.spyOn(OpenHands, "getConversation");
+    // @ts-expect-error - only required for testing
+    getConversationSpy.mockResolvedValue({
+      selected_repository: "test-repo",
+      git_provider: "gitlab"
+    });
+    renderActionSuggestions();
+
+    // Find all buttons with data-testid="suggestion"
+    const buttons = await screen.findAllByTestId("suggestion");
+
+    // Check if we have at least 2 buttons
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+
+    // Check if the buttons contain the expected text for GitLab
+    const pushButton = buttons.find((button) =>
+      button.textContent?.includes("Push to Branch"),
+    );
+    const mrButton = buttons.find((button) =>
+      button.textContent?.includes("Push & Create PR"),
+    );
+
+    expect(pushButton).toBeInTheDocument();
+    expect(mrButton).toBeInTheDocument();
   });
 
   it("should have different prompts for 'Push to Branch' and 'Push & Create PR' buttons", () => {

--- a/frontend/src/components/features/chat/action-suggestions.tsx
+++ b/frontend/src/components/features/chat/action-suggestions.tsx
@@ -19,7 +19,8 @@ export function ActionSuggestions({
   const [hasPullRequest, setHasPullRequest] = React.useState(false);
 
   const providersAreSet = providers.length > 0;
-  const isGitLab = providers.includes("gitlab");
+  // Use the git_provider from the conversation metadata instead of just checking if gitlab is connected
+  const isGitLab = conversation?.git_provider === "gitlab";
 
   const pr = isGitLab ? "merge request" : "pull request";
   const prShort = isGitLab ? "MR" : "PR";


### PR DESCRIPTION
## Description

This PR fixes an issue with the action suggestions component in the chat interface. Previously, the component was showing GitLab options for ALL users that have connected to GitLab, even if they are connected to both GitHub and GitLab and are currently using a GitHub repository.

The fix changes the logic to use the `git_provider` field from the conversation metadata instead of just checking if the user has connected to GitLab. This ensures that the correct options (GitHub or GitLab) are shown based on the currently selected repository.

## Changes

- Modified `frontend/src/components/features/chat/action-suggestions.tsx` to use `conversation?.git_provider === "gitlab"` instead of `providers.includes("gitlab")` to determine whether to show GitLab or GitHub options
- Updated the tests in `frontend/__tests__/components/chat/action-suggestions.test.tsx` to reflect this change:
  - Updated the existing GitHub test to include the `git_provider: "github"` in the mock conversation
  - Added a new test for GitLab to verify that GitLab options are shown when the conversation has `git_provider: "gitlab"`

## Testing

- Ran the tests for the action-suggestions component and verified they pass
- Manually verified that the correct options are shown based on the git provider of the selected repository

Robert Brennan can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/{})

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:317168f-nikolaik   --name openhands-app-317168f   docker.all-hands.dev/all-hands-ai/openhands:317168f
```