### PR TITLE
Move get_agent_obs_text function to browser utils and add return_all option

### DIFF
--- a/openhands/events/action/browse.py
+++ b/openhands/events/action/browse.py
@@ -10,6 +10,7 @@ class BrowseURLAction(Action):
     url: str
     thought: str = ''
     action: str = ActionType.BROWSE
+    return_all: bool = False
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
 
@@ -31,6 +32,7 @@ class BrowseInteractiveAction(Action):
     thought: str = ''
     browsergym_send_msg_to_user: str = ''
     action: str = ActionType.BROWSE_INTERACTIVE
+    return_all: bool = False
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
 

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -391,7 +391,9 @@ class ConversationMemory:
                 role='user', content=[TextContent(text=obs.content)]
             )  # Content is already truncated by openhands-aci
         elif isinstance(obs, BrowserOutputObservation):
-            text = obs.get_agent_obs_text()
+            from openhands.runtime.browser.utils import get_agent_obs_text
+
+            text = get_agent_obs_text(obs)
             if (
                 obs.trigger_by_action == ActionType.BROWSE_INTERACTIVE
                 and enable_som_visual_browsing


### PR DESCRIPTION
## Description
This PR moves the `get_agent_obs_text` function from `openhands/events/observation/browse.py` to `openhands/runtime/browser/utils.py` as requested. This change helps consolidate browser-related functionality in a more appropriate location.

Additionally, it adds a new `return_all` field (defaulting to `false`) to both `BrowseURLAction` and `BrowseInteractiveAction` classes. When this field is set to `false`, the browser observation's content is set to the result of `get_agent_obs_text`. When set to `true`, the current implementation remains unchanged.

## Changes
- Moved `get_agent_obs_text` function to `openhands/runtime/browser/utils.py`
- Added `return_all` field to `BrowseURLAction` and `BrowseInteractiveAction` classes
- Updated the `browse` function in `utils.py` to use the `return_all` field
- Fixed circular import issues by using local imports where necessary
- Updated `conversation_memory.py` to use the imported function

## Testing
The changes have been tested by running the pre-commit hooks, which include mypy type checking to ensure type safety.

## Related Issues
This PR addresses the issue where the default agent needs the accessibility tree when converting a browser observation to text.

## Additional Notes
This change allows for more flexibility in how browser observations are processed, making it easier to pre-process the data in the action execution server before sending it back to the agent.