### PR TITLE
Fix SambaNova context length exception handling

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -821,10 +821,11 @@ class AgentController:
                     or 'input length and `max_tokens` exceed context limit' in error_str
                     or 'please reduce the length of either one'
                     in error_str  # For OpenRouter context window errors
-                    or 'sambanovaexception'
-                    in error_str  # For SambaNova context window errors
-                    or 'maximum context length'
-                    in error_str  # For SambaNova context window errors
+                    or (
+                        'sambanovaexception' in error_str
+                        and 'maximum context length' in error_str
+                    )
+                    # For SambaNova context window errors - only match when both patterns are present
                     or isinstance(e, ContextWindowExceededError)
                 ):
                     if self.agent.config.enable_history_truncation:

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -821,6 +821,10 @@ class AgentController:
                     or 'input length and `max_tokens` exceed context limit' in error_str
                     or 'please reduce the length of either one'
                     in error_str  # For OpenRouter context window errors
+                    or 'sambanovaexception'
+                    in error_str  # For SambaNova context window errors
+                    or 'maximum context length'
+                    in error_str  # For SambaNova context window errors
                     or isinstance(e, ContextWindowExceededError)
                 ):
                     if self.agent.config.enable_history_truncation:

--- a/tests/unit/test_agent_controller.py
+++ b/tests/unit/test_agent_controller.py
@@ -1682,3 +1682,70 @@ async def test_openrouter_context_window_exceeded_error(
     )
 
     await controller.close()
+
+
+@pytest.mark.asyncio
+async def test_sambanova_context_window_exceeded_error(
+    mock_agent, test_event_stream, mock_status_callback
+):
+    """Test that SambaNova context window exceeded errors are properly detected and handled."""
+    max_iterations = 5
+    error_after = 2
+
+    class StepState:
+        def __init__(self):
+            self.has_errored = False
+            self.index = 0
+            self.views = []
+
+        def step(self, state: State):
+            # Store the view for later inspection
+            self.views.append(state.view)
+            # only throw it once.
+            if self.index < error_after or self.has_errored:
+                self.index += 1
+                return MessageAction(content=f'Test message {self.index}')
+
+            # Create a BadRequestError with the SambaNova context window exceeded message pattern
+            error = BadRequestError(
+                message='litellm.BadRequestError: SambanovaException - The maximum context length of DeepSeek-V3-0324 is 32768. However, answering your request will take 39732 tokens. Please reduce the length of the messages or the specified max_completion_tokens value.',
+                model='sambanova/deepseek-v3-0324',
+                llm_provider='sambanova',
+            )
+            self.has_errored = True
+            raise error
+
+    step_state = StepState()
+    mock_agent.step = step_state.step
+    mock_agent.config = AgentConfig(enable_history_truncation=True)
+
+    controller = AgentController(
+        agent=mock_agent,
+        event_stream=test_event_stream,
+        iteration_delta=max_iterations,
+        sid='test',
+        confirmation_mode=False,
+        headless_mode=True,
+        status_callback=mock_status_callback,
+    )
+
+    # Set the agent state to RUNNING
+    controller.state.agent_state = AgentState.RUNNING
+
+    # Run the controller until it hits the error
+    for _ in range(error_after + 2):  # +2 to ensure we go past the error
+        await controller._step()
+        if step_state.has_errored:
+            break
+
+    # Verify that the error was handled as a context window exceeded error
+    # by checking that _handle_long_context_error was called (which adds a CondensationAction)
+    events = list(test_event_stream.get_events())
+    condensation_actions = [e for e in events if isinstance(e, CondensationAction)]
+
+    # There should be at least one CondensationAction if the error was handled correctly
+    assert len(condensation_actions) > 0, (
+        'SambaNova context window exceeded error was not handled correctly'
+    )
+
+    await controller.close()


### PR DESCRIPTION
## Summary

This PR fixes the issue where SambaNova context window exceeded errors were not being properly caught and handled by OpenHands' existing context window error handling logic.

## Changes

- **Added SambaNova exception detection**: Added detection for `'sambanovaexception'` and `'maximum context length'` patterns in error messages in `agent_controller.py`
- **Added comprehensive test**: Added `test_sambanova_context_window_exceeded_error` to verify the fix works correctly

## Problem

Users were experiencing unhandled context window errors when using SambaNova models, as reported in issue #9227. The error message pattern:

```
BadRequestError: litellm.BadRequestError: SambanovaException - The maximum context length of DeepSeek-V3-0324 is 32768. However, answering your request will take 39732 tokens. Please reduce the length of the messages or the specified max_completion_tokens value.
```

Was not being caught by the existing context window error handling logic, causing the agent to error out instead of gracefully handling the situation by condensing the conversation history.

## Solution

Extended the existing context window error detection logic in `agent_controller.py` to include SambaNova-specific error patterns:
- `'sambanovaexception'` (case-insensitive)
- `'maximum context length'` (case-insensitive)

This ensures that when SambaNova context window errors occur, they are properly handled by the existing `_handle_long_context_error` method, which creates a `CondensationAction` to reduce the conversation history and allow the agent to continue.

## Testing

- Added comprehensive test case `test_sambanova_context_window_exceeded_error` that simulates the exact error pattern from the issue
- Test verifies that a `CondensationAction` is created when the SambaNova error occurs
- All existing context window error tests continue to pass
- Pre-commit hooks pass

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/675abcd0aa674ffd983bd8f341bcce06)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ed19b3c-nikolaik   --name openhands-app-ed19b3c   docker.all-hands.dev/all-hands-ai/openhands:ed19b3c
```