### PR TITLE
[feat] Make MCP timeouts configurable

### DIFF
--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -2,7 +2,7 @@ import os
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 if TYPE_CHECKING:
     from openhands.core.config.openhands_config import OpenHandsConfig
@@ -98,6 +98,20 @@ class MCPConfig(BaseModel):
                 data['shttp_servers'] = cls._normalize_servers(data['shttp_servers'])
 
         return data
+
+    @field_validator('default_timeout')
+    def validate_default_timeout(cls, value: float):
+        """Custom validator to ensure default_timeout is greater than zero.
+
+        Prevents invalid configurations that could lead to timeouts in MCP connections."""
+        try:
+            value = float(value)
+        except ValueError:
+            raise ValueError('default_timeout must be of type float')
+
+        if value <= 0:
+            raise ValueError('default_timeout must be greater than zero')
+        return value
 
     def validate_servers(self) -> None:
         """Validate that server URLs are valid and unique."""

--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -64,10 +64,12 @@ class MCPConfig(BaseModel):
     """Configuration for MCP (Message Control Protocol) settings.
 
     Attributes:
+        default_timeout: Default timeout for MCP connections, configurable via environment variables
         sse_servers: List of MCP SSE server configs
         stdio_servers: List of MCP stdio server configs. These servers will be added to the MCP Router running inside runtime container.
     """
 
+    default_timeout: float = 30.0
     sse_servers: list[MCPSSEServerConfig] = Field(default_factory=list)
     stdio_servers: list[MCPStdioServerConfig] = Field(default_factory=list)
     shttp_servers: list[MCPSHTTPServerConfig] = Field(default_factory=list)

--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -151,6 +151,11 @@ class OpenHandsConfig(BaseModel):
         )
         return self.get_llm_config(llm_config_name)
 
+    def get_mcp_config(self) -> MCPConfig:
+        if not self.mcp:
+            self.mcp = MCPConfig()
+        return self.mcp
+
     def get_agent_configs(self) -> dict[str, AgentConfig]:
         return self.agents
 

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -120,6 +120,9 @@ def load_from_env(
     # load default agent config from env
     default_agent_config = cfg.get_agent_config()
     set_attr_from_env(default_agent_config, 'AGENT_')
+    # load default MCP config from env
+    default_mcp_config = cfg.get_mcp_config()
+    set_attr_from_env(default_mcp_config, 'MCP_')
 
 
 def load_from_toml(cfg: OpenHandsConfig, toml_file: str = 'config.toml') -> None:

--- a/openhands/mcp/client.py
+++ b/openhands/mcp/client.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from openhands.core.config.mcp_config import MCPSHTTPServerConfig, MCPSSEServerConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.mcp.tool import MCPClientTool
+from openhands.core.config import load_app_config
 
 
 class MCPClient(BaseModel):
@@ -52,11 +53,14 @@ class MCPClient(BaseModel):
         self,
         server: MCPSSEServerConfig | MCPSHTTPServerConfig,
         conversation_id: str | None = None,
-        timeout: float = 30.0,
+        timeout: float = None,
     ):
         """Connect to MCP server using SHTTP or SSE transport"""
         server_url = server.url
         api_key = server.api_key
+
+        if timeout is None:
+            timeout = server.timeout if getattr(server, 'timeout', None) else load_app_config().mcp.default_timeout
 
         if not server_url:
             raise ValueError('Server URL is required.')

--- a/openhands/mcp/client.py
+++ b/openhands/mcp/client.py
@@ -7,9 +7,9 @@ from mcp.types import CallToolResult
 from pydantic import BaseModel, Field
 
 from openhands.core.config.mcp_config import MCPSHTTPServerConfig, MCPSSEServerConfig
+from openhands.core.config.utils import load_openhands_config
 from openhands.core.logger import openhands_logger as logger
 from openhands.mcp.tool import MCPClientTool
-from openhands.core.config import load_app_config
 
 
 class MCPClient(BaseModel):
@@ -60,7 +60,11 @@ class MCPClient(BaseModel):
         api_key = server.api_key
 
         if timeout is None:
