### PR TITLE
Revert "Simplify max_output_tokens handling in LLM classes"

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -163,7 +163,6 @@ class LLM(RetryMixin, DebugMixin):
             'temperature': self.config.temperature,
             'max_completion_tokens': self.config.max_output_tokens,
         }
-
         if self.config.top_k is not None:
             # openai doesn't expose top_k
             # litellm will handle it a bit differently than the openai-compatible params
@@ -492,6 +491,26 @@ class LLM(RetryMixin, DebugMixin):
             else:
                 # Safe fallback for any potentially viable model
                 self.config.max_input_tokens = 4096
+
+        if self.config.max_output_tokens is None:
+            # Safe default for any potentially viable model
+            self.config.max_output_tokens = 4096
+            if self.model_info is not None:
+                # max_output_tokens has precedence over max_tokens, if either exists.
+                # litellm has models with both, one or none of these 2 parameters!
+                if 'max_output_tokens' in self.model_info and isinstance(
+                    self.model_info['max_output_tokens'], int
+                ):
+                    self.config.max_output_tokens = self.model_info['max_output_tokens']
+                elif 'max_tokens' in self.model_info and isinstance(
+                    self.model_info['max_tokens'], int
+                ):
+                    self.config.max_output_tokens = self.model_info['max_tokens']
+            if any(
+                model in self.config.model
+                for model in ['claude-3-7-sonnet', 'claude-3.7-sonnet']
+            ):
+                self.config.max_output_tokens = 64000  # litellm set max to 128k, but that requires a header to be set
 
         # Initialize function calling capability
         # Check if model name is in our supported list

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -132,7 +132,7 @@ def test_llm_init_with_model_info(mock_get_model_info, default_config):
     llm = LLM(default_config)
     llm.init_model_info()
     assert llm.config.max_input_tokens == 8000
-    assert llm.config.max_output_tokens is None
+    assert llm.config.max_output_tokens == 2000
 
 
 @patch('openhands.llm.llm.litellm.get_model_info')
@@ -141,7 +141,7 @@ def test_llm_init_without_model_info(mock_get_model_info, default_config):
     llm = LLM(default_config)
     llm.init_model_info()
     assert llm.config.max_input_tokens == 4096
-    assert llm.config.max_output_tokens is None
+    assert llm.config.max_output_tokens == 4096
 
 
 def test_llm_init_with_custom_config():
@@ -260,7 +260,7 @@ def test_llm_init_with_openrouter_model(mock_get_model_info, default_config):
     llm = LLM(default_config)
     llm.init_model_info()
     assert llm.config.max_input_tokens == 7000
-    assert llm.config.max_output_tokens is None
+    assert llm.config.max_output_tokens == 1500
     mock_get_model_info.assert_called_once_with('openrouter:gpt-4o-mini')
 
 


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#9296

We suspect this was the issue causing the LLM to not finish its generation, hence this to this recent issue: https://github.com/All-Hands-AI/OpenHands/issues/9343

Looking at our production log, we've observed a drop in P99 output token on LLM request (likely due to lower default value for max token output). We also find that there's an increase in agent stuck in loop error, and @raymyers identified some of them are associated with #9343.

This revert should fix #9343

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a8608b5-nikolaik   --name openhands-app-a8608b5   docker.all-hands.dev/all-hands-ai/openhands:a8608b5
```