### PR TITLE
Simplify microagent loading

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -597,21 +597,6 @@ fi
 
         return loaded
 
-    def _load_microagents_from_directory(
-        self, microagents_dir: Path, source_description: str
-    ) -> list[BaseMicroagent]:
-        """Load microagents from a directory.
-
-        Args:
-            microagents_dir: Path to the directory containing microagents
-            source_description: Description of the source for logging purposes
-
-        Returns:
-            A list of loaded microagents
-        """
-        # Use the new implementation that uses TemporaryDirectory
-        return self.load_microagents_from_directory(microagents_dir, source_description)
-
     async def _get_authenticated_git_url(
         self, repo_name: str, git_provider_tokens: PROVIDER_TOKEN_TYPE | None
     ) -> str:
@@ -735,7 +720,7 @@ fi
 
                     # Load microagents from the org-level repo
                     org_microagents_dir = org_repo_dir / 'microagents'
-                    loaded_microagents = self._load_microagents_from_directory(
+                    loaded_microagents = self.load_microagents_from_directory(
                         org_microagents_dir, 'org-level'
                     )
                 else:
@@ -805,7 +790,7 @@ fi
             )
 
         # Load microagents from directory
-        repo_microagents = self._load_microagents_from_directory(
+        repo_microagents = self.load_microagents_from_directory(
             microagents_dir, 'repository'
         )
         loaded_microagents.extend(repo_microagents)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR simplifies microagent loading by using modern tempfile syntax.

The goal is to fix an error that I was encountering while loading.

```
^[[92m21:15:34 - openhands:INFO^[[0m: base.py:711 - [runtime 788d4ed644234f90b7cd434920d70a92] Successfully cloned org-level microagents from neubig/.openhands
^[[92m21:15:34 - openhands:DEBUG^[[0m: log_streamer.py:46 - [runtime 788d4ed644234f90b7cd434920d70a92] [inside container] INFO:     192.168.65.1:19812 - "POST /execute_action HTTP/1.1" 200 OK
^[[92m21:15:34 - openhands:DEBUG^[[0m: log_streamer.py:46 - [runtime 788d4ed644234f90b7cd434920d70a92] [inside container] INFO:     192.168.65.1:19812 - "POST /list_files HTTP/1.1" 200 OK
^[[92m21:15:34 - openhands:ERROR^[[0m: base.py:731 - [runtime 788d4ed644234f90b7cd434920d70a92] Error loading org-level microagents: [Errno 2] No such file or directory: '/workspace/org_openhands_neubig'
Traceback (most recent call last):
  File "/Users/gneubig/work/OpenHands/openhands/runtime/base.py", line 723, in get_microagents_from_org_or_user
    shutil.rmtree(org_repo_dir)
  File "/Users/gneubig/miniconda3/lib/python3.12/shutil.py", line 775, in rmtree
    onexc(os.lstat, path, err)
  File "/Users/gneubig/miniconda3/lib/python3.12/shutil.py", line 773, in rmtree
    orig_st = os.lstat(path, dir_fd=dir_fd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/org_openhands_neubig'
  File "/Users/gneubig/miniconda3/lib/python3.12/threading.py", line 1030, in _bootstrap
    self._bootstrap_inner()
  File "/Users/gneubig/miniconda3/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/Users/gneubig/miniconda3/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/gneubig/miniconda3/lib/python3.12/concurrent/futures/thread.py", line 92, in _worker
    work_item.run()
  File "/Users/gneubig/miniconda3/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/gneubig/work/OpenHands/openhands/utils/async_utils.py", line 17, in <lambda>
    coro = loop.run_in_executor(None, lambda: fn(*args, **kwargs))
  File "/Users/gneubig/work/OpenHands/openhands/runtime/base.py", line 753, in get_microagents_from_selected_repo
    org_microagents = self.get_microagents_from_org_or_user(selected_repository)
  File "/Users/gneubig/work/OpenHands/openhands/runtime/base.py", line 731, in get_microagents_from_org_or_user
    self.log('error', f'Error loading org-level microagents: {str(e)}')
  File "/Users/gneubig/work/OpenHands/openhands/runtime/base.py", line 209, in log
    getattr(logger, level)(message, stacklevel=2)
  File "/Users/gneubig/miniconda3/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/Users/gneubig/miniconda3/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:738840c-nikolaik   --name openhands-app-738840c   docker.all-hands.dev/all-hands-ai/openhands:738840c
```