### PR TITLE
feat: Allow additive custom prompts from .openhands-user directory

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,4 +1,4 @@
-# 🙌 The OpenHands Community
+remind # 🙌 The OpenHands Community
 
 The OpenHands community is built around the belief that (1) AI and AI agents are going to fundamentally change the way
 we build software, and (2) if this is true, we should do everything we can to make sure that the benefits provided by

--- a/openhands/agenthub/browsing_agent/browsing_agent.py
+++ b/openhands/agenthub/browsing_agent/browsing_agent.py
@@ -104,13 +104,16 @@ class BrowsingAgent(Agent):
         self,
         llm: LLM,
         config: AgentConfig,
+        workspace_root: str | None,
     ) -> None:
         """Initializes a new instance of the BrowsingAgent class.
 
         Parameters:
         - llm (LLM): The llm to be used by this agent
+        - config (AgentConfig): The configuration for this agent
+        - workspace_root (str | None): The root of the workspace directory
         """
-        super().__init__(llm, config)
+        super().__init__(llm, config, workspace_root=workspace_root)
         # define a configurable action space, with chat functionality, web navigation, and webpage grounding using accessibility tree and HTML.
         # see https://github.com/ServiceNow/BrowserGym/blob/main/core/src/browsergym/core/action/highlevel.py for more details
         action_subsets = ['chat', 'bid']

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -72,14 +72,16 @@ class CodeActAgent(Agent):
         self,
         llm: LLM,
         config: AgentConfig,
+        workspace_root: str | None,
     ) -> None:
         """Initializes a new instance of the CodeActAgent class.
 
         Parameters:
         - llm (LLM): The llm to be used by this agent
         - config (AgentConfig): The configuration for this agent
+        - workspace_root (str | None): The root of the workspace directory
         """
-        super().__init__(llm, config)
+        super().__init__(llm, config, workspace_root=workspace_root)
         self.pending_actions: deque['Action'] = deque()
         self.reset()
         self.tools = self._get_tools()

--- a/openhands/agenthub/dummy_agent/agent.py
+++ b/openhands/agenthub/dummy_agent/agent.py
@@ -45,8 +45,8 @@ class DummyAgent(Agent):
     without making any LLM calls.
     """
 
-    def __init__(self, llm: LLM, config: AgentConfig):
-        super().__init__(llm, config)
+    def __init__(self, llm: LLM, config: AgentConfig, workspace_root: str | None):
+        super().__init__(llm, config, workspace_root=workspace_root)
         self.steps: list[ActionObs] = [
             {
                 'action': MessageAction('Time to get started!'),

--- a/openhands/agenthub/loc_agent/loc_agent.py
+++ b/openhands/agenthub/loc_agent/loc_agent.py
@@ -18,14 +18,16 @@ class LocAgent(CodeActAgent):
         self,
         llm: LLM,
         config: AgentConfig,
+        workspace_root: str | None,
     ) -> None:
         """Initializes a new instance of the LocAgent class.
 
         Parameters:
         - llm (LLM): The llm to be used by this agent
         - config (AgentConfig): The configuration for the agent
+        - workspace_root (str | None): The root of the workspace directory
         """
-        super().__init__(llm, config)
+        super().__init__(llm, config, workspace_root=workspace_root)
 
         self.tools = locagent_function_calling.get_tools()
         logger.debug(

--- a/openhands/agenthub/readonly_agent/readonly_agent.py
+++ b/openhands/agenthub/readonly_agent/readonly_agent.py
@@ -41,19 +41,12 @@ class ReadOnlyAgent(CodeActAgent):
         self,
         llm: LLM,
         config: AgentConfig,
+        workspace_root: str | None,
     ) -> None:
-        """Initializes a new instance of the ReadOnlyAgent class.
-
-        Parameters:
-        - llm (LLM): The llm to be used by this agent
-        - config (AgentConfig): The configuration for this agent
-        """
-        # Initialize the CodeActAgent class; some of it is overridden with class methods
-        super().__init__(llm, config)
-
-        logger.debug(
-            f'TOOLS loaded for ReadOnlyAgent: {", ".join([tool.get("function").get("name") for tool in self.tools])}'
-        )
+        """Initializes a new instance of the ReadOnlyAgent class."""
+        super().__init__(llm, config, workspace_root=workspace_root)
+        # self.tools are set by the parent CodeActAgent's __init__ which calls _get_tools.
+        # This class overrides _get_tools to provide its specific read-only tools.
 
     @property
     def prompt_manager(self) -> PromptManager:

--- a/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
+++ b/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
@@ -131,13 +131,16 @@ class VisualBrowsingAgent(Agent):
         self,
         llm: LLM,
         config: AgentConfig,
+        workspace_root: str | None,
     ) -> None:
         """Initializes a new instance of the VisualBrowsingAgent class.
 
         Parameters:
         - llm (LLM): The llm to be used by this agent
