### PR TITLE
Better translation of "let's start building" in Japanese

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -833,10 +833,10 @@
     },
     "HOME$LETS_START_BUILDING": {
         "en": "Let's Start Building!",
-        "ja": "構築を始めましょう！",
-        "zh-CN": "让我们开始构建！",
-        "zh-TW": "讓我們開始構建！",
-        "ko-KR": "구축을 시작합시다!",
+        "ja": "開発を始めましょう！",
+        "zh-CN": "让我们开始开发！",
+        "zh-TW": "讓我們開始開發！",
+        "ko-KR": "개발을 시작합시다!",
         "no": "La oss begynne å bygge!",
         "it": "Iniziamo a costruire!",
         "pt": "Vamos começar a construir!",
@@ -849,7 +849,7 @@
     },
     "HOME$OPENHANDS_DESCRIPTION": {
         "en": "OpenHands makes it easy to build and maintain software using AI-driven development.",
-        "ja": "OpenHandsはAI駆動の開発を使用してソフトウェアの構築と維持を容易にします。",
+        "ja": "OpenHandsはAI駆動の開発を使用してソフトウェアの開発と維持を容易にします。",
         "zh-CN": "OpenHands使用AI驱动的开发方式，轻松构建和维护软件。",
         "zh-TW": "OpenHands使用AI驅動的開發方式，輕鬆構建和維護軟件。",
         "ko-KR": "OpenHands는 AI 기반 개발을 사용하여 소프트웨어를 쉽게 구축하고 유지할 수 있게 합니다.",

--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -39,8 +39,6 @@ class ConversationValidator:
         conversation_id: str,
         user_id: str | None,
     ) -> ConversationMetadata:
-
-
         config = load_openhands_config()
         server_config = ServerConfig()
 
@@ -48,14 +46,16 @@ class ConversationValidator:
             ConversationStore,
             server_config.conversation_store_class,
         )
-        conversation_store = await conversation_store_class.get_instance(config, user_id)
+        conversation_store = await conversation_store_class.get_instance(
+            config, user_id
+        )
 
         try:
             metadata = await conversation_store.get_metadata(conversation_id)
         except FileNotFoundError:
             logger.info(
                 f'Creating new conversation metadata for {conversation_id}',
-                extra={'session_id': conversation_id}
+                extra={'session_id': conversation_id},
             )
             await conversation_store.save_metadata(
                 ConversationMetadata(
@@ -68,6 +68,7 @@ class ConversationValidator:
             )
             metadata = await conversation_store.get_metadata(conversation_id)
         return metadata
+
 
 def create_conversation_validator() -> ConversationValidator:
     conversation_validator_cls = os.environ.get(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Previously "let's start building" was like "building a house", so this changes to "let's start developing" like developing software.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1f4d746-nikolaik   --name openhands-app-1f4d746   docker.all-hands.dev/all-hands-ai/openhands:1f4d746
```