### PR TITLE
feat: increase requests timeout to 60s

### DIFF
--- a/openhands/runtime/utils/request.py
+++ b/openhands/runtime/utils/request.py
@@ -38,7 +38,7 @@ def send_request(
     session: HttpSession,
     method: str,
     url: str,
-    timeout: int = 10,
+    timeout: int = 60,
     **kwargs: Any,
 ) -> httpx.Response:
     response = session.request(method, url, timeout=timeout, **kwargs)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Reduces timeout errors during runtime download or git clone by increasing the default request timeout from 10s to 60s.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Increases the default timeout in send_request from 10 to 60 seconds.

---
**Link of any specific issues this addresses:**
