### PR TITLE
Fix hardcoded localhost for VSCode URL in docker_runtime.py

### DIFF
--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -498,7 +498,8 @@ class DockerRuntime(ActionExecutionClient):
         if not token:
             return None
 
-        vscode_url = f'http://localhost:{self._vscode_port}/?tkn={token}&folder={self.config.workspace_mount_path_in_sandbox}'
+        base_url = self.config.local_runtime_url.rstrip('/')
+        vscode_url = f'{base_url}:{self._vscode_port}/?tkn={token}&folder={self.config.workspace_mount_path_in_sandbox}'
         return vscode_url
 
     @property

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -498,8 +498,13 @@ class DockerRuntime(ActionExecutionClient):
         if not token:
             return None
 
-        base_url = self.config.local_runtime_url.rstrip('/')
-        vscode_url = f'{base_url}:{self._vscode_port}/?tkn={token}&folder={self.config.workspace_mount_path_in_sandbox}'
+        web_host = os.environ.get('WEB_HOST', 'localhost')
+        if web_host != 'localhost':
+          # Use external domain with proxy path
+          vscode_url = f'https://{web_host}/api/vscode-proxy/{self.runtime_id}/?tkn={token}&folder={self.config.workspace_mount_path_in_sandbox}'
+        else:
+          # Local development - use localhost with direct port
+          vscode_url = f'http://localhost:{self._vscode_port}/?tkn={token}&folder={self.config.workspace_mount_path_in_sandbox}'
         return vscode_url
 
     @property


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below
The OpenHands Docker runtime hardcodes `localhost` in VS Code URL generation, ignoring available configuration that could provide the external domain.


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

**End-user friendly description of the problem this fixes or functionality this introduces.**
The OpenHands Docker runtime should be updated to use `local_runtime_url` configuration for VS Code URL generation, similar to how the Remote runtime constructs external URLs.

**Required change in** `/app/openhands/runtime/impl/docker/docker_runtime.py:484`:

```python
# FROM:
vscode_url = f'http://localhost:{self._vscode_port}/?tkn={token}&folder={self.config.workspace_mount_path_in_sandbox}'

# TO:
base_url = self.config.local_runtime_url.rstrip('/')
vscode_url = f'{base_url}:{self._vscode_port}/?tkn={token}&folder={self.config.workspace_mount_path_in_sandbox}'
```

here is a link to existing, but not used, property https://github.com/All-Hands-AI/OpenHands/blob/11ae4f96c25c4bf8161ba3584f279f12b85e3279/openhands/core/config/sandbox_config.py#L47

---
**Link of any specific issues this addresses:**
