### PR TITLE
fix(cli): avoid race condition from multiple process_agent_pause tasks

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -121,6 +121,7 @@ async def run_session(
     sid = generate_sid(config, session_name)
     is_loaded = asyncio.Event()
     is_paused = asyncio.Event()  # Event to track agent pause requests
+    pause_task: asyncio.Task | None = None  # No more than one pause task
     always_confirm_mode = False  # Flag to enable always confirm mode
 
     # Show runtime initialization message
@@ -236,9 +237,11 @@ async def run_session(
 
             if event.agent_state == AgentState.RUNNING:
                 display_agent_running_message()
-                loop.create_task(
-                    process_agent_pause(is_paused, event_stream)
-                )  # Create a task to track agent pause requests from the user
+                nonlocal pause_task
+                if pause_task is None or pause_task.done():
+                    pause_task = loop.create_task(
+                        process_agent_pause(is_paused, event_stream)
+                    )  # Create a task to track agent pause requests from the user
 
     def on_event(event: Event) -> None:
         loop.create_task(on_event_async(event))


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes a bug where the terminal could be left in a broken state (raw mode) after exiting the CLI, due to improperly restored terminal settings.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Ensures process_agent_pause is only started once, preventing multiple conflicting state snapshots and conflicting restores at shutdown.

---
**Link of any specific issues this addresses:**
