### PR TITLE
feat(agent): remind the agent that it can use timeout to increase the amount of time the command is running

### DIFF
--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -381,7 +381,8 @@ class BashSession:
             f'\n[The command has no new output after {self.NO_CHANGE_TIMEOUT_SECONDS} seconds. '
             "You may wait longer to see additional output by sending empty command '', "
             'send other commands to interact with the current process, '
-            'or send keys to interrupt/kill the command.]'
+            'send keys to interrupt/kill the command, '
+            'or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
         )
         command_output = self._get_command_output(
             command,
@@ -416,7 +417,8 @@ class BashSession:
             f'\n[The command timed out after {timeout} seconds. '
             "You may wait longer to see additional output by sending empty command '', "
             'send other commands to interact with the current process, '
-            'or send keys to interrupt/kill the command.]'
+            'send keys to interrupt/kill the command, '
+            'or use a higher timeout parameter in execute_bash for future commands.]'
         )
         command_output = self._get_command_output(
             command,

--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -380,7 +380,7 @@ class BashSession:
         metadata = CmdOutputMetadata()  # No metadata available
         metadata.suffix = (
             f'\n[The command has no new output after {self.NO_CHANGE_TIMEOUT_SECONDS} seconds. '
-            f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+            f'{TIMEOUT_MESSAGE_TEMPLATE}]'
         )
         command_output = self._get_command_output(
             command,
@@ -413,7 +413,7 @@ class BashSession:
         metadata = CmdOutputMetadata()  # No metadata available
         metadata.suffix = (
             f'\n[The command timed out after {timeout} seconds. '
-            f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="a higher timeout", timeout_action="")}]'
+            f'{TIMEOUT_MESSAGE_TEMPLATE}]'
         )
         command_output = self._get_command_output(
             command,

--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -17,6 +17,7 @@ from openhands.events.observation.commands import (
     CmdOutputMetadata,
     CmdOutputObservation,
 )
+from openhands.runtime.utils.bash_constants import TIMEOUT_MESSAGE_TEMPLATE
 from openhands.utils.shutdown_listener import should_continue
 
 
@@ -379,10 +380,7 @@ class BashSession:
         metadata = CmdOutputMetadata()  # No metadata available
         metadata.suffix = (
             f'\n[The command has no new output after {self.NO_CHANGE_TIMEOUT_SECONDS} seconds. '
-            "You may wait longer to see additional output by sending empty command '', "
-            'send other commands to interact with the current process, '
-            'send keys to interrupt/kill the command, '
-            'or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
+            f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
         )
         command_output = self._get_command_output(
             command,
@@ -415,10 +413,7 @@ class BashSession:
         metadata = CmdOutputMetadata()  # No metadata available
         metadata.suffix = (
             f'\n[The command timed out after {timeout} seconds. '
-            "You may wait longer to see additional output by sending empty command '', "
-            'send other commands to interact with the current process, '
-            'send keys to interrupt/kill the command, '
-            'or use a higher timeout parameter in execute_bash for future commands.]'
+            f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="a higher timeout", timeout_action="")}]'
         )
         command_output = self._get_command_output(
             command,

--- a/openhands/runtime/utils/bash_constants.py
+++ b/openhands/runtime/utils/bash_constants.py
@@ -3,5 +3,5 @@ TIMEOUT_MESSAGE_TEMPLATE = (
     "You may wait longer to see additional output by sending empty command '', "
     'send other commands to interact with the current process, '
     'send keys to interrupt/kill the command, '
-    'or use {timeout_param} parameter in execute_bash {timeout_action} for future commands..'
+    'or use {timeout_param} parameter in execute_bash {timeout_action} for future commands.'
 )

--- a/openhands/runtime/utils/bash_constants.py
+++ b/openhands/runtime/utils/bash_constants.py
@@ -1,0 +1,7 @@
+# Common timeout message template that can be used across different timeout scenarios
+TIMEOUT_MESSAGE_TEMPLATE = (
+    "You may wait longer to see additional output by sending empty command '', "
+    'send other commands to interact with the current process, '
+    'send keys to interrupt/kill the command, '
+    'or use {timeout_param} parameter in execute_bash {timeout_action} for future commands..'
+)

--- a/openhands/runtime/utils/bash_constants.py
+++ b/openhands/runtime/utils/bash_constants.py
@@ -1,7 +1,7 @@
-# Common timeout message template that can be used across different timeout scenarios
+# Common timeout message that can be used across different timeout scenarios
 TIMEOUT_MESSAGE_TEMPLATE = (
     "You may wait longer to see additional output by sending empty command '', "
     'send other commands to interact with the current process, '
     'send keys to interrupt/kill the command, '
-    'or use {timeout_param} parameter in execute_bash {timeout_action} for future commands.'
+    'or use the timeout parameter in execute_bash for future commands.'
 )

--- a/openhands/runtime/utils/windows_bash.py
+++ b/openhands/runtime/utils/windows_bash.py
@@ -20,6 +20,7 @@ from openhands.events.observation.commands import (
     CmdOutputMetadata,
     CmdOutputObservation,
 )
+from openhands.runtime.utils.bash_constants import TIMEOUT_MESSAGE_TEMPLATE
 from openhands.utils.shutdown_listener import should_continue
 
 pythonnet.load('coreclr')
@@ -559,9 +560,7 @@ class WindowsPowershellSession:
             else:
                 metadata.suffix = (
                     f'\n[The command timed out after {timeout_seconds} seconds. '
-                    "You may wait longer to see additional output by sending empty command '', "
-                    'send other commands to interact with the current process, '
-                    'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+                    f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
                 )
 
             return CmdOutputObservation(
@@ -1331,9 +1330,7 @@ class WindowsPowershellSession:
             # Align suffix with bash.py timeout message
             suffix = (
                 f'\n[The command timed out after {timeout_seconds} seconds. '
-                "You may wait longer to see additional output by sending empty command '', "
-                'send other commands to interact with the current process, '
-                'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+                f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
             )
         elif shutdown_requested:
             # Align suffix with bash.py equivalent (though bash.py might not have specific shutdown message)

--- a/openhands/runtime/utils/windows_bash.py
+++ b/openhands/runtime/utils/windows_bash.py
@@ -560,7 +560,7 @@ class WindowsPowershellSession:
             else:
                 metadata.suffix = (
                     f'\n[The command timed out after {timeout_seconds} seconds. '
-                    f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+                    f'{TIMEOUT_MESSAGE_TEMPLATE}]'
                 )
 
             return CmdOutputObservation(
@@ -1330,7 +1330,7 @@ class WindowsPowershellSession:
             # Align suffix with bash.py timeout message
             suffix = (
                 f'\n[The command timed out after {timeout_seconds} seconds. '
-                f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+                f'{TIMEOUT_MESSAGE_TEMPLATE}]'
             )
         elif shutdown_requested:
             # Align suffix with bash.py equivalent (though bash.py might not have specific shutdown message)

--- a/openhands/runtime/utils/windows_bash.py
+++ b/openhands/runtime/utils/windows_bash.py
@@ -561,7 +561,7 @@ class WindowsPowershellSession:
                     f'\n[The command timed out after {timeout_seconds} seconds. '
                     "You may wait longer to see additional output by sending empty command '', "
                     'send other commands to interact with the current process, '
-                    'or send keys to interrupt/kill the command.]'
+                    'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
                 )
 
             return CmdOutputObservation(
@@ -1333,7 +1333,7 @@ class WindowsPowershellSession:
                 f'\n[The command timed out after {timeout_seconds} seconds. '
                 "You may wait longer to see additional output by sending empty command '', "
                 'send other commands to interact with the current process, '
-                'or send keys to interrupt/kill the command.]'
+                'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
             )
         elif shutdown_requested:
             # Align suffix with bash.py equivalent (though bash.py might not have specific shutdown message)

--- a/tests/runtime/test_bash.py
+++ b/tests/runtime/test_bash.py
@@ -23,7 +23,7 @@ def get_timeout_suffix(timeout_seconds):
     """Helper function to generate the expected timeout suffix."""
     return (
         f'[The command timed out after {timeout_seconds} seconds. '
-        f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+        f'{TIMEOUT_MESSAGE_TEMPLATE}]'
     )
 
 

--- a/tests/runtime/test_bash.py
+++ b/tests/runtime/test_bash.py
@@ -57,7 +57,7 @@ def test_bash_server(temp_dir, runtime_cls, run_as_openhands):
             assert '[The command timed out after 1.0 seconds.]' in obs.metadata.suffix
         else:
             assert (
-                "[The command timed out after 1.0 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, or send keys to interrupt/kill the command.]"
+                "[The command timed out after 1.0 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]"
                 in obs.metadata.suffix
             )
 

--- a/tests/runtime/test_bash.py
+++ b/tests/runtime/test_bash.py
@@ -16,6 +16,16 @@ from openhands.events.action import CmdRunAction
 from openhands.events.observation import CmdOutputObservation, ErrorObservation
 from openhands.runtime.impl.cli.cli_runtime import CLIRuntime
 from openhands.runtime.impl.local.local_runtime import LocalRuntime
+from openhands.runtime.utils.bash_constants import TIMEOUT_MESSAGE_TEMPLATE
+
+
+def get_timeout_suffix(timeout_seconds):
+    """Helper function to generate the expected timeout suffix."""
+    return (
+        f'[The command timed out after {timeout_seconds} seconds. '
+        f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+    )
+
 
 # ============================================================================================================================
 # Bash-specific tests
@@ -56,10 +66,7 @@ def test_bash_server(temp_dir, runtime_cls, run_as_openhands):
         if runtime_cls == CLIRuntime:
             assert '[The command timed out after 1.0 seconds.]' in obs.metadata.suffix
         else:
-            assert (
-                "[The command timed out after 1.0 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]"
-                in obs.metadata.suffix
-            )
+            assert get_timeout_suffix(1.0) in obs.metadata.suffix
 
         action = CmdRunAction(command='C-c', is_input=True)
         action.set_hard_timeout(30)

--- a/tests/runtime/trajs/basic_gui_mode.json
+++ b/tests/runtime/trajs/basic_gui_mode.json
@@ -589,7 +589,7 @@
         "working_dir": null,
         "py_interpreter_path": null,
         "prefix": "",
-        "suffix": "\n[The command has no new output after 30 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, or send keys to interrupt/kill the command.]"
+        "suffix": "\n[The command has no new output after 30 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]"
       },
       "hidden": false
     },

