### PR TITLE
Add important warning about not pushing/creating PRs unless explicitly asked

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -32,6 +32,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </VERSION_CONTROL>
 
 <PULL_REQUESTS>
+**Important**: Do not push to the remote branch and/or start pull request unless explicitly asked to do so.
 * When creating pull requests, create only ONE per session/issue unless explicitly instructed otherwise.
 * When working with an existing PR, update it with new commits rather than creating additional PRs for the same issue.
 * When updating a PR, preserve the original PR title and purpose, updating description only when necessary.

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -32,7 +32,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </VERSION_CONTROL>
 
 <PULL_REQUESTS>
-**Important**: Do not push to the remote branch and/or start pull request unless explicitly asked to do so.
+* **Important**: Do not push to the remote branch and/or start a pull request unless explicitly asked to do so.
 * When creating pull requests, create only ONE per session/issue unless explicitly instructed otherwise.
 * When working with an existing PR, update it with new commits rather than creating additional PRs for the same issue.
 * When updating a PR, preserve the original PR title and purpose, updating description only when necessary.


### PR DESCRIPTION
## Summary

This PR adds an important warning to the `<PULL_REQUESTS>` section of the system prompt to address the issue where Claude-4 has been too eager to start PRs without being explicitly requested to do so by users.

## Changes

- Added `**Important**: Do not push to the remote branch and/or start pull request unless explicitly asked to do so.` as the first line of the `<PULL_REQUESTS>` section in `openhands/agenthub/codeact_agent/prompts/system_prompt.j2`

## Context

Based on team discussion, Claude-4 has been ignoring existing prompt guidance about not opening PRs until asked, causing user confusion. This change makes the instruction more prominent with bold formatting and explicit placement at the beginning of the section.

## Testing

- [x] Pre-commit hooks pass
- [x] Change is minimal and focused
- [x] Existing functionality preserved

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c2c62a0610694501b68613670931640e)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9694cc9-nikolaik   --name openhands-app-9694cc9   docker.all-hands.dev/all-hands-ai/openhands:9694cc9
```