### PR TITLE
Enhance AsyncLLM to match LLM functionality

### DIFF
--- a/openhands/llm/async_llm.py
+++ b/openhands/llm/async_llm.py
@@ -1,14 +1,30 @@
 import asyncio
+import copy
+import os
+import time
+import warnings
 from functools import partial
 from typing import Any, Callable
 
-from litellm import acompletion as litellm_acompletion
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    import litellm
 
-from openhands.core.exceptions import UserCancelledError
+from litellm import Message as LiteLLMMessage
+from litellm import acompletion as litellm_acompletion
+from litellm.types.utils import ModelResponse
+
+from openhands.core.exceptions import LLMNoResponseError, UserCancelledError
 from openhands.core.logger import openhands_logger as logger
+from openhands.llm.fn_call_converter import (
+    STOP_WORDS,
+    convert_fncall_messages_to_non_fncall_messages,
+    convert_non_fncall_messages_to_fncall_messages,
+)
 from openhands.llm.llm import (
     LLM,
     LLM_RETRY_EXCEPTIONS,
+    MODELS_WITHOUT_STOP_WORDS,
     REASONING_EFFORT_SUPPORTED_MODELS,
 )
 from openhands.utils.shutdown_listener import should_continue
@@ -20,6 +36,29 @@ class AsyncLLM(LLM):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
+        # Set up completion_kwargs for async completion
+        completion_kwargs: dict[str, Any] = {
+            'temperature': self.config.temperature,
+            'max_tokens': self.config.max_output_tokens,
+        }
+
+        if self.config.top_k is not None:
+            completion_kwargs['top_k'] = self.config.top_k
+
+        if (
+            self.config.model.lower() in REASONING_EFFORT_SUPPORTED_MODELS
+            or self.config.model.split('/')[-1] in REASONING_EFFORT_SUPPORTED_MODELS
+        ):
+            completion_kwargs['reasoning_effort'] = self.config.reasoning_effort
+            completion_kwargs.pop(
+                'temperature'
+            )  # temperature is not supported for reasoning models
+
+        # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/6777
+        if self.config.model.startswith('azure'):
+            completion_kwargs['max_tokens'] = self.config.max_output_tokens
+            completion_kwargs.pop('max_tokens', None)
+
         self._async_completion = partial(
             self._call_acompletion,
             model=self.config.model,
@@ -29,12 +68,11 @@ class AsyncLLM(LLM):
             base_url=self.config.base_url,
             api_version=self.config.api_version,
             custom_llm_provider=self.config.custom_llm_provider,
-            max_tokens=self.config.max_output_tokens,
             timeout=self.config.timeout,
-            temperature=self.config.temperature,
             top_p=self.config.top_p,
             drop_params=self.config.drop_params,
             seed=self.config.seed,
+            **completion_kwargs,
         )
 
         async_completion_unwrapped = self._async_completion
@@ -45,29 +83,63 @@ class AsyncLLM(LLM):
             retry_min_wait=self.config.retry_min_wait,
             retry_max_wait=self.config.retry_max_wait,
             retry_multiplier=self.config.retry_multiplier,
+            retry_listener=self.retry_listener,
         )
         async def async_completion_wrapper(*args: Any, **kwargs: Any) -> Any:
             """Wrapper for the litellm acompletion function that adds logging and cost tracking."""
-            messages: list[dict[str, Any]] | dict[str, Any] = []
+            from openhands.io import json
+
+            messages_kwarg: list[dict[str, Any]] | dict[str, Any] = []
+            mock_function_calling = not self.is_function_calling_active()
 
             # some callers might send the model and messages directly
             # litellm allows positional args, like completion(model, messages, **kwargs)
-            # see llm.py for more details
             if len(args) > 1:
-                messages = args[1] if len(args) > 1 else args[0]
-                kwargs['messages'] = messages
+                # ignore the first argument if it's provided (it would be the model)
+                messages_kwarg = args[1] if len(args) > 1 else args[0]
+                kwargs['messages'] = messages_kwarg
 
                 # remove the first args, they're sent in kwargs
                 args = args[2:]
             elif 'messages' in kwargs:
-                messages = kwargs['messages']
-
-            # Set reasoning effort for models that support it
-            if self.config.model.lower() in REASONING_EFFORT_SUPPORTED_MODELS:
-                kwargs['reasoning_effort'] = self.config.reasoning_effort
+                messages_kwarg = kwargs['messages']
 
             # ensure we work with a list of messages