--- a/tests/runtime/trajs/basic_gui_mode.json
+++ b/tests/runtime/trajs/basic_gui_mode.json
@@ -589,7 +589,7 @@
         "working_dir": null,
         "py_interpreter_path": null,
         "prefix": "",
-        "suffix": "\n[The command has no new output after 30 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]"
+        "suffix": "\n[The command has no new output after 30 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash for future commands.]"
       },
       "hidden": false
     },

--- a/tests/unit/test_bash_session.py
+++ b/tests/unit/test_bash_session.py
@@ -5,6 +5,15 @@ import time
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import CmdRunAction
 from openhands.runtime.utils.bash import BashCommandStatus, BashSession
+from openhands.runtime.utils.bash_constants import TIMEOUT_MESSAGE_TEMPLATE
+
+
+def get_no_change_timeout_suffix(timeout_seconds):
+    """Helper function to generate the expected no-change timeout suffix."""
+    return (
+        f'\n[The command has no new output after {timeout_seconds} seconds. '
+        f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+    )
 
 
 def test_session_initialization():

--- a/tests/unit/test_bash_session.py
+++ b/tests/unit/test_bash_session.py
@@ -12,7 +12,7 @@ def get_no_change_timeout_suffix(timeout_seconds):
     """Helper function to generate the expected no-change timeout suffix."""
     return (
         f'\n[The command has no new output after {timeout_seconds} seconds. '
-        f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+        f'{TIMEOUT_MESSAGE_TEMPLATE}]'
     )
 
 
