### PR TITLE
Fix missing None-check in get_conversations

### DIFF
--- a/openhands/server/conversation_manager/standalone_conversation_manager.py
+++ b/openhands/server/conversation_manager/standalone_conversation_manager.py
@@ -111,7 +111,8 @@ class StandaloneConversationManager(ConversationManager):
                 return None
             end_time = time.time()
             logger.info(
-                f'ServerConversation {c.sid} connected in {end_time - start_time} seconds'
+                f'ServerConversation {c.sid} connected in {end_time - start_time} seconds',
+                extra={'session_id': sid}
             )
             self._active_conversations[sid] = (c, 1)
             return c

--- a/openhands/server/routes/conversation.py
+++ b/openhands/server/routes/conversation.py
@@ -145,5 +145,5 @@ async def search_events(
 @app.post('/events')
 async def add_event(request: Request, conversation: ServerConversation = Depends(get_conversation)):
     data = request.json()
-    conversation_manager.send_to_event_stream(conversation.sid, data)
+    await conversation_manager.send_to_event_stream(conversation.sid, data)
     return JSONResponse({'success': True})

--- a/openhands/server/utils.py
+++ b/openhands/server/utils.py
@@ -1,5 +1,6 @@
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Request, status
 
+from openhands.core.logger import openhands_logger as logger
 from openhands.server.shared import ConversationStoreImpl, config, conversation_manager
 from openhands.server.user_auth import get_user_id
 from openhands.storage.conversation.conversation_store import ConversationStore
@@ -24,6 +25,15 @@ async def get_conversation(
     conversation = await conversation_manager.attach_to_conversation(
         conversation_id, user_id
     )
+    if not conversation:
+        logger.warn(
+            f'get_conversation: conversation {conversation_id} not found, attach_to_conversation returned None',
+            extra={'session_id': conversation_id, 'user_id': user_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Conversation {conversation_id} not found',
+        )
     try:
         yield conversation
     finally:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Handle the case were get_conversation gets None from attach_conversation, it should be an HTTP 404, currently it's passing it into detach_conversation causing 500s and this runtime exception:
```
openhands/server/conversation_manager/standalone_conversation_manager.py", line 136, in detach_from_conversation
    sid = conversation.sid
          ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'sid'
```

Also added a missing await on call to an async conversation_manager function.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:02987b1-nikolaik   --name openhands-app-02987b1   docker.all-hands.dev/all-hands-ai/openhands:02987b1
```