### PR TITLE
fix(devcontainer): mark workspace as safe dir

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Mark the current repository as safe for Git to prevent "dubious ownership" errors,
+# which can occur in containerized environments when directory ownership doesn't match the current user.
+git config --global --add safe.directory "$(realpath .)"
+
 # Install `nc`
 sudo apt update && sudo apt install netcat -y
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Prevents Git dubious ownership errors in containers due to ownership mismatch on mounted project folders (more likely on Windows/WSL2).

Fixes issue #5529

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Adds the repo to git's safe.directory to avoid ownership errors in Dev Containers.

---
**Link of any specific issues this addresses:**
