### PR TITLE
Fix Marshmallow __version_info__ deprecation warning

### DIFF
--- a/openhands/__init__.py
+++ b/openhands/__init__.py
@@ -1,5 +1,16 @@
 import os
 
+# Suppress marshmallow deprecation warning from environs (used by daytona)
+# This must be done before any imports that might trigger the warning
+import warnings
+
+warnings.filterwarnings(
+    'ignore',
+    message=r'.*__version_info__.*deprecated.*',
+    category=DeprecationWarning,
+    module=r'.*environs.*',
+)
+
 __package_name__ = 'openhands_ai'
 
 

--- a/openhands/utils/warnings_utils.py
+++ b/openhands/utils/warnings_utils.py
@@ -1,0 +1,48 @@
+"""Utilities for managing warnings in OpenHands."""
+
+import warnings
+from contextlib import contextmanager
+from typing import Generator
+
+
+@contextmanager
+def suppress_marshmallow_version_info_warning() -> Generator[None, None, None]:
+    """
+    Context manager to suppress the specific Marshmallow __version_info__ deprecation warning.
+
+    This warning is triggered by the environs library (used by daytona) when it checks
+    marshmallow version compatibility using the deprecated __version_info__ attribute.
+
+    The warning message is:
+    "The '__version_info__' attribute is deprecated and will be removed in a future version.
+    Use feature detection or 'packaging.Version(importlib.metadata.version("marshmallow")).release' instead."
+
+    This is a temporary fix until daytona updates to a newer version of environs
+    that doesn't use the deprecated attribute.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message=r'.*__version_info__.*deprecated.*',
+            category=DeprecationWarning,
+            module=r'.*environs.*',
+        )
+        yield
+
+
+def suppress_marshmallow_version_info_warning_globally() -> None:
+    """
+    Globally suppress the specific Marshmallow __version_info__ deprecation warning.
+
+    This function adds a warning filter that will suppress the deprecation warning
+    from environs about using marshmallow's __version_info__ attribute.
+
+    This is a temporary fix until daytona updates to a newer version of environs
+    that doesn't use the deprecated attribute.
+    """
+    warnings.filterwarnings(
+        'ignore',
+        message=r'.*__version_info__.*deprecated.*',
+        category=DeprecationWarning,
+        module=r'.*environs.*',
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Global test configuration for OpenHands tests."""
+
+import warnings
+
+# Suppress marshmallow deprecation warning from environs (used by daytona)
+# This must be done before any imports that might trigger the warning
+warnings.filterwarnings(
+    'ignore',
+    message=r'.*__version_info__.*deprecated.*',
+    category=DeprecationWarning,
+    module=r'.*environs.*',
+)

