### PR TITLE
fix: Change terminal command truncation to middle instead of end

### DIFF
--- a/frontend/src/components/features/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/features/chat/event-content-helpers/get-event-content.tsx
@@ -18,7 +18,13 @@ const hasCommandProperty = (
 
 const trimText = (text: string, maxLength: number): string => {
   if (!text) return "";
-  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+  if (text.length <= maxLength) return text;
+
+  // Truncate in the middle, keeping beginning and end
+  const half = Math.floor(maxLength / 2);
+  const beginning = text.substring(0, half);
+  const end = text.substring(text.length - half);
+  return `${beginning}...${end}`;
 };
 
 export const getEventContent = (

--- a/frontend/src/components/features/chat/expandable-message.tsx
+++ b/frontend/src/components/features/chat/expandable-message.tsx
@@ -21,7 +21,13 @@ import { PathComponent } from "./path-component";
 
 const trimText = (text: string, maxLength: number): string => {
   if (!text) return "";
-  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+  if (text.length <= maxLength) return text;
+
+  // Truncate in the middle, keeping beginning and end
+  const half = Math.floor(maxLength / 2);
+  const beginning = text.substring(0, half);
+  const end = text.substring(text.length - half);
+  return `${beginning}...${end}`;
 };
 
 interface ExpandableMessageProps {


### PR DESCRIPTION
## Summary

This PR fixes the command truncation logic in the terminal tab to use middle truncation instead of end truncation, improving readability by preserving both the beginning and end of long commands.

## Changes

- Modified `trimText` functions in `frontend/src/components/features/chat/expandable-message.tsx`
- Modified `trimText` functions in `frontend/src/components/features/chat/event-content-helpers/get-event-content.tsx`
- Commands longer than 80 characters now show as: `beginning...end` instead of `beginning...`

## Before

Long commands were truncated from the end:
```
this is a very long command that should be truncated in the middle to show...
```

## After

Long commands are now truncated in the middle:
```
this is a very long ...th beginning and end
```

## Testing

- Tested the new `trimText` function with various input lengths
- Verified that short commands (≤80 chars) remain unchanged
- Confirmed that long commands show both beginning and end portions

## Impact

This change affects the display of command text in:
- Terminal tab command history
- Chat expandable messages for command actions
- Event content helpers for command observations

The change improves user experience by making it easier to identify commands by seeing both their start and end portions.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2493b24500454700a246b72ac75f9bd5)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3e917b8-nikolaik   --name openhands-app-3e917b8   docker.all-hands.dev/all-hands-ai/openhands:3e917b8
```