### PR TITLE
Fix Windows signal compatibility in CLI runtime

### DIFF
--- a/tests/unit/test_cli_runtime_signals.py
+++ b/tests/unit/test_cli_runtime_signals.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for CLI runtime signal handling, specifically testing Windows compatibility.
+"""
+
+import signal
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openhands.core.config import OpenHandsConfig
+from openhands.events import EventStream
+from openhands.runtime.impl.cli.cli_runtime import CLIRuntime, _get_signal_constant
+from openhands.storage import get_file_store
+
+
+class TestSignalHandling:
+    """Test signal handling in CLI runtime."""
+
+    def test_get_signal_constant_existing(self):
+        """Test that _get_signal_constant returns existing signals."""
+        # SIGTERM should exist on all platforms
+        sigterm = _get_signal_constant('SIGTERM')
+        assert sigterm is not None
+        assert sigterm == signal.SIGTERM
+
+    def test_get_signal_constant_nonexistent(self):
+        """Test that _get_signal_constant returns None for non-existent signals."""
+        fake_signal = _get_signal_constant('FAKE_SIGNAL_THAT_DOES_NOT_EXIST')
+        assert fake_signal is None
+
+    def test_get_signal_constant_sigkill(self):
+        """Test SIGKILL handling - exists on Unix, may not exist on Windows."""
+        sigkill = _get_signal_constant('SIGKILL')
+
+        if sys.platform == 'win32':
+            # On Windows, SIGKILL may not exist
+            # This test just ensures no exception is raised
+            assert sigkill is None or isinstance(sigkill, int)
+        else:
+            # On Unix-like systems, SIGKILL should exist
+            assert sigkill is not None
+            assert sigkill == signal.SIGKILL
+
+    @patch('sys.platform', 'win32')
+    def test_safe_terminate_process_windows_terminate(self):
+        """Test Windows process termination with terminate signal."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = OpenHandsConfig()
+            config.workspace_base = temp_dir
+            file_store = get_file_store('local', temp_dir)
+            event_stream = EventStream('test', file_store)
+
+            runtime = CLIRuntime(
+                config=config, event_stream=event_stream, sid='test_session'
+            )
+
+            # Mock process object
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+
+            # Test with SIGTERM (should call terminate)
+            sigterm = _get_signal_constant('SIGTERM')
+            runtime._safe_terminate_process(mock_process, signal_to_send=sigterm)
+
+            mock_process.terminate.assert_called_once()
+            mock_process.kill.assert_not_called()
+
+    @patch('sys.platform', 'win32')
+    @patch('openhands.runtime.impl.cli.cli_runtime._get_signal_constant')
+    def test_safe_terminate_process_windows_kill(self, mock_get_signal):
+        """Test Windows process termination with kill signal."""
+        # Mock SIGKILL to exist for this test
+        mock_sigkill = 9
+        mock_get_signal.side_effect = (
+            lambda name: mock_sigkill if name == 'SIGKILL' else None
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = OpenHandsConfig()
+            config.workspace_base = temp_dir
+            file_store = get_file_store('local', temp_dir)
+            event_stream = EventStream('test', file_store)
+
+            runtime = CLIRuntime(
+                config=config, event_stream=event_stream, sid='test_session'
+            )
+
+            # Mock process object
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+
+            # Test with SIGKILL (should call kill)
+            runtime._safe_terminate_process(mock_process, signal_to_send=mock_sigkill)
+
+            mock_process.kill.assert_called_once()
+            mock_process.terminate.assert_not_called()
+
+    @patch('sys.platform', 'linux')
+    def test_safe_terminate_process_unix_with_signals(self):
+        """Test Unix process termination uses signals."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = OpenHandsConfig()
+            config.workspace_base = temp_dir
+            file_store = get_file_store('local', temp_dir)
+            event_stream = EventStream('test', file_store)
+
+            runtime = CLIRuntime(
+                config=config, event_stream=event_stream, sid='test_session'
+            )
+
+            # Mock process object
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+
+            # Mock os.getpgid and os.killpg to avoid actual signal sending
+            with (
+                patch('os.getpgid', return_value=12345),
+                patch('os.killpg') as mock_killpg,
+            ):
+                sigterm = _get_signal_constant('SIGTERM')
+                runtime._safe_terminate_process(mock_process, signal_to_send=sigterm)
+
+                # Should use killpg with the signal
+                mock_killpg.assert_called_once_with(12345, sigterm)
+
+    def test_safe_terminate_process_none_signal(self):
+        """Test that None signal defaults to SIGTERM on Unix."""
+        if sys.platform == 'win32':
+            pytest.skip('This test is for Unix-like systems')
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = OpenHandsConfig()
+            config.workspace_base = temp_dir
+            file_store = get_file_store('local', temp_dir)
+            event_stream = EventStream('test', file_store)
+
+            runtime = CLIRuntime(
+                config=config, event_stream=event_stream, sid='test_session'
+            )
+
+            # Mock process object
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+
+            # Mock os.getpgid and os.killpg
+            with (
+                patch('os.getpgid', return_value=12345),
+                patch('os.killpg') as mock_killpg,
+            ):
+                # Call with None signal
+                runtime._safe_terminate_process(mock_process, signal_to_send=None)
+
+                # Should default to SIGTERM
+                expected_signal = _get_signal_constant('SIGTERM') or signal.SIGTERM
+                mock_killpg.assert_called_once_with(12345, expected_signal)
+
+    def test_safe_terminate_process_no_pid(self):
+        """Test that method handles process with no PID gracefully."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = OpenHandsConfig()
+            config.workspace_base = temp_dir
+            file_store = get_file_store('local', temp_dir)
+            event_stream = EventStream('test', file_store)
+
+            runtime = CLIRuntime(
+                config=config, event_stream=event_stream, sid='test_session'
+            )
+
+            # Mock process object without PID
+            mock_process = MagicMock()
+            mock_process.pid = None
+
+            # Should return early without error
+            runtime._safe_terminate_process(mock_process)
+
+            # No methods should be called
+            mock_process.terminate.assert_not_called()
+            mock_process.kill.assert_not_called()
+
+    @patch('sys.platform', 'win32')
+    def test_safe_terminate_process_windows_exception(self):
+        """Test Windows process termination handles exceptions gracefully."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = OpenHandsConfig()
+            config.workspace_base = temp_dir
+            file_store = get_file_store('local', temp_dir)
+            event_stream = EventStream('test', file_store)
+
+            runtime = CLIRuntime(
+                config=config, event_stream=event_stream, sid='test_session'
+            )
+
+            # Mock process object that raises exception
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+            mock_process.terminate.side_effect = Exception('Test exception')
+
+            # Should not raise exception
+            runtime._safe_terminate_process(mock_process)
+
+            mock_process.terminate.assert_called_once()


### PR DESCRIPTION
## Problem

The OpenHands CLI runtime was failing on Windows with `AttributeError: module 'signal' has no attribute 'SIGKILL'` because Windows doesn't support all POSIX signals that are available on Unix-like systems.

## Root Cause

In `/openhands/runtime/impl/cli/cli_runtime.py`, the code was directly accessing `signal.SIGKILL` and `signal.SIGTERM` without checking if they exist on the current platform. On Windows, these constants don't exist, causing crashes.

## Solution

This PR implements a cross-platform solution:

### 1. Safe Signal Constant Access
- Added `_get_signal_constant()` helper function that safely accesses signal constants using `getattr()` with fallback to `None`
- Prevents `AttributeError` when signal constants don't exist

### 2. Platform-Specific Process Termination
- **Windows (`sys.platform == 'win32'`)**: Uses `process.terminate()` and `process.kill()` methods directly
- **Unix-like systems**: Continues using POSIX signals with safe constant access
- Maintains full backward compatibility

### 3. Updated All Signal References
- Replaced all direct `signal.SIGKILL` and `signal.SIGTERM` usage with safe accessor calls
- Updated `_safe_terminate_process()` method signature to handle `None` signal parameter

## Testing

Added comprehensive unit tests covering:
- Safe signal constant access for existing and non-existent signals
- Platform detection and Windows-specific behavior
- Unix-specific signal handling
- Error handling and edge cases
- Process termination with different signal types

All tests pass and the code follows project style guidelines.

## Benefits

- ✅ **Cross-Platform Support**: OpenHands CLI runtime now works on Windows
- ✅ **Robust Error Handling**: No more AttributeError crashes on Windows  
- ✅ **Backward Compatibility**: Unix-like systems retain full functionality
- ✅ **Future-Proof**: Safe signal access pattern can be reused elsewhere

## Files Changed

- `openhands/runtime/impl/cli/cli_runtime.py`: Core signal handling fixes
- `tests/unit/test_cli_runtime_signals.py`: Comprehensive test coverage

Fixes the Windows compatibility issue reported in the CLI runtime.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/35ae2639f9b6429bb989fb8d6c4023f4)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e05bffe-nikolaik   --name openhands-app-e05bffe   docker.all-hands.dev/all-hands-ai/openhands:e05bffe
```