@@ -92,12 +92,7 @@ def test_long_running_command_follow_by_execute():
     assert '1' in obs.content  # First number should appear before timeout
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
-    assert obs.metadata.suffix == (
-        '\n[The command has no new output after 2 seconds. '
-        "You may wait longer to see additional output by sending empty command '', "
-        'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
-    )
+    assert obs.metadata.suffix == get_no_change_timeout_suffix(2)
     assert obs.metadata.prefix == ''
 
     # Continue watching output
@@ -105,12 +100,7 @@ def test_long_running_command_follow_by_execute():
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
     assert '2' in obs.content
     assert obs.metadata.prefix == '[Below is the output of the previous command.]\n'
-    assert obs.metadata.suffix == (
-        '\n[The command has no new output after 2 seconds. '
-        "You may wait longer to see additional output by sending empty command '', "
-        'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
-    )
+    assert obs.metadata.suffix == get_no_change_timeout_suffix(2)
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
 
@@ -151,12 +141,7 @@ def test_interactive_command():
     assert 'Enter name:' in obs.content
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
-    assert obs.metadata.suffix == (
-        '\n[The command has no new output after 3 seconds. '
-        "You may wait longer to see additional output by sending empty command '', "
-        'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
-    )
+    assert obs.metadata.suffix == get_no_change_timeout_suffix(3)
     assert obs.metadata.prefix == ''
 
     # Send input
