### PR TITLE
Fix: Retry on Bedrock ServiceUnavailableError

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -19,6 +19,7 @@ from litellm import completion as litellm_completion
 from litellm import completion_cost as litellm_completion_cost
 from litellm.exceptions import (
     RateLimitError,
+    ServiceUnavailableError,
 )
 from litellm.types.utils import CostPerToken, ModelResponse, Usage
 from litellm.utils import create_pretrained_tokenizer
@@ -40,6 +41,7 @@ __all__ = ['LLM']
 # tuple of exceptions to retry on
 LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
     RateLimitError,
+    ServiceUnavailableError,
     litellm.Timeout,
     litellm.InternalServerError,
     LLMNoResponseError,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
We've been seeing this error when using bedrock:
```
litellm.exceptions.ServiceUnavailableError: litellm.ServiceUnavailableError: BedrockException - {"message":"The system encountered an unexpected error during processing. Try your request again."}
```
This seems like a pretty safe things to blindly retry.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Adds ServiceUnavailableError to retryable errors

---
**Link of any specific issues this addresses:**
