### PR TITLE
Add CLI option to bug template installation dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -33,6 +33,7 @@ body:
         - Docker command in README
         - GitHub resolver
         - Development workflow
+        - CLI
         - app.all-hands.dev
         - Other
       default: 0


### PR DESCRIPTION
This PR adds the CLI option to the installation dropdown in the bug report template.

The issue was that the bug template didn't mention CLI as a way of running OpenHands, even though CLI support has been added to the project.

This PR adds "CLI" as an option in the dropdown list of installation methods in the bug template.

Fixes #9000

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/{})

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:149ce12-nikolaik   --name openhands-app-149ce12   docker.all-hands.dev/all-hands-ai/openhands:149ce12
```