### PR TITLE
Read command line args in CLI

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import logging
 import os
@@ -347,9 +348,10 @@ async def run_setup_flow(config: OpenHandsConfig, settings_store: FileSettingsSt
     await modify_llm_settings_basic(config, settings_store)
 
 
-async def main_with_loop(loop: asyncio.AbstractEventLoop) -> None:
+async def main_with_loop(
+    loop: asyncio.AbstractEventLoop, args: argparse.Namespace
+) -> None:
     """Runs the agent in CLI mode."""
-    args = parse_arguments()
 
     logger.setLevel(logging.WARNING)
 
@@ -454,10 +456,12 @@ async def main_with_loop(loop: asyncio.AbstractEventLoop) -> None:
 
 
 def main():
+    """Main entry point for the OpenHands CLI."""
+    args = parse_arguments()
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        loop.run_until_complete(main_with_loop(loop))
+        loop.run_until_complete(main_with_loop(loop, args))
     except KeyboardInterrupt:
         print('Received keyboard interrupt, shutting down...')
     except ConnectionRefusedError as e:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -381,7 +381,7 @@ async def test_main_without_task(
     mock_run_session.return_value = False
 
     # Run the function
-    await cli.main_with_loop(loop)
+    await cli.main_with_loop(loop, mock_args)
 
     # Assertions
     mock_parse_args.assert_called_once()
@@ -464,7 +464,7 @@ async def test_main_with_task(
     mock_run_session.side_effect = [True, False]
 
     # Run the function
-    await cli.main_with_loop(loop)
+    await cli.main_with_loop(loop, mock_args)
 
     # Assertions
     mock_parse_args.assert_called_once()
@@ -559,7 +559,7 @@ async def test_main_with_session_name_passes_name_to_run_session(
     mock_run_session.return_value = False
 
     # Run the function
-    await cli.main_with_loop(loop)
+    await cli.main_with_loop(loop, mock_args)
 
     # Assertions
     mock_parse_args.assert_called_once()
@@ -720,7 +720,7 @@ async def test_main_security_check_fails(
     mock_check_security.return_value = False
 
     # Run the function
-    await cli.main_with_loop(loop)
+    await cli.main_with_loop(loop, mock_args)
 
     # Assertions
     mock_parse_args.assert_called_once()
@@ -803,7 +803,7 @@ async def test_config_loading_order(
     mock_run_session.return_value = False  # No new session requested
 
     # Run the function
-    await cli.main_with_loop(loop)
+    await cli.main_with_loop(loop, mock_args)
 
     # Assertions for argument parsing and config setup
     mock_parse_args.assert_called_once()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR proposes a fix for command line arguments not being read in CLI mode.

We seem to have lost these sometime.

---
**Link of any specific issues this addresses:**
