### PR TITLE
Enhance logging for org-level microagent loading to improve debugging

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -561,7 +561,7 @@ fi
         loaded_microagents: list[BaseMicroagent] = []
 
         self.log(
-            'debug',
+            'info',
             f'Attempting to list files in {source_description} microagents directory: {microagents_dir}',
         )
 
@@ -569,7 +569,7 @@ fi
 
         if not files:
             self.log(
-                'debug',
+                'warning',
                 f'No files found in {source_description} microagents directory: {microagents_dir}',
             )
             return loaded_microagents
@@ -713,14 +713,10 @@ fi
         )
 
         repo_parts = selected_repository.split('/')
-        self.log(
-            'debug',
-            f'Repository parts: {repo_parts} (length: {len(repo_parts)})',
-        )
 
         if len(repo_parts) < 2:
             self.log(
-                'debug',
+                'warning',
                 f'Repository path has insufficient parts ({len(repo_parts)} < 2), skipping org-level microagents',
             )
             return loaded_microagents
@@ -728,7 +724,7 @@ fi
         # Extract the domain and org/user name
         org_name = repo_parts[-2]
         self.log(
-            'debug',
+            'info',
             f'Extracted org/user name: {org_name}',
         )
 
@@ -762,23 +758,15 @@ fi
 
             # Get authenticated URL and do a shallow clone (--depth 1) for efficiency
             try:
-                self.log(
-                    'debug',
-                    f'Attempting to get authenticated URL for {org_openhands_repo}',
-                )
                 remote_url = call_async_from_sync(
                     self._get_authenticated_git_url,
                     GENERAL_TIMEOUT,
                     org_openhands_repo,
                     self.git_provider_tokens,
                 )
-                self.log(
-                    'debug',
-                    f'Successfully obtained authenticated URL for {org_openhands_repo}',
-                )
             except Exception as e:
                 self.log(
-                    'debug',
+                    'error',
                     f'Failed to get authenticated URL for {org_openhands_repo}: {str(e)}',
                 )
                 raise Exception(str(e))
@@ -787,8 +775,8 @@ fi
                 f'GIT_TERMINAL_PROMPT=0 git clone --depth 1 {remote_url} {org_repo_dir}'
             )
             self.log(
-                'debug',
-                'Executing clone command for org-level repo (URL redacted for security)',
+                'info',
+                'Executing clone command for org-level repo',
             )
 
             action = CmdRunAction(command=clone_cmd)
@@ -803,7 +791,7 @@ fi
                 # Load microagents from the org-level repo
                 org_microagents_dir = org_repo_dir / 'microagents'
                 self.log(
-                    'debug',
+                    'info',
                     f'Looking for microagents in directory: {org_microagents_dir}',
                 )
 

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -559,9 +559,19 @@ fi
             A list of loaded microagents
         """
         loaded_microagents: list[BaseMicroagent] = []
+
+        self.log(
+            'debug',
+            f'Attempting to list files in {source_description} microagents directory: {microagents_dir}',
+        )
+
         files = self.list_files(str(microagents_dir))
 
         if not files:
+            self.log(
+                'debug',
+                f'No files found in {source_description} microagents directory: {microagents_dir}',
+            )
             return loaded_microagents
 
         self.log(
@@ -697,15 +707,37 @@ fi
         """
         loaded_microagents: list[BaseMicroagent] = []
 
+        self.log(
+            'debug',
+            f'Starting org-level microagent loading for repository: {selected_repository}',
+        )
+
         repo_parts = selected_repository.split('/')
+        self.log(
+            'debug',
+            f'Repository parts: {repo_parts} (length: {len(repo_parts)})',
+        )
+
         if len(repo_parts) < 2:
+            self.log(
+                'debug',
+                f'Repository path has insufficient parts ({len(repo_parts)} < 2), skipping org-level microagents',
+            )
             return loaded_microagents
 
         # Extract the domain and org/user name
         org_name = repo_parts[-2]
+        self.log(
+            'debug',
+            f'Extracted org/user name: {org_name}',
+        )
 
         # Determine if this is a GitLab repository
         is_gitlab = self._is_gitlab_repository(selected_repository)
