### PR TITLE
feat(chat): show message timestamp

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -8,15 +8,18 @@ import { CopyToClipboardButton } from "#/components/shared/buttons/copy-to-clipb
 import { anchor } from "../markdown/anchor";
 import { OpenHandsSourceType } from "#/types/core/base";
 import { paragraph } from "../markdown/paragraph";
+import { useRelativeDateFormatter } from "#/hooks/query/use-relative-date-formatter";
 
 interface ChatMessageProps {
   type: OpenHandsSourceType;
   message: string;
+  timestamp: string;
 }
 
 export function ChatMessage({
   type,
   message,
+  timestamp,
   children,
 }: React.PropsWithChildren<ChatMessageProps>) {
   const [isHovering, setIsHovering] = React.useState(false);
@@ -26,6 +29,8 @@ export function ChatMessage({
     await navigator.clipboard.writeText(message);
     setIsCopy(true);
   };
+
+  const dateFormatter = useRelativeDateFormatter();
 
   React.useEffect(() => {
     let timeout: NodeJS.Timeout;
@@ -53,6 +58,9 @@ export function ChatMessage({
         type === "agent" && "mt-6 max-w-full bg-transparent",
       )}
     >
+      <span className="text-gray-400 font-light text-sm italic">
+        {dateFormatter(timestamp)}
+      </span>
       <CopyToClipboardButton
         isHidden={!isHovering}
         isDisabled={isCopy}

--- a/frontend/src/components/features/chat/event-message.tsx
+++ b/frontend/src/components/features/chat/event-message.tsx
@@ -50,14 +50,24 @@ export function EventMessage({
 
   if (hasObservationPair && isOpenHandsAction(event)) {
     if (hasThoughtProperty(event.args)) {
-      return <ChatMessage type="agent" message={event.args.thought} />;
+      return (
+        <ChatMessage
+          type="agent"
+          message={event.args.thought}
+          timestamp={event.timestamp}
+        />
+      );
     }
     return null;
   }
 
   if (isFinishAction(event)) {
     return (
-      <ChatMessage type="agent" message={getEventContent(event).details} />
+      <ChatMessage
+        type="agent"
+        message={getEventContent(event).details}
+        timestamp={event.timestamp}
+      />
     );
   }
 
@@ -65,6 +75,7 @@ export function EventMessage({
     return (
       <ChatMessage
         type={event.source}
+        timestamp={event.timestamp}
         message={isUserMessage(event) ? event.args.content : event.message}
       >
         {event.args.image_urls && event.args.image_urls.length > 0 && (
@@ -76,12 +87,19 @@ export function EventMessage({
   }
 
   if (isRejectObservation(event)) {
-    return <ChatMessage type="agent" message={event.content} />;
+    return (
+      <ChatMessage
+        type="agent"
+        message={event.content}
+        timestamp={event.timestamp}
+      />
+    );
   }
 
   if (isMcpObservation(event)) {
     return (
       <div>
+        {event.timestamp}
         <GenericEventMessage
           title={getEventContent(event).title}
           details={<MCPObservationContent event={event} />}
@@ -95,7 +113,11 @@ export function EventMessage({
   return (
     <div>
       {isOpenHandsAction(event) && hasThoughtProperty(event.args) && (
-        <ChatMessage type="agent" message={event.args.thought} />
+        <ChatMessage
+          type="agent"
+          message={event.args.thought}
+          timestamp={event.timestamp}
+        />
       )}
 
       <GenericEventMessage

--- a/frontend/src/hooks/query/use-localized-date-formatter.ts
+++ b/frontend/src/hooks/query/use-localized-date-formatter.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+type LocalizedFormatter = (date: string | Date) => string;
+
+export function useLocalizedDateFormatter(
+  formatType?: "date" | "time",
+): LocalizedFormatter {
+  const { i18n } = useTranslation();
+
+  const formatterOptions: Intl.DateTimeFormatOptions =
+    formatType === "time"
+      ? {
+          hour: "2-digit",
+          minute: "2-digit",
+        }
+      : {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        };
+
+  const formatter = useMemo(
+    () => new Intl.DateTimeFormat(i18n.language, formatterOptions),
+    [i18n.language],
+  );
+
+  const wrappedFormatter = useCallback(
+    (value: string | Date) =>
+      formatter.format(typeof value === "string" ? new Date(value) : value),
+    [formatter],
+  );
+
+  return wrappedFormatter;
+}

--- a/frontend/src/hooks/query/use-relative-date-formatter.ts
+++ b/frontend/src/hooks/query/use-relative-date-formatter.ts
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+import { useLocalizedDateFormatter } from "./use-localized-date-formatter";
+
+type RelativeFormatter = (date: string | Date) => string;
+
+export function useRelativeDateFormatter(): RelativeFormatter {
+  const dateFormatter = useLocalizedDateFormatter("date");
+  const timeFormatter = useLocalizedDateFormatter("time");
+
+  const formatter = useCallback((value: string | Date) => {
+    const now = new Date();
+    const date = typeof value === "string" ? new Date(value) : value;
+    const isToday =
+      date.getFullYear() === now.getFullYear() &&
+      date.getMonth() === now.getMonth() &&
+      date.getDate() === now.getDate();
+    return isToday ? timeFormatter(date) : dateFormatter(date);
+  }, []);
+
+  return formatter;
+}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This PR creates 2 hooks. 
1. use-localized-date-formatter - idea is to use locale from our react i18n instance to find how the date should by formatted. Additionally, it accepts formatType which allows you to pick between only showing hh:mm and showing the full date (hours included). 
2. use-relative-date-formatter - utilize 1. hook to provide flexible way to render dates in UI. If the date is today - this hook will pick formatType which shows only hh:mm, otherwise it picks full dat formatter.

Example are in the images below:
![today](https://github.com/user-attachments/assets/82c8fc8b-b339-4303-8e4a-54060ca69daa)
![old](https://github.com/user-attachments/assets/6649c3b2-a092-4ab9-b44a-fdfe8b9a770e)
![localized](https://github.com/user-attachments/assets/20ef4195-1012-4243-9672-d560071c8265)


---
**Link of any specific issues this addresses:**
