### PR TITLE
(Hotfix): make sure MCP tool error observations are surfaced to agent

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -483,35 +483,33 @@ class GitHubService(BaseGitService, GitService):
             - PR URL when successful
             - Error message when unsuccessful
         """
-        try:
-            url = f'{self.BASE_URL}/repos/{repo_name}/pulls'
 
-            # Set default body if none provided
-            if not body:
-                body = f'Merging changes from {source_branch} into {target_branch}'
+        url = f'{self.BASE_URL}/repos/{repo_name}/pulls'
 
-            # Prepare the request payload
-            payload = {
-                'title': title,
-                'head': source_branch,
-                'base': target_branch,
-                'body': body,
-                'draft': draft,
-            }
+        # Set default body if none provided
+        if not body:
+            body = f'Merging changes from {source_branch} into {target_branch}'
 
-            # Make the POST request to create the PR
-            response, _ = await self._make_request(
-                url=url, params=payload, method=RequestMethod.POST
-            )
+        # Prepare the request payload
+        payload = {
+            'title': title,
+            'head': source_branch,
+            'base': target_branch,
+            'body': body,
+            'draft': draft,
+        }
 
-            # Return the HTML URL of the created PR
-            if 'html_url' in response:
-                return response['html_url']
-            else:
-                return f'PR created but URL not found in response: {response}'
+        # Make the POST request to create the PR
+        response, _ = await self._make_request(
+            url=url, params=payload, method=RequestMethod.POST
+        )
 
-        except Exception as e:
-            return f'Error creating pull request: {str(e)}'
+        # Return the HTML URL of the created PR
+        if 'html_url' in response:
+            return response['html_url']
+        else:
+            return f'PR created but URL not found in response: {response}'
+
 
 
 github_service_cls = os.environ.get(

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -476,38 +476,37 @@ class GitLabService(BaseGitService, GitService):
             - MR URL when successful
             - Error message when unsuccessful
         """
-        try:
-            # Convert string ID to URL-encoded path if needed
-            project_id = str(id).replace('/', '%2F') if isinstance(id, str) else id
-            url = f'{self.BASE_URL}/projects/{project_id}/merge_requests'
 
-            # Set default description if none provided
-            if not description:
-                description = (
-                    f'Merging changes from {source_branch} into {target_branch}'
-                )
+        # Convert string ID to URL-encoded path if needed
+        project_id = str(id).replace('/', '%2F') if isinstance(id, str) else id
+        url = f'{self.BASE_URL}/projects/{project_id}/merge_requests'
 
-            # Prepare the request payload
-            payload = {
-                'source_branch': source_branch,
-                'target_branch': target_branch,
-                'title': title,
-                'description': description,
-            }
-
-            # Make the POST request to create the MR
-            response, _ = await self._make_request(
-                url=url, params=payload, method=RequestMethod.POST
+        # Set default description if none provided
+        if not description:
+            description = (
+                f'Merging changes from {source_branch} into {target_branch}'
             )
 
-            # Return the web URL of the created MR
-            if 'web_url' in response:
-                return response['web_url']
-            else:
-                return f'MR created but URL not found in response: {response}'
+        # Prepare the request payload
+        payload = {
+            'source_branch': source_branch,
+            'target_branch': target_branch,
+            'title': title,
+            'description': description,
+        }
 
-        except Exception as e:
-            return f'Error creating merge request: {str(e)}'
+        # Make the POST request to create the MR
+        response, _ = await self._make_request(
+            url=url, params=payload, method=RequestMethod.POST
+        )
+
+        # Return the web URL of the created MR
+        if 'web_url' in response:
+            return response['web_url']
+        else:
+            return f'MR created but URL not found in response: {response}'
+
+
 
 
 gitlab_service_cls = os.environ.get(

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -167,11 +167,11 @@ class BaseGitService(ABC):
             return RateLimitError('GitHub API rate limit exceeded')
 
         logger.warning(f'Status error on {self.provider} API: {e}')
-        return UnknownException('Unknown error')
+        return UnknownException(f'Unknown error: {e}')
 
     def handle_http_error(self, e: HTTPError) -> UnknownException:
         logger.warning(f'HTTP error on {self.provider} API: {type(e).__name__} : {e}')
-        return UnknownException(f'HTTP error {type(e).__name__}')
+        return UnknownException(f'HTTP error {type(e).__name__} : {e}')
 
 
 class GitService(Protocol):

--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -97,7 +97,8 @@ async def create_pr(
             await save_pr_metadata(user_id, conversation_id, response)
 
     except Exception as e:
-        raise ToolError(str(e))
+        error = f"Error creating pull request: {e}"
+        raise ToolError(str(error))
 
     return response
 
@@ -152,6 +153,7 @@ async def create_mr(
             await save_pr_metadata(user_id, conversation_id, response)
 
     except Exception as e:
-        raise ToolError(str(e))
+        error = f"Error creating merge request: {e}"
+        raise ToolError(str(error))
 
     return response

--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -2,6 +2,7 @@ import re
 from typing import Annotated
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_http_request
 from pydantic import Field
 
@@ -19,7 +20,7 @@ from openhands.server.user_auth import (
 )
 from openhands.storage.data_models.conversation_metadata import ConversationMetadata
 
-mcp_server = FastMCP('mcp', stateless_http=True, dependencies=get_dependencies())
+mcp_server = FastMCP('mcp', stateless_http=True, dependencies=get_dependencies(), mask_error_details=True)
 
 async def save_pr_metadata(
     user_id: str, conversation_id: str, tool_result: str
@@ -96,7 +97,7 @@ async def create_pr(
             await save_pr_metadata(user_id, conversation_id, response)
 
     except Exception as e:
-        response = str(e)
+        raise ToolError(str(e))
 
     return response
 
@@ -151,6 +152,6 @@ async def create_mr(
             await save_pr_metadata(user_id, conversation_id, response)
 
     except Exception as e:
-        response = str(e)
+        raise ToolError(str(e))
 
     return response


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Ensure agent gets error observations for failed MCP tool calls in OpenHands MCP server

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Currently, because of the way we want handles in the git MCP server we have two problems

1. We return a normal response for errors, which causes the UI to display tool calls with errors as successful
2. The agent gets vague error messages, like `Unknown error` instead of the actual message


This PR ensures that 

1. Exceptions in tool calls aren't sent to the MCP client by default
2. Only errors which are wrapped in `ToolError` are plumbed back to the MCP client (overrides exception handling this way)
3. Git service passes readable error messages to Git MCP server


QA for UI (isError attrib is fixed)

![image](https://github.com/user-attachments/assets/0ea9a154-af62-423e-ae64-7ffe312871c8)
![image](https://github.com/user-attachments/assets/5c126d7b-8084-4653-afab-38f30190240d)




QA where error observation is plumbed to MCP client

![image](https://github.com/user-attachments/assets/5d500b0f-d659-4b38-9ce4-a6e30882fc68)



---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c3e16c4-nikolaik   --name openhands-app-c3e16c4   docker.all-hands.dev/all-hands-ai/openhands:c3e16c4
```