--- a/tests/unit/test_marshmallow_deprecation_fix.py
+++ b/tests/unit/test_marshmallow_deprecation_fix.py
@@ -1,0 +1,110 @@
+"""Test for Marshmallow __version_info__ deprecation warning fix."""
+
+
+def test_no_marshmallow_deprecation_warning_on_import():
+    """Test that importing OpenHands modules doesn't trigger Marshmallow deprecation warnings."""
+    # Test that the warning filter is working by trying to import in a subprocess
+    # This ensures we test the actual user experience
+    import subprocess
+    import sys
+
+    # Run a subprocess that imports openhands and checks for warnings
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            """
+import warnings
+import sys
+
+# Capture warnings
+with warnings.catch_warnings(record=True) as warning_list:
+    warnings.simplefilter("always")
+
+    # Import modules that might trigger the warning
+    import openhands
+    import environs
+
+    # Check for the specific deprecation warning
+    marshmallow_warnings = [
+        w for w in warning_list
+        if issubclass(w.category, DeprecationWarning)
+        and "__version_info__" in str(w.message)
+        and "marshmallow" in str(w.message).lower()
+    ]
+
+    if marshmallow_warnings:
+        print(f"FOUND_WARNINGS: {len(marshmallow_warnings)}")
+        for w in marshmallow_warnings:
+            print(f"WARNING: {w.message}")
+        sys.exit(1)
+    else:
+        print("NO_WARNINGS_FOUND")
+        sys.exit(0)
+        """,
+        ],
+        capture_output=True,
+        text=True,
+        cwd='/workspace/OpenHands',
+    )
+
+    # Check the result
+    assert result.returncode == 0, (
+        f'Subprocess found marshmallow warnings. '
+        f'stdout: {result.stdout}, stderr: {result.stderr}'
+    )
+
+
+def test_environs_import_no_deprecation_warning():
+    """Test that importing environs specifically doesn't trigger the deprecation warning."""
+    # Test that the warning filter is working by trying to import in a subprocess
+    import subprocess
+    import sys
+
+    # Run a subprocess that imports environs and checks for warnings
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            """
+import warnings
+import sys
+
+# Capture warnings
+with warnings.catch_warnings(record=True) as warning_list:
+    warnings.simplefilter("always")
+
+    # Import openhands first to apply our warning filter
+    import openhands
+
+    # Import environs which should trigger the warning without our fix
+    from environs import Env
+
+    # Check for the specific deprecation warning from environs
+    environs_warnings = [
+        w for w in warning_list
+        if issubclass(w.category, DeprecationWarning)
+        and "__version_info__" in str(w.message)
+        and "environs" in str(w.filename)
+    ]
+
+    if environs_warnings:
+        print(f"FOUND_WARNINGS: {len(environs_warnings)}")
+        for w in environs_warnings:
+            print(f"WARNING: {w.message}")
+        sys.exit(1)
+    else:
+        print("NO_WARNINGS_FOUND")
+        sys.exit(0)
+        """,
+        ],
+        capture_output=True,
+        text=True,
+        cwd='/workspace/OpenHands',
+    )
+
+    # Check the result
+    assert result.returncode == 0, (
+        f'Subprocess found environs warnings. '
+        f'stdout: {result.stdout}, stderr: {result.stderr}'
+    )


### PR DESCRIPTION
## Summary

This PR fixes issue #9275 by suppressing the Marshmallow `__version_info__` deprecation warning that appears when importing OpenHands.

## Problem

The warning was caused by the `environs` library (version 9.5.0) used by the `daytona` package. The environs library checks `marshmallow.__version_info__` for version compatibility, but this attribute was deprecated in marshmallow 3.26.1.

The warning message was:
```
The '__version_info__' attribute is deprecated and will be removed in a future version. 
Use feature detection or 'packaging.Version(importlib.metadata.version("marshmallow")).release' instead.
```

## Solution

- **Added warning filter** in `openhands/__init__.py` to suppress the specific deprecation warning from the environs module
- **Created utility module** `openhands/utils/warnings_utils.py` for centralized warning management (for future use)
- **Added comprehensive tests** to verify the fix works correctly
- **Added global test configuration** in `tests/conftest.py` to ensure consistent test behavior

## Technical Details

The root cause is a dependency chain:
- OpenHands → daytona (0.21.1) → environs (>=9.5.0,<10.0.0) → marshmallow.__version_info__
- The fix in environs was released in version 11.0.0, but daytona constrains environs to <10.0.0
- This is a temporary fix until daytona updates to support environs 11.0.0+

## Testing

- Added two comprehensive tests that verify the warning is suppressed
- Tests use subprocess execution to ensure they test the actual user experience
- All existing tests continue to pass
- Pre-commit hooks pass successfully

## Impact

- **User-facing**: Eliminates the annoying deprecation warning when importing OpenHands
- **Developer-facing**: No functional changes, purely cosmetic fix
- **Future-proof**: Warning filter is specific and won't interfere with other warnings

Fixes #9275

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e91f4763816f4a2c97b081622f00f329)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:dc2f229-nikolaik   --name openhands-app-dc2f229   docker.all-hands.dev/all-hands-ai/openhands:dc2f229
```