### PR TITLE
Clarify GitHub integration docs regarding @openhands mentions in pull requests

### DIFF
--- a/docs/usage/cloud/github-installation.mdx
+++ b/docs/usage/cloud/github-installation.mdx
@@ -65,6 +65,8 @@ To get OpenHands to work on pull requests, mention `@openhands` in the comments 
 - Request updates
 - Get code explanations
 
+**Important Note**: The `@openhands` mention functionality in pull requests only works if the pull request is both *to* and *from* a repository that you have added through the interface. This is because OpenHands needs appropriate permissions to access both repositories.
+
 ## Next Steps
 
 - [Learn about the Cloud UI](/usage/cloud/cloud-ui).


### PR DESCRIPTION
This PR clarifies the GitHub integration documentation for OpenHands Cloud to note that writing `@openhands` on a pull request will only work if the pull request is both *to* and *from* a repository that you have added through the interface.

The change adds an important note in the "Working with Pull Requests" section of the GitHub installation documentation to make this limitation clear to users.

This addresses the issue where users might be confused when the `@openhands` mention doesn't work on pull requests from forks or external repositories.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/02391367a2db46b7a0e8c86c3f6ab393)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5a4f00f-nikolaik   --name openhands-app-5a4f00f   docker.all-hands.dev/all-hands-ai/openhands:5a4f00f
```