### PR TITLE
[Fix]: make sure to track opened PRs using Git MCP

### DIFF
--- a/openhands/mcp/client.py
+++ b/openhands/mcp/client.py
@@ -73,7 +73,7 @@ class MCPClient(BaseModel):
             )
 
             if conversation_id:
-                headers['X-OpenHands-Conversation-ID'] = conversation_id
+                headers['X-OpenHands-ServerConversation-ID'] = conversation_id
 
             # Instantiate custom transports due to custom headers
             if isinstance(server, MCPSHTTPServerConfig):

--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -72,6 +72,8 @@ async def save_pr_metadata(
     if pr_number:
         logger.info(f'Saving PR number: {pr_number} for convo {conversation_id}')
         conversation.pr_number.append(pr_number)
+    else:
+        logger.warning(f'Failed to extract PR number for convo {conversation_id}')
 
     await conversation_store.save_metadata(conversation)
 

--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -70,6 +70,7 @@ async def save_pr_metadata(
         pr_number = int(match_merge_request.group(1))
 
     if pr_number:
+        logger.info(f'Saving PR number: {pr_number} for convo {conversation_id}')
         conversation.pr_number.append(pr_number)
 
     await conversation_store.save_metadata(conversation)

--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -49,7 +49,7 @@ async def get_convo_link(service: GitService, conversation_id: str, body: str) -
 
 
 async def save_pr_metadata(
-    user_id: str, conversation_id: str, tool_result: str
+    user_id: str | None, conversation_id: str, tool_result: str
 ) -> None:
     conversation_store = await ConversationStoreImpl.get_instance(config, user_id)
     conversation: ConversationMetadata = await conversation_store.get_metadata(
@@ -71,6 +71,7 @@ async def save_pr_metadata(
 
     if pr_number:
         conversation.pr_number.append(pr_number)
+
     await conversation_store.save_metadata(conversation)
 
 
@@ -124,7 +125,7 @@ async def create_pr(
             body=body,
         )
 
-        if conversation_id and user_id:
+        if conversation_id:
             await save_pr_metadata(user_id, conversation_id, response)
 
     except Exception as e:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- PRs opened by agent is properly tracked in conversation metadata

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

There are two fixes here

1. User ID is `None` on OSS, which prevents tracking opened PRs in convo metadata; we've made user_id optional now
2. The header attribute was mismatched between the mcp client and server for the conversation id, which is also fixed now

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:bb440f3-nikolaik   --name openhands-app-bb440f3   docker.all-hands.dev/all-hands-ai/openhands:bb440f3
```