### PR TITLE
fix(frontend): Response issue - the content of the “Agent Tools & Metadata” modal is overflow.

### DIFF
--- a/frontend/src/components/features/conversation-panel/system-message-modal.tsx
+++ b/frontend/src/components/features/conversation-panel/system-message-modal.tsx
@@ -118,7 +118,7 @@ export function SystemMessageModal({
               )}
             </div>
 
-            <div className="h-[60vh] overflow-auto rounded-md">
+            <div className="max-h-[51vh] overflow-auto rounded-md">
               {activeTab === "system" && (
                 <div className="p-4 whitespace-pre-wrap font-mono text-sm leading-relaxed text-gray-300 shadow-inner">
                   {systemMessage.content}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The content inside the `Agent Tools & Metadata` modal is overflowing, which affects readability and layout consistency.

**Reproduction steps:**

- On the home page, click on the `Launch from Scratch` button to create a new conversation.
- On the conversation page, click on the vertical dots icon in the bottom right corner.
- Select the `Show Agent Tools & Metadata` option to open the modal.

You can refer to the video below for more information:

https://github.com/user-attachments/assets/1189de12-be30-436e-bc3f-d5b3b73b2854

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR updates the CSS to ensure that the content within the `Agent Tools & Metadata` modal is properly constrained, preventing any overflow issues and maintaining layout integrity.

For more details, refer to the video below:

https://github.com/user-attachments/assets/1fb15488-4b89-494f-b00b-877e0199af72

---
**Link of any specific issues this addresses:**

#9448 
