### PR TITLE
Fix the issue where the shttp_services configuration from config.toml fails to load correctly.

### DIFF
--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -158,6 +158,7 @@ class MCPConfig(BaseModel):
             mcp_mapping['mcp'] = cls(
                 sse_servers=mcp_config.sse_servers,
                 stdio_servers=mcp_config.stdio_servers,
+                shttp_servers=mcp_config.shttp_servers,
             )
         except ValidationError as e:
             raise ValueError(f'Invalid MCP configuration: {e}')


### PR DESCRIPTION
… from config.toml.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

A very minor change: this issue occurs when shttp_servers is configured in config.toml; it fails to be loaded into OpenHandsConfig.mcp.

---
**Link of any specific issues this addresses:**