+        self.log(
+            'debug',
+            f'Repository type detection - is_gitlab: {is_gitlab}',
+        )
 
         # For GitLab, use openhands-config (since .openhands is not a valid repo name)
         # For other providers, use .openhands
@@ -723,19 +755,40 @@ fi
         try:
             # Create a temporary directory for the org-level repo
             org_repo_dir = self.workspace_root / f'org_openhands_{org_name}'
+            self.log(
+                'debug',
+                f'Creating temporary directory for org repo: {org_repo_dir}',
+            )
 
             # Get authenticated URL and do a shallow clone (--depth 1) for efficiency
             try:
+                self.log(
+                    'debug',
+                    f'Attempting to get authenticated URL for {org_openhands_repo}',
+                )
                 remote_url = call_async_from_sync(
                     self._get_authenticated_git_url,
                     GENERAL_TIMEOUT,
                     org_openhands_repo,
                     self.git_provider_tokens,
                 )
+                self.log(
+                    'debug',
+                    f'Successfully obtained authenticated URL for {org_openhands_repo}',
+                )
             except Exception as e:
+                self.log(
+                    'debug',
+                    f'Failed to get authenticated URL for {org_openhands_repo}: {str(e)}',
+                )
                 raise Exception(str(e))
+
             clone_cmd = (
                 f'GIT_TERMINAL_PROMPT=0 git clone --depth 1 {remote_url} {org_repo_dir}'
+            )
+            self.log(
+                'debug',
+                'Executing clone command for org-level repo (URL redacted for security)',
             )
 
             action = CmdRunAction(command=clone_cmd)
@@ -749,17 +802,39 @@ fi
 
                 # Load microagents from the org-level repo
                 org_microagents_dir = org_repo_dir / 'microagents'
+                self.log(
+                    'debug',
+                    f'Looking for microagents in directory: {org_microagents_dir}',
+                )
+
                 loaded_microagents = self._load_microagents_from_directory(
                     org_microagents_dir, 'org-level'
+                )
+
+                self.log(
+                    'info',
+                    f'Loaded {len(loaded_microagents)} microagents from org-level repository {org_openhands_repo}',
                 )
 
                 # Clean up the org repo directory
                 action = CmdRunAction(f'rm -rf {org_repo_dir}')
                 self.run_action(action)
             else:
+                clone_error_msg = (
+                    obs.content
+                    if isinstance(obs, CmdOutputObservation)
+                    else 'Unknown error'
+                )
+                exit_code = (
+                    obs.exit_code if isinstance(obs, CmdOutputObservation) else 'N/A'
+                )
                 self.log(
                     'info',
-                    f'No org-level microagents found at {org_openhands_repo}',
+                    f'No org-level microagents found at {org_openhands_repo} (exit_code: {exit_code})',
+                )
+                self.log(
+                    'debug',
+                    f'Clone command output: {clone_error_msg}',
                 )
 
         except Exception as e:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This change improves debugging capabilities for administrators and developers when users report that their organization-level microagents are not loading properly. The enhanced logging provides detailed visibility into the microagent loading process, making it easier to identify where failures occur.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds comprehensive debug and info logging to the org-level microagent loading path in `openhands/runtime/base.py`. The changes include:

1. **Repository parsing logging**: Logs the repository parts extraction and validation process
2. **GitLab detection logging**: Shows when GitLab repositories are detected and how the org repo name is constructed
3. **Authentication logging**: Tracks attempts to get authenticated URLs for cloning
4. **Clone operation logging**: Provides detailed feedback on git clone operations, including exit codes and error messages
5. **Directory scanning logging**: Shows when microagent directories are being scanned and whether files are found
6. **Success metrics logging**: Reports the number of microagents successfully loaded

The logging is structured with appropriate levels:
- `debug` level for detailed step-by-step information
- `info` level for important status updates and success/failure summaries

This maintains backward compatibility while providing much better visibility into the microagent loading process for troubleshooting purposes.

---
**Link of any specific issues this addresses:**

This addresses debugging challenges where users report that their org-level microagents aren't loading, but there was insufficient logging to determine the root cause.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9ce471091e414b499063e73c1e62ced9)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ac2823f-nikolaik   --name openhands-app-ac2823f   docker.all-hands.dev/all-hands-ai/openhands:ac2823f
```