-            messages = messages if isinstance(messages, list) else [messages]
+            messages: list[dict[str, Any]] = (
+                messages_kwarg if isinstance(messages_kwarg, list) else [messages_kwarg]
+            )
+
+            # handle conversion of to non-function calling messages if needed
+            original_fncall_messages = copy.deepcopy(messages)
+            mock_fncall_tools = None
+            # if the agent or caller has defined tools, and we mock via prompting, convert the messages
+            if mock_function_calling and 'tools' in kwargs:
+                add_in_context_learning_example = True
+                if (
+                    'openhands-lm' in self.config.model
+                    or 'devstral' in self.config.model
+                ):
+                    add_in_context_learning_example = False
+
+                messages = convert_fncall_messages_to_non_fncall_messages(
+                    messages,
+                    kwargs['tools'],
+                    add_in_context_learning_example=add_in_context_learning_example,
+                )
+                kwargs['messages'] = messages
+
+                # add stop words if the model supports it
+                if self.config.model not in MODELS_WITHOUT_STOP_WORDS:
+                    kwargs['stop'] = STOP_WORDS
+
+                mock_fncall_tools = kwargs.pop('tools')
+                if 'openhands-lm' in self.config.model:
+                    # If we don't have this, we might run into issue when serving openhands-lm
+                    # using SGLang
+                    kwargs['tool_choice'] = 'none'
+                else:
+                    # tool_choice should not be specified when mocking function calling
+                    kwargs.pop('tool_choice', None)
 
             # if we have no messages, something went very wrong
             if not messages:
@@ -75,7 +147,17 @@ class AsyncLLM(LLM):
                     'The messages list is empty. At least one message is required.'
                 )
 
+            # log the entire LLM prompt
             self.log_prompt(messages)
+
+            # set litellm modify_params to the configured value
+            # True by default to allow litellm to do transformations like adding a default message, when a message is empty
+            # NOTE: this setting is global; unlike drop_params, it cannot be overridden in the litellm completion partial
+            litellm.modify_params = self.config.modify_params
+
+            # if we're not using litellm proxy, remove the extra_body
+            if 'litellm_proxy' not in self.config.model:
+                kwargs.pop('extra_body', None)
 
             async def check_stopped() -> None:
                 while should_continue():
@@ -90,14 +172,98 @@ class AsyncLLM(LLM):
             stop_check_task = asyncio.create_task(check_stopped())
 
             try:
+                # Record start time for latency measurement
+                start_time = time.time()
                 # Directly call and await litellm_acompletion
-                resp = await async_completion_unwrapped(*args, **kwargs)
+                resp: ModelResponse = await async_completion_unwrapped(*args, **kwargs)
 
-                message_back = resp['choices'][0]['message']['content']
+                # Calculate and record latency
+                latency = time.time() - start_time
+                response_id = resp.get('id', 'unknown')
+                self.metrics.add_response_latency(latency, response_id)
+
+                non_fncall_response = copy.deepcopy(resp)
+
+                # if we mocked function calling, and we have tools, convert the response back to function calling format
+                if mock_function_calling and mock_fncall_tools is not None:
+                    if not resp.get('choices') or len(resp['choices']) < 1:
+                        raise LLMNoResponseError(
+                            'Response choices is less than 1 - This is only seen in Gemini models so far. Response: '
+                            + str(resp)
+                        )
+
+                    non_fncall_response_message = resp['choices'][0]['message']
+                    # messages is already a list with proper typing
+                    fn_call_messages_with_response = (
+                        convert_non_fncall_messages_to_fncall_messages(
+                            messages + [non_fncall_response_message], mock_fncall_tools
+                        )
+                    )
+                    fn_call_response_message = fn_call_messages_with_response[-1]
+                    if not isinstance(fn_call_response_message, LiteLLMMessage):
+                        fn_call_response_message = LiteLLMMessage(
+                            **fn_call_response_message
+                        )
+                    resp['choices'][0]['message'] = fn_call_response_message
+
+                # Check if resp has 'choices' key with at least one item
+                if not resp.get('choices') or len(resp['choices']) < 1:
+                    raise LLMNoResponseError(
+                        'Response choices is less than 1 - This is only seen in Gemini models so far. Response: '
+                        + str(resp)
+                    )
+
+                message_back: str = resp['choices'][0]['message']['content'] or ''
+                tool_calls = resp['choices'][0]['message'].get('tool_calls', [])
+                if tool_calls:
+                    for tool_call in tool_calls:
+                        if isinstance(tool_call, dict):
+                            fn_name = tool_call['function']['name']
+                            fn_args = tool_call['function']['arguments']
+                        else:
+                            fn_name = tool_call.function.name
+                            fn_args = tool_call.function.arguments
+                        message_back += f'\nFunction call: {fn_name}({fn_args})'
+
+                # log the LLM response
                 self.log_response(message_back)
 