@@ -185,25 +170,14 @@ def test_interactive_command():
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
     assert obs.metadata.exit_code == -1
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
-    assert obs.metadata.suffix == (
-        '\n[The command has no new output after 3 seconds. '
-        "You may wait longer to see additional output by sending empty command '', "
-        'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
-    )
+    assert obs.metadata.suffix == get_no_change_timeout_suffix(3)
     assert obs.metadata.prefix == '[Below is the output of the previous command.]\n'
 
     obs = session.execute(CmdRunAction('line 2', is_input=True))
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
     assert obs.metadata.exit_code == -1
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
-    assert obs.metadata.suffix == (
-        '\n[The command has no new output after 3 seconds. '
-        "You may wait longer to see additional output by sending empty command '', "
-        'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, '
-        'or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
-    )
+    assert obs.metadata.suffix == get_no_change_timeout_suffix(3)
     assert obs.metadata.prefix == '[Below is the output of the previous command.]\n'
 
     obs = session.execute(CmdRunAction('EOF', is_input=True))
@@ -226,12 +200,7 @@ def test_ctrl_c():
     )
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
     assert 'looping' in obs.content
-    assert obs.metadata.suffix == (
-        '\n[The command has no new output after 2 seconds. '
-        "You may wait longer to see additional output by sending empty command '', "
-        'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
-    )
+    assert obs.metadata.suffix == get_no_change_timeout_suffix(2)
     assert obs.metadata.prefix == ''
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT

--- a/tests/unit/test_bash_session.py
+++ b/tests/unit/test_bash_session.py
@@ -96,7 +96,7 @@ def test_long_running_command_follow_by_execute():
         '\n[The command has no new output after 2 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
     )
     assert obs.metadata.prefix == ''
 
@@ -109,7 +109,7 @@ def test_long_running_command_follow_by_execute():
         '\n[The command has no new output after 2 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
     )
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
@@ -155,7 +155,7 @@ def test_interactive_command():
         '\n[The command has no new output after 3 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
     )
     assert obs.metadata.prefix == ''
 
@@ -177,7 +177,7 @@ def test_interactive_command():
         '\n[The command has no new output after 3 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
     )
     assert obs.metadata.prefix == ''
 
@@ -189,7 +189,7 @@ def test_interactive_command():
         '\n[The command has no new output after 3 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
     )
     assert obs.metadata.prefix == '[Below is the output of the previous command.]\n'
 
@@ -230,7 +230,7 @@ def test_ctrl_c():
         '\n[The command has no new output after 2 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
     )
     assert obs.metadata.prefix == ''
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running

--- a/tests/unit/test_bash_session.py
+++ b/tests/unit/test_bash_session.py
@@ -87,7 +87,7 @@ def test_long_running_command_follow_by_execute():
         '\n[The command has no new output after 2 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'or send keys to interrupt/kill the command.]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
     )
     assert obs.metadata.prefix == ''
 
@@ -100,7 +100,7 @@ def test_long_running_command_follow_by_execute():
         '\n[The command has no new output after 2 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'or send keys to interrupt/kill the command.]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
     )
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
@@ -146,7 +146,7 @@ def test_interactive_command():
         '\n[The command has no new output after 3 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'or send keys to interrupt/kill the command.]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
     )
     assert obs.metadata.prefix == ''
 
@@ -168,7 +168,7 @@ def test_interactive_command():
         '\n[The command has no new output after 3 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'or send keys to interrupt/kill the command.]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
     )
     assert obs.metadata.prefix == ''
 
