### PR TITLE
Fixes #9394 - Improve CLI exit messaging to distinguish intentional exits and inter…

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -9,6 +9,7 @@ from prompt_toolkit.shortcuts import clear
 
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 import openhands.cli.suppress_warnings  # noqa: F401
+from openhands.core.schema.exit_reason import ExitReason
 from openhands.cli.commands import (
     check_folder_security_agreement,
     handle_commands,
@@ -117,6 +118,7 @@ async def run_session(
 ) -> bool:
     reload_microagents = False
     new_session_requested = False
+    exit_reason = ExitReason.INTENTIONAL
 
     sid = generate_sid(config, session_name)
     is_loaded = asyncio.Event()
@@ -152,7 +154,7 @@ async def run_session(
     usage_metrics = UsageMetrics()
 
     async def prompt_for_next_task(agent_state: str) -> None:
-        nonlocal reload_microagents, new_session_requested
+        nonlocal reload_microagents, new_session_requested, exit_reason
         while True:
             next_message = await read_prompt_input(
                 config, agent_state, multiline=config.cli_multiline_input
@@ -165,6 +167,7 @@ async def run_session(
                 close_repl,
                 reload_microagents,
                 new_session_requested,
+                exit_reason,
             ) = await handle_commands(
                 next_message,
                 event_stream,
@@ -328,6 +331,11 @@ async def run_session(
 
     await cleanup_session(loop, agent, runtime, controller)
 
+    if exit_reason == ExitReason.INTENTIONAL:
+        print_formatted_text("✅ Session terminated successfully.\n")
+    else:
+        print_formatted_text(f"⚠️ Session was interrupted: {exit_reason.value}\n")
+
     return new_session_requested
 
 
@@ -460,7 +468,7 @@ def main():
     try:
         loop.run_until_complete(main_with_loop(loop))
     except KeyboardInterrupt:
-        print('Received keyboard interrupt, shutting down...')
+        print_formatted_text("⚠️ Session was interrupted: interrupted\n")
     except ConnectionRefusedError as e:
         print(f'Connection refused: {e}')
         sys.exit(1)

--- a/openhands/core/schema/exit_reason.py
+++ b/openhands/core/schema/exit_reason.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class ExitReason(Enum):
+    INTENTIONAL = "intentional"
+    INTERRUPTED = "interrupted"
+    ERROR = "error"

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -45,7 +45,7 @@ class TestHandleCommands:
     async def test_handle_exit_command(self, mock_handle_exit, mock_dependencies):
         mock_handle_exit.return_value = True
 
-        close_repl, reload_microagents, new_session = await handle_commands(
+        close_repl, reload_microagents, new_session, _ = await handle_commands(
             '/exit', **mock_dependencies
         )
 
@@ -64,7 +64,7 @@ class TestHandleCommands:
     async def test_handle_help_command(self, mock_handle_help, mock_dependencies):
         mock_handle_help.return_value = (False, False, False)
 
-        close_repl, reload_microagents, new_session = await handle_commands(
+        close_repl, reload_microagents, new_session, _ = await handle_commands(
             '/help', **mock_dependencies
         )
 
@@ -78,7 +78,7 @@ class TestHandleCommands:
     async def test_handle_init_command(self, mock_handle_init, mock_dependencies):
         mock_handle_init.return_value = (True, True)
 
-        close_repl, reload_microagents, new_session = await handle_commands(
+        close_repl, reload_microagents, new_session, _ = await handle_commands(
             '/init', **mock_dependencies
         )
 
@@ -96,7 +96,7 @@ class TestHandleCommands:
     async def test_handle_status_command(self, mock_handle_status, mock_dependencies):
         mock_handle_status.return_value = (False, False, False)
 
-        close_repl, reload_microagents, new_session = await handle_commands(
+        close_repl, reload_microagents, new_session, _ = await handle_commands(
             '/status', **mock_dependencies
         )
 
@@ -112,7 +112,7 @@ class TestHandleCommands:
     async def test_handle_new_command(self, mock_handle_new, mock_dependencies):
         mock_handle_new.return_value = (True, True)
 
-        close_repl, reload_microagents, new_session = await handle_commands(
+        close_repl, reload_microagents, new_session, _ = await handle_commands(
             '/new', **mock_dependencies
         )
 
@@ -131,7 +131,7 @@ class TestHandleCommands:
     async def test_handle_settings_command(
         self, mock_handle_settings, mock_dependencies
     ):
-        close_repl, reload_microagents, new_session = await handle_commands(
+        close_repl, reload_microagents, new_session, _ = await handle_commands(
             '/settings', **mock_dependencies
         )
 
@@ -147,7 +147,7 @@ class TestHandleCommands:
     async def test_handle_unknown_command(self, mock_dependencies):
         user_message = 'Hello, this is not a command'
 
-        close_repl, reload_microagents, new_session = await handle_commands(
+        close_repl, reload_microagents, new_session, _ = await handle_commands(
             user_message, **mock_dependencies
         )
 

--- a/tests/unit/test_cli_pause_resume.py
+++ b/tests/unit/test_cli_pause_resume.py
@@ -253,7 +253,7 @@ class TestCliCommandsPauseResume:
         mock_handle_resume.return_value = (False, False)
 
         # Call handle_commands
-        close_repl, reload_microagents, new_session_requested = await handle_commands(
+        close_repl, reload_microagents, new_session_requested, _ = await handle_commands(
             message,
             event_stream,
             usage_metrics,

--- a/tests/unit/test_exit_reason.py
+++ b/tests/unit/test_exit_reason.py
@@ -1,0 +1,16 @@
+import pytest
+from openhands.core.schema.exit_reason import ExitReason
+
+def test_exit_reason_enum_values():
+    assert ExitReason.INTENTIONAL.value == "intentional"
+    assert ExitReason.INTERRUPTED.value == "interrupted"
+    assert ExitReason.ERROR.value == "error"
+
+def test_exit_reason_enum_names():
+    assert ExitReason["INTENTIONAL"] == ExitReason.INTENTIONAL
+    assert ExitReason["INTERRUPTED"] == ExitReason.INTERRUPTED
+    assert ExitReason["ERROR"] == ExitReason.ERROR
+
+def test_exit_reason_str_representation():
+    assert str(ExitReason.INTENTIONAL) == "ExitReason.INTENTIONAL"
+    assert repr(ExitReason.ERROR) == "<ExitReason.ERROR: 'error'>"


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**  
This update improves the CLI experience by clearly showing a positive confirmation message when users intentionally exit a session, and a distinct warning when sessions are interrupted unexpectedly. Previously, users saw confusing error messages even on normal exits, causing unnecessary anxiety.

---

**Summarize what the PR does, explaining any non-trivial design decisions.**  
This PR introduces an `ExitReason` enum to differentiate between intentional exits, interruptions, and errors. The CLI’s exit handling logic was updated to return and check this reason, enabling it to display clear, context-appropriate messages to users. Additionally, the PR includes friendly handling of keyboard interrupts (Ctrl+C) and updates related tests to accommodate the extended return signature of the `handle_commands()` function. A new unit test for `ExitReason` was added to ensure enum integrity.

---

**Link of any specific issues this addresses:**  
Fixes #9394