### PR TITLE
Suppress pending action timeout warning in CLI mode

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -876,7 +876,10 @@ class AgentController:
         elapsed_time = current_time - timestamp
 
         # Log if the pending action has been active for a long time (but don't clear it)
-        if elapsed_time > 60.0:  # 1 minute - just for logging purposes
+        # Skip this warning in headless mode (CLI) as it's not useful for users
+        if (
+            elapsed_time > 60.0 and not self.headless_mode
+        ):  # 1 minute - just for logging purposes
             action_id = getattr(action, 'id', 'unknown')
             action_type = type(action).__name__
             self.log(


### PR DESCRIPTION
## Summary

Suppresses the annoying "Pending action active for X seconds" warning message that appears in CLI mode when actions take longer than 60 seconds to complete.

## Problem

Users reported that this warning message is annoying in CLI mode:
```
14:13:21 - openhands:warning: agent_controller.py:882 - [Agent Controller ...] Pending action active for 275.31s: CmdRunAction (id=40)
```

The warning serves a debugging purpose in the web UI but is not useful for CLI users and creates noise in the terminal output.

## Solution

- Modified `agent_controller.py` to check `headless_mode` before logging the pending action timeout warning
- Added condition `and not self.headless_mode` to suppress warning when in CLI mode (`headless_mode=True`)
- Warning is still shown in web UI mode (`headless_mode=False`) for debugging purposes
- Added comprehensive unit tests to verify the behavior in both modes

## Technical Details

The fix leverages the existing `headless_mode` parameter that's already properly set:
- **CLI mode**: `headless_mode=True` (default in `create_controller()`) → Warning suppressed
- **Web UI mode**: `headless_mode=False` (explicit in `agent_session.py`) → Warning shown

## Testing

- Added unit test `test_pending_action_warning_suppressed_in_headless_mode` that verifies:
  - Warning is suppressed in CLI mode (`headless_mode=True`)
  - Warning is still shown in GUI mode (`headless_mode=False`)
- All pre-commit hooks pass (ruff, mypy, formatting)
- Verified the logic with manual testing

## Impact

- **CLI users**: No more annoying timeout warnings ✅
- **Web UI users**: Still get debugging warnings when needed ✅
- **Backward compatibility**: Fully maintained ✅
- **Code quality**: Minimal, targeted change ✅

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c574dbebe9da4c709df62d68fafc8fd3)