### PR TITLE
Migrate to modern logger interface in server utils

### DIFF
--- a/openhands/server/utils.py
+++ b/openhands/server/utils.py
@@ -26,7 +26,7 @@ async def get_conversation(
         conversation_id, user_id
     )
     if not conversation:
-        logger.warn(
+        logger.warning(
             f'get_conversation: conversation {conversation_id} not found, attach_to_conversation returned None',
             extra={'session_id': conversation_id, 'user_id': user_id},
         )


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
Please note that we addressed these issues previously in PR #8432, but PR #8936 introduced another instance. It would be helpful to document this tip somewhere to avoid reintroducing deprecated methods into the codebase.