### PR TITLE
Fix NoneType error in get_conversation and other typesafety

### DIFF
--- a/openhands/events/async_event_store_wrapper.py
+++ b/openhands/events/async_event_store_wrapper.py
@@ -2,11 +2,11 @@ import asyncio
 from typing import Any, AsyncIterator
 
 from openhands.events.event import Event
-from openhands.events.event_store import EventStore
+from openhands.events.event_store import EventStoreABC
 
 
 class AsyncEventStoreWrapper:
-    def __init__(self, event_store: EventStore, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, event_store: EventStoreABC, *args: Any, **kwargs: Any) -> None:
         self.event_store = event_store
         self.args = args
         self.kwargs = kwargs

--- a/openhands/server/routes/conversation.py
+++ b/openhands/server/routes/conversation.py
@@ -145,5 +145,5 @@ async def search_events(
 @app.post('/events')
 async def add_event(request: Request, conversation: ServerConversation = Depends(get_conversation)):
     data = request.json()
-    conversation_manager.send_to_event_stream(conversation.sid, data)
+    await conversation_manager.send_to_event_stream(conversation.sid, data)
     return JSONResponse({'success': True})

--- a/openhands/server/shared.py
+++ b/openhands/server/shared.py
@@ -58,7 +58,7 @@ ConversationManagerImpl = get_impl(
     server_config.conversation_manager_class,
 )
 
-conversation_manager = ConversationManagerImpl.get_instance(
+conversation_manager: ConversationManager = ConversationManagerImpl.get_instance(
     sio, config, file_store, server_config, monitoring_listener
 )
 

--- a/openhands/server/utils.py
+++ b/openhands/server/utils.py
@@ -27,4 +27,5 @@ async def get_conversation(
     try:
         yield conversation
     finally:
-        await conversation_manager.detach_from_conversation(conversation)
+        if conversation:
+            await conversation_manager.detach_from_conversation(conversation)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Adding the type annotation to conversation_manager in shared.py makes it so mypy catches the missing None check behind this recent runtime exception:

```
openhands/server/conversation_manager/standalone_conversation_manager.py", line 136, in detach_from_conversation
    sid = conversation.sid
          ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'sid'
```

It also appears to have flagged a missing async. It's possible that these constants have left a larger hole in our type-checking. I originally tried to solve this by forcing return type annotations in #8911 (maybe still a good idea), but this turned out to me enough.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d2c5c00-nikolaik   --name openhands-app-d2c5c00   docker.all-hands.dev/all-hands-ai/openhands:d2c5c00
```