### PR TITLE
docs: Add uvx alternative installation method for CLI mode

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -70,8 +70,7 @@ Documentation files are located in the `docs/` directory and use `.mdx` format (
 
 ### Documentation Format Standards:
 - Use `<Note>` tags for callouts instead of `**Note**` markdown formatting
-- Follow Mintlify documentation format conventions
-- CLI documentation is located at `docs/usage/how-to/cli-mode.mdx`
+- Follow Mintlify documentation format conventions: https://mintlify.com/docs/components/callouts
 
 ## Template for Github Pull Request
 

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -64,6 +64,15 @@ Frontend:
   - Mutation hooks should follow the pattern use[Action] (e.g., `useDeleteConversation`)
   - Architecture rule: UI components → TanStack Query hooks → Data Access Layer (`frontend/src/api`) → API endpoints
 
+## Documentation
+
+Documentation files are located in the `docs/` directory and use `.mdx` format (Mintlify documentation format).
+
+### Documentation Format Standards:
+- Use `<Note>` tags for callouts instead of `**Note**` markdown formatting
+- Follow Mintlify documentation format conventions
+- CLI documentation is located at `docs/usage/how-to/cli-mode.mdx`
+
 ## Template for Github Pull Request
 
 If you are starting a pull request (PR), please follow the template in `.github/pull_request_template.md`.

--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -11,7 +11,9 @@ for scripting.
 
 ### Running with Python
 
-**Note** - OpenHands CLI requires Python 3.12 to run - If you run into issues during pip install, you can also use uv (https://docs.astral.sh/uv/) to launch OpenHands CLI in one line: `uvx --python 3.12 --from openhands-ai openhands`
+<Note>
+OpenHands CLI requires Python 3.12 to run - If you run into issues during pip install, you can also use uv (https://docs.astral.sh/uv/) to launch OpenHands CLI in one line: `uvx --python 3.12 --from openhands-ai openhands`
+</Note>
 
 1. Install OpenHands using pip:
 

--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -11,7 +11,7 @@ for scripting.
 
 ### Running with Python
 
-**Note** - OpenHands requires Python version 3.12 or higher (Python 3.14 is not currently supported)
+**Note** - OpenHands CLI requires Python 3.12 to run - If you run into issues during pip install, you can also use uv (https://docs.astral.sh/uv/) to launch OpenHands CLI in one line: `uvx --python 3.12 --from openhands-ai openhands`
 
 1. Install OpenHands using pip:
 
@@ -24,6 +24,16 @@ pip install openhands-ai
 ```bash
 openhands
 ```
+
+**Alternative: Using uvx**
+
+If you encounter issues with the pip installation or want to run OpenHands without installing it globally, you can use `uvx`:
+
+```bash
+uvx --python 3.12 --from openhands-ai openhands
+```
+
+This command will automatically handle the Python 3.12 requirement and run OpenHands directly without needing to install it in your current environment.
 
 3. Set your model, API key, and other preferences using the UI (or alternatively environment variables, below).
 


### PR DESCRIPTION
## Summary

This PR updates the CLI mode documentation to include `uvx` as an alternative installation method for users who encounter issues with the standard pip installation.

## Changes

- Added a note about Python 3.12 requirement and uvx alternative in the CLI documentation
- Included the specific uvx command: `uvx --python 3.12 --from openhands-ai openhands`
- Provided explanation for when to use uvx (installation issues or avoiding global install)
- Added reference to uv documentation for users who want to learn more

## Context

OpenHands CLI requires Python 3.12 to run. Some users may encounter issues during pip installation, and uvx provides a convenient alternative that automatically handles the Python version requirement and runs OpenHands without needing to install it globally.

## Documentation Source

The uvx command and information about uv are based on:
- The official uv documentation at https://docs.astral.sh/uv/
- User request specifying the exact command format and use case

## Testing

- Verified the documentation renders correctly
- Pre-commit hooks passed successfully
- No functional code changes, only documentation updates

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5e47cb848a4b4e19b8e715e7838eee31)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:61f0f7e-nikolaik   --name openhands-app-61f0f7e   docker.all-hands.dev/all-hands-ai/openhands:61f0f7e
```