@@ -180,7 +180,7 @@ def test_interactive_command():
         '\n[The command has no new output after 3 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'or send keys to interrupt/kill the command.]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
     )
     assert obs.metadata.prefix == '[Below is the output of the previous command.]\n'
 
@@ -192,7 +192,8 @@ def test_interactive_command():
         '\n[The command has no new output after 3 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'or send keys to interrupt/kill the command.]'
+        'send keys to interrupt/kill the command, '
+        'or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
     )
     assert obs.metadata.prefix == '[Below is the output of the previous command.]\n'
 
@@ -220,7 +221,7 @@ def test_ctrl_c():
         '\n[The command has no new output after 2 seconds. '
         "You may wait longer to see additional output by sending empty command '', "
         'send other commands to interact with the current process, '
-        'or send keys to interrupt/kill the command.]'
+        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]'
     )
     assert obs.metadata.prefix == ''
     assert obs.metadata.exit_code == -1  # -1 indicates command is still running

--- a/tests/unit/test_bash_session.py
+++ b/tests/unit/test_bash_session.py
@@ -158,12 +158,7 @@ def test_interactive_command():
     logger.info(obs, extra={'msg_type': 'OBSERVATION'})
     assert obs.metadata.exit_code == -1
     assert session.prev_status == BashCommandStatus.NO_CHANGE_TIMEOUT
-    assert obs.metadata.suffix == (
-        '\n[The command has no new output after 3 seconds. '
-        "You may wait longer to see additional output by sending empty command '', "
-        'send other commands to interact with the current process, '
-        'send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands.]'
-    )
+    assert obs.metadata.suffix == get_no_change_timeout_suffix(3)
     assert obs.metadata.prefix == ''
 
     obs = session.execute(CmdRunAction('line 1', is_input=True))

--- a/tests/unit/test_windows_bash.py
+++ b/tests/unit/test_windows_bash.py
@@ -12,6 +12,16 @@ from openhands.events.observation import ErrorObservation
 from openhands.events.observation.commands import (
     CmdOutputObservation,
 )
+from openhands.runtime.utils.bash_constants import TIMEOUT_MESSAGE_TEMPLATE
+
+
+def get_timeout_suffix(timeout_seconds):
+    """Helper function to generate the expected timeout suffix."""
+    return (
+        f'[The command timed out after {timeout_seconds} seconds. '
+        f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+    )
+
 
 # Skip all tests in this module if not running on Windows
 pytestmark = pytest.mark.skipif(
@@ -168,10 +178,7 @@ def test_long_running_command(windows_bash_session):
     # Verify the initial output was captured
     assert 'Serving HTTP on' in result.content
     # Check for timeout specific metadata
-    assert (
-        "[The command timed out after 1.0 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]"
-        in result.metadata.suffix
-    )
+    assert get_timeout_suffix(1.0) in result.metadata.suffix
     assert result.exit_code == -1
 
     # The action timed out, but the command should be still running

--- a/tests/unit/test_windows_bash.py
+++ b/tests/unit/test_windows_bash.py
@@ -169,7 +169,7 @@ def test_long_running_command(windows_bash_session):
     assert 'Serving HTTP on' in result.content
     # Check for timeout specific metadata
     assert (
-        "[The command timed out after 1.0 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, or send keys to interrupt/kill the command.]"
+        "[The command timed out after 1.0 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash to set a longer timeout for future commands..]"
         in result.metadata.suffix
     )
     assert result.exit_code == -1

--- a/tests/unit/test_windows_bash.py
+++ b/tests/unit/test_windows_bash.py
@@ -19,7 +19,7 @@ def get_timeout_suffix(timeout_seconds):
     """Helper function to generate the expected timeout suffix."""
     return (
         f'[The command timed out after {timeout_seconds} seconds. '
-        f'{TIMEOUT_MESSAGE_TEMPLATE.format(timeout_param="the timeout", timeout_action="to set a longer timeout")}]'
+        f'{TIMEOUT_MESSAGE_TEMPLATE}]'
     )
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4e7638e-nikolaik   --name openhands-app-4e7638e   docker.all-hands.dev/all-hands-ai/openhands:4e7638e
```