### PR TITLE
Add labels support to PR and MR creation tools

### DIFF
--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -468,6 +468,7 @@ class GitHubService(BaseGitService, GitService):
         title: str,
         body: str | None = None,
         draft: bool = True,
+        labels: list[str] | None = None,
     ) -> str:
         """
         Creates a PR using user credentials
@@ -479,6 +480,7 @@ class GitHubService(BaseGitService, GitService):
             title: The title of the pull request (optional, defaults to a generic title)
             body: The body/description of the pull request (optional)
             draft: Whether to create the PR as a draft (optional, defaults to False)
+            labels: A list of labels to apply to the pull request (optional)
 
         Returns:
             - PR URL when successful
@@ -504,6 +506,15 @@ class GitHubService(BaseGitService, GitService):
         response, _ = await self._make_request(
             url=url, params=payload, method=RequestMethod.POST
         )
+
+        # Add labels if provided (PRs are a type of issue in GitHub's API)
+        if labels and len(labels) > 0:
+            pr_number = response['number']
+            labels_url = f'{self.BASE_URL}/repos/{repo_name}/issues/{pr_number}/labels'
+            labels_payload = {'labels': labels}
+            await self._make_request(
+                url=labels_url, params=labels_payload, method=RequestMethod.POST
+            )
 
         # Return the HTML URL of the created PR
         return response['html_url']

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -460,6 +460,7 @@ class GitLabService(BaseGitService, GitService):
         target_branch: str,
         title: str,
         description: str | None = None,
+        labels: list[str] | None = None,
     ) -> str:
         """
         Creates a merge request in GitLab
@@ -470,6 +471,7 @@ class GitLabService(BaseGitService, GitService):
             target_branch: The name of the branch you want the changes merged into
             title: The title of the merge request (optional, defaults to a generic title)
             description: The description of the merge request (optional)
+            labels: A list of labels to apply to the merge request (optional)
 
         Returns:
             - MR URL when successful
@@ -491,6 +493,10 @@ class GitLabService(BaseGitService, GitService):
             'title': title,
             'description': description,
         }
+
+        # Add labels if provided
+        if labels and len(labels) > 0:
+            payload['labels'] = ','.join(labels)
 
         # Make the POST request to create the MR
         response, _ = await self._make_request(

--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -89,6 +89,9 @@ async def create_pr(
     title: Annotated[str, Field(description='PR Title')],
     body: Annotated[str | None, Field(description='PR body')],
     draft: Annotated[bool, Field(description='Whether PR opened is a draft')] = True,
+    labels: Annotated[
+        list[str] | None, Field(description='Labels to apply to the PR')
+    ] = None,
 ) -> str:
     """Open a PR in GitHub"""
 
@@ -129,6 +132,7 @@ async def create_pr(
             title=title,
             body=body,
             draft=draft,
+            labels=labels,
         )
 
         if conversation_id:
@@ -156,6 +160,9 @@ async def create_mr(
         ),
     ],
     description: Annotated[str | None, Field(description='MR description')],
+    labels: Annotated[
+        list[str] | None, Field(description='Labels to apply to the MR')
+    ] = None,
 ) -> str:
     """Open a MR in GitLab"""
 
@@ -197,6 +204,7 @@ async def create_mr(
             target_branch=target_branch,
             title=title,
             description=description,
+            labels=labels,
         )
 
         if conversation_id and user_id:


### PR DESCRIPTION
This PR adds support for labels to the PR and MR creation tools:

1. GitHub PR Creation:
   - Added a `labels` parameter to the `create_pr` tool
   - Updated the GitHub service to apply labels after PR creation using the issues API

2. GitLab MR Creation:
   - Added a `labels` parameter to the `create_mr` tool
   - Updated the GitLab service to include labels in the MR creation payload

These changes conform to the underlying GitHub and GitLab APIs:
- GitHub: Labels are applied via a separate API call to the issues endpoint
- GitLab: Labels are included directly in the MR creation payload as a comma-separated string

No changes were made to the Bitbucket PR creation tool as Bitbucket doesn't have a direct concept of labels for pull requests.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ef396ff2d54e4ff193f3086a7a863a99)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:465e2e3-nikolaik   --name openhands-app-465e2e3   docker.all-hands.dev/all-hands-ai/openhands:465e2e3
```