### PR TITLE
Fix grammar issues in Slack documentation

### DIFF
--- a/docs/usage/cloud/slack-installation.mdx
+++ b/docs/usage/cloud/slack-installation.mdx
@@ -25,13 +25,13 @@ description: This guide walks you through installing the OpenHands Slack app.
 
   **Make sure your Slack workspace admin/owner has installed OpenHands Slack App first**
 
-  Every user in the slack workspace (including admins/owners) must link their Cloud OpenHands account to the OpenHands Slack App. To do this
+  Every user in the Slack workspace (including admins/owners) must link their Cloud OpenHands account to the OpenHands Slack App. To do this:
   1. Visit [integrations settings](https://app.all-hands.dev/settings/integrations) in OpenHands Cloud.
   2. Click the button "Install Slack App".
   3. In the top right corner, select the workspace to install the OpenHands Slack app.
   4. Review permissions and click allow.
 
-  Depending on the workspace settings, you may need approval from your slack admin to authorize the Slack App.
+  Depending on the workspace settings, you may need approval from your Slack admin to authorize the Slack App.
 
 </Accordion>
 
@@ -68,6 +68,6 @@ You can mention a repo name when starting a new conversation in the following fo
 2. "All-Hands-AI/OpenHands" (e.g `@openhands in All-Hands-AI/OpenHands ...`)
 
 The repo match is case insensitive. If a repo name match is made, it will kick off the conversation.
-If the repo name partially matches against, multiple repos, you'll be asked to select a repo from the filtered list.
+If the repo name partially matches against multiple repos, you'll be asked to select a repo from the filtered list.
 
 ![slack-pro-tip.png](/static/img/slack-pro-tip.png)


### PR DESCRIPTION
## Summary

This PR fixes several grammar issues in the Slack installation documentation (`docs/usage/cloud/slack-installation.mdx`) without rewriting any content.

## Changes Made

1. **Fixed comma placement**: Changed "against, multiple repos, you'll" to "against multiple repos, you'll" (line 71)
2. **Added missing colon**: Completed the sentence "To do this" with a colon to properly introduce the numbered list (line 28)
3. **Capitalization consistency**: Changed "slack" to "Slack" in two instances for consistency with the rest of the document (lines 28 and 34)

## Testing

- All pre-commit hooks passed
- Changes are minimal and only address grammar issues
- No content was rewritten, only corrected

## Type of Change

- [x] Documentation update
- [x] Bug fix (grammar corrections)

Fixes grammar issues identified in the Slack documentation.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3dbc4919f1cc423287a488dc14cb945b)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:387a633-nikolaik   --name openhands-app-387a633   docker.all-hands.dev/all-hands-ai/openhands:387a633
```