### PR TITLE
Fix: Automatically disable Jupyter plugin for CLI runtime by default

### DIFF
--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -17,14 +17,14 @@ class AgentConfig(BaseModel):
     """Filename of the system prompt template file within the agent's prompt directory. Defaults to 'system_prompt.j2'."""
     enable_browsing: bool = Field(default=True)
     """Whether to enable browsing tool.
-    Note: If using CLIRuntime, browsing is not implemented and should be disabled."""
+    Note: If using CLIRuntime, browsing is not implemented and will be automatically disabled."""
     enable_llm_editor: bool = Field(default=False)
     """Whether to enable LLM editor tool"""
     enable_editor: bool = Field(default=True)
     """Whether to enable the standard editor tool (str_replace_editor), only has an effect if enable_llm_editor is False."""
     enable_jupyter: bool = Field(default=True)
     """Whether to enable Jupyter tool.
-    Note: If using CLIRuntime, Jupyter use is not implemented and should be disabled."""
+    Note: If using CLIRuntime, Jupyter use is not implemented and will be automatically disabled."""
     enable_cmd: bool = Field(default=True)
     """Whether to enable bash tool"""
     enable_think: bool = Field(default=True)

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -399,17 +399,27 @@ def finalize_config(cfg: OpenHandsConfig) -> None:
             )
         )
 
-    # If CLIRuntime is selected, disable Jupyter for all agents
-    # Assuming 'cli' is the identifier for CLIRuntime
+    # If CLIRuntime is selected, disable Jupyter and browsing for all agents
+    # since CLIRuntime does not support IPython execution or browsing
     if cfg.runtime and cfg.runtime.lower() == 'cli':
-        for age_nt_name, agent_config in cfg.agents.items():
+        # Disable for existing agent configs
+        for agent_name, agent_config in cfg.agents.items():
             if agent_config.enable_jupyter:
                 agent_config.enable_jupyter = False
             if agent_config.enable_browsing:
                 agent_config.enable_browsing = False
+
+        # Also ensure the default agent config has these disabled
+        # This handles the case where no explicit agent configs are defined
+        default_agent_config = cfg.get_agent_config()
+        if default_agent_config.enable_jupyter:
+            default_agent_config.enable_jupyter = False
+        if default_agent_config.enable_browsing:
+            default_agent_config.enable_browsing = False
+
         logger.openhands_logger.debug(
             'Automatically disabled Jupyter plugin and browsing for all agents '
-            'because CLIRuntime is selected and does not support IPython execution.'
+            'because CLIRuntime is selected and does not support IPython execution or browsing.'
         )
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where CLI runtime users would see confusing warnings about Jupyter plugin not being implemented. The system now automatically disables the Jupyter and browsing plugins when using CLI runtime, eliminating these warnings and providing a smoother user experience.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR improves the existing auto-disable functionality for CLI runtime in the `finalize_config()` function:

1. **Fixed a typo**: Changed `age_nt_name` to `agent_name` in the loop variable
2. **Enhanced logic**: Added handling for the default agent config case, which was previously missed. This ensures Jupyter/browsing are disabled even when no explicit agent configs are defined
3. **Updated documentation**: Changed AgentConfig field descriptions to clarify that Jupyter/browsing will be "automatically disabled" rather than "should be disabled"
4. **Improved comments**: Enhanced code comments for better clarity

The key insight was that the existing code only disabled Jupyter/browsing for explicitly defined agents in `cfg.agents`, but didn't handle the default agent config returned by `cfg.get_agent_config()`. This meant users with default configurations would still encounter the warnings.

---
**Link of any specific issues this addresses:**

Addresses the CLI runtime warning: `cli_runtime.py:491 - run_ipython is called on CLIRuntime, but it's not implemented. Please disable the Jupyter plugin in AgentConfig`

@li-boxuan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8119c003d0684f648f4b46c974a740c6)