### PR TITLE
Add uvx installation option to CLI documentation

### DIFF
--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -19,6 +19,12 @@ for scripting.
 pip install openhands-ai
 ```
 
+   Or if you prefer not to manage your own Python environment, you can use `uvx`:
+
+```bash
+uvx --python 3.12 --from openhands-ai openhands
+```
+
 2. Launch an interactive OpenHands conversation from the command line:
 
 ```bash


### PR DESCRIPTION
This PR adds the `uvx` installation method as an alternative to `pip install` in the CLI documentation.

## Changes
- Added uvx installation instructions to the CLI mode documentation
- Provides users with an option that doesn't require managing their own Python environment
- Follows the same pattern as the blog post update

## Installation Methods
The documentation now includes both:
1. `pip install openhands-ai` (existing method)
2. `uvx --python 3.12 --from openhands-ai openhands` (new alternative method)

## Context
The uvx method was identified as a valuable alternative that automatically handles Python environment management, making it easier for users to get started with the OpenHands CLI without needing to set up their own Python environment.

This aligns with the recent blog post update that also includes the uvx installation method.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fa744a80ec1e45ffbd82aeea78af5c07)