### PR TITLE
Fix Devstral system prompt issue with Ollama

### DIFF
--- a/DEVSTRAL_OLLAMA_FIX.md
+++ b/DEVSTRAL_OLLAMA_FIX.md
@@ -1,0 +1,109 @@
+# Devstral + Ollama System Prompt Fix
+
+## Problem Description
+
+When using Devstral models with Ollama, the model fails to behave as an agentic coding assistant and instead acts like a generic chat model. This happens because Ollama's Go template system doesn't apply the default system prompt that Devstral expects, unlike LMStudio which properly applies the Jinja template with a default system message.
+
+### Root Cause
+
+1. **LMStudio (Works Correctly)**: Uses Jinja templates that include a `default_system_message` when no system message is provided. This ensures Devstral gets its proper system prompt.
+
+2. **Ollama (Broken)**: Uses Go templates that don't include a default system message mechanism. The template only applies system prompts if they're explicitly provided in the messages.
+
+3. **Devstral Requirement**: Devstral is specifically trained to work as an agentic coding model and requires its specific system prompt to function correctly.
+
+## Solution
+
+This fix automatically detects when:
+1. A Devstral model is being used (`devstral` in model name)
+2. Ollama is the LLM provider (detected via `base_url` containing `:11434` or `ollama`, or `custom_llm_provider` containing `ollama`)
+3. No proper Devstral system prompt is already present
+
+When these conditions are met, it automatically injects the official Devstral system prompt.
+
+## Implementation
+
+### Files Added/Modified
+
+1. **`openhands/llm/devstral_utils.py`** (New): Contains utility functions for detecting Devstral/Ollama usage and injecting the system prompt.
+
+2. **`openhands/llm/llm.py`** (Modified): Integrated the fix into the LLM wrapper to automatically apply the system prompt when needed.
+
+3. **`tests/unit/test_devstral_utils.py`** (New): Comprehensive tests for the utility functions.
+
+### Key Functions
+
+- `is_devstral_model(model_name)`: Detects if the model is a Devstral variant
+- `is_ollama_provider(base_url, custom_llm_provider)`: Detects if Ollama is being used
+- `needs_devstral_system_prompt_injection()`: Determines if injection is needed
+- `ensure_devstral_system_prompt()`: Main function that applies the fix when needed
+
+## Usage
+
+The fix is automatic and transparent. Users don't need to change anything in their configuration. When using Devstral with Ollama, the system prompt will be automatically injected.
+
+### Before the Fix
+```
+User: Create a button component
+Devstral: I can help you with that. You should create the files yourself...
+```
+
+### After the Fix
+```
+User: Create a button component
+Devstral: I'll create a button component for you. Let me start by exploring the project structure...
+<function=execute_bash>
+<parameter=command>find . -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" | head -10</parameter>
+</function>
+```
+
+## System Prompt Content
+
+The injected system prompt is the official Devstral system prompt from the model repository, which includes:
+
+- Role definition as an agentic coding assistant
+- Efficiency guidelines for combining actions
+- File system operation guidelines
+- Code quality standards
+- Version control best practices
+- Problem-solving workflow
+- Security considerations
+- Environment setup instructions
+- Troubleshooting guidelines
+
+## Compatibility
+
+- **LMStudio**: No impact (already works correctly)
+- **Other providers**: No impact (only applies to Ollama + Devstral)
+- **Non-Devstral models**: No impact (only applies to Devstral models)
+- **Existing system prompts**: If a system prompt containing "Devstral" is already present, no injection occurs
+
+## Testing
+
+Run the tests to verify the fix:
+
+```bash
+poetry run pytest tests/unit/test_devstral_utils.py -v
+```
+
+All tests should pass, confirming that:
+- Devstral models are correctly detected
+- Ollama provider is correctly detected
+- System prompt injection logic works correctly
+- Existing functionality is preserved
+
+## Future Considerations
+
+This fix addresses the immediate compatibility issue between Devstral and Ollama. In the future, this could be enhanced by:
+
+1. **Template Updates**: Working with the Ollama team to update the Devstral template to include a default system message
+2. **Model-Specific Handling**: Extending this pattern to other models that might have similar requirements
+3. **Configuration Options**: Adding user configuration to override the automatic injection behavior if needed
+
+## References
+
+- [GitHub Issue #8955](https://github.com/All-Hands-AI/OpenHands/issues/8955)
+- [Devstral Model Repository](https://huggingface.co/mistralai/Devstral-Small-2505)
+- [Devstral System Prompt](https://huggingface.co/mistralai/Devstral-Small-2505/blob/main/SYSTEM_PROMPT.txt)
+- [Ollama Template Documentation](https://github.com/ollama/ollama/blob/main/docs/template.md)
+- [Mistral Chat Templates Documentation](https://github.com/mistralai/cookbook/blob/main/concept-deep-dive/tokenization/chat_templates.md)

--- a/openhands/llm/devstral_utils.py
+++ b/openhands/llm/devstral_utils.py
@@ -1,0 +1,170 @@
+"""Utilities for handling Devstral model-specific requirements."""
+
+from typing import Any
+
+from openhands.core.logger import openhands_logger as logger
+
+# Devstral system prompt - this is the official system prompt from the Devstral model
+DEVSTRAL_SYSTEM_PROMPT = """You are Devstral, a helpful agentic model trained by Mistral AI and using the OpenHands scaffold. You can interact with a computer to solve tasks.
+
+<ROLE>
+Your primary role is to assist users by executing commands, modifying code, and solving technical problems effectively. You should be thorough, methodical, and prioritize quality over speed.
+* If the user asks a question, like "why is X happening", don't try to fix the problem. Just give an answer to the question.
+</ROLE>
+
+<EFFICIENCY>
+* Each action you take is somewhat expensive. Wherever possible, combine multiple actions into a single action, e.g. combine multiple bash commands into one, using sed and grep to edit/view multiple files at once.
+* When exploring the codebase, use efficient tools like find, grep, and git commands with appropriate filters to minimize unnecessary operations.
+</EFFICIENCY>
+
+<FILE_SYSTEM_GUIDELINES>
+* When a user provides a file path, do NOT assume it's relative to the current working directory. First explore the file system to locate the file before working on it.
+* If asked to edit a file, edit the file directly, rather than creating a new file with a different filename.
+* For global search-and-replace operations, consider using `sed` instead of opening file editors multiple times.
+</FILE_SYSTEM_GUIDELINES>
+
+<CODE_QUALITY>
+* Write clean, efficient code with minimal comments. Avoid redundancy in comments: Do not repeat information that can be easily inferred from the code itself.
+* When implementing solutions, focus on making the minimal changes needed to solve the problem.
+* Before implementing any changes, first thoroughly understand the codebase through exploration.
+* If you are adding a lot of code to a function or file, consider splitting the function or file into smaller pieces when appropriate.
+</CODE_QUALITY>
+
+<VERSION_CONTROL>
+* When configuring git credentials, use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
+* When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
+* Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
+* If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
+</VERSION_CONTROL>
+
+<PULL_REQUESTS>
+* When creating pull requests, create only ONE per session/issue unless explicitly instructed otherwise.
+* When working with an existing PR, update it with new commits rather than creating additional PRs for the same issue.
+* When updating a PR, preserve the original PR title and purpose, updating description only when necessary.
+</PULL_REQUESTS>
+
+<PROBLEM_SOLVING_WORKFLOW>
+1. EXPLORATION: Thoroughly explore relevant files and understand the context before proposing solutions
+2. ANALYSIS: Consider multiple approaches and select the most promising one
+3. TESTING:
+   * For bug fixes: Create tests to verify issues before implementing fixes
+   * For new features: Consider test-driven development when appropriate
+   * If the repository lacks testing infrastructure and implementing tests would require extensive setup, consult with the user before investing time in building testing infrastructure
+   * If the environment is not set up to run tests, consult with the user first before investing time to install all dependencies
+4. IMPLEMENTATION: Make focused, minimal changes to address the problem
+5. VERIFICATION: If the environment is set up to run tests, test your implementation thoroughly, including edge cases. If the environment is not set up to run tests, consult with the user first before investing time to run tests.
+</PROBLEM_SOLVING_WORKFLOW>
+
+<SECURITY>
+* Only use GITHUB_TOKEN and other credentials in ways the user has explicitly requested and would expect.
+* Use APIs to work with GitHub or other platforms, unless the user asks otherwise or your task requires browsing.
+</SECURITY>
+
+<ENVIRONMENT_SETUP>
+* When user asks you to run an application, don't stop if the application is not installed. Instead, please install the application and run the command again.
+* If you encounter missing dependencies:
+  1. First, look around in the repository for existing dependency files (requirements.txt, pyproject.toml, package.json, Gemfile, etc.)
+  2. If dependency files exist, use them to install all dependencies at once (e.g., `pip install -r requirements.txt`, `npm install`, etc.)
+  3. Only install individual packages directly if no dependency files are found or if only specific packages are needed
+* Similarly, if you encounter missing dependencies for essential tools requested by the user, install them when possible.
+</ENVIRONMENT_SETUP>
+
+<TROUBLESHOOTING>
+* If you've made repeated attempts to solve a problem but tests still fail or the user reports it's still broken:
+  1. Step back and reflect on 5-7 different possible sources of the problem
+  2. Assess the likelihood of each possible cause
+  3. Methodically address the most likely causes, starting with the highest probability
+  4. Document your reasoning process
+* When you run into any major issue while executing a plan from the user, please don't try to directly work around it. Instead, propose a new plan and confirm with the user before proceeding.
+</TROUBLESHOOTING>"""
+
+
+def is_devstral_model(model_name: str) -> bool:
+    """Check if the model is a Devstral model."""
+    return 'devstral' in model_name.lower()
+
+
+def is_ollama_provider(base_url: str | None, custom_llm_provider: str | None) -> bool:
+    """Check if we're using Ollama as the LLM provider."""
+    if custom_llm_provider and 'ollama' in custom_llm_provider.lower():
+        return True
+    if base_url and ('ollama' in base_url.lower() or ':11434' in base_url):
+        return True
+    return False
+
+
+def needs_devstral_system_prompt_injection(
+    model_name: str,
+    base_url: str | None,
+    custom_llm_provider: str | None,
+    messages: list[dict[str, Any]],
+) -> bool:
+    """
+    Determine if we need to inject the Devstral system prompt.
+
+    This is needed when:
+    1. Using a Devstral model
+    2. Using Ollama as the provider (which doesn't apply default system prompts properly)
+    3. No system message is present, or the system message doesn't contain Devstral-specific content
+    """
+    if not is_devstral_model(model_name):
+        return False
+
+    if not is_ollama_provider(base_url, custom_llm_provider):
+        return False
+
+    # Check if there's already a proper system message
+    for message in messages:
+        if message.get('role') == 'system':
+            content = message.get('content', '')
+            if isinstance(content, str) and 'Devstral' in content:
+                # Already has a Devstral system prompt
+                return False
+
+    return True
+
+
+def inject_devstral_system_prompt(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Inject the Devstral system prompt into the messages list.
+
+    This ensures that Devstral gets its proper system prompt when using Ollama,
+    which doesn't apply default system prompts like LMStudio does.
+    """
+    # Check if there's already a system message
+    has_system_message = any(msg.get('role') == 'system' for msg in messages)
+
+    if has_system_message:
+        # Replace the first system message with the Devstral system prompt
+        for i, message in enumerate(messages):
+            if message.get('role') == 'system':
+                messages[i] = {'role': 'system', 'content': DEVSTRAL_SYSTEM_PROMPT}
+                break
+    else:
+        # Insert the Devstral system prompt at the beginning
+        messages.insert(0, {'role': 'system', 'content': DEVSTRAL_SYSTEM_PROMPT})
+
+    logger.info('Injected Devstral system prompt for Ollama compatibility')
+    return messages
+
+
+def ensure_devstral_system_prompt(
+    model_name: str,
+    base_url: str | None,
+    custom_llm_provider: str | None,
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Ensure that Devstral models get their proper system prompt when using Ollama.
+
+    This is the main function to call from the LLM wrapper to fix the Ollama/Devstral
+    system prompt issue.
+    """
+    if needs_devstral_system_prompt_injection(
+        model_name, base_url, custom_llm_provider, messages
+    ):
+        return inject_devstral_system_prompt(messages)
+    return messages

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -27,6 +27,7 @@ from openhands.core.exceptions import LLMNoResponseError
 from openhands.core.logger import openhands_logger as logger
 from openhands.core.message import Message
 from openhands.llm.debug_mixin import DebugMixin
+from openhands.llm.devstral_utils import ensure_devstral_system_prompt
 from openhands.llm.fn_call_converter import (
     STOP_WORDS,
     convert_fncall_messages_to_non_fncall_messages,
@@ -232,6 +233,16 @@ class LLM(RetryMixin, DebugMixin):
             # ensure we work with a list of messages
             messages: list[dict[str, Any]] = (
                 messages_kwarg if isinstance(messages_kwarg, list) else [messages_kwarg]
+            )
+
+            # Fix Devstral system prompt issue with Ollama
+            # Ollama doesn't apply default system prompts like LMStudio does,
+            # so we need to explicitly inject the Devstral system prompt
+            messages = ensure_devstral_system_prompt(
+                self.config.model,
+                self.config.base_url,
+                self.config.custom_llm_provider,
+                messages,
             )
 
             # handle conversion of to non-function calling messages if needed

--- a/tests/unit/test_devstral_utils.py
+++ b/tests/unit/test_devstral_utils.py
@@ -1,0 +1,124 @@
+"""Tests for Devstral utilities."""
+
+from openhands.llm.devstral_utils import (
+    DEVSTRAL_SYSTEM_PROMPT,
+    ensure_devstral_system_prompt,
+    inject_devstral_system_prompt,
+    is_devstral_model,
+    is_ollama_provider,
+    needs_devstral_system_prompt_injection,
+)
+
+
+class TestDevstralUtils:
+    """Test Devstral utility functions."""
+
+    def test_is_devstral_model(self):
+        """Test detection of Devstral models."""
+        assert is_devstral_model('mistralai/devstral-small-2505')
+        assert is_devstral_model('devstral')
+        assert is_devstral_model('DEVSTRAL-LARGE')
+        assert not is_devstral_model('mistralai/mistral-7b')
+        assert not is_devstral_model('gpt-4')
+        assert not is_devstral_model('claude-3')
+
+    def test_is_ollama_provider(self):
+        """Test detection of Ollama provider."""
+        # Test via custom_llm_provider
+        assert is_ollama_provider(None, 'ollama')
+        assert is_ollama_provider(None, 'OLLAMA')
+        assert not is_ollama_provider(None, 'openai')
+
+        # Test via base_url
+        assert is_ollama_provider('http://localhost:11434', None)
+        assert is_ollama_provider('https://ollama.example.com', None)
+        assert not is_ollama_provider('https://api.openai.com', None)
+
+        # Test both None
+        assert not is_ollama_provider(None, None)
+
+    def test_needs_devstral_system_prompt_injection(self):
+        """Test logic for determining when to inject system prompt."""
+        # Should inject for Devstral + Ollama without system message
+        messages = [{'role': 'user', 'content': 'Hello'}]
+        assert needs_devstral_system_prompt_injection(
+            'devstral', 'http://localhost:11434', None, messages
+        )
+
+        # Should not inject for non-Devstral models
+        assert not needs_devstral_system_prompt_injection(
+            'gpt-4', 'http://localhost:11434', None, messages
+        )
+
+        # Should not inject for non-Ollama providers
+        assert not needs_devstral_system_prompt_injection(
+            'devstral', 'https://api.openai.com', None, messages
+        )
+
+        # Should not inject if Devstral system message already exists
+        messages_with_devstral = [
+            {
+                'role': 'system',
+                'content': 'You are Devstral, a helpful agentic model...',
+            },
+            {'role': 'user', 'content': 'Hello'},
+        ]
+        assert not needs_devstral_system_prompt_injection(
+            'devstral', 'http://localhost:11434', None, messages_with_devstral
+        )
+
+    def test_inject_devstral_system_prompt_no_existing_system(self):
+        """Test injecting system prompt when no system message exists."""
+        messages = [{'role': 'user', 'content': 'Hello'}]
+        result = inject_devstral_system_prompt(messages)
+
+        assert len(result) == 2
+        assert result[0]['role'] == 'system'
+        assert result[0]['content'] == DEVSTRAL_SYSTEM_PROMPT
+        assert result[1]['role'] == 'user'
+        assert result[1]['content'] == 'Hello'
+
+    def test_inject_devstral_system_prompt_replace_existing_system(self):
+        """Test replacing existing system message with Devstral prompt."""
+        messages = [
+            {'role': 'system', 'content': 'You are a helpful assistant'},
+            {'role': 'user', 'content': 'Hello'},
+        ]
+        result = inject_devstral_system_prompt(messages)
+
+        assert len(result) == 2
+        assert result[0]['role'] == 'system'
+        assert result[0]['content'] == DEVSTRAL_SYSTEM_PROMPT
+        assert result[1]['role'] == 'user'
+        assert result[1]['content'] == 'Hello'
+
+    def test_ensure_devstral_system_prompt_injection_needed(self):
+        """Test the main function when injection is needed."""
+        messages = [{'role': 'user', 'content': 'Hello'}]
+        result = ensure_devstral_system_prompt(
+            'devstral', 'http://localhost:11434', None, messages
+        )
+
+        assert len(result) == 2
+        assert result[0]['role'] == 'system'
+        assert result[0]['content'] == DEVSTRAL_SYSTEM_PROMPT
+
+    def test_ensure_devstral_system_prompt_injection_not_needed(self):
+        """Test the main function when injection is not needed."""
+        messages = [{'role': 'user', 'content': 'Hello'}]
+        result = ensure_devstral_system_prompt(
+            'gpt-4', 'https://api.openai.com', None, messages
+        )
+
+        # Should return original messages unchanged
+        assert result == messages
+        assert len(result) == 1
+        assert result[0]['role'] == 'user'
+
+    def test_devstral_system_prompt_content(self):
+        """Test that the Devstral system prompt contains expected content."""
+        assert 'Devstral' in DEVSTRAL_SYSTEM_PROMPT
+        assert 'OpenHands scaffold' in DEVSTRAL_SYSTEM_PROMPT
+        assert '<ROLE>' in DEVSTRAL_SYSTEM_PROMPT
+        assert '<EFFICIENCY>' in DEVSTRAL_SYSTEM_PROMPT
+        assert '<FILE_SYSTEM_GUIDELINES>' in DEVSTRAL_SYSTEM_PROMPT


### PR DESCRIPTION
## Problem

When using Devstral models with Ollama, the model fails to behave as an agentic coding assistant and instead acts like a generic chat model. This happens because Ollama's Go template system doesn't apply the default system prompt that Devstral expects, unlike LMStudio which properly applies the Jinja template with a default system message.

## Root Cause

- **LMStudio (Works Correctly)**: Uses Jinja templates that include a `default_system_message` when no system message is provided
- **Ollama (Broken)**: Uses Go templates that don't include a default system message mechanism
- **Devstral Requirement**: Devstral is specifically trained to work as an agentic coding model and requires its specific system prompt to function correctly

## Solution

This PR automatically detects when:
1. A Devstral model is being used (`devstral` in model name)
2. Ollama is the LLM provider (detected via `base_url` or `custom_llm_provider`)
3. No proper Devstral system prompt is already present

When these conditions are met, it automatically injects the official Devstral system prompt from the model repository.

## Changes

- **`openhands/llm/devstral_utils.py`** (New): Utility functions for detecting Devstral/Ollama usage and injecting the system prompt
- **`openhands/llm/llm.py`** (Modified): Integrated the fix into the LLM wrapper to automatically apply the system prompt when needed
- **`tests/unit/test_devstral_utils.py`** (New): Comprehensive tests for all scenarios
- **`DEVSTRAL_OLLAMA_FIX.md`** (New): Detailed documentation explaining the problem and solution

## Compatibility

- **LMStudio**: No impact (already works correctly)
- **Other providers**: No impact (only applies to Ollama + Devstral)
- **Non-Devstral models**: No impact (only applies to Devstral models)
- **Existing system prompts**: If a system prompt containing "Devstral" is already present, no injection occurs

## Testing

All tests pass:
```bash
poetry run pytest tests/unit/test_devstral_utils.py -v
```

The fix is automatic and transparent - users don't need to change anything in their configuration.

Fixes #8955

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/09ccc0d2a28644c589dea11e3178384c)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d28bf22-nikolaik   --name openhands-app-d28bf22   docker.all-hands.dev/all-hands-ai/openhands:d28bf22
```