### PR TITLE
fix(cli): fix terminal input lag on Windows by start&stopping pause task

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -23,9 +23,10 @@ from openhands.cli.tui import (
     display_initialization_animation,
     display_runtime_initialization_message,
     display_welcome_message,
-    process_agent_pause,
     read_confirmation_input,
     read_prompt_input,
+    start_pause_listener,
+    stop_pause_listener,
     update_streaming_output,
 )
 from openhands.cli.utils import (
@@ -120,7 +121,6 @@ async def run_session(
     sid = generate_sid(config, session_name)
     is_loaded = asyncio.Event()
     is_paused = asyncio.Event()  # Event to track agent pause requests
-    pause_task: asyncio.Task | None = None  # No more than one pause task
     always_confirm_mode = False  # Flag to enable always confirm mode
 
     # Show runtime initialization message
@@ -184,6 +184,10 @@ async def run_session(
         update_usage_metrics(event, usage_metrics)
 
         if isinstance(event, AgentStateChangedObservation):
+            if event.agent_state not in [AgentState.RUNNING, AgentState.PAUSED]:
+                await stop_pause_listener()
+
+        if isinstance(event, AgentStateChangedObservation):
             if event.agent_state in [
                 AgentState.AWAITING_USER_INPUT,
                 AgentState.FINISHED,
@@ -236,11 +240,7 @@ async def run_session(
 
             if event.agent_state == AgentState.RUNNING:
                 display_agent_running_message()
-                nonlocal pause_task
-                if pause_task is None or pause_task.done():
-                    pause_task = loop.create_task(
-                        process_agent_pause(is_paused, event_stream)
-                    )  # Create a task to track agent pause requests from the user
+                start_pause_listener(loop, is_paused, event_stream)
 
     def on_event(event: Event) -> None:
         loop.create_task(on_event_async(event))

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -3,6 +3,7 @@
 # CLI Settings are handled separately in cli_settings.py
 
 import asyncio
+import contextlib
 import sys
 import threading
 import time
@@ -74,6 +75,8 @@ COMMANDS = {
 }
 
 print_lock = threading.Lock()
+
+pause_task: asyncio.Task | None = None  # No more than one pause task
 
 
 class UsageMetrics:
@@ -585,6 +588,28 @@ async def read_confirmation_input(config: OpenHandsConfig) -> str:
         return 'no'
 
 
+def start_pause_listener(
+    loop: asyncio.AbstractEventLoop,
+    done_event: asyncio.Event,
+    event_stream,
+) -> None:
+    global pause_task
+    if pause_task is None or pause_task.done():
+        pause_task = loop.create_task(
+            process_agent_pause(done_event, event_stream)
+        )  # Create a task to track agent pause requests from the user
+
+
+async def stop_pause_listener() -> None:
+    global pause_task
+    if pause_task and not pause_task.done():
+        pause_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pause_task
+        await asyncio.sleep(0)
+    pause_task = None
+
+
 async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) -> None:
     input = create_input()
 
@@ -603,9 +628,12 @@ async def process_agent_pause(done: asyncio.Event, event_stream: EventStream) ->
                 )
                 done.set()
 
-    with input.raw_mode():
-        with input.attach(keys_ready):
-            await done.wait()
+    try:
+        with input.raw_mode():
+            with input.attach(keys_ready):
+                await done.wait()
+    finally:
+        input.close()
 
 
 def cli_confirm(

--- a/tests/unit/test_cli_pause_resume.py
+++ b/tests/unit/test_cli_pause_resume.py
@@ -275,7 +275,7 @@ class TestCliCommandsPauseResume:
 class TestAgentStatePauseResume:
     @pytest.mark.asyncio
     @patch('openhands.cli.main.display_agent_running_message')
-    @patch('openhands.cli.main.process_agent_pause')
+    @patch('openhands.cli.tui.process_agent_pause')
     async def test_agent_running_enables_pause(
         self, mock_process_agent_pause, mock_display_message
     ):


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes terminal input lag/loss on Windows
Fixes CPR warnings after ctrl-c
Fixes exit through ctrl-c still leaving terminal in raw mode

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Adds start&stop functions stop the agent pause listener
Stops the agent pause listener when the agent is not in running/paused state.
Adds a finally block to ensure raw mode is always exited.

---
**Link of any specific issues this addresses:**
