### PR TITLE
fix(frontend): When the users hover on the pause button, the circle will not be fully displayed

### DIFF
--- a/frontend/src/components/features/controls/agent-control-bar.tsx
+++ b/frontend/src/components/features/controls/agent-control-bar.tsx
@@ -22,7 +22,7 @@ export function AgentControlBar() {
   };
 
   return (
-    <div className="flex justify-between items-center gap-20">
+    <div className="flex justify-between items-center gap-20 pl-2">
       <ActionButton
         isDisabled={
           curAgentState !== AgentState.RUNNING &&


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When users hover over the pause button, the circle is not fully displayed. To reproduce the issue, follow the steps below:

- Go to the home page.
- Click on the `Launch from Scratch` button to create a new conversation.
- Hover over the pause button.

The circle is cut off and not fully visible. For more details, refer to the video below:

https://github.com/user-attachments/assets/04981aaf-937f-4f06-aba8-fc766b57230f

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds `padding-left` to the pause button to ensure the circle is fully visible when users hover over it.

---
**Link of any specific issues this addresses:**

#9443 
