### PR TITLE
Fix issue labeled prompts to include API usage instructions

### DIFF
--- a/openhands/integrations/templates/resolver/github/issue_labeled_prompt.j2
+++ b/openhands/integrations/templates/resolver/github/issue_labeled_prompt.j2
@@ -1,1 +1,13 @@
 Please fix issue number #{{ issue_number }} in your repository.
+
+Your task is to fix an issue in your repository. Do the following:
+
+1. Read the issue body and comments using the Github API
+2. For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed
+3. Run the tests, and if they pass you are done!
+4. You do NOT need to write new tests if there are only changes to documentation or configuration files.
+
+When you're done, make sure to:
+
+1. Use the `create_pr` tool to open a new PR
+2. The PR description should mention that it "fixes" or "closes" the issue number

--- a/openhands/integrations/templates/resolver/gitlab/issue_labeled_prompt.j2
+++ b/openhands/integrations/templates/resolver/gitlab/issue_labeled_prompt.j2
@@ -1,1 +1,13 @@
 Please fix issue number #{{ issue_number }} in your repository.
+
+Your task is to fix an issue in your repository. Do the following:
+
+1. Read the issue body and comments using the GitLab API
+2. For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed
+3. Run the tests, and if they pass you are done!
+4. You do NOT need to write new tests if there are only changes to documentation or configuration files.
+
+When you're done, make sure to:
+
+1. Use the `create_mr` tool to open a new MR
+2. The MR description should mention that it "fixes" or "closes" the issue number


### PR DESCRIPTION
## Summary

This PR fixes an issue where OpenHands agents couldn't access private repository issues because they weren't instructed to use the GitHub/GitLab APIs.

## Problem

The `issue_labeled_prompt.j2` templates for both GitHub and GitLab were very minimal and only contained:
```
Please fix issue number #{{ issue_number }} in your repository.
```

This caused agents to fail when trying to access private repository issues, resulting in 404 errors because they didn't know to use the appropriate API with authentication tokens.

## Solution

Updated both templates to include detailed instructions that match their corresponding `issue_labeled_conversation_instructions.j2` files:

### GitHub (`openhands/integrations/templates/resolver/github/issue_labeled_prompt.j2`)
- Added instruction to "Read the issue body and comments using the Github API"
- Added testing requirements for code changes
- Added PR creation instructions using `create_pr` tool

### GitLab (`openhands/integrations/templates/resolver/gitlab/issue_labeled_prompt.j2`)
- Added instruction to "Read the issue body and comments using the GitLab API"  
- Added testing requirements for code changes
- Added MR creation instructions using `create_mr` tool

## Testing

- Pre-commit hooks pass successfully
- Templates now provide clear API usage instructions that should resolve the private repository access issues

## Related Issues

This addresses the issue reported where agents would randomly submit unrelated PRs because they couldn't access the actual issue content in private repositories.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d25e9ba97ada4c948fba3e1f3418ecc4)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b15691d-nikolaik   --name openhands-app-b15691d   docker.all-hands.dev/all-hands-ai/openhands:b15691d
```