### PR TITLE
Fix search_events signature mismatches after get_events replacement

### DIFF
--- a/openhands/server/routes/feedback.py
+++ b/openhands/server/routes/feedback.py
@@ -3,6 +3,7 @@ from fastapi.responses import JSONResponse
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.async_event_store_wrapper import AsyncEventStoreWrapper
+from openhands.events.event_filter import EventFilter
 from openhands.events.serialization import event_to_dict
 from openhands.server.data_models.feedback import FeedbackDataModel, store_feedback
 from openhands.server.dependencies import get_dependencies
@@ -41,7 +42,9 @@ async def submit_feedback(
     # Assuming the storage service is already configured in the backend
     # and there is a function to handle the storage.
     body = await request.json()
-    async_store = AsyncEventStoreWrapper(conversation.event_stream, filter_hidden=True)
+    async_store = AsyncEventStoreWrapper(
+        conversation.event_stream, filter=EventFilter(exclude_hidden=True)
+    )
     trajectory = []
     async for event in async_store:
         trajectory.append(event_to_dict(event))

--- a/openhands/server/routes/trajectory.py
+++ b/openhands/server/routes/trajectory.py
@@ -3,6 +3,7 @@ from fastapi.responses import JSONResponse
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.async_event_store_wrapper import AsyncEventStoreWrapper
+from openhands.events.event_filter import EventFilter
 from openhands.events.serialization import event_to_trajectory
 from openhands.server.dependencies import get_dependencies
 from openhands.server.session.conversation import ServerConversation
@@ -30,7 +31,7 @@ async def get_trajectory(
     """
     try:
         async_store = AsyncEventStoreWrapper(
-            conversation.event_stream, filter_hidden=True
+            conversation.event_stream, filter=EventFilter(exclude_hidden=True)
         )
         trajectory = []
         async for event in async_store:


### PR DESCRIPTION
## Summary

This PR fixes signature mismatches that occurred after the global replacement of `get_events` with `search_events`. The issue was that some calls were still using the old `get_events` parameter signature.

## Changes Made

- **Fixed `openhands/server/routes/trajectory.py`**: 
  - Replaced `filter_hidden=True` with `filter=EventFilter(exclude_hidden=True)`
  - Added `EventFilter` import

- **Fixed `openhands/server/routes/feedback.py`**: 
  - Replaced `filter_hidden=True` with `filter=EventFilter(exclude_hidden=True)`
  - Added `EventFilter` import

## Root Cause

The global find-and-replace of `get_events` → `search_events` changed the function name but didn't update the parameter signatures. The old `get_events` signature used `filter_hidden=True`, while the new `search_events` signature uses `filter=EventFilter(exclude_hidden=True)`.

## Testing

- ✅ Pre-commit hooks pass
- ✅ Core functionality verified with test script
- ✅ No other instances of signature mismatch found in codebase

## Files Changed

- `openhands/server/routes/trajectory.py`
- `openhands/server/routes/feedback.py`

Fixes the signature mismatch issue mentioned in the conversation.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fc3b3014060d466ab01532e8129aa63a)