### PR TITLE
Fix /init on CLI Runtime

### DIFF
--- a/openhands/cli/commands.py
+++ b/openhands/cli/commands.py
@@ -129,7 +129,7 @@ async def handle_init_command(
     close_repl = False
     reload_microagents = False
 
-    if config.runtime == 'local' or config.runtime == 'cli':
+    if config.runtime in ('local', 'cli'):
         init_repo = await init_repository(config, current_dir)
         if init_repo:
             event_stream.add_event(

--- a/openhands/cli/commands.py
+++ b/openhands/cli/commands.py
@@ -129,7 +129,7 @@ async def handle_init_command(
     close_repl = False
     reload_microagents = False
 
-    if config.runtime == 'local':
+    if config.runtime == 'local' or config.runtime == 'cli':
         init_repo = await init_repository(config, current_dir)
         if init_repo:
             event_stream.add_event(
@@ -140,7 +140,7 @@ async def handle_init_command(
             close_repl = True
     else:
         print_formatted_text(
-            '\nRepository initialization through the CLI is only supported for local runtime.\n'
+            '\nRepository initialization through the CLI is only supported for CLI and local runtimes.\n'
         )
 
     return close_repl, reload_microagents


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fix /init command on CLI Runtime

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR proposes a fix for CLIRuntime to accept and run the ‘/init’ command in CLI mode.

---
**Link of any specific issues this addresses:**
Fix https://github.com/All-Hands-AI/OpenHands/issues/9473

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:270b667-nikolaik   --name openhands-app-270b667   docker.all-hands.dev/all-hands-ai/openhands:270b667
```