### PR TITLE
Add gray circle background to pause button for better visibility

### DIFF
--- a/frontend/src/assets/pause.tsx
+++ b/frontend/src/assets/pause.tsx
@@ -6,14 +6,18 @@ function PauseIcon() {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-      className="w-5 h-5"
+      className="w-5 h-5 relative"
     >
+      {/* Gray circle background */}
+      <circle cx="12" cy="12" r="10" fill="#E5E7EB" />
+      
+      {/* Pause icon lines */}
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
         d="M15.75 5.25v13.5m-7.5-13.5v13.5"
+        strokeWidth={1.5}
+        stroke="currentColor"
       />
     </svg>
   );


### PR DESCRIPTION
This PR improves the visibility of the pause button by adding a gray circle background to it.

## Changes
- Modified the PauseIcon component to include a gray circle background (#E5E7EB)
- Kept the original pause icon lines on top of the background

## Why
The pause button was difficult to see, and this change makes it more visible to users.

## Screenshots
Before: The pause button was just two vertical lines with no background.
After: The pause button now has a gray circle background, making it more visible and easier to click.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9da8ae8-nikolaik   --name openhands-app-9da8ae8   docker.all-hands.dev/all-hands-ai/openhands:9da8ae8
```