### PR TITLE
Fix str_replace_editor command validation for required parameters

### DIFF
--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -159,6 +159,32 @@ def response_to_actions(
                     )
                 path = arguments['path']
                 command = arguments['command']
+
+                # Validate command-specific required parameters
+                if command == 'create':
+                    if 'file_text' not in arguments:
+                        raise FunctionCallValidationError(
+                            f'Missing required argument "file_text" for command "create" in tool call {tool_call.function.name}'
+                        )
+                elif command == 'str_replace':
+                    if 'old_str' not in arguments:
+                        raise FunctionCallValidationError(
+                            f'Missing required argument "old_str" for command "str_replace" in tool call {tool_call.function.name}'
+                        )
+                    if 'new_str' not in arguments:
+                        raise FunctionCallValidationError(
+                            f'Missing required argument "new_str" for command "str_replace" in tool call {tool_call.function.name}'
+                        )
+                elif command == 'insert':
+                    if 'new_str' not in arguments:
+                        raise FunctionCallValidationError(
+                            f'Missing required argument "new_str" for command "insert" in tool call {tool_call.function.name}'
+                        )
+                    if 'insert_line' not in arguments:
+                        raise FunctionCallValidationError(
+                            f'Missing required argument "insert_line" for command "insert" in tool call {tool_call.function.name}'
+                        )
+
                 other_kwargs = {
                     k: v for k, v in arguments.items() if k not in ['command', 'path']
                 }

--- a/tests/unit/test_function_calling.py
+++ b/tests/unit/test_function_calling.py
@@ -243,3 +243,144 @@ def test_unexpected_argument_handling():
     # Verify the error message mentions the unexpected argument
     assert 'old_str_prefix' in str(exc_info.value)
     assert 'Unexpected argument' in str(exc_info.value)
+
+
+def test_str_replace_editor_create_missing_file_text():
+    """Test that str_replace_editor create command fails when file_text is missing."""
+    response = create_mock_response(
+        'str_replace_editor',
+        {
+            'command': 'create',
+            'path': '/test/file.py',
+            # Missing file_text parameter
+        },
+    )
+
+    with pytest.raises(FunctionCallValidationError) as exc_info:
+        response_to_actions(response)
+
+    assert 'Missing required argument "file_text" for command "create"' in str(
+        exc_info.value
+    )
+
+
+def test_str_replace_editor_create_with_file_text():
+    """Test that str_replace_editor create command works when file_text is provided."""
+    response = create_mock_response(
+        'str_replace_editor',
+        {
+            'command': 'create',
+            'path': '/test/file.py',
+            'file_text': 'print("Hello, World!")',
+        },
+    )
+
+    actions = response_to_actions(response)
+    assert len(actions) == 1
+    action = actions[0]
+    assert isinstance(action, FileEditAction)
+    assert action.path == '/test/file.py'
+    assert action.command == 'create'
+    assert action.file_text == 'print("Hello, World!")'
+
+
+def test_str_replace_editor_str_replace_missing_old_str():
+    """Test that str_replace_editor str_replace command fails when old_str is missing."""
+    response = create_mock_response(
+        'str_replace_editor',
+        {
+            'command': 'str_replace',
+            'path': '/test/file.py',
+            'new_str': 'new content',
+            # Missing old_str parameter
+        },
+    )
+
+    with pytest.raises(FunctionCallValidationError) as exc_info:
+        response_to_actions(response)
+
+    assert 'Missing required argument "old_str" for command "str_replace"' in str(
+        exc_info.value
+    )
+
+
+def test_str_replace_editor_str_replace_missing_new_str():
+    """Test that str_replace_editor str_replace command fails when new_str is missing."""
+    response = create_mock_response(
+        'str_replace_editor',
+        {
+            'command': 'str_replace',
+            'path': '/test/file.py',
+            'old_str': 'old content',
+            # Missing new_str parameter
+        },
+    )
+
+    with pytest.raises(FunctionCallValidationError) as exc_info:
+        response_to_actions(response)
+
+    assert 'Missing required argument "new_str" for command "str_replace"' in str(
+        exc_info.value
+    )
+
+
+def test_str_replace_editor_insert_missing_new_str():
+    """Test that str_replace_editor insert command fails when new_str is missing."""
+    response = create_mock_response(
+        'str_replace_editor',
+        {
+            'command': 'insert',
+            'path': '/test/file.py',
+            'insert_line': 5,
+            # Missing new_str parameter
+        },
+    )
+
+    with pytest.raises(FunctionCallValidationError) as exc_info:
+        response_to_actions(response)
+
+    assert 'Missing required argument "new_str" for command "insert"' in str(
+        exc_info.value
+    )
+
+
+def test_str_replace_editor_insert_missing_insert_line():
+    """Test that str_replace_editor insert command fails when insert_line is missing."""
+    response = create_mock_response(
+        'str_replace_editor',
+        {
+            'command': 'insert',
+            'path': '/test/file.py',
+            'new_str': 'new content',
+            # Missing insert_line parameter
+        },
+    )
+
+    with pytest.raises(FunctionCallValidationError) as exc_info:
+        response_to_actions(response)
+
+    assert 'Missing required argument "insert_line" for command "insert"' in str(
+        exc_info.value
+    )
+
+
+def test_str_replace_editor_insert_with_all_params():
+    """Test that str_replace_editor insert command works when all parameters are provided."""
+    response = create_mock_response(
+        'str_replace_editor',
+        {
+            'command': 'insert',
+            'path': '/test/file.py',
+            'new_str': 'new content',
+            'insert_line': 5,
+        },
+    )
+
+    actions = response_to_actions(response)
+    assert len(actions) == 1
+    action = actions[0]
+    assert isinstance(action, FileEditAction)
+    assert action.path == '/test/file.py'
+    assert action.command == 'insert'
+    assert action.new_str == 'new content'
+    assert action.insert_line == 5


### PR DESCRIPTION
## Summary

This PR fixes issue #9341 by adding proper validation for command-specific required parameters in the `str_replace_editor` tool.

## Problem

The `str_replace_editor` tool's commands (`create`, `str_replace`, `insert`) were not validating their required parameters, leading to confusing behavior where actions would be created with `None` values instead of failing with clear error messages.

## Solution

Added validation logic in `openhands/agenthub/codeact_agent/function_calling.py` to check for command-specific required parameters:

- **`create` command**: now requires `file_text` parameter
- **`str_replace` command**: now requires `old_str` and `new_str` parameters  
- **`insert` command**: now requires `new_str` and `insert_line` parameters

## Changes

### Core Changes
- **`openhands/agenthub/codeact_agent/function_calling.py`**: Added validation logic for command-specific required parameters

### Tests
- **`tests/unit/test_function_calling.py`**: Added comprehensive tests covering:
  - Missing `file_text` for `create` command
  - Missing `old_str` or `new_str` for `str_replace` command
  - Missing `new_str` or `insert_line` for `insert` command
  - Successful cases with all required parameters

## Testing

All new tests pass and existing tests continue to pass:

```bash
poetry run pytest tests/unit/test_function_calling.py -v
# 19 passed in 6.12s
```

## Impact

- **Better User Experience**: Users now get clear error messages instead of confusing behavior
- **Improved Debugging**: Missing parameters are caught early with descriptive error messages
- **Data Integrity**: Prevents creation of actions with `None` values that could cause issues downstream

## Related Issues

Fixes #9341

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3da9df4a513d4c1da06c3586c8b81a0d)