### PR TITLE
Add Bitbucket integration documentation for local usage

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,6 +50,7 @@
               "usage/how-to/cli-mode",
               "usage/how-to/headless-mode",
               "usage/how-to/github-action",
+              "usage/how-to/bitbucket-integration",
               {
                 "group": "Advanced Configuration",
                 "pages": [

--- a/docs/usage/how-to/bitbucket-integration.mdx
+++ b/docs/usage/how-to/bitbucket-integration.mdx
@@ -1,0 +1,93 @@
+---
+title: Bitbucket Integration (Local)
+description: This guide walks you through setting up Bitbucket integration when running OpenHands locally.
+---
+
+## Prerequisites
+
+- OpenHands running locally (see [Local Setup](/usage/local-setup))
+- A Bitbucket account with access to the repositories you want to work with
+
+## Setting Up Bitbucket Integration
+
+### 1. Create a Bitbucket App Password
+
+To integrate OpenHands with Bitbucket, you'll need to create an app password:
+
+1. Visit [Bitbucket's app passwords settings](https://bitbucket.org/account/settings/app-passwords/)
+2. Click "Create app password"
+3. Give your app password a descriptive name (e.g., "OpenHands Integration")
+4. Select the following scopes:
+
+<Accordion title="Required Bitbucket App Password Scopes">
+  - **Repositories: Read** - Allows OpenHands to read repository content
+  - **Repositories: Write** - Allows OpenHands to make changes to repositories
+  - **Pull requests: Read** - Allows OpenHands to read pull request information
+  - **Pull requests: Write** - Allows OpenHands to create and update pull requests
+  - **Issues: Read** - Allows OpenHands to read issue information
+  - **Issues: Write** - Allows OpenHands to create and update issues
+</Accordion>
+
+5. Click "Create" and copy the generated app password
+
+### 2. Configure Environment Variables
+
+Set up the following environment variables for Bitbucket integration:
+
+```bash
+# Bitbucket credentials
+export BITBUCKET_TOKEN="your-bitbucket-app-password"
+export GIT_USERNAME="your-bitbucket-username"  # Optional, defaults to token owner
+```
+
+### 3. Using OpenHands with Bitbucket Repositories
+
+Once configured, you can use OpenHands with your Bitbucket repositories in several ways:
+
+#### CLI Mode
+When using [CLI mode](/usage/how-to/cli-mode), OpenHands will automatically use your Bitbucket credentials when working with Bitbucket repositories.
+
+#### Headless Mode
+For [headless mode](/usage/how-to/headless-mode), ensure your environment variables are set before running OpenHands.
+
+#### Issue Resolution
+You can use the OpenHands resolver to automatically work on Bitbucket issues:
+
+```bash
+python -m openhands.resolver.resolve_issue --selected-repo [OWNER]/[REPO] --issue-number [NUMBER]
+```
+
+For example:
+```bash
+python -m openhands.resolver.resolve_issue --selected-repo mycompany/myproject --issue-number 42
+```
+
+## Security Considerations
+
+- Store your Bitbucket app password securely and never commit it to version control
+- Consider using environment variable files (`.env`) that are excluded from version control
+- Regularly rotate your app passwords for enhanced security
+- Only grant the minimum required scopes for your use case
+
+## Troubleshooting
+
+### Authentication Issues
+- Verify your app password is correct and hasn't expired
+- Ensure all required scopes are granted to your app password
+- Check that your username is correct if specified
+
+### Repository Access Issues
+- Confirm you have the necessary permissions on the Bitbucket repository
+- Verify the repository URL format is correct (`owner/repo`)
+
+### Need Help?
+If you encounter issues with Bitbucket integration, please:
+- Check the [troubleshooting guide](/usage/troubleshooting/troubleshooting)
+- [Open an issue](https://github.com/all-hands-ai/openhands/issues) on the OpenHands repository
+- Contact us at [contact@all-hands.dev](mailto:contact@all-hands.dev)
+
+## Next Steps
+
+- Learn about [CLI mode](/usage/how-to/cli-mode) for interactive development
+- Explore [headless mode](/usage/how-to/headless-mode) for automated workflows
+- Set up [repository microagents](/usage/prompting/microagents-repo) for custom instructions

--- a/docs/usage/local-setup.mdx
+++ b/docs/usage/local-setup.mdx
@@ -166,6 +166,7 @@ This version is unstable and is recommended for testing or development purposes 
 ## Next Steps
 
 - [Connect OpenHands to your local filesystem.](/usage/runtimes/docker#connecting-to-your-filesystem) to use OpenHands with your GitHub repositories
+- [Set up Bitbucket integration for local usage.](/usage/how-to/bitbucket-integration)
 - [Run OpenHands in a scriptable headless mode.](/usage/how-to/headless-mode)
 - [Run OpenHands with a friendly CLI.](/usage/how-to/cli-mode)
 - [Run OpenHands on tagged issues with a GitHub action.](/usage/how-to/github-action)


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for Bitbucket integration when running OpenHands locally, following the user's request to provide local integration docs similar to the existing GitHub/GitLab cloud integration patterns.

## Changes

- **New documentation file**: `docs/usage/how-to/bitbucket-integration.mdx`
  - Comprehensive guide for setting up Bitbucket integration for local OpenHands usage
  - Includes required app password scopes extracted from `openhands/resolver/README.md`
  - Follows the same structure and style as existing GitHub/GitLab integration docs
  - Covers prerequisites, setup steps, usage examples, security considerations, and troubleshooting

- **Navigation updates**: Added the new guide to `docs/docs.json` navigation structure

- **Reference updates**: Added link to the new Bitbucket integration guide in the "Next Steps" section of `docs/usage/local-setup.mdx`

## Documentation Sources Referenced

- `openhands/resolver/README.md` (lines 96-104) for Bitbucket app password scopes
- `docs/usage/cloud/github-installation.mdx` and `docs/usage/cloud/gitlab-installation.mdx` for documentation pattern and structure

## Key Features

✅ **Follows existing documentation pattern** - Uses same structure as GitHub/GitLab integration docs  
✅ **Includes required token scopes** - All 6 required Bitbucket app password scopes with explanations  
✅ **Concise and focused** - Covers all necessary information without being verbose  
✅ **Local usage only** - Specifically for local OpenHands setup, not cloud integration  

The documentation provides users with a clear, step-by-step guide to integrate their local OpenHands installation with Bitbucket repositories, enabling them to work with Bitbucket issues and repositories using the resolver and other OpenHands features.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fe3e92ea46d84aa88a304424446e9745)