### PR TITLE
Add CLI arguments for local LLM configuration

### DIFF
--- a/tests/unit/test_arg_parser.py
+++ b/tests/unit/test_arg_parser.py
@@ -21,6 +21,9 @@ def test_parser_default_values():
     assert args.name == ''
     assert not args.no_auto_continue
     assert args.selected_repo is None
+    assert args.llm_model is None
+    assert args.llm_base_url is None
+    assert args.llm_api_key is None
 
 
 def test_parser_custom_values():
@@ -55,6 +58,12 @@ def test_parser_custom_values():
             '--no-auto-continue',
             '--selected-repo',
             'owner/repo',
+            '--llm-model',
+            'openai/gpt-4',
+            '--llm-base-url',
+            'http://localhost:1234/v1',
+            '--llm-api-key',
+            'test-api-key',
         ]
     )
 
@@ -73,6 +82,9 @@ def test_parser_custom_values():
     assert args.no_auto_continue
     assert args.version
     assert args.selected_repo == 'owner/repo'
+    assert args.llm_model == 'openai/gpt-4'
+    assert args.llm_base_url == 'http://localhost:1234/v1'
+    assert args.llm_api_key == 'test-api-key'
 
 
 def test_parser_file_overrides_task():
@@ -138,13 +150,16 @@ def test_help_message(capsys):
         '--no-auto-continue',
         '--selected-repo SELECTED_REPO',
         '--override-cli-mode OVERRIDE_CLI_MODE',
+        '--llm-model LLM_MODEL',
+        '--llm-base-url LLM_BASE_URL',
+        '--llm-api-key LLM_API_KEY',
     ]
 
     for element in expected_elements:
         assert element in help_output, f"Expected '{element}' to be in the help message"
 
     option_count = help_output.count('  -')
-    assert option_count == 20, f'Expected 20 options, found {option_count}'
+    assert option_count == 23, f'Expected 23 options, found {option_count}'
 
 
 def test_selected_repo_format():


### PR DESCRIPTION
## Summary

This PR adds CLI arguments to enable users to configure local models like devstral directly through command-line arguments, addressing a gap in the current CLI functionality.

## Problem

Previously, users wanting to use local models like devstral through the CLI had to:
- Use the interactive settings flow (`/settings` command)
- Set environment variables (`LLM_MODEL`, `LLM_BASE_URL`, `LLM_API_KEY`)
- Manually edit config files

There was no way to configure LLM settings directly via CLI arguments.

## Solution

Added three new CLI arguments:
- `--llm-model`: LLM model to use (e.g., "lm_studio/devstral", "openai/gpt-4")
- `--llm-base-url`: Base URL for LLM API (required for local models, e.g., "http://localhost:1234/v1")
- `--llm-api-key`: API key for LLM (use "dummy" for local models)

## Usage Example

Users can now configure local models directly:
```bash
openhands --llm-model "lm_studio/devstral" --llm-base-url "http://localhost:1234/v1" --llm-api-key "dummy" --task "echo hello world"
```

## Changes Made

1. **Added CLI arguments** in `get_parser()` function in `openhands/core/config/utils.py`
2. **Added configuration logic** in `setup_config_from_args()` function to apply the CLI arguments to the LLM configuration
3. **Maintained backward compatibility** - existing configuration methods still work

## Testing

- ✅ CLI arguments are properly parsed
- ✅ Configuration is correctly applied to LLM config
- ✅ Backward compatibility maintained
- ✅ Pre-commit hooks pass

This change makes it much more convenient for users to quickly test local models without needing to modify configuration files or go through interactive setup flows.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/83efa4ce397e4e6fbcd42f93b476c687)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4cbe46b-nikolaik   --name openhands-app-4cbe46b   docker.all-hands.dev/all-hands-ai/openhands:4cbe46b
```