-            timeout = server.timeout if getattr(server, 'timeout', None) else load_app_config().mcp.default_timeout
+            timeout = (
+                server.timeout
+                if getattr(server, 'timeout', None)
+                else load_openhands_config().mcp.default_timeout
+            )
 
         if not server_url:
             raise ValueError('Server URL is required.')

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -1,3 +1,7 @@
+import os
+from unittest import mock
+from unittest.mock import patch
+
 import pytest
 from pydantic import ValidationError
 
@@ -6,6 +10,7 @@ from openhands.core.config.mcp_config import (
     MCPSSEServerConfig,
     MCPStdioServerConfig,
 )
+from openhands.core.config.utils import load_openhands_config
 
 
 def test_valid_sse_config():
@@ -252,7 +257,7 @@ def test_stdio_server_equality_with_different_env_order():
 def test_mcp_config_default_timeout():
     """Verify that the default_timeout in MCPConfig is initialized to 30.0.
 
-    This test ensures the timeout has a standard fallback value, which is crucial for 
+    This test ensures the timeout has a standard fallback value, which is crucial for
     maintaining default behavior in MCP connections when no overrides are provided.
     It checks the basic initialization to confirm consistency across environments.
     """
@@ -264,8 +269,8 @@ def test_mcp_config_default_timeout():
 def test_mcp_config_timeout_override():
     """Test manual overriding of the default_timeout in MCPConfig.
 
-    This verifies that users can specify custom timeout values, allowing for 
-    flexibility in scenarios like high-latency networks. It ensures the field 
+    This verifies that users can specify custom timeout values, allowing for
+    flexibility in scenarios like high-latency networks. It ensures the field
     accepts and retains overrides correctly.
     """
     config = MCPConfig(default_timeout=60.0)
@@ -276,23 +281,21 @@ def test_mcp_config_timeout_override():
 def test_mcp_config_timeout_with_env_override(monkeypatch):
     """Test overriding default_timeout via environment variables.
 
-    This test simulates real-world configuration scenarios where environment 
-    variables take precedence, ensuring the system integrates with external 
+    This test simulates real-world configuration scenarios where environment
+    variables take precedence, ensuring the system integrates with external
     settings. It covers dynamic overrides and validates their application.
     """
-    monkeypatch.setenv('MCP_DEFAULT_TIMEOUT', '90.0')
-    with patch('openhands.core.config.load_from_env') as mock_load_env:
-        mock_load_env.return_value = {'default_timeout': 90.0}
-        config = MCPConfig()
-        assert config.default_timeout == 90.0
+    with mock.patch.dict(os.environ, {'MCP_DEFAULT_TIMEOUT': '45.5'}):
+        config = load_openhands_config()
+        assert config.mcp.default_timeout == 45.5
 
 
 @pytest.mark.unit
 def test_mcp_config_invalid_timeout():
     """Test that invalid timeout values (e.g., negative) raise a ValidationError.
 
-    This ensures type and value safety, preventing misconfigurations that could 
-    lead to runtime errors. It covers edge cases like negative values to enforce 
+    This ensures type and value safety, preventing misconfigurations that could
+    lead to runtime errors. It covers edge cases like negative values to enforce
     positive timeouts only.
     """
     with pytest.raises(ValidationError):
@@ -303,7 +306,7 @@ def test_mcp_config_invalid_timeout():
 def test_mcp_config_zero_timeout():
     """Test that zero timeout values raise a ValidationError.
 
-    Zero timeouts could cause immediate failures in connections, so this test 
+    Zero timeouts could cause immediate failures in connections, so this test
     enforces that only positive values are accepted, improving overall reliability.
     """
     with pytest.raises(ValidationError):
@@ -314,7 +317,7 @@ def test_mcp_config_zero_timeout():
 def test_mcp_config_non_float_timeout():
     """Test that non-float values for timeout raise a ValidationError.
 
-    This verifies type enforcement, ensuring the field only accepts numeric values 
+    This verifies type enforcement, ensuring the field only accepts numeric values
     to prevent configuration errors in production environments.
     """
     with pytest.raises(ValidationError):

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -246,3 +246,76 @@ def test_stdio_server_equality_with_different_env_order():
 
     # Should not be equal
     assert server1 != server5
