### PR TITLE
Enhance pause button visibility with gray background

### DIFF
--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -20,7 +20,7 @@ export function ActionButton({
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out"
+        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out bg-gray-200 p-2 rounded-full"
         type="button"
       >
         <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">


### PR DESCRIPTION
## Description
Added a gray background to the pause button to make it more prominent and improve visibility.

## Changes
- Modified the ActionButton component to include a gray background and rounded corners
- Added padding to make the button more clickable

## Testing
- Built and tested the frontend to ensure the changes work as expected
- Verified that the pause button is now more visible with the gray background

## Screenshots
Before: The pause button was not prominent enough
After: The pause button now has a gray background making it more visible

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f4c50477f19241279727e07d512d520b)