### PR TITLE
Add /conversation/{conv_id}/microagents endpoint

### DIFF
--- a/tests/unit/test_conversation_routes.py
+++ b/tests/unit/test_conversation_routes.py
@@ -1,0 +1,136 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import JSONResponse
+
+from openhands.microagent.microagent import KnowledgeMicroagent, RepoMicroagent
+from openhands.microagent.types import MicroagentMetadata, MicroagentType
+from openhands.server.routes.conversation import get_microagents
+from openhands.server.session.conversation import ServerConversation
+
+
+@pytest.mark.asyncio
+async def test_get_microagents():
+    """Test the get_microagents function directly."""
+    # Create mock microagents
+    repo_microagent = RepoMicroagent(
+        name='test_repo',
+        content='This is a test repo microagent',
+        metadata=MicroagentMetadata(
+            name='test_repo', type=MicroagentType.REPO_KNOWLEDGE
+        ),
+        source='test_source',
+        type=MicroagentType.REPO_KNOWLEDGE,
+    )
+
+    knowledge_microagent = KnowledgeMicroagent(
+        name='test_knowledge',
+        content='This is a test knowledge microagent',
+        metadata=MicroagentMetadata(
+            name='test_knowledge',
+            type=MicroagentType.KNOWLEDGE,
+            triggers=['test', 'knowledge'],
+        ),
+        source='test_source',
+        type=MicroagentType.KNOWLEDGE,
+    )
+
+    # Mock the agent session and memory
+    mock_memory = MagicMock()
+    mock_memory.repo_microagents = {'test_repo': repo_microagent}
+    mock_memory.knowledge_microagents = {'test_knowledge': knowledge_microagent}
+
+    mock_agent_session = MagicMock()
+    mock_agent_session.memory = mock_memory
+
+    # Create a mock ServerConversation
+    mock_conversation = MagicMock(spec=ServerConversation)
+    mock_conversation.sid = 'test_sid'
+
+    # Mock the conversation manager
+    with patch(
+        'openhands.server.routes.conversation.conversation_manager'
+    ) as mock_manager:
+        # Set up the mocks
+        mock_manager.get_agent_session.return_value = mock_agent_session
+
+        # Call the function directly
+        response = await get_microagents(conversation=mock_conversation)
+
+        # Verify the response
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 200
+
+        # Parse the JSON content
+        content = json.loads(response.body)
+        assert 'microagents' in content
+        assert len(content['microagents']) == 2
+
+        # Check repo microagent
+        repo_agent = next(m for m in content['microagents'] if m['name'] == 'test_repo')
+        assert repo_agent['type'] == 'repo'
+        assert repo_agent['content'] == 'This is a test repo microagent'
+        assert repo_agent['triggers'] == []
+
+        # Check knowledge microagent
+        knowledge_agent = next(
+            m for m in content['microagents'] if m['name'] == 'test_knowledge'
+        )
+        assert knowledge_agent['type'] == 'knowledge'
+        assert knowledge_agent['content'] == 'This is a test knowledge microagent'
+        assert knowledge_agent['triggers'] == ['test', 'knowledge']
+
+
+@pytest.mark.asyncio
+async def test_get_microagents_no_agent_session():
+    """Test the get_microagents function when no agent session is found."""
+    # Create a mock ServerConversation
+    mock_conversation = MagicMock(spec=ServerConversation)
+    mock_conversation.sid = 'test_sid'
+
+    # Mock the conversation manager
+    with patch(
+        'openhands.server.routes.conversation.conversation_manager'
+    ) as mock_manager:
+        # Set up the mocks
+        mock_manager.get_agent_session.return_value = None
+
+        # Call the function directly
+        response = await get_microagents(conversation=mock_conversation)
+
+        # Verify the response
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 404
+
+        # Parse the JSON content
+        content = json.loads(response.body)
+        assert 'error' in content
+        assert 'Agent session not found' in content['error']
+
+
+@pytest.mark.asyncio
+async def test_get_microagents_exception():
+    """Test the get_microagents function when an exception occurs."""
+    # Create a mock ServerConversation
+    mock_conversation = MagicMock(spec=ServerConversation)
+    mock_conversation.sid = 'test_sid'
+
+    # Mock the conversation manager
+    with patch(
+        'openhands.server.routes.conversation.conversation_manager'
+    ) as mock_manager:
+        # Set up the mocks to raise an exception
+        mock_manager.get_agent_session.side_effect = Exception('Test exception')
+
+        # Call the function directly
+        response = await get_microagents(conversation=mock_conversation)
+
+        # Verify the response
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 500
+
+        # Parse the JSON content
+        content = json.loads(response.body)
+        assert 'error' in content
+        assert 'Test exception' in content['error']


### PR DESCRIPTION
This PR adds a new endpoint `/conversation/{conv_id}/microagents` that returns all microagents (both repository and knowledge types) associated with a conversation.

The endpoint returns a JSON response with the following structure:
```json
{
  "microagents": [
    {
      "name": "microagent_name",
      "type": "repo|knowledge",
      "content": "microagent content",
      "triggers": ["trigger1", "trigger2"] // only for knowledge microagents
    }
  ]
}
```

This PR includes:
1. Implementation of the endpoint in `openhands/server/routes/conversation.py`
2. Unit tests for the endpoint in `tests/unit/test_conversation_routes.py`

Fixes #8982

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/{})

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:16ed830-nikolaik   --name openhands-app-16ed830   docker.all-hands.dev/all-hands-ai/openhands:16ed830
```