-                # log costs and tokens used
-                self._post_completion(resp)
+                # post-process the response first to calculate cost
+                cost = self._post_completion(resp)
+
+                # log for evals or other scripts that need the raw completion
+                if self.config.log_completions:
+                    assert self.config.log_completions_folder is not None
+                    log_file = os.path.join(
+                        self.config.log_completions_folder,
+                        # use the metric model name (for draft editor)
+                        f'{self.metrics.model_name.replace("/", "__")}-{time.time()}.json',
+                    )
+
+                    # set up the dict to be logged
+                    _d = {
+                        'messages': messages,
+                        'response': resp,
+                        'args': args,
+                        'kwargs': {
+                            k: v
+                            for k, v in kwargs.items()
+                            if k not in ('messages', 'client')
+                        },
+                        'timestamp': time.time(),
+                        'cost': cost,
+                    }
+
+                    # if non-native function calling, save messages/response separately
+                    if mock_function_calling:
+                        # Overwrite response as non-fncall to be consistent with messages
+                        _d['response'] = non_fncall_response
+
+                        # Save fncall_messages/response separately
+                        _d['fncall_messages'] = original_fncall_messages
+                        _d['fncall_response'] = resp
+                    with open(log_file, 'w') as f:
+                        f.write(json.dumps(_d))
 
                 # We do not support streaming in this method, thus return resp
                 return resp

--- a/openhands/llm/streaming_llm.py
+++ b/openhands/llm/streaming_llm.py
@@ -5,7 +5,9 @@ from typing import Any, Callable
 from openhands.core.exceptions import UserCancelledError
 from openhands.core.logger import openhands_logger as logger
 from openhands.llm.async_llm import LLM_RETRY_EXCEPTIONS, AsyncLLM
-from openhands.llm.llm import REASONING_EFFORT_SUPPORTED_MODELS
+from openhands.llm.llm import (
+    REASONING_EFFORT_SUPPORTED_MODELS,
+)
 
 
 class StreamingLLM(AsyncLLM):

