### PR TITLE
Fix deprecation warning: Replace get_events with search_events

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -179,7 +179,7 @@ class AgentController:
         self._add_system_message()
 
     def _add_system_message(self):
-        for event in self.event_stream.get_events(start_id=self.state.start_id):
+        for event in self.event_stream.search_events(start_id=self.state.start_id):
             if isinstance(event, MessageAction) and event.source == EventSource.USER:
                 # FIXME: Remove this after 6/1/2025
                 # Do not try to add a system message if we first run into
@@ -1216,7 +1216,7 @@ class AgentController:
         )
 
     def _is_awaiting_observation(self) -> bool:
-        events = self.event_stream.get_events(reverse=True)
+        events = self.event_stream.search_events(reverse=True)
         for event in events:
             if isinstance(event, AgentStateChangedObservation):
                 result = event.agent_state == AgentState.RUNNING
@@ -1257,7 +1257,7 @@ class AgentController:
         self._cached_first_user_message = next(
             (
                 e
-                for e in self.event_stream.get_events(
+                for e in self.event_stream.search_events(
                     start_id=self.state.start_id,
                 )
                 if isinstance(e, MessageAction) and e.source == EventSource.USER

--- a/openhands/events/async_event_store_wrapper.py
+++ b/openhands/events/async_event_store_wrapper.py
@@ -15,8 +15,8 @@ class AsyncEventStoreWrapper:
         loop = asyncio.get_running_loop()
 
         # Create an async generator that yields events
-        for event in self.event_store.get_events(*self.args, **self.kwargs):
-            # Run the blocking get_events() in a thread pool
+        for event in self.event_store.search_events(*self.args, **self.kwargs):
+            # Run the blocking search_events() in a thread pool
             def get_event(e: Event = event) -> Event:
                 return e
 

--- a/openhands/events/event_store.py
+++ b/openhands/events/event_store.py
@@ -140,7 +140,7 @@ class EventStore(EventStoreABC):
         return self.cur_id - 1
 
     def filtered_events_by_source(self, source: EventSource) -> Iterable[Event]:
-        for event in self.get_events():
+        for event in self.search_events():
             if event.source == source:
                 yield event
 

--- a/openhands/utils/conversation_summary.py
+++ b/openhands/utils/conversation_summary.py
@@ -95,7 +95,7 @@ async def auto_generate_title(
 
         # Find the first user message
         first_user_message = None
-        for event in event_stream.get_events():
+        for event in event_stream.search_events():
             if (
                 event.source == EventSource.USER
                 and isinstance(event, MessageAction)

--- a/tests/unit/test_auto_generate_title.py
+++ b/tests/unit/test_auto_generate_title.py
@@ -43,7 +43,7 @@ async def test_auto_generate_title_with_llm():
     ) as mock_event_stream_cls:
         # Configure the mock event stream to return our test message
         mock_event_stream = MagicMock(spec=EventStream)
-        mock_event_stream.get_events.return_value = [user_message]
+        mock_event_stream.search_events.return_value = [user_message]
         mock_event_stream_cls.return_value = mock_event_stream
 
         # Mock the LLM response
@@ -108,7 +108,7 @@ async def test_auto_generate_title_fallback():
     ) as mock_event_stream_cls:
         # Configure the mock event stream to return our test message
         mock_event_stream = MagicMock(spec=EventStream)
-        mock_event_stream.get_events.return_value = [user_message]
+        mock_event_stream.search_events.return_value = [user_message]
         mock_event_stream_cls.return_value = mock_event_stream
 
         # Mock the LLM to raise an exception
@@ -154,7 +154,7 @@ async def test_auto_generate_title_no_messages():
     ) as mock_event_stream_cls:
         # Configure the mock event stream to return no events
         mock_event_stream = MagicMock(spec=EventStream)
-        mock_event_stream.get_events.return_value = []
+        mock_event_stream.search_events.return_value = []
         mock_event_stream_cls.return_value = mock_event_stream
 
         # Create test settings


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR eliminates annoying deprecation warnings that appear in the CLI when using OpenHands. Users will no longer see repeated "DeprecationWarning: Call to deprecated method get_events. (Use search_events instead)" messages cluttering their terminal output, providing a cleaner and more professional user experience.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR replaces all instances of the deprecated `get_events()` method with the recommended `search_events()` method across the codebase. The changes are straightforward replacements as both methods have compatible signatures and behavior.

**Files modified:**
- **agent_controller.py**: Replaced 3 instances in `_add_system_message()`, `_is_awaiting_observation()`, and `_get_first_user_message_from_event_stream()` methods
- **event_store.py**: Replaced 1 instance in `filtered_events_by_source()` method
- **async_event_store_wrapper.py**: Replaced 1 instance in `__aiter__()` method and updated related comment
- **conversation_summary.py**: Replaced 1 instance in `get_conversation_summary()` method

**Design decisions:**
- Used direct method replacement since `search_events()` is a drop-in replacement for `get_events()`
- No functional changes were needed as the method signatures and return types are identical
- All non-test usages of the deprecated method have been systematically replaced

**Testing:**
- ✅ All pre-commit hooks pass
- ✅ Verified no deprecation warnings are generated after changes
- ✅ Confirmed `search_events()` has compatible signature with `get_events()`

---
**Link of any specific issues this addresses:**

Fixes https://github.com/All-Hands-AI/OpenHands/issues/9167

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/719b28a0d442414fa3b882753f7012b6)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0a56339-nikolaik   --name openhands-app-0a56339   docker.all-hands.dev/all-hands-ai/openhands:0a56339
```