### PR TITLE
Suppress pydub warning about ffmpeg/avconv not found

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -50,6 +50,9 @@ from openhands.core.setup import (
     generate_sid,
     initialize_repository_for_runtime,
 )
+
+# Import warnings filter to suppress common warnings
+from openhands.core.warnings_filter import warnings  # noqa
 from openhands.events import EventSource, EventStreamSubscriber
 from openhands.events.action import (
     ChangeAgentStateAction,

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -25,6 +25,9 @@ from openhands.core.setup import (
     generate_sid,
     initialize_repository_for_runtime,
 )
+
+# Import warnings filter to suppress common warnings
+from openhands.core.warnings_filter import warnings  # noqa
 from openhands.events import EventSource, EventStreamSubscriber
 from openhands.events.action import MessageAction, NullAction
 from openhands.events.action.action import Action

--- a/openhands/core/warnings_filter.py
+++ b/openhands/core/warnings_filter.py
@@ -1,0 +1,10 @@
+"""Module to filter out common warnings."""
+
+import warnings
+
+# Suppress pydub warning about ffmpeg or avconv
+warnings.filterwarnings(
+    'ignore',
+    message="Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work",
+    category=RuntimeWarning,
+)


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
This change suppresses the warning message about ffmpeg or avconv not being found when using pydub. This warning was appearing frequently but doesn't affect functionality since pydub defaults to ffmpeg anyway.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This PR adds a centralized warnings filter module that suppresses the pydub warning about ffmpeg/avconv not being found. The approach:

1. Creates a new module `openhands/core/warnings_filter.py` that filters out the specific warning from pydub
2. Modifies the main entry points (`openhands/cli/main.py` and `openhands/core/main.py`) to import this module early in the startup process

This approach has several advantages:
- It's centralized - all warning filters can be managed in one place
- It's reusable - any module that needs to suppress this warning can import it
- It's maintainable - if we need to add more warning filters in the future, we can add them to this module

---
**Link of any specific issues this addresses:**
N/A