+
+
+@pytest.mark.unit
+def test_mcp_config_default_timeout():
+    """Verify that the default_timeout in MCPConfig is initialized to 30.0.
+
+    This test ensures the timeout has a standard fallback value, which is crucial for 
+    maintaining default behavior in MCP connections when no overrides are provided.
+    It checks the basic initialization to confirm consistency across environments.
+    """
+    config = MCPConfig()
+    assert config.default_timeout == 30.0
+
+
+@pytest.mark.unit
+def test_mcp_config_timeout_override():
+    """Test manual overriding of the default_timeout in MCPConfig.
+
+    This verifies that users can specify custom timeout values, allowing for 
+    flexibility in scenarios like high-latency networks. It ensures the field 
+    accepts and retains overrides correctly.
+    """
+    config = MCPConfig(default_timeout=60.0)
+    assert config.default_timeout == 60.0
+
+
+@pytest.mark.unit
+def test_mcp_config_timeout_with_env_override(monkeypatch):
+    """Test overriding default_timeout via environment variables.
+
+    This test simulates real-world configuration scenarios where environment 
+    variables take precedence, ensuring the system integrates with external 
+    settings. It covers dynamic overrides and validates their application.
+    """
+    monkeypatch.setenv('MCP_DEFAULT_TIMEOUT', '90.0')
+    with patch('openhands.core.config.load_from_env') as mock_load_env:
+        mock_load_env.return_value = {'default_timeout': 90.0}
+        config = MCPConfig()
+        assert config.default_timeout == 90.0
+
+
+@pytest.mark.unit
+def test_mcp_config_invalid_timeout():
+    """Test that invalid timeout values (e.g., negative) raise a ValidationError.
+
+    This ensures type and value safety, preventing misconfigurations that could 
+    lead to runtime errors. It covers edge cases like negative values to enforce 
+    positive timeouts only.
+    """
+    with pytest.raises(ValidationError):
+        MCPConfig(default_timeout=-10.0)
+
+
+@pytest.mark.unit
+def test_mcp_config_zero_timeout():
+    """Test that zero timeout values raise a ValidationError.
+
+    Zero timeouts could cause immediate failures in connections, so this test 
+    enforces that only positive values are accepted, improving overall reliability.
+    """
+    with pytest.raises(ValidationError):
+        MCPConfig(default_timeout=0.0)
+
+
+@pytest.mark.unit
+def test_mcp_config_non_float_timeout():
+    """Test that non-float values for timeout raise a ValidationError.
+
+    This verifies type enforcement, ensuring the field only accepts numeric values 
+    to prevent configuration errors in production environments.
+    """
+    with pytest.raises(ValidationError):
+        MCPConfig(default_timeout='not_a_float')

--- a/tests/unit/test_mcp_timeout.py
+++ b/tests/unit/test_mcp_timeout.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest import mock
 
 import pytest
+from fastmcp import Client
 
 from openhands.core.config.mcp_config import MCPConfig, MCPSSEServerConfig
 from openhands.mcp import MCPClient, create_mcp_clients, fetch_mcp_tools_from_config
@@ -81,3 +82,28 @@ async def test_mixed_connection_results():
 
         # Verify that tools were returned
         assert len(tools) > 0
+
+
+@pytest.mark.asyncio
+async def test_connect_http_with_different_server_types(mock_client):
+	"""Test connect_http instantiates Client with correct timeout across server types."""
+
+    mock_sse_server = mock.MagicMock(spec=MCPSSEServerConfig)
+    mock_http_server = mock.MagicMock(spec=MCPSHTTPServerConfig)
+
+    for server in (mock_sse_server, mock_http_server):
+        server.url = "https://example.com"
+
+    mock_config = mock.MagicMock(spec=MCPConfig)
+    mock_config.mcp.default_timeout = timeout = 1.0
+
+    with patch('openhands.core.config.load_app_config', return_value=mock_config), \
+         patch('fastmcp.Client') as MockClient:
+
+        wrapper = MCPClient()
+
+        await wrapper.connect_http(server=mock_sse_server)
+        MockClient.assert_called_with(timeout=timeout)
+
+        await wrapper.connect_http(server=mock_http_server)
+        assert MockClient.call_args_list[-1] == mock.call(timeout=timeout)

