### PR TITLE
Add stricter type checking for conversation manager and utils

### DIFF
--- a/dev_config/python/mypy.ini
+++ b/dev_config/python/mypy.ini
@@ -7,3 +7,11 @@ warn_unreachable = True
 warn_redundant_casts = True
 no_implicit_optional = True
 strict_optional = True
+
+[mypy-openhands.server.utils]
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+
+[mypy-openhands.server.conversation_manager.*]
+disallow_incomplete_defs = True
+disallow_untyped_defs = True


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This configures mypy to require type annotations including return types on a subset of files in `openhands.server`. Requiring these should catching missing None checks such as this recent runtime exception:
```
openhands/server/conversation_manager/standalone_conversation_manager.py", line 136, in detach_from_conversation
    sid = conversation.sid
          ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'sid'
```

Eventually, everything in openhands.server and anything we consider an integration point should probably have this enabled, but starting with a small change.
---
**Link of any specific issues this addresses:**
