### PR TITLE
[Fix]: allow agent to configure draft status for opened prs/mrs via git mcp

### DIFF
--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -470,7 +470,6 @@ class GitLabService(BaseGitService, GitService):
             target_branch: The name of the branch you want the changes merged into
             title: The title of the merge request (optional, defaults to a generic title)
             description: The description of the merge request (optional)
-            draft: Whether to create the MR as a draft (optional, defaults to False)
 
         Returns:
             - MR URL when successful

--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -87,6 +87,7 @@ async def create_pr(
     target_branch: Annotated[str, Field(description='Target branch on repo')],
     title: Annotated[str, Field(description='PR Title')],
     body: Annotated[str | None, Field(description='PR body')],
+    draft: Annotated[bool, Field(description='Whether PR opened is a draft')] = True
 ) -> str:
     """Open a PR in GitHub"""
 
@@ -126,6 +127,7 @@ async def create_pr(
             target_branch=target_branch,
             title=title,
             body=body,
+            draft=draft
         )
 
         if conversation_id:
@@ -146,7 +148,7 @@ async def create_mr(
     ],
     source_branch: Annotated[str, Field(description='Source branch on repo')],
     target_branch: Annotated[str, Field(description='Target branch on repo')],
-    title: Annotated[str, Field(description='MR Title')],
+    title: Annotated[str, Field(description='MR Title. Start title with `DRAFT:` or `WIP:` if applicable.')],
     description: Annotated[str | None, Field(description='MR description')],
 ) -> str:
     """Open a MR in GitLab"""


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Agent can control whether PRs/MRs opened via Git MCP have draft status

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Some repos don't support draft PRs. This causes the MCP tool call to fail, because we set draft status as the default. The agent resorts to the using CURL in these situations.

This PR ensures that the agent can configure the draft status for opened PRs/MRs.

---
**Link of any specific issues this addresses:**
#9115

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f371582-nikolaik   --name openhands-app-f371582   docker.all-hands.dev/all-hands-ai/openhands:f371582
```