### PR TITLE
Fix terminal truncation to trim middle of long outputs instead of suffix

### DIFF
--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -13,8 +13,10 @@ export function handleObservationMessage(message: ObservationMessage) {
       let { content } = message;
 
       if (content.length > 5000) {
-        const head = content.slice(0, 5000);
-        content = `${head}\r\n\n... (truncated ${message.content.length - 5000} characters) ...`;
+        const halfLength = 2500;
+        const head = content.slice(0, halfLength);
+        const tail = content.slice(content.length - halfLength);
+        content = `${head}\r\n\n... (truncated ${message.content.length - 5000} characters) ...\r\n\n${tail}`;
       }
 
       store.dispatch(appendOutput(content));


### PR DESCRIPTION
## Description

This PR modifies the terminal output truncation logic to trim the middle of long command outputs instead of the suffix. This change ensures that users can see both the beginning and end of long command outputs in the Terminal Tab.

## Changes

- Modified the truncation logic in `frontend/src/services/observations.ts` to split long outputs into two parts (head and tail) and display them with a truncation message in the middle.
- When a command output exceeds 5000 characters, the first 2500 and last 2500 characters are displayed with a message indicating how many characters were truncated in the middle.

## Testing

The change has been manually verified to work as expected. The terminal now shows both the beginning and end of long command outputs, making it easier to see important information that might be at the end of the output.

## Screenshots

N/A

## Related Issues

N/A

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0c90f73ab9cd481eb9e28abeb917385d)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1874c8c-nikolaik   --name openhands-app-1874c8c   docker.all-hands.dev/all-hands-ai/openhands:1874c8c
```