### PR TITLE
Increase max iterations from 250 to 500

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -64,7 +64,7 @@
 #max_budget_per_task = 0.0
 
 # Maximum number of iterations
-#max_iterations = 250
+#max_iterations = 500
 
 # Path to mount the workspace in the sandbox
 #workspace_mount_path_in_sandbox = "/workspace"

--- a/openhands/core/config/config_utils.py
+++ b/openhands/core/config/config_utils.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
 OH_DEFAULT_AGENT = 'CodeActAgent'
-OH_MAX_ITERATIONS = 250
+OH_MAX_ITERATIONS = 500
 
 
 def get_field_info(field: FieldInfo) -> dict[str, Any]:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Increases the default maximum number of iterations for OpenHands agents from 250 to 500. This allows agents to work on more complex tasks that require additional steps to complete, improving the overall capability and success rate for challenging software development tasks.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR updates the `OH_MAX_ITERATIONS` constant from 250 to 500 in the core configuration. The change affects:

1. **Core Configuration**: Updated `OH_MAX_ITERATIONS` constant in `openhands/core/config/config_utils.py`
2. **Configuration Template**: Updated the example value in `config.template.toml` to maintain consistency

The change is minimal and focused, affecting only the default value. Users can still override this setting via:
- Configuration files (TOML)
- Environment variables
- Command-line arguments (`--max-iterations`)

All existing tests continue to pass, ensuring backward compatibility.

---
**Link of any specific issues this addresses:**

This addresses user feedback requesting higher iteration limits for complex tasks.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a1c92ba8aaf4612977e4d4f14f0276c)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:972153c-nikolaik   --name openhands-app-972153c   docker.all-hands.dev/all-hands-ai/openhands:972153c
```