### PR TITLE
Fix broken link to LLMs section in GUI mode documentation

### DIFF
--- a/docs/usage/how-to/gui-mode.mdx
+++ b/docs/usage/how-to/gui-mode.mdx
@@ -154,7 +154,7 @@ is loaded. Typically these include:
 ## Tips for Effective Use
 
 - Be specific in your requests to get the most accurate and helpful responses, as described in the [prompting best practices](../prompting/prompting-best-practices).
-- Use one of the recommended models, as described in the [LLMs section](usage/llms/llms.md).
+- Use one of the recommended models, as described in the [LLMs section](/usage/llms/llms).
 
 ## Other Ways to Run Openhands
 - [Run OpenHands in a scriptable headless mode.](/usage/how-to/headless-mode)


### PR DESCRIPTION
## Summary

Fixes a broken link in the GUI mode documentation that was causing a 500 error due to an incorrect URL path.

## Problem

The link to the "LLMs section" in `/docs/usage/how-to/gui-mode.mdx` was incorrectly formatted as:
```markdown
[LLMs section](usage/llms/llms.md)
```

This caused the documentation system to generate a URL with double "/usage" paths:
`https://docs.all-hands.dev/usage/how-to/usage/llms/llms.md`

## Solution

Fixed the link to use the correct absolute path and file reference:
```markdown
[LLMs section](/usage/llms/llms)
```

This change:
- Uses an absolute path starting with `/usage/` to prevent path duplication
- Removes the `.md` extension since the actual file is `llms.mdx` and the documentation system handles extensions automatically
- Points to the correct LLMs overview page

## Testing

- ✅ Verified the target file `/docs/usage/llms/llms.mdx` exists
- ✅ Searched for other similar link issues - none found
- ✅ Pre-commit hooks pass successfully

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Fixes: https://docs.all-hands.dev/usage/how-to/usage/llms/llms.md

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/56571a02481d4947ac6738c364db6dfb)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:be76325-nikolaik   --name openhands-app-be76325   docker.all-hands.dev/all-hands-ai/openhands:be76325
```