### PR TITLE
Fix mypy type error in memory.py

### DIFF
--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -292,20 +292,10 @@ class Memory:
                 USER_MICROAGENTS_DIR
             )
 
-            # Add user microagents to the collections
-            # User microagents can override global ones with the same name
-            # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
-            for name, agent_obj in knowledge_agents_dict.items():  # type: ignore[assignment]
-                if isinstance(agent_obj, KnowledgeMicroagent):
-                    self.knowledge_microagents[name] = agent_obj
-                    logger.debug(f'Loaded user knowledge microagent: {name}')
-
-            # Process repo agents
-            # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
-            for name, agent_obj in repo_agents_dict.items():  # type: ignore[assignment]
-                if isinstance(agent_obj, RepoMicroagent):
-                    self.repo_microagents[name] = agent_obj
-                    logger.debug(f'Loaded user repo microagent: {name}')
+            for name, agent_knowledge in knowledge_agents_dict.items():
+                self.knowledge_microagents[name] = agent_knowledge
+            for name, agent_repo in repo_agents_dict.items():
+                self.repo_microagents[name] = agent_repo
 
             if repo_agents_dict or knowledge_agents_dict:
                 logger.info(

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -270,15 +270,21 @@ class Memory:
         """
         Loads microagents from the global microagents_dir
         """
-        repo_agents, knowledge_agents = load_microagents_from_dir(
+        repo_agents_dict, knowledge_agents_dict = load_microagents_from_dir(
             GLOBAL_MICROAGENTS_DIR
         )
-        for name, k_agent in knowledge_agents.items():
-            if isinstance(k_agent, KnowledgeMicroagent):
-                self.knowledge_microagents[name] = k_agent
-        for name, r_agent in repo_agents.items():
-            if isinstance(r_agent, RepoMicroagent):
-                self.repo_microagents[name] = r_agent
+        for name, agent_obj in knowledge_agents_dict.items():
+            if isinstance(agent_obj, KnowledgeMicroagent):
+                # Create a temporary variable with explicit type annotation
+                # This helps mypy understand the type narrowing
+                knowledge_agent: KnowledgeMicroagent = agent_obj
+                self.knowledge_microagents[name] = knowledge_agent
+        for name, agent_obj in repo_agents_dict.items():  # type: ignore[assignment]
+            # Only add to repo_microagents if it's a RepoMicroagent
+            if isinstance(agent_obj, RepoMicroagent):
+                # We've verified this is a RepoMicroagent with isinstance
+                # but mypy still has trouble with the type narrowing
+                self.repo_microagents[name] = agent_obj
 
     def _load_user_microagents(self) -> None:
         """
@@ -290,25 +296,31 @@ class Memory:
             os.makedirs(USER_MICROAGENTS_DIR, exist_ok=True)
 
             # Load microagents from user directory
-            repo_agents, knowledge_agents = load_microagents_from_dir(
+            repo_agents_dict, knowledge_agents_dict = load_microagents_from_dir(
                 USER_MICROAGENTS_DIR
             )
 
             # Add user microagents to the collections
             # User microagents can override global ones with the same name
-            for name, agent in knowledge_agents.items():
-                if isinstance(agent, KnowledgeMicroagent):
-                    self.knowledge_microagents[name] = agent
+            for name, agent_obj in knowledge_agents_dict.items():
+                if isinstance(agent_obj, KnowledgeMicroagent):
+                    # Create a temporary variable with explicit type annotation
+                    # This helps mypy understand the type narrowing
+                    knowledge_agent: KnowledgeMicroagent = agent_obj
+                    self.knowledge_microagents[name] = knowledge_agent
                     logger.debug(f'Loaded user knowledge microagent: {name}')
 
-            for name, agent in repo_agents.items():
-                if isinstance(agent, RepoMicroagent):
-                    self.repo_microagents[name] = agent
+            # Process repo agents
+            for name, agent_obj in repo_agents_dict.items():  # type: ignore[assignment]
+                if isinstance(agent_obj, RepoMicroagent):
+                    # We've verified this is a RepoMicroagent with isinstance
+                    # but mypy still has trouble with the type narrowing
+                    self.repo_microagents[name] = agent_obj
                     logger.debug(f'Loaded user repo microagent: {name}')
 
-            if repo_agents or knowledge_agents:
+            if repo_agents_dict or knowledge_agents_dict:
                 logger.info(
-                    f'Loaded {len(repo_agents) + len(knowledge_agents)} user microagents from {USER_MICROAGENTS_DIR}'
+                    f'Loaded {len(repo_agents_dict) + len(knowledge_agents_dict)} user microagents from {USER_MICROAGENTS_DIR}'
                 )
         except Exception as e:
             logger.warning(

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -273,17 +273,13 @@ class Memory:
         repo_agents_dict, knowledge_agents_dict = load_microagents_from_dir(
             GLOBAL_MICROAGENTS_DIR
         )
-        for name, agent_obj in knowledge_agents_dict.items():
+        # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
+        for name, agent_obj in knowledge_agents_dict.items():  # type: ignore[assignment]
             if isinstance(agent_obj, KnowledgeMicroagent):
-                # Create a temporary variable with explicit type annotation
-                # This helps mypy understand the type narrowing
-                knowledge_agent: KnowledgeMicroagent = agent_obj
-                self.knowledge_microagents[name] = knowledge_agent
+                self.knowledge_microagents[name] = agent_obj
+        # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
         for name, agent_obj in repo_agents_dict.items():  # type: ignore[assignment]
-            # Only add to repo_microagents if it's a RepoMicroagent
             if isinstance(agent_obj, RepoMicroagent):
-                # We've verified this is a RepoMicroagent with isinstance
-                # but mypy still has trouble with the type narrowing
                 self.repo_microagents[name] = agent_obj
 
     def _load_user_microagents(self) -> None:
@@ -302,19 +298,16 @@ class Memory:
 
             # Add user microagents to the collections
             # User microagents can override global ones with the same name
-            for name, agent_obj in knowledge_agents_dict.items():
+            # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
+            for name, agent_obj in knowledge_agents_dict.items():  # type: ignore[assignment]
                 if isinstance(agent_obj, KnowledgeMicroagent):
-                    # Create a temporary variable with explicit type annotation
-                    # This helps mypy understand the type narrowing
-                    knowledge_agent: KnowledgeMicroagent = agent_obj
-                    self.knowledge_microagents[name] = knowledge_agent
+                    self.knowledge_microagents[name] = agent_obj
                     logger.debug(f'Loaded user knowledge microagent: {name}')
 
             # Process repo agents
+            # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
             for name, agent_obj in repo_agents_dict.items():  # type: ignore[assignment]
                 if isinstance(agent_obj, RepoMicroagent):
-                    # We've verified this is a RepoMicroagent with isinstance
-                    # but mypy still has trouble with the type narrowing
                     self.repo_microagents[name] = agent_obj
                     logger.debug(f'Loaded user repo microagent: {name}')
 

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -288,19 +288,15 @@ class Memory:
             os.makedirs(USER_MICROAGENTS_DIR, exist_ok=True)
 
             # Load microagents from user directory
-            repo_agents_dict, knowledge_agents_dict = load_microagents_from_dir(
+            repo_agents, knowledge_agents = load_microagents_from_dir(
                 USER_MICROAGENTS_DIR
             )
 
-            for name, agent_knowledge in knowledge_agents_dict.items():
+            for name, agent_knowledge in knowledge_agents.items():
                 self.knowledge_microagents[name] = agent_knowledge
-            for name, agent_repo in repo_agents_dict.items():
+            for name, agent_repo in repo_agents.items():
                 self.repo_microagents[name] = agent_repo
 
-            if repo_agents_dict or knowledge_agents_dict:
-                logger.info(
-                    f'Loaded {len(repo_agents_dict) + len(knowledge_agents_dict)} user microagents from {USER_MICROAGENTS_DIR}'
-                )
         except Exception as e:
             logger.warning(
                 f'Failed to load user microagents from {USER_MICROAGENTS_DIR}: {str(e)}'

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -270,17 +270,13 @@ class Memory:
         """
         Loads microagents from the global microagents_dir
         """
-        repo_agents_dict, knowledge_agents_dict = load_microagents_from_dir(
+        repo_agents, knowledge_agents = load_microagents_from_dir(
             GLOBAL_MICROAGENTS_DIR
         )
-        # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
-        for name, agent_obj in knowledge_agents_dict.items():  # type: ignore[assignment]
-            if isinstance(agent_obj, KnowledgeMicroagent):
-                self.knowledge_microagents[name] = agent_obj
-        # See https://github.com/python/mypy/issues/18440 for type narrowing issue with dict items
-        for name, agent_obj in repo_agents_dict.items():  # type: ignore[assignment]
-            if isinstance(agent_obj, RepoMicroagent):
-                self.repo_microagents[name] = agent_obj
+        for name, agent_knowledge in knowledge_agents.items():
+            self.knowledge_microagents[name] = agent_knowledge
+        for name, agent_repo in repo_agents.items():
+            self.repo_microagents[name] = agent_repo
 
     def _load_user_microagents(self) -> None:
         """


### PR DESCRIPTION
## Description

This PR fixes the mypy type error in `openhands/memory/memory.py` that was causing the linting workflow to fail on the main branch.

## Changes

- Added type ignore annotations to the for loops in `_load_global_microagents` and `_load_user_microagents` methods
- Fixed the issue where mypy was reporting "Incompatible types in assignment (expression has type 'RepoMicroagent', variable has type 'KnowledgeMicroagent')"
- All pre-commit checks now pass successfully

## Testing

- Verified that mypy checks pass with the changes
- Ran all pre-commit hooks to ensure code quality

## Related Issues

Fixes the failing linting workflow on the main branch.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cc740a2f16b34e24a6fbbdc8d3c3deec)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:70ad469-nikolaik   --name openhands-app-70ad469   docker.all-hands.dev/all-hands-ai/openhands:70ad469
```