### PR TITLE
Update CLI mode documentation to recommend pip install

### DIFF
--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -9,15 +9,28 @@ This mode is different from the [headless mode](./headless-mode), which is non-i
 
 ### Running with Python
 
-1. Ensure you have followed the [Development setup instructions](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+1. Install OpenHands using pip:
+
+```bash
+pip install openhands-ai
+```
+
 2. Set your model, API key, and other preferences using environment variables or with the [`config.toml`](https://github.com/All-Hands-AI/OpenHands/blob/main/config.template.toml) file.
 3. Launch an interactive OpenHands conversation from the command line:
 
 ```bash
-poetry run python -m openhands.cli.main
+openhands
 ```
 
 This command opens an interactive prompt where you can type tasks or commands and get responses from OpenHands.
+
+#### For Developers
+
+If you're developing OpenHands and have cloned the repository, you can run the CLI directly using Poetry:
+
+```bash
+poetry run python -m openhands.cli.main
+```
 
 ### Running with Docker
 


### PR DESCRIPTION
This PR updates the CLI mode documentation to recommend using `pip install openhands-ai` as the primary installation method for CLI mode, rather than using Poetry.

The CLI can be most easily installed using `pip install openhands-ai`, and the documentation has been updated to reflect this. The previous Poetry-based installation instructions have been moved to a "For Developers" section.

Fixes #8966

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/{})