### PR TITLE
Fix Ctrl+C behavior in OpenHands CLI

### DIFF
--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -591,8 +591,16 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
     def keys_ready() -> None:
         for key_press in input.read_keys():
             if key_press.key == Keys.ControlC:
-                # Ctrl+C should interrupt the application, not pause it
-                raise KeyboardInterrupt()
+                # Ctrl+C should stop the application cleanly
+                print_formatted_text('')
+                print_formatted_text(
+                    HTML('<red>Keyboard interrupt, shutting down...</red>')
+                )
+                event_stream.add_event(
+                    ChangeAgentStateAction(AgentState.STOPPED),
+                    EventSource.USER,
+                )
+                done.set()
             elif key_press.key == Keys.ControlP or key_press.key == Keys.ControlD:
                 print_formatted_text('')
                 print_formatted_text(HTML('<gold>Pausing the agent...</gold>'))

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -46,6 +46,7 @@ from openhands.events.observation import (
     FileReadObservation,
 )
 from openhands.llm.metrics import Metrics
+from openhands.utils import shutdown_listener
 
 ENABLE_STREAMING = False  # FIXME: this doesn't work
 
@@ -601,7 +602,9 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
                     # Double Ctrl+C within 2 seconds - force quit
                     print_formatted_text('')
                     print_formatted_text(HTML('<red>Force quitting...</red>'))
-                    raise KeyboardInterrupt()
+                    # Trigger global shutdown instead of KeyboardInterrupt
+                    shutdown_listener._should_exit = True
+                    done.set()
                 else:
                     # First Ctrl+C - stop agent gracefully
                     ctrl_c_pressed_time = current_time

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -590,7 +590,10 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
 
     def keys_ready() -> None:
         for key_press in input.read_keys():
-            if key_press.key == Keys.ControlP or key_press.key == Keys.ControlD:
+            if key_press.key == Keys.ControlC:
+                # Ctrl+C should interrupt the application, not pause it
+                raise KeyboardInterrupt()
+            elif key_press.key == Keys.ControlP or key_press.key == Keys.ControlD:
                 print_formatted_text('')
                 print_formatted_text(HTML('<gold>Pausing the agent...</gold>'))
                 event_stream.add_event(

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -590,11 +590,7 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
 
     def keys_ready() -> None:
         for key_press in input.read_keys():
-            if (
-                key_press.key == Keys.ControlP
-                or key_press.key == Keys.ControlC
-                or key_press.key == Keys.ControlD
-            ):
+            if key_press.key == Keys.ControlP or key_press.key == Keys.ControlD:
                 print_formatted_text('')
                 print_formatted_text(HTML('<gold>Pausing the agent...</gold>'))
                 event_stream.add_event(

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -3,8 +3,6 @@
 # CLI Settings are handled separately in cli_settings.py
 
 import asyncio
-import os
-import signal
 import sys
 import threading
 import time
@@ -603,9 +601,8 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
                     # Double Ctrl+C within 2 seconds - force quit
                     print_formatted_text('')
                     print_formatted_text(HTML('<red>Force quitting...</red>'))
-                    # Trigger global shutdown via proper signal mechanism
-                    os.kill(os.getpid(), signal.SIGTERM)
-                    done.set()
+                    # Let the CLI main function handle the KeyboardInterrupt properly
+                    raise KeyboardInterrupt()
                 else:
                     # First Ctrl+C - stop agent gracefully
                     ctrl_c_pressed_time = current_time

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -3,6 +3,8 @@
 # CLI Settings are handled separately in cli_settings.py
 
 import asyncio
+import os
+import signal
 import sys
 import threading
 import time
@@ -46,7 +48,6 @@ from openhands.events.observation import (
     FileReadObservation,
 )
 from openhands.llm.metrics import Metrics
-from openhands.utils import shutdown_listener
 
 ENABLE_STREAMING = False  # FIXME: this doesn't work
 
@@ -602,8 +603,8 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
                     # Double Ctrl+C within 2 seconds - force quit
                     print_formatted_text('')
                     print_formatted_text(HTML('<red>Force quitting...</red>'))
-                    # Trigger global shutdown instead of KeyboardInterrupt
-                    shutdown_listener._should_exit = True
+                    # Trigger global shutdown via proper signal mechanism
+                    os.kill(os.getpid(), signal.SIGTERM)
                     done.set()
                 else:
                     # First Ctrl+C - stop agent gracefully


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed Ctrl+C behavior in the OpenHands CLI to work as expected:
- **First Ctrl+C**: Gracefully stops the current agent task and shows "Stopping agent... (press Ctrl+C again within 2 seconds to force quit)"
- **Second Ctrl+C** (within 2 seconds): Force quits the entire CLI application

Previously, Ctrl+C was being ignored during agent execution, causing it to behave like Ctrl+P (pause) instead of providing a way to stop or quit the application.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

## Problem
The OpenHands CLI was intercepting Ctrl+C during agent execution due to the `process_agent_pause` function running in raw input mode. This caused Ctrl+C to be completely ignored instead of allowing users to stop the agent or quit the application.

## Root Cause
The `process_agent_pause` function in `openhands/cli/tui.py` captures ALL input in raw mode during agent execution, including Ctrl+C keystrokes, but was not handling them appropriately.

## Solution
Implemented a double Ctrl+C pattern commonly used in CLI applications:

1. **First Ctrl+C**: Sets agent state to `STOPPED` for graceful shutdown of the current task
2. **Second Ctrl+C** (within 2 seconds): Raises `KeyboardInterrupt` for immediate application exit

## Design Decisions
- **Double Ctrl+C pattern**: Provides both graceful task stopping and force quit options
- **2-second timeout**: Reasonable window for users to decide between graceful vs force quit
- **Clear messaging**: Shows exactly what each Ctrl+C press will do
- **Preserves existing behavior**: Ctrl+P and Ctrl+D still pause the agent as before

## Technical Details
- Modified `keys_ready()` function in `process_agent_pause()` to track Ctrl+C timing
- First Ctrl+C sets `AgentState.STOPPED` which is handled by `run_agent_until_done()`
- Second Ctrl+C raises `KeyboardInterrupt` which is caught by the main function's exception handler
- Avoids race conditions by using the existing agent state management system

---
**Link of any specific issues this addresses:**

Fixes the issue where Ctrl+C was not working as expected in the OpenHands CLI, causing users to be unable to stop agent execution or quit the application normally.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:70ad153-nikolaik   --name openhands-app-70ad153   docker.all-hands.dev/all-hands-ai/openhands:70ad153
```