### PR TITLE
Fix capitalization in 'Initializing agent...' status message

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -4064,7 +4064,7 @@
         "uk": "Зупинено"
     },
     "CHAT_INTERFACE$INITIALIZING_AGENT_LOADING_MESSAGE": {
-        "en": "Initializing Agent...",
+        "en": "Initializing agent...",
         "de": "Agent wird initialisiert...",
         "zh-CN": "正在初始化智能体...",
         "zh-TW": "正在初始化智能體...",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed the capitalization of the "Initializing agent..." status message to follow proper UI text conventions. The message now displays with a lowercase 'a' in "agent" instead of the previous uppercase 'A' in "Agent".

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR makes a simple text correction in the frontend internationalization file (`frontend/src/i18n/translation.json`). It changes the English translation for the `CHAT_INTERFACE$INITIALIZING_AGENT_LOADING_MESSAGE` key from "Initializing Agent..." to "Initializing agent..." to follow standard UI text capitalization conventions where only the first word of a sentence or proper nouns are capitalized.

---
**Link of any specific issues this addresses:**

This addresses a user-reported UI text inconsistency.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1314523e7d444173b146e383e4d3ed6d)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9320bee-nikolaik   --name openhands-app-9320bee   docker.all-hands.dev/all-hands-ai/openhands:9320bee
```