### PR TITLE
chore - Don't build ubuntu image on PR

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -40,9 +40,7 @@ jobs:
           # Only build nikolaik on PRs, otherwise build both nikolaik and ubuntu.
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             json=$(jq -n -c '[
-                { image: "nikolaik/python-nodejs:python3.12-nodejs22", tag: "nikolaik" },
-                { image: "ubuntu:24.04", tag: "ubuntu" }
-
+                { image: "nikolaik/python-nodejs:python3.12-nodejs22", tag: "nikolaik" }
               ]')
           else
             json=$(jq -n -c '[


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The ubuntu image takes a long time to build and doesn't usually provide extra feedback in PRs (with rare exceptions), so removing it from PRs to only run on main's ci. This was previously the configuration but was rolled back as a side effect of #8029
---
**Link of any specific issues this addresses:**
