### PR TITLE
[Fix]: Broken links from cloud resolver

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -505,10 +505,7 @@ class GitHubService(BaseGitService, GitService):
         )
 
         # Return the HTML URL of the created PR
-        if 'html_url' in response:
-            return response['html_url']
-        else:
-            return f'PR created but URL not found in response: {response}'
+        return response['html_url']
 
 
 

--- a/openhands/integrations/templates/resolver/github/issue_comment_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/github/issue_comment_conversation_instructions.j2
@@ -15,4 +15,3 @@ When you're done, make sure to
 2. Use the `create_pr` tool to open a new PR
 3. Name the branch using `openhands/` as a prefix (e.g `openhands/update-readme`)
 4. The PR description should mention that it "fixes" or "closes" the issue number
-5. Make sure to leave the following sentence at the end of the PR description: `@{{ username }} can click here to [continue refining the PR]({{ conversation_url }})`

--- a/openhands/integrations/templates/resolver/github/issue_labeled_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/github/issue_labeled_conversation_instructions.j2
@@ -9,4 +9,3 @@ When you're done, make sure to
 
 1. Use the `create_pr` tool to open a new PR
 2. The PR description should mention that it "fixes" or "closes" the issue number
-3. Make sure to leave the following sentence at the end of the PR description: `@{{ username }} can click here to [continue refining the PR]({{ conversation_url }})`

--- a/openhands/integrations/templates/resolver/gitlab/issue_comment_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/gitlab/issue_comment_conversation_instructions.j2
@@ -15,4 +15,3 @@ When you're done, make sure to
 2. Use the `create_mr` tool to open a new MR
 3. Name the branch using `openhands/` as a prefix (e.g `openhands/update-readme`)
 4. The MR description should mention that it "fixes" or "closes" the issue number
-5. Make sure to leave the following sentence at the end of the MR description: `@{{ username }} can click here to [continue refining the MR]({{ conversation_url }})`

--- a/openhands/integrations/templates/resolver/gitlab/issue_labeled_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/gitlab/issue_labeled_conversation_instructions.j2
@@ -9,4 +9,3 @@ When you're done, make sure to
 
 1. Use the `create_mr` tool to open a new MR
 2. The MR description should mention that it "fixes" or "closes" the issue number
-3. Make sure to leave the following sentence at the end of the MR description: `@{{ username }} can click here to [continue refining the MR]({{ conversation_url }})`

--- a/openhands/integrations/templates/resolver/slack/user_message_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/slack/user_message_conversation_instructions.j2
@@ -8,4 +8,3 @@ These are a list of text messages attached in order of most recent.
 
 
 If you opened a pull request, please leave the following comment at the end your summary and pull request description
-`{{ username }} can click here to [continue refining the PR]({{ conversation_url }})`


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Improve reliability of followup links to convo

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

When the cloud resolver opens a new PR, it is responsible for leaving a link the PR body (`user can continue refining pr here ...`)

However, the agent often leaves broken links. This PR fixes this issue by having the `create_pr` MCP tool append the link at the end of the PR body. This does two things

1. Improves the reliability of the followup link 
2. Reduces the number of tasks the agent is responsible of doing

---
**Link of any specific issues this addresses:**
