### PR TITLE
Fix: Normalize file_text=None to empty string for create command

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -124,6 +124,11 @@ def _execute_file_editor(
     """
     result: ToolResult | None = None
 
+    # Normalize file_text for create command: convert None to empty string
+    # This allows users to create empty files when file_text is None
+    if command == 'create' and file_text is None:
+        file_text = ''
+
     # Convert insert_line from string to int if needed
     if insert_line is not None and isinstance(insert_line, str):
         try:

--- a/tests/runtime/test_aci_edit.py
+++ b/tests/runtime/test_aci_edit.py
@@ -133,10 +133,19 @@ def test_create_with_none_file_text(temp_dir, runtime_cls, run_as_openhands):
         )
         obs = runtime.run_action(action)
         logger.info(obs, extra={'msg_type': 'OBSERVATION'})
-        assert (
-            obs.content
-            == 'ERROR:\nParameter `file_text` is required for command: create.'
+        # After the fix, file_text=None should be normalized to empty string
+        # and the file should be created successfully
+        assert 'File created successfully' in obs.content
+
+        # Verify file was created and is empty
+        action = FileEditAction(
+            command='view',
+            path=new_file,
         )
+        obs = runtime.run_action(action)
+        logger.info(obs, extra={'msg_type': 'OBSERVATION'})
+        # Empty file should show just the line number with no content
+        assert '1\t' in obs.content
     finally:
         _close_test_runtime(runtime)
 


### PR DESCRIPTION
## Summary

This PR fixes issue #9343 where users encounter the error "Parameter `file_text` is required for command: create" when using the file editor in OpenHands Cloud.

## Problem

Users were experiencing an error when attempting to create files through the file editor interface. The error occurred when `FileEditAction` with `command='create'` was called but `file_text` parameter was `None`. According to the issue analysis, this happens when the system sends `file_text=None` instead of `file_text=""` when the user intends to create an empty file.

## Solution

Added normalization in the `_execute_file_editor` function in `action_execution_server.py` to convert `file_text=None` to `file_text=""` for create commands. This approach:

- Maintains backward compatibility
- Provides a defensive programming solution
- Handles the edge case gracefully
- Doesn't require changes to frontend or agent logic

## Changes

1. **Backend Fix**: Modified `_execute_file_editor` function to normalize `file_text=None` to empty string for create commands
2. **Test Update**: Updated the existing test `test_create_with_none_file_text` to verify that the fix works correctly - now expects successful file creation instead of an error

## Testing

- ✅ Created and ran comprehensive unit tests to verify the fix works correctly
- ✅ Verified that `file_text=None` is normalized to empty string for create commands
- ✅ Confirmed that `file_text=""` and `file_text="content"` still work as before
- ✅ Ensured other commands (not 'create') are not affected by the change
- ✅ All pre-commit hooks pass

## Expected Behavior After Fix

- **Before**: `file_text=None` → Error: "Parameter `file_text` is required for command: create"
- **After**: `file_text=None` → Successfully creates empty file (same as `file_text=""`)

This change improves the user experience in OpenHands Cloud by allowing users to create empty files even when `file_text` is `None`, which can happen due to various reasons in the system (frontend handling, serialization, agent logic, etc.).

Fixes #9343

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/74b322d622604c23a0f2ceab78cedb20)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0c60a14-nikolaik   --name openhands-app-0c60a14   docker.all-hands.dev/all-hands-ai/openhands:0c60a14
```