### PR TITLE
Condensation request signal in event stream

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 import openhands.agenthub.codeact_agent.function_calling as codeact_function_calling
 from openhands.agenthub.codeact_agent.tools.bash import create_cmd_run_tool
 from openhands.agenthub.codeact_agent.tools.browser import BrowserTool
+from openhands.agenthub.codeact_agent.tools.condensation_request import (
+    CondensationRequestTool,
+)
 from openhands.agenthub.codeact_agent.tools.finish import FinishTool
 from openhands.agenthub.codeact_agent.tools.ipython import IPythonTool
 from openhands.agenthub.codeact_agent.tools.llm_based_edit import LLMBasedFileEditTool
@@ -118,6 +121,8 @@ class CodeActAgent(Agent):
             tools.append(ThinkTool)
         if self.config.enable_finish:
             tools.append(FinishTool)
+        if self.config.enable_condensation_request:
+            tools.append(CondensationRequestTool)
         if self.config.enable_browsing:
             if sys.platform == 'win32':
                 logger.warning('Windows runtime does not support browsing yet')

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -11,6 +11,7 @@ from litellm import (
 
 from openhands.agenthub.codeact_agent.tools import (
     BrowserTool,
+    CondensationRequestTool,
     FinishTool,
     IPythonTool,
     LLMBasedFileEditTool,
@@ -35,6 +36,7 @@ from openhands.events.action import (
     IPythonRunCellAction,
     MessageAction,
 )
+from openhands.events.action.agent import CondensationRequestAction
 from openhands.events.action.mcp import MCPAction
 from openhands.events.event import FileEditSource, FileReadSource
 from openhands.events.tool import ToolCallMetadata
@@ -202,6 +204,12 @@ def response_to_actions(
             # ================================================
             elif tool_call.function.name == ThinkTool['function']['name']:
                 action = AgentThinkAction(thought=arguments.get('thought', ''))
+
+            # ================================================
+            # CondensationRequestAction
+            # ================================================
+            elif tool_call.function.name == CondensationRequestTool['function']['name']:
+                action = CondensationRequestAction()
 
             # ================================================
             # BrowserTool

--- a/openhands/agenthub/codeact_agent/tools/__init__.py
+++ b/openhands/agenthub/codeact_agent/tools/__init__.py
@@ -1,5 +1,6 @@
 from .bash import create_cmd_run_tool
 from .browser import BrowserTool
+from .condensation_request import CondensationRequestTool
 from .finish import FinishTool
 from .ipython import IPythonTool
 from .llm_based_edit import LLMBasedFileEditTool
@@ -8,6 +9,7 @@ from .think import ThinkTool
 
 __all__ = [
     'BrowserTool',
+    'CondensationRequestTool',
     'create_cmd_run_tool',
     'FinishTool',
     'IPythonTool',

--- a/openhands/agenthub/codeact_agent/tools/condensation_request.py
+++ b/openhands/agenthub/codeact_agent/tools/condensation_request.py
@@ -1,0 +1,23 @@
+from litellm import ChatCompletionToolParam, ChatCompletionToolParamFunctionChunk
+
+_CONDENSATION_REQUEST_DESCRIPTION = """Request a condensation of the conversation history when the context becomes too long or when you need to focus on the most relevant information.
+
+This tool helps manage conversation context by requesting a summary of the conversation history. Use it when:
+1. The conversation has become very long and you need to reduce context size
+2. You want to focus on the most important information from the conversation
+3. You're experiencing issues with context limits
+
+The tool takes no arguments and simply requests the system to condense the conversation history."""
+
+CondensationRequestTool = ChatCompletionToolParam(
+    type='function',
+    function=ChatCompletionToolParamFunctionChunk(
+        name='request_condensation',
+        description=_CONDENSATION_REQUEST_DESCRIPTION,
+        parameters={
+            'type': 'object',
+            'properties': {},
+            'required': [],
+        },
+    ),
+)

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -59,7 +59,11 @@ from openhands.events.action import (
     NullAction,
     SystemMessageAction,
 )
-from openhands.events.action.agent import CondensationAction, RecallAction
+from openhands.events.action.agent import (
+    CondensationAction,
+    CondensationRequestAction,
+    RecallAction,
+)
 from openhands.events.event import Event
 from openhands.events.event_filter import EventFilter
 from openhands.events.observation import (
@@ -72,7 +76,6 @@ from openhands.events.observation import (
 from openhands.events.serialization.event import event_to_trajectory, truncate_content
 from openhands.llm.llm import LLM
 from openhands.llm.metrics import Metrics, TokenUsage
-from openhands.memory.view import View
 
 # note: RESUME is only available on web GUI
 TRAFFIC_CONTROL_REMINDER = (
@@ -865,7 +868,10 @@ class AgentController:
                     or isinstance(e, ContextWindowExceededError)
                 ):
                     if self.agent.config.enable_history_truncation:
-                        self._handle_long_context_error()
+                        self.event_stream.add_event(
+                            CondensationRequestAction(),
+                            EventSource.AGENT,
+                        )
                         return
                     else:
                         raise LLMContextWindowExceedError()
@@ -1159,180 +1165,6 @@ class AgentController:
 
         # make sure history is in sync
         self.state.start_id = start_id
-
-    def _handle_long_context_error(self) -> None:
-        # When context window is exceeded, keep roughly half of agent interactions
-        current_view = View.from_events(self.state.history)
-        kept_events = self._apply_conversation_window(current_view.events)
-        kept_event_ids = {e.id for e in kept_events}
-
-        self.log(
-            'info',
-            f'Context window exceeded. Keeping events with IDs: {kept_event_ids}',
-        )
-
-        # The events to forget are those that are not in the kept set
-        forgotten_event_ids = {e.id for e in self.state.history} - kept_event_ids
-
-        if len(kept_event_ids) == 0:
-            self.log(
-                'warning',
-                'No events kept after applying conversation window. This should not happen.',
-            )
-
-        # verify that the first event id in kept_event_ids is the same as the start_id
-        if len(kept_event_ids) > 0 and self.state.history[0].id not in kept_event_ids:
-            self.log(
-                'warning',
-                f'First event after applying conversation window was not kept: {self.state.history[0].id} not in {kept_event_ids}',
-            )
-
-        # Add an error event to trigger another step by the agent
-        self.event_stream.add_event(
-            CondensationAction(
-                forgotten_events_start_id=min(forgotten_event_ids)
-                if forgotten_event_ids
-                else 0,
-                forgotten_events_end_id=max(forgotten_event_ids)
-                if forgotten_event_ids
-                else 0,
-            ),
-            EventSource.AGENT,
-        )
-
-    def _apply_conversation_window(self, history: list[Event]) -> list[Event]:
-        """Cuts history roughly in half when context window is exceeded.
-
-        It preserves action-observation pairs and ensures that the system message,
-        the first user message, and its associated recall observation are always included
-        at the beginning of the context window.
-
-        The algorithm:
-        1. Identify essential initial events: System Message, First User Message, Recall Observation.
-        2. Determine the slice of recent events to potentially keep.
-        3. Validate the start of the recent slice for dangling observations.
-        4. Combine essential events and validated recent events, ensuring essentials come first.
-
-        Args:
-            events: List of events to filter
-
-        Returns:
-            Filtered list of events keeping newest half while preserving pairs and essential initial events.
-        """
-        # Handle empty history
-        if not history:
-            return []
-        # 1. Identify essential initial events
-        system_message: SystemMessageAction | None = None
-        first_user_msg: MessageAction | None = None
-        recall_action: RecallAction | None = None
-        recall_observation: Observation | None = None
-
-        # Find System Message (should be the first event, if it exists)
-        system_message = next(
-            (e for e in history if isinstance(e, SystemMessageAction)), None
-        )
-        assert (
-            system_message is None
-            or isinstance(system_message, SystemMessageAction)
-            and system_message.id == history[0].id
-        )
-
-        # Find First User Message in the history, which MUST exist
-        first_user_msg = self._first_user_message(history)
-        if first_user_msg is None:
-            # If not found in history, try the event stream
-            first_user_msg = self._first_user_message()
-            if first_user_msg is None:
-                raise RuntimeError('No first user message found in the event stream.')
-            self.log(
-                'warning',
-                'First user message not found in history. Using cached version from event stream.',
-            )
-
-        # Find the first user message index in the history
-        first_user_msg_index = -1
-        for i, event in enumerate(history):
-            if isinstance(event, MessageAction) and event.source == EventSource.USER:
-                first_user_msg_index = i
-                break
-
-        # Find Recall Action and Observation related to the First User Message
-        # Look for RecallAction after the first user message
-        for i in range(first_user_msg_index + 1, len(history)):
-            event = history[i]
-            if (
-                isinstance(event, RecallAction)
-                and event.query == first_user_msg.content
-            ):
-                # Found RecallAction, now look for its Observation
-                recall_action = event
-                for j in range(i + 1, len(history)):
-                    obs_event = history[j]
-                    # Check for Observation caused by this RecallAction
-                    if (
-                        isinstance(obs_event, Observation)
-                        and obs_event.cause == recall_action.id
-                    ):
-                        recall_observation = obs_event
-                        break  # Found the observation, stop inner loop
-                break  # Found the recall action (and maybe obs), stop outer loop
-
-        essential_events: list[Event] = []
-        if system_message:
-            essential_events.append(system_message)
-        # Only include first user message if history is not empty
-        if history:
-            essential_events.append(first_user_msg)
-            # Include recall action and observation if both exist
-            if recall_action and recall_observation:
-                essential_events.append(recall_action)
-                essential_events.append(recall_observation)
-            # Include recall action without observation for backward compatibility
-            elif recall_action:
-                essential_events.append(recall_action)
-
-        # 2. Determine the slice of recent events to potentially keep
-        num_non_essential_events = len(history) - len(essential_events)
-        # Keep roughly half of the non-essential events, minimum 1
-        num_recent_to_keep = max(1, num_non_essential_events // 2)
-
-        # Calculate the starting index for the recent slice
-        slice_start_index = len(history) - num_recent_to_keep
-        slice_start_index = max(0, slice_start_index)  # Ensure index is not negative
-        recent_events_slice = history[slice_start_index:]
-
-        # 3. Validate the start of the recent slice for dangling observations
-        # IMPORTANT: Most observations in history are tool call results, which cannot be without their action, or we get an LLM API error
-        first_valid_event_index = 0
-        for i, event in enumerate(recent_events_slice):
-            if isinstance(event, Observation):
-                first_valid_event_index += 1
-            else:
-                break
-        # If all events in the slice are dangling observations, we need to keep at least one
-        if first_valid_event_index == len(recent_events_slice):
-            self.log(
-                'warning',
-                'All recent events are dangling observations, which we truncate. This means the agent has only the essential first events. This should not happen.',
-            )
-
-        # Adjust the recent_events_slice if dangling observations were found at the start
-        if first_valid_event_index < len(recent_events_slice):
-            validated_recent_events = recent_events_slice[first_valid_event_index:]
-            if first_valid_event_index > 0:
-                self.log(
-                    'debug',
-                    f'Removed {first_valid_event_index} dangling observation(s) from the start of recent event slice.',
-                )
-        else:
-            validated_recent_events = []
-
-        # 4. Combine essential events and validated recent events
-        events_to_keep: list[Event] = essential_events + validated_recent_events
-        self.log('debug', f'History truncated. Kept {len(events_to_keep)} events.')
-
-        return events_to_keep
 
     def _is_stuck(self) -> bool:
         """Checks if the agent or its delegate is stuck in a loop.

--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -28,6 +28,8 @@ class AgentConfig(BaseModel):
     """Whether to enable think tool"""
     enable_finish: bool = Field(default=True)
     """Whether to enable finish tool"""
+    enable_condensation_request: bool = Field(default=True)
+    """Whether to enable condensation request tool"""
     enable_prompt_extensions: bool = Field(default=True)
     """Whether to enable prompt extensions"""
     enable_mcp: bool = Field(default=True)

--- a/openhands/core/schema/action.py
+++ b/openhands/core/schema/action.py
@@ -91,3 +91,6 @@ class ActionType(str, Enum):
 
     CONDENSATION = 'condensation'
     """Condenses a list of events into a summary."""
+
+    CONDENSATION_REQUEST = 'condensation_request'
+    """Request for condensation of a list of events."""

--- a/openhands/events/action/agent.py
+++ b/openhands/events/action/agent.py
@@ -195,3 +195,17 @@ class CondensationAction(Action):
         if self.summary:
             return f'Summary: {self.summary}'
         return f'Condenser is dropping the events: {self.forgotten}.'
+
+@dataclass
+class CondensationRequestAction(Action):
+    """This action is used to request a condensation of the conversation history.
+
+    Attributes:
+        action (str): The action type, namely ActionType.CONDENSATION_REQUEST.
+    """
+
+    action: str = ActionType.CONDENSATION_REQUEST
+
+    @property
+    def message(self) -> str:
+        return 'Requesting a condensation of the conversation history.'

--- a/openhands/memory/condenser/impl/llm_summarizing_condenser.py
+++ b/openhands/memory/condenser/impl/llm_summarizing_condenser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from openhands.core.config.condenser_config import LLMSummarizingCondenserConfig
 from openhands.core.message import Message, TextContent
-from openhands.events.action.agent import CondensationAction
+from openhands.events.action.agent import CondensationAction, CondensationRequestAction
 from openhands.events.observation.agent import AgentCondensationObservation
 from openhands.events.serialization.event import truncate_content
 from openhands.llm import LLM
@@ -150,6 +150,9 @@ CURRENT_STATE: Last flip: Heads, Haiku count: 15/20"""
         )
 
     def should_condense(self, view: View) -> bool:
+        if isinstance(view[-1], CondensationRequestAction):
+            # If the last event is a condensation request, we should condense
+            return True
         return len(view) > self.max_size
 
     @classmethod


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds a new event that represents a request for a condensation. This is intended to clean up the control flow of the agent controller by allowing us to use existing condensation implementations instead of the `apply_conversation_window` logic (which is a bit brittle and doesn't produce any kind of summary for the forgotten events).

As a bonus, it becomes possible to trigger condensation with a tool call, meaning the agent can now choose to condense or can do so when requested by the user.

---
**Link of any specific issues this addresses:**
