### PR TITLE
docs: Add Python version requirement to CLI documentation

### DIFF
--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -11,6 +11,12 @@ for scripting.
 
 ### Running with Python
 
+#### Prerequisites
+
+- **Python 3.12 or higher** - OpenHands requires Python version 3.12 or higher (Python 3.14 is not currently supported)
+
+#### Installation
+
 1. Install OpenHands using pip:
 
 ```bash

--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -11,11 +11,7 @@ for scripting.
 
 ### Running with Python
 
-#### Prerequisites
-
-- **Python 3.12 or higher** - OpenHands requires Python version 3.12 or higher (Python 3.14 is not currently supported)
-
-#### Installation
+**Note** - OpenHands requires Python version 3.12 or higher (Python 3.14 is not currently supported)
 
 1. Install OpenHands using pip:
 


### PR DESCRIPTION
## Summary

This PR adds the Python version requirement to the CLI documentation to help users understand the prerequisites before attempting to install OpenHands.

## Changes

- Added a **Prerequisites** section to the CLI documentation under "Running with Python"
- Documented that Python 3.12 or higher is required
- Noted that Python 3.14 is not currently supported
- Added an **Installation** subheading to maintain proper document structure

## References

- Python version requirement verified from `pyproject.toml` line 22: `python = "^3.12,<3.14"`
- Consistent with existing documentation in `docs/usage/windows-without-wsl.mdx`

## Impact

This improves the user experience by setting clear expectations before installation, preventing potential installation failures due to incompatible Python versions.

## Testing

- Verified documentation formatting with pre-commit hooks
- Confirmed the change is minimal and focused on the specific requirement

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/6dd554fe54124c6b83ecbd1f49f531f1)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5fd6dfc-nikolaik   --name openhands-app-5fd6dfc   docker.all-hands.dev/all-hands-ai/openhands:5fd6dfc
```