### PR TITLE
fix (cli): issue 9386 - show settings.json path in /settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,8 @@ cython_debug/
 .roo/rules
 .cline/rules
 .windsurf/rules
+.repomix
+repomix-output.txt
 
 # evaluation
 evaluation/evaluation_outputs
@@ -252,3 +254,4 @@ containers/runtime/Dockerfile
 containers/runtime/project.tar.gz
 containers/runtime/code
 **/node_modules/
+

--- a/.gitignore
+++ b/.gitignore
@@ -254,4 +254,3 @@ containers/runtime/Dockerfile
 containers/runtime/project.tar.gz
 containers/runtime/code
 **/node_modules/
-

--- a/openhands/cli/settings.py
+++ b/openhands/cli/settings.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from prompt_toolkit import PromptSession, print_formatted_text
 from prompt_toolkit.completion import FuzzyWordCompleter
 from prompt_toolkit.formatted_text import HTML
@@ -73,7 +75,7 @@ def display_settings(config: OpenHandsConfig) -> None:
             ),
             (
                 '   Configuration File',
-                '~/.openhands/settings.json',
+                str(Path(config.file_store_path) / 'settings.json'),
             ),
         ]
     )

--- a/openhands/cli/settings.py
+++ b/openhands/cli/settings.py
@@ -71,6 +71,10 @@ def display_settings(config: OpenHandsConfig) -> None:
                 '   Memory Condensation',
                 'Enabled' if config.enable_default_condenser else 'Disabled',
             ),
+            (
+                '   Configuration File',
+                '~/.openhands/settings.json',
+            ),
         ]
     )
 

--- a/tests/unit/test_cli_settings.py
+++ b/tests/unit/test_cli_settings.py
@@ -31,13 +31,16 @@ class MockNoOpCondenserConfig:
 class TestDisplaySettings:
     @pytest.fixture
     def app_config(self):
-        config = MagicMock(spec=OpenHandsConfig)
+        config = MagicMock()
         llm_config = MagicMock()
         llm_config.base_url = None
         llm_config.model = 'openai/gpt-4'
         llm_config.api_key = SecretStr('test-api-key')
         config.get_llm_config.return_value = llm_config
         config.default_agent = 'test-agent'
+        config.file_store_path = (
+            '/tmp'  # necessary for TestSettingsCommandShowsConfigFilePath to pass
+        )
 
         # Set up security as a separate mock
         security_mock = MagicMock()
@@ -49,13 +52,16 @@ class TestDisplaySettings:
 
     @pytest.fixture
     def advanced_app_config(self):
-        config = MagicMock(spec=OpenHandsConfig)
+        config = MagicMock()
         llm_config = MagicMock()
         llm_config.base_url = 'https://custom-api.com'
         llm_config.model = 'custom-model'
         llm_config.api_key = SecretStr('test-api-key')
         config.get_llm_config.return_value = llm_config
         config.default_agent = 'test-agent'
+        config.file_store_path = (
+            '/tmp'  # necessary for TestSettingsCommandShowsConfigFilePath to pass
+        )
 
         # Set up security as a separate mock
         security_mock = MagicMock()

--- a/tests/unit/test_cli_settings.py
+++ b/tests/unit/test_cli_settings.py
@@ -15,6 +15,7 @@ from openhands.core.config import OpenHandsConfig
 from openhands.storage.data_models.settings import Settings
 from openhands.storage.settings.file_settings_store import FileSettingsStore
 
+
 # Mock classes for condensers
 class MockLLMSummarizingCondenserConfig:
     def __init__(self, llm_config, type):


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**CLI /settings now shows the path to the configuration file.**


---
**Added the Path of 'config' object in  the corresponding 'labels_and_values' list within 'display_settings' function of  'settings.py'.
Added Test Class 'TestSettingsCommandShowsConfigFilePath'.**


---
**Link of any specific issues this addresses: **
Fix #9386 

![grafik](https://github.com/user-attachments/assets/42384f5c-52d3-4a3e-bd07-62e4d449ee4a)
