### PR TITLE
Add ability to enable/disable string replace editor independently

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -231,9 +231,8 @@ enable_browsing = true
 # Whether the LLM draft editor is enabled
 enable_llm_editor = false
 
-# Whether the standard editor tool (str_replace_editor) is enabled
-# Only has an effect if enable_llm_editor is False
-enable_editor = true
+# Whether the string replace editor tool is enabled
+enable_str_replace_editor = true
 
 # Whether the IPython tool is enabled
 enable_jupyter = true

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -133,7 +133,7 @@ class CodeActAgent(Agent):
             tools.append(IPythonTool)
         if self.config.enable_llm_editor:
             tools.append(LLMBasedFileEditTool)
-        elif self.config.enable_editor:
+        if self.config.enable_str_replace_editor:
             tools.append(
                 create_str_replace_editor_tool(
                     use_short_description=use_short_tool_desc

--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -20,8 +20,11 @@ class AgentConfig(BaseModel):
     Note: If using CLIRuntime, browsing is not implemented and should be disabled."""
     enable_llm_editor: bool = Field(default=False)
     """Whether to enable LLM editor tool"""
-    enable_editor: bool = Field(default=True)
-    """Whether to enable the standard editor tool (str_replace_editor), only has an effect if enable_llm_editor is False."""
+    enable_str_replace_editor: bool = Field(default=True)
+    """Whether to enable the string replace editor tool."""
+    # Kept for backward compatibility, will be removed in a future version
+    enable_editor: bool = Field(default=True, deprecated=True)
+    """Deprecated: Use enable_str_replace_editor instead."""
     enable_jupyter: bool = Field(default=True)
     """Whether to enable Jupyter tool.
     Note: If using CLIRuntime, Jupyter use is not implemented and should be disabled."""


### PR DESCRIPTION
## Description
This PR adds the ability to enable or disable the string replace editor independently of the LLM editor. Previously, the string replace editor could only be enabled if the LLM editor was disabled and the `enable_editor` flag was set to true.

## Changes
- Modified the `_get_tools` method in `CodeActAgent` to make the string replace editor independent of the `enable_editor` option
- Kept the `enable_editor` field in the `AgentConfig` class but marked it as deprecated for backward compatibility
- Updated documentation in the `AgentConfig` class to reflect these changes
- Removed the `enable_editor` option from the config.template.toml file since it's deprecated

## Benefits
Users now have more flexibility:
- Can enable both the LLM editor and string replace editor simultaneously
- Can enable just the LLM editor
- Can enable just the string replace editor
- Can disable both editors

## Testing
- Ran unit tests to ensure changes don't break existing functionality
- Verified that the string replace editor can be enabled/disabled independently

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a01a35dbcffd475fb85f4db221e27b4a)