### PR TITLE
Fix conversation URL format in pull request links

### DIFF
--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -27,7 +27,7 @@ mcp_server = FastMCP(
 )
 
 HOST = f'https://{os.getenv("WEB_HOST", "app.all-hands.dev").strip()}'
-CONVO_URL = HOST + '/{}'
+CONVO_URL = HOST + '/conversations/{}'
 
 
 async def get_convo_link(service: GitService, conversation_id: str, body: str) -> str:

--- a/tests/unit/test_mcp_routes.py
+++ b/tests/unit/test_mcp_routes.py
@@ -40,7 +40,10 @@ async def test_get_convo_link_saas_mode():
     # Test with SAAS mode
     with (
         patch('openhands.server.routes.mcp.server_config') as mock_config,
-        patch('openhands.server.routes.mcp.CONVO_URL', 'https://test.example.com/{}'),
+        patch(
+            'openhands.server.routes.mcp.CONVO_URL',
+            'https://test.example.com/conversations/{}',
+        ),
     ):
         mock_config.app_mode = AppMode.SAAS
 
@@ -50,7 +53,7 @@ async def test_get_convo_link_saas_mode():
         )
 
         # Verify the result
-        expected_link = '@testuser can click here to [continue refining the PR](https://test.example.com/test-convo-id)'
+        expected_link = '@testuser can click here to [continue refining the PR](https://test.example.com/conversations/test-convo-id)'
         assert result == f'Original body\n\n{expected_link}'
 
         # Verify that get_user was called
@@ -69,7 +72,10 @@ async def test_get_convo_link_empty_body():
     # Test with SAAS mode and empty body
     with (
         patch('openhands.server.routes.mcp.server_config') as mock_config,
-        patch('openhands.server.routes.mcp.CONVO_URL', 'https://test.example.com/{}'),
+        patch(
+            'openhands.server.routes.mcp.CONVO_URL',
+            'https://test.example.com/conversations/{}',
+        ),
     ):
         mock_config.app_mode = AppMode.SAAS
 
@@ -79,7 +85,7 @@ async def test_get_convo_link_empty_body():
         )
 
         # Verify the result
-        expected_link = '@testuser can click here to [continue refining the PR](https://test.example.com/test-convo-id)'
+        expected_link = '@testuser can click here to [continue refining the PR](https://test.example.com/conversations/test-convo-id)'
         assert result == f'\n\n{expected_link}'
 
         # Verify that get_user was called


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed broken conversation links in pull request descriptions. When OpenHands creates pull requests, it now includes working links that allow users to continue refining the PR by returning to the original OpenHands conversation. Previously, these links were broken due to an incorrect URL format.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes a regression introduced in commit aa54a25241 where conversation URLs in pull request bodies were missing the `/conversations/` path segment. 

**Changes made:**
- Updated `CONVO_URL` in `openhands/server/routes/mcp.py` from `HOST + '/{}' ` to `HOST + '/conversations/{}'`
- Updated corresponding tests to reflect the correct URL format
- Ensured URLs now follow the correct format: `https://app.all-hands.dev/conversations/{conv_id}` instead of `https://app.all-hands.dev/{conv_id}`

The fix aligns with the frontend routing structure which uses `/conversations/:conversationId` and the API endpoints which use `/api/conversations/{conversation_id}`.

**Testing:**
- All existing tests pass
- Updated test cases to verify the correct URL format
- Pre-commit hooks pass successfully

---
**Link of any specific issues this addresses:**

This addresses a recent regression where pull request links to OpenHands conversations were broken due to incorrect URL formatting.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/b94d660765d14240ada2d7b05b3725df)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:66a2204-nikolaik   --name openhands-app-66a2204   docker.all-hands.dev/all-hands-ai/openhands:66a2204
```