### PR TITLE
Make pause button more prominent with gray background

### DIFF
--- a/frontend/src/components/features/controls/agent-control-bar.tsx
+++ b/frontend/src/components/features/controls/agent-control-bar.tsx
@@ -39,6 +39,11 @@ export function AgentControlBar() {
             : AgentState.PAUSED
         }
         handleAction={handleAction}
+        className={
+          curAgentState !== AgentState.PAUSED
+            ? "bg-gray-200 rounded-full p-1"
+            : ""
+        }
       >
         {curAgentState === AgentState.PAUSED ? <PlayIcon /> : <PauseIcon />}
       </ActionButton>

--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -6,6 +6,7 @@ interface ActionButtonProps {
   content: string;
   action: AgentState;
   handleAction: (action: AgentState) => void;
+  className?: string;
 }
 
 export function ActionButton({
@@ -13,6 +14,7 @@ export function ActionButton({
   content,
   action,
   handleAction,
+  className = "",
   children,
 }: React.PropsWithChildren<ActionButtonProps>) {
   return (
@@ -20,7 +22,7 @@ export function ActionButton({
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out"
+        className={`relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out ${className}`}
         type="button"
       >
         <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">


### PR DESCRIPTION
This PR adds a gray background to the pause button to make it more prominent in the UI.

Changes:
1. Added a `className` prop to the `ActionButton` component to allow custom styling
2. Applied a gray background specifically to the pause button in the `AgentControlBar` component

The pause button now has a gray circular background that makes it more visible and easier to locate in the UI.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f1162686947b42edb190eb252e9ee4b3)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:310c220-nikolaik   --name openhands-app-310c220   docker.all-hands.dev/all-hands-ai/openhands:310c220
```