### PR TITLE
Fix CLI runtime not disabling jupyter plugin by default

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -40,6 +40,7 @@ from openhands.core.config import (
 )
 from openhands.core.config.condenser_config import NoOpCondenserConfig
 from openhands.core.config.mcp_config import OpenHandsMCPConfigImpl
+from openhands.core.config.utils import finalize_config
 from openhands.core.logger import openhands_logger as logger
 from openhands.core.loop import run_agent_until_done
 from openhands.core.schema import AgentState
@@ -432,6 +433,10 @@ async def main_with_loop(loop: asyncio.AbstractEventLoop) -> None:
         if not config.workspace_base:
             config.workspace_base = os.getcwd()
         config.security.confirmation_mode = True
+
+        # Need to finalize config again after setting runtime to 'cli'
+        # This ensures Jupyter plugin is disabled for CLI runtime
+        finalize_config(config)
 
     # TODO: Set working directory from config or use current working directory?
     current_dir = config.workspace_base

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -127,7 +127,9 @@ def mock_config():
 
     # Mock sandbox with volumes attribute to prevent finalize_config issues
     config.sandbox = MagicMock()
-    config.sandbox.volumes = None  # This prevents finalize_config from overriding workspace_base
+    config.sandbox.volumes = (
+        None  # This prevents finalize_config from overriding workspace_base
+    )
 
     return config
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -125,6 +125,10 @@ def mock_config():
     )
     config.search_api_key = search_api_key_mock
 
+    # Mock sandbox with volumes attribute to prevent finalize_config issues
+    config.sandbox = MagicMock()
+    config.sandbox.volumes = None  # This prevents finalize_config from overriding workspace_base
+
     return config
 
 
@@ -327,7 +331,9 @@ async def test_run_session_with_initial_action(
 @patch('openhands.cli.main.run_session')
 @patch('openhands.cli.main.LLMSummarizingCondenserConfig')
 @patch('openhands.cli.main.NoOpCondenserConfig')
+@patch('openhands.cli.main.finalize_config')
 async def test_main_without_task(
+    mock_finalize_config,
     mock_noop_condenser,
     mock_llm_condenser,
     mock_run_session,
@@ -411,7 +417,9 @@ async def test_main_without_task(
 @patch('openhands.cli.main.run_session')
 @patch('openhands.cli.main.LLMSummarizingCondenserConfig')
 @patch('openhands.cli.main.NoOpCondenserConfig')
+@patch('openhands.cli.main.finalize_config')
 async def test_main_with_task(
+    mock_finalize_config,
     mock_noop_condenser,
     mock_llm_condenser,
     mock_run_session,
@@ -506,7 +514,9 @@ async def test_main_with_task(
 @patch('openhands.cli.main.run_session')
 @patch('openhands.cli.main.LLMSummarizingCondenserConfig')
 @patch('openhands.cli.main.NoOpCondenserConfig')
+@patch('openhands.cli.main.finalize_config')
 async def test_main_with_session_name_passes_name_to_run_session(
+    mock_finalize_config,
     mock_noop_condenser,
     mock_llm_condenser,
     mock_run_session,
@@ -600,7 +610,9 @@ async def test_main_with_session_name_passes_name_to_run_session(
 @patch('openhands.cli.main.display_initialization_animation')  # Cosmetic
 @patch('openhands.cli.main.initialize_repository_for_runtime')  # Cosmetic / setup
 @patch('openhands.cli.main.display_initial_user_prompt')  # Cosmetic
+@patch('openhands.cli.main.finalize_config')
 async def test_run_session_with_name_attempts_state_restore(
+    mock_finalize_config,
     mock_display_initial_user_prompt,
     mock_initialize_repo,
     mock_display_init_anim,
@@ -684,11 +696,17 @@ async def test_run_session_with_name_attempts_state_restore(
 @patch('openhands.cli.main.setup_config_from_args')
 @patch('openhands.cli.main.FileSettingsStore.get_instance')
 @patch('openhands.cli.main.check_folder_security_agreement')
+@patch('openhands.cli.main.read_task')
+@patch('openhands.cli.main.run_session')
 @patch('openhands.cli.main.LLMSummarizingCondenserConfig')
 @patch('openhands.cli.main.NoOpCondenserConfig')
+@patch('openhands.cli.main.finalize_config')
 async def test_main_security_check_fails(
+    mock_finalize_config,
     mock_noop_condenser,
     mock_llm_condenser,
+    mock_run_session,
+    mock_read_task,
     mock_check_security,
     mock_get_settings_store,
     mock_setup_config,
@@ -743,7 +761,9 @@ async def test_main_security_check_fails(
 @patch('openhands.cli.main.run_session')
 @patch('openhands.cli.main.LLMSummarizingCondenserConfig')
 @patch('openhands.cli.main.NoOpCondenserConfig')
+@patch('openhands.cli.main.finalize_config')
 async def test_config_loading_order(
+    mock_finalize_config,
     mock_noop_condenser,
     mock_llm_condenser,
     mock_run_session,
@@ -841,15 +861,19 @@ async def test_config_loading_order(
 @patch('openhands.cli.main.setup_config_from_args')
 @patch('openhands.cli.main.FileSettingsStore.get_instance')
 @patch('openhands.cli.main.check_folder_security_agreement')
+@patch('openhands.cli.main.read_task')
 @patch('openhands.cli.main.run_session')
 @patch('openhands.cli.main.LLMSummarizingCondenserConfig')
 @patch('openhands.cli.main.NoOpCondenserConfig')
+@patch('openhands.cli.main.finalize_config')
 @patch('builtins.open', new_callable=MagicMock)
 async def test_main_with_file_option(
     mock_open,
+    mock_finalize_config,
     mock_noop_condenser,
     mock_llm_condenser,
     mock_run_session,
+    mock_read_task,
     mock_check_security,
     mock_get_settings_store,
     mock_setup_config,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Disable Jupyter plugin by default in CLI runtime

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

CLI runtime doesn't support jupyter plugin, 

> 11:24:54 - openhands:WARNING: cli_runtime.py:491 - run_ipython is called on CLIRuntime, but it's not implemented. Please disable the Jupyter plugin in AgentConfig.

yet it is enabled by default, due to a timing bug of when runtime option is set: https://github.com/All-Hands-AI/OpenHands/blob/34bf645d644ae03167cfb06834c576257e20b8a5/openhands/cli/main.py#L431

Note that by the time this happens, the configs have already been "finalized", thus the below code didn't take effect:

https://github.com/All-Hands-AI/OpenHands/blob/34bf645d644ae03167cfb06834c576257e20b8a5/openhands/core/config/utils.py#L402-L413

This PR fixes this bug by calling finalization method again.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e0b2252-nikolaik   --name openhands-app-e0b2252   docker.all-hands.dev/all-hands-ai/openhands:e0b2252
```