### PR TITLE
Converted exponential backoff to fixed

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -406,7 +406,7 @@ class LocalRuntime(ActionExecutionClient):
         return port
 
     @tenacity.retry(
-        wait=tenacity.wait_exponential(min=1, max=10),
+        wait=tenacity.wait_fixed(2),
         stop=tenacity.stop_after_attempt(10) | stop_if_should_exit(),
         before_sleep=lambda retry_state: logger.debug(
             f'Waiting for server to be ready... (attempt {retry_state.attempt_number})'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Converted the exponential backoff to a fixed backoff.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This aligns with the other runtime implementations (e.g.: DockerRuntime, RemoteRuntime).

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2a11c30-nikolaik   --name openhands-app-2a11c30   docker.all-hands.dev/all-hands-ai/openhands:2a11c30
```