--- a/tests/unit/test_mcp_timeout.py
+++ b/tests/unit/test_mcp_timeout.py
@@ -1,10 +1,17 @@
 import asyncio
+import os
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from fastmcp import Client
 
-from openhands.core.config.mcp_config import MCPConfig, MCPSSEServerConfig
+from openhands.core.config.mcp_config import (
+    MCPConfig,
+    MCPSHTTPServerConfig,
+    MCPSSEServerConfig,
+)
+from openhands.core.config.utils import load_openhands_config
 from openhands.mcp import MCPClient, create_mcp_clients, fetch_mcp_tools_from_config
 
 
@@ -85,25 +92,26 @@ async def test_mixed_connection_results():
 
 
 @pytest.mark.asyncio
-async def test_connect_http_with_different_server_types(mock_client):
-	"""Test connect_http instantiates Client with correct timeout across server types."""
-
+async def test_connect_http_with_different_server_types():
+    """Test connect_http instantiates Client with correct timeout across server types."""
     mock_sse_server = mock.MagicMock(spec=MCPSSEServerConfig)
     mock_http_server = mock.MagicMock(spec=MCPSHTTPServerConfig)
 
     for server in (mock_sse_server, mock_http_server):
-        server.url = "https://example.com"
+        server.url = 'https://example.com'
+        server.api_key = None
 
-    mock_config = mock.MagicMock(spec=MCPConfig)
-    mock_config.mcp.default_timeout = timeout = 1.0
-
-    with patch('openhands.core.config.load_app_config', return_value=mock_config), \
-         patch('fastmcp.Client') as MockClient:
-
+    timeout = 1.0
+    with (
+        mock.patch.dict(os.environ, {'MCP_DEFAULT_TIMEOUT': str(timeout)}),
+        patch('openhands.mcp.client.MCPClient._initialize_and_list_tools'),
+        patch('openhands.mcp.client.Client') as MockClient,
+    ):
         wrapper = MCPClient()
 
-        await wrapper.connect_http(server=mock_sse_server)
-        MockClient.assert_called_with(timeout=timeout)
-
-        await wrapper.connect_http(server=mock_http_server)
-        assert MockClient.call_args_list[-1] == mock.call(timeout=timeout)
+        for server in (mock_sse_server, mock_http_server):
+            await wrapper.connect_http(server=server)
+            assert any(
+                call.kwargs.get('timeout') == timeout
+                for call in MockClient.call_args_list
+            )


### PR DESCRIPTION
- [X] This change is worth documenting at https://docs.all-hands.dev/  
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below  

**End-user friendly description of the problem this fixes or functionality this introduces.**  
This update introduces configurable timeouts for MCP connections, allowing users to set custom values via environment variables. It helps prevent issues with invalid timeouts and improves reliability in varying network and compute conditions, making OpenHands more adaptable for production use.

---  
**Summarize what the PR does, explaining any non-trivial design decisions.**  
This PR adds a `default_timeout` field to the `MCPConfig` class in `mcp_config.py`, including a Pydantic field validator to enforce positive float values. It updates `utils.py` to explicitly handle the `MCP_DEFAULT_TIMEOUT` environment variable during config loading, ensuring seamless integration with the existing system. Non-trivial decisions include:  
- Using Pydantic's `@field_validator` for custom validation to maintain consistency with the project's validation patterns, rather than adding global checks.  
- Extending tests in `test_mcp_config.py` to cover edge cases, as the original implementation lacked automatic detection in `load_from_env`.  
This approach minimizes invasive changes while enhancing configurability, as recommended in `CONTRIBUTING.md`.

---  
**Link of any specific issues this addresses:**  
This PR seeks to address an issue I raised here https://github.com/All-Hands-AI/OpenHands/issues/9149 about encountering invalid timeouts for MCP operations, which happen to take longer than usual, but are not necessary failing.

---
**Addendum:**
It is possible to expand the scope of this PR to include per-MCP timeout configuration, but as it stands now, a global default is configurable, which applies to all registered MCP servers.