### PR TITLE
Fix search API key reset when saving settings

### DIFF
--- a/frontend/__tests__/hooks/mutation/use-save-settings.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-save-settings.test.tsx
@@ -1,15 +1,29 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import OpenHands from "#/api/open-hands";
 import { useSaveSettings } from "#/hooks/mutation/use-save-settings";
 
+// Mock the useSettings hook
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({
+    data: {},
+  }),
+}));
+
 describe("useSaveSettings", () => {
+  let saveSettingsSpy: any;
+  let queryClient: QueryClient;
+  
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    saveSettingsSpy = vi.spyOn(OpenHands, "saveSettings").mockResolvedValue(true);
+  });
+
   it("should send an empty string for llm_api_key if an empty string is passed, otherwise undefined", async () => {
-    const saveSettingsSpy = vi.spyOn(OpenHands, "saveSettings");
     const { result } = renderHook(() => useSaveSettings(), {
       wrapper: ({ children }) => (
-        <QueryClientProvider client={new QueryClient()}>
+        <QueryClientProvider client={queryClient}>
           {children}
         </QueryClientProvider>
       ),
@@ -24,6 +38,7 @@ describe("useSaveSettings", () => {
       );
     });
 
+    saveSettingsSpy.mockClear();
     result.current.mutate({ llm_api_key: null });
     await waitFor(() => {
       expect(saveSettingsSpy).toHaveBeenCalledWith(
@@ -31,6 +46,35 @@ describe("useSaveSettings", () => {
           llm_api_key: undefined,
         }),
       );
+    });
+  });
+
+  it("should only include search_api_key in the request when explicitly provided", async () => {
+    const { result } = renderHook(() => useSaveSettings(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    // When SEARCH_API_KEY is provided, it should be included in the request
+    result.current.mutate({ SEARCH_API_KEY: "test-api-key" });
+    await waitFor(() => {
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search_api_key: "test-api-key",
+        }),
+      );
+    });
+
+    // When SEARCH_API_KEY is not provided, it should not be included in the request
+    saveSettingsSpy.mockClear();
+    result.current.mutate({ LLM_MODEL: "test-model" });
+    await waitFor(() => {
+      expect(saveSettingsSpy).toHaveBeenCalled();
+      const callArg = saveSettingsSpy.mock.calls[0][0];
+      expect(callArg.search_api_key).toBeUndefined();
     });
   });
 });

--- a/frontend/src/hooks/mutation/use-save-settings.ts
+++ b/frontend/src/hooks/mutation/use-save-settings.ts
@@ -6,6 +6,7 @@ import { PostSettings, PostApiSettings } from "#/types/settings";
 import { useSettings } from "../query/use-settings";
 
 const saveSettingsMutationFn = async (settings: Partial<PostSettings>) => {
+  // Create a base settings object without search_api_key
   const apiSettings: Partial<PostApiSettings> = {
     llm_model: settings.LLM_MODEL,
     llm_base_url: settings.LLM_BASE_URL,
@@ -25,9 +26,13 @@ const saveSettingsMutationFn = async (settings: Partial<PostSettings>) => {
     mcp_config: settings.MCP_CONFIG,
     enable_proactive_conversation_starters:
       settings.ENABLE_PROACTIVE_CONVERSATION_STARTERS,
-    search_api_key: settings.SEARCH_API_KEY?.trim() || "",
     max_budget_per_task: settings.MAX_BUDGET_PER_TASK,
   };
+
+  // Only include search_api_key if it's explicitly provided in the settings
+  if (Object.prototype.hasOwnProperty.call(settings, "SEARCH_API_KEY")) {
+    apiSettings.search_api_key = settings.SEARCH_API_KEY?.trim() || "";
+  }
 
   await OpenHands.saveSettings(apiSettings);
 };


### PR DESCRIPTION
## Description

This PR fixes issue #9497 where the search API key gets reset when saving other settings.

### Problem
When saving settings, the search API key was always included in the request, even when it wasn't being explicitly changed. This caused the search API key to be reset to an empty string when saving other settings.

### Solution
Modified the `saveSettingsMutationFn` function in `use-save-settings.ts` to only include the search API key in the request when it's explicitly provided in the settings being saved. This ensures that the search API key is preserved when saving other settings.

### Testing
Added a test case to verify that the search API key is only included in the request when explicitly provided.

Fixes #9497

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cd964620c9db45c08a0a4241c0e73aa4)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3e73d61-nikolaik   --name openhands-app-3e73d61   docker.all-hands.dev/all-hands-ai/openhands:3e73d61
```