+        - config (AgentConfig): The configuration for this agent
+        - workspace_root (str | None): The root of the workspace directory
         """
-        super().__init__(llm, config)
+        super().__init__(llm, config, workspace_root=workspace_root)
         # define a configurable action space, with chat functionality, web navigation, and webpage grounding using accessibility tree and HTML.
         # see https://github.com/ServiceNow/BrowserGym/blob/main/core/src/browsergym/core/action/highlevel.py for more details
         action_subsets = [

--- a/openhands/controller/agent.py
+++ b/openhands/controller/agent.py
@@ -37,9 +37,11 @@ class Agent(ABC):
         self,
         llm: LLM,
         config: 'AgentConfig',
+        workspace_root: str | None,  # Added workspace_root, now optional
     ):
         self.llm = llm
         self.config = config
+        self.workspace_root = workspace_root  # Store workspace_root
         self._complete = False
         self._prompt_manager: 'PromptManager' | None = None
         self.mcp_tools: dict[str, ChatCompletionToolParam] = {}
@@ -70,7 +72,9 @@ class Agent(ABC):
                 )
                 return None
 
-            system_message = self.prompt_manager.get_system_message()
+            system_message = self.prompt_manager.get_system_message(
+                workspace_root=self.workspace_root
+            )
 
             # Get tools if available
             tools = getattr(self, 'tools', None)

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -687,7 +687,9 @@ class AgentController:
         agent_config = self.agent_configs.get(action.agent, self.agent.config)
         llm_config = self.agent_to_llm_config.get(action.agent, self.agent.llm.config)
         llm = LLM(config=llm_config, retry_listener=self._notify_on_llm_retry)
-        delegate_agent = agent_cls(llm=llm, config=agent_config)
+        delegate_agent = agent_cls(
+            llm=llm, config=agent_config, workspace_root=self.agent.workspace_root
+        )
         state = State(
             session_id=self.id.removesuffix('-delegate'),
             inputs=action.inputs or {},

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -180,6 +180,7 @@ def create_agent(config: OpenHandsConfig) -> Agent:
     agent = agent_cls(
         llm=LLM(config=llm_config),
         config=agent_config,
+        workspace_root=config.workspace_base,  # Pass workspace_base
     )
 
     return agent

--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -471,7 +471,9 @@ class DockerNestedConversationManager(ConversationManager):
         )
         llm = session._create_llm(agent_cls)
         agent_config = self.config.get_agent_config(agent_cls)
-        agent = Agent.get_cls(agent_cls)(llm, agent_config)
+        agent = Agent.get_cls(agent_cls)(
+            llm, agent_config, workspace_root=self.config.workspace_base
+        )
 
         config = self.config.model_copy(deep=True)
         env_vars = config.sandbox.runtime_startup_env_vars

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -169,7 +169,9 @@ class Session:
                 f' keep_first=4, max_size=80)'
             )
             agent_config.condenser = default_condenser_config
-        agent = Agent.get_cls(agent_cls)(llm, agent_config)
+        agent = Agent.get_cls(agent_cls)(
+            llm, agent_config, workspace_root=self.config.workspace_base
+        )
 
         git_provider_tokens = None
         selected_repository = None

--- a/openhands/utils/user_prompts.py
+++ b/openhands/utils/user_prompts.py
@@ -1,0 +1,36 @@
+import os
+
+from openhands.core.logger import openhands_logger as logger
+
+DEFAULT_PROMPT_DIR = '.openhands-user/prompts'
+CUSTOM_SYSTEM_APPEND_FILENAME = 'custom_system_append.txt'
+CUSTOM_TOOL_APPEND_FILENAME = 'custom_tool_append.txt'
+
+
+def get_custom_prompt_addition(filename: str, workspace_root: str | None) -> str:
+    """
+    Reads a custom prompt file from the .openhands-user/prompts directory.
+
+    Args:
+        filename: The name of the file in .openhands-user/prompts/
+                  (e.g., "custom_system_append.txt").
+        workspace_root: The absolute path to the OpenHands workspace root.
+                        If None, custom prompts will not be loaded.
+
+    Returns:
+        The content of the file as a string, or an empty string if not found or on error.
+    """
+    if not workspace_root:
+        return ''
+
+    custom_prompt_path = os.path.join(workspace_root, DEFAULT_PROMPT_DIR, filename)
+    if os.path.exists(custom_prompt_path):
+        try:
+            with open(custom_prompt_path, 'r', encoding='utf-8') as f:
+                return f.read().strip()
+        except Exception as e:
+            logger.warning(
+                f'Could not read custom prompt file {custom_prompt_path}: {e}'
+            )
+            return ''
+    return ''


### PR DESCRIPTION
This change introduces the ability for users to inject custom, additive prompts into the agent's system and tool instruction sets.

Key changes:
- Added  to handle loading custom prompt additions from and .
- Modified  to accept a  and append these custom prompts if the files exist.
- Updated  to accept and store .
- Updated  subclasses (, , , , , ) to accept in their  and pass it to .
- Adjusted , , , and

  to correctly pass the  during agent instantiation.

The custom prompts are optional and the system will not fail if the directory or files are not present.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
