### PR TITLE
[Docs]: add info about lower scope tokens for gitlab

### DIFF
--- a/docs/usage/cloud/gitlab-installation.mdx
+++ b/docs/usage/cloud/gitlab-installation.mdx
@@ -19,6 +19,12 @@ appropriate repository and branch you'd like OpenHands to work on. Then click on
 
 ![Connect Repo](/static/img/connect-repo.png)
 
+## Using Tokens with Reduced Scopes
+
+OpenHands requests an API-scoped token during OAuth authentication. By default, this token is provided to the agent.
+To restrict the agent's permissions, you can define a custom GITLAB_TOKEN in the secrets, which will override the default token assigned to the agent.
+While the high-permission API token is still requested and used for other components of the application (e.g. opening merge requests), the agent will not have access to it.
+
 ## Next Steps
 
 - [Learn about the Cloud UI](/usage/cloud/cloud-ui).


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Ability to provide two tokens (with/without API scope). API Scope token will be used by OpenHands application while the token without API scope is used by the agent.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


This PR adds information about how we can reduce the number of permissions that agent gets access to, by allowing users to pass two types of tokens.

---
**Link of any specific issues this addresses:**