--- a/tests/unit/test_async_llm.py
+++ b/tests/unit/test_async_llm.py
@@ -1,0 +1,285 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openhands.core.config import LLMConfig
+from openhands.core.exceptions import LLMNoResponseError
+from openhands.llm.async_llm import AsyncLLM
+
+
+@pytest.fixture
+def default_config():
+    return LLMConfig(
+        model='gpt-4o',
+        api_key='test_key',
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+    )
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    # suppress logging of completion data to file
+    mock_logger = MagicMock()
+    monkeypatch.setattr('openhands.llm.debug_mixin.llm_prompt_logger', mock_logger)
+    monkeypatch.setattr('openhands.llm.debug_mixin.llm_response_logger', mock_logger)
+    monkeypatch.setattr('openhands.llm.async_llm.logger', mock_logger)
+    return mock_logger
+
+
+@pytest.mark.asyncio
+async def test_async_llm_init(default_config):
+    """Test that AsyncLLM initializes correctly with default config."""
+    llm = AsyncLLM(default_config)
+    assert llm.config.model == 'gpt-4o'
+    assert llm.config.api_key.get_secret_value() == 'test_key'
+    assert callable(llm.async_completion)
+
+
+@pytest.mark.asyncio
+async def test_async_completion_basic(default_config, mock_logger):
+    """Test basic async completion functionality."""
+    with patch(
+        'openhands.llm.async_llm.litellm_acompletion', new_callable=AsyncMock
+    ) as mock_acompletion:
+        mock_acompletion.return_value = {
+            'id': 'test-response-id',
+            'choices': [{'message': {'content': 'Test response'}}],
+            'usage': {'prompt_tokens': 10, 'completion_tokens': 5, 'total_tokens': 15},
+        }
+
+        llm = AsyncLLM(default_config)
+        response = await llm.async_completion(
+            messages=[{'role': 'user', 'content': 'Hello!'}]
+        )
+
+        assert response['choices'][0]['message']['content'] == 'Test response'
+        assert mock_acompletion.call_count == 1
+
+        # Verify metrics were updated
+        assert len(llm.metrics.token_usages) == 1
+        assert llm.metrics.token_usages[0].prompt_tokens == 10
+        assert llm.metrics.token_usages[0].completion_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_async_completion_with_function_calling(default_config):
+    """Test that function calling works correctly in AsyncLLM."""
+    with (
+        patch(
+            'openhands.llm.async_llm.litellm_acompletion', new_callable=AsyncMock
+        ) as mock_acompletion,
+        patch.object(AsyncLLM, 'is_function_calling_active', return_value=True),
+    ):
+        # Mock a function call response
+        mock_acompletion.return_value = {
+            'id': 'test-response-id',
+            'choices': [
+                {
+                    'message': {
+                        'content': None,
+                        'tool_calls': [
+                            {
+                                'function': {
+                                    'name': 'test_function',
+                                    'arguments': '{"arg1": "value1", "arg2": "value2"}',
+                                },
+                                'id': 'call_123',
+                            }
+                        ],
+                    }
+                }
+            ],
+            'usage': {'prompt_tokens': 15, 'completion_tokens': 10, 'total_tokens': 25},
+        }
+
+        # Set model to one that supports function calling
+        config = LLMConfig(model='claude-3-5-sonnet-20240620', api_key='test_key')
+
+        llm = AsyncLLM(config)
+
+        # Define a test tool
+        test_tool = {
+            'type': 'function',
+            'function': {
+                'name': 'test_function',
+                'description': 'A test function',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {
+                        'arg1': {'type': 'string'},
+                        'arg2': {'type': 'string'},
+                    },
+                    'required': ['arg1', 'arg2'],
+                },
+            },
+        }
+
+        await llm.async_completion(
+            messages=[{'role': 'user', 'content': 'Call the test function'}],
+            tools=[test_tool],
+            tool_choice='auto',
+        )
+
+        # Verify the API was called correctly
+        assert mock_acompletion.call_count == 1
+        # Verify the tools were passed correctly
+        kwargs = mock_acompletion.call_args[1]
+        assert 'tools' in kwargs
+        assert kwargs['tools'][0]['function']['name'] == 'test_function'
+
+
+@pytest.mark.asyncio
+async def test_async_completion_with_mock_function_calling(default_config):
+    """Test that function calling mocking works correctly for models that don't support it natively."""
+    with patch(
+        'openhands.llm.async_llm.litellm_acompletion', new_callable=AsyncMock
+    ) as mock_acompletion:
+        # Mock a text response that will be converted to a function call
+        mock_acompletion.return_value = {
+            'id': 'test-response-id',
+            'choices': [
+                {
+                    'message': {
+                        'content': 'I need to call test_function with arg1="value1" and arg2="value2"',
+                        'role': 'assistant',
+                    }
+                }
+            ],
+            'usage': {'prompt_tokens': 20, 'completion_tokens': 15, 'total_tokens': 35},
+        }
+
+        # Use a model that doesn't support function calling
+        config = LLMConfig(
+            model='some-model-without-function-calling', api_key='test_key'
+        )
+
+        llm = AsyncLLM(config)
+
+        # Define a test tool
+        test_tool = {
+            'type': 'function',
+            'function': {
+                'name': 'test_function',
+                'description': 'A test function',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {
+                        'arg1': {'type': 'string'},
+                        'arg2': {'type': 'string'},
+                    },
+                    'required': ['arg1', 'arg2'],
+                },
+            },
+        }
+
+        # Patch the is_function_calling_active method to return False
+        # and patch the convert_fncall_messages_to_non_fncall_messages function
+        with (
+            patch.object(AsyncLLM, 'is_function_calling_active', return_value=False),
+            patch(
+                'openhands.llm.async_llm.convert_fncall_messages_to_non_fncall_messages'
+            ) as mock_convert_to_non_fncall,
+            patch(
+                'openhands.llm.async_llm.convert_non_fncall_messages_to_fncall_messages'
+            ) as mock_convert_to_fncall,
+        ):
+            # Set up the mocks
+            mock_convert_to_non_fncall.return_value = [
+                {'role': 'user', 'content': 'Call the test function (converted)'}
+            ]
+            mock_convert_to_fncall.return_value = [
+                {'role': 'user', 'content': 'Call the test function'},
+                {
+                    'role': 'assistant',
+                    'content': None,
+                    'tool_calls': [
+                        {
+                            'function': {
+                                'name': 'test_function',
+                                'arguments': '{"arg1": "value1", "arg2": "value2"}',
+                            },
+                            'id': 'call_123',
+                        }
+                    ],
+                },
+            ]
+
+            await llm.async_completion(
+                messages=[{'role': 'user', 'content': 'Call the test function'}],
+                tools=[test_tool],
+                tool_choice='auto',
+            )
+
+            # Verify the conversion functions were called
+            mock_convert_to_non_fncall.assert_called_once()
+            # Verify the API was called correctly
+            assert mock_acompletion.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_completion_with_retry(default_config):
+    """Test that retries work correctly in AsyncLLM."""
+    with patch(
+        'openhands.llm.async_llm.litellm_acompletion', new_callable=AsyncMock
+    ) as mock_acompletion:
+        # First call raises an error, second call succeeds
+        mock_acompletion.side_effect = [
+            LLMNoResponseError('No response from LLM'),
+            {
+                'id': 'test-retry-id',
+                'choices': [{'message': {'content': 'Retry successful'}}],
+                'usage': {
+                    'prompt_tokens': 10,
+                    'completion_tokens': 5,
+                    'total_tokens': 15,
+                },
+            },
+        ]
+
+        llm = AsyncLLM(default_config)
+        response = await llm.async_completion(
+            messages=[{'role': 'user', 'content': 'Hello!'}]
+        )
+
+        assert response['choices'][0]['message']['content'] == 'Retry successful'
+        assert mock_acompletion.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_completion_with_logging(default_config):
+    """Test that completion logging works correctly in AsyncLLM."""
+    with (
+        patch(
+            'openhands.llm.async_llm.litellm_acompletion', new_callable=AsyncMock
+        ) as mock_acompletion,
+        patch('openhands.llm.async_llm.open', MagicMock()) as mock_open,
+        patch('openhands.io.json.dumps') as mock_json_dumps,
+    ):
+        mock_acompletion.return_value = {
+            'id': 'test-log-id',
+            'choices': [{'message': {'content': 'Test logging'}}],
+            'usage': {'prompt_tokens': 10, 'completion_tokens': 5, 'total_tokens': 15},
+        }
+
+        # Create a temp directory for logs
+        with patch('os.makedirs') as mock_makedirs:
+            log_dir = '/tmp/llm_logs'
+            config = LLMConfig(
+                model='gpt-4o',
+                api_key='test_key',
+                log_completions=True,
+                log_completions_folder=log_dir,
+            )
+
+            llm = AsyncLLM(config)
+            response = await llm.async_completion(
+                messages=[{'role': 'user', 'content': 'Hello!'}]
+            )
+
+            assert response['choices'][0]['message']['content'] == 'Test logging'
+            mock_makedirs.assert_called_once_with(log_dir, exist_ok=True)
+            mock_open.assert_called_once()
+            # We don't check the exact number of calls to json.dumps as it might be called multiple times
+            assert mock_json_dumps.call_count >= 1


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR enhances the AsyncLLM class to have feature parity with the LLM class, ensuring that both synchronous and asynchronous LLM implementations provide the same functionality. This includes support for function calling, detailed logging, and proper handling of model-specific features.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR makes the following changes:
1. Updates AsyncLLM to support function calling in the same way as LLM
2. Adds proper handling of tool calls and function arguments
3. Implements detailed logging and completion tracking
4. Adds support for model-specific features like reasoning effort
5. Adds comprehensive unit tests for AsyncLLM functionality

The implementation closely follows the pattern established in the LLM class to ensure consistency and maintainability. The AsyncLLM class now properly handles both native function calling and function calling mocking for models that don't support it natively.

---
**Link of any specific issues this addresses:**

N/A

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/2c0c5903f22142e28d639177753074d6)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a09f5f8-nikolaik   --name openhands-app-a09f5f8   docker.all-hands.dev/all-hands-ai/openhands:a09f5f8
```