### PR TITLE
[Docs]: add optional step for slack app installation

### DIFF
--- a/docs/usage/cloud/slack-installation.mdx
+++ b/docs/usage/cloud/slack-installation.mdx
@@ -16,6 +16,7 @@ description: This guide walks you through installing the OpenHands Slack app.
 2. Click the button below to OpenHands Slack App <a target="_blank" href="https://slack.com/oauth/v2/authorize?client_id=7477886716822.8729519890534&scope=app_mentions:read,chat:write,users:read,channels:history,groups:history,mpim:history,im:history&user_scope=channels:history,groups:history,im:history,mpim:history"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
 3. In the top right corner, select the workspace to install the OpenHands Slack app.
 4. Review permissions and click allow
+5. (Optional): Manage who can use Openhands from Slack via [workspace settings](https://slack.com/help/articles/222386767-Manage-app-approval-for-your-workspace)
 
 ## Working With the Slack App
 

--- a/docs/usage/cloud/slack-installation.mdx
+++ b/docs/usage/cloud/slack-installation.mdx
@@ -16,7 +16,7 @@ description: This guide walks you through installing the OpenHands Slack app.
 2. Click the button below to OpenHands Slack App <a target="_blank" href="https://slack.com/oauth/v2/authorize?client_id=7477886716822.8729519890534&scope=app_mentions:read,chat:write,users:read,channels:history,groups:history,mpim:history,im:history&user_scope=channels:history,groups:history,im:history,mpim:history"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
 3. In the top right corner, select the workspace to install the OpenHands Slack app.
 4. Review permissions and click allow
-5. (Optional): Manage who can use Openhands from Slack via [workspace settings](https://slack.com/help/articles/222386767-Manage-app-approval-for-your-workspace)
+5. (Optional): Manage which workspace members can use Openhands via [workspace settings](https://slack.com/help/articles/222386767-Manage-app-approval-for-your-workspace)
 
 ## Working With the Slack App
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Adds info about how to restrict who can use the Openhands slack app for a given workspace (this info is only relevant to workspace owners/admins/those who can manage app approvals in a workspace)


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e342cd0-nikolaik   --name openhands-app-e342cd0   docker.all-hands.dev/all-hands-ai/openhands:e342cd0
```