### PR TITLE
Conditionally render 'Add GitHub repos' link based on provider

### DIFF
--- a/frontend/__tests__/components/features/home/repo-connector.test.tsx
+++ b/frontend/__tests__/components/features/home/repo-connector.test.tsx
@@ -119,16 +119,46 @@ describe("RepoConnector", () => {
     expect(launchButton).toBeEnabled();
   });
 
-  it("should render the 'add git(hub|lab) repos' links if saas mode", async () => {
+  it("should render the 'add github repos' link if saas mode and github provider is set", async () => {
     const getConfiSpy = vi.spyOn(OpenHands, "getConfig");
     // @ts-expect-error - only return the APP_MODE
     getConfiSpy.mockResolvedValue({
       APP_MODE: "saas",
     });
 
+    const getSettingsSpy = vi.spyOn(OpenHands, "getSettings");
+    getSettingsSpy.mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      provider_tokens_set: {
+        github: "some-token",
+        gitlab: null,
+      },
+    });
+
     renderRepoConnector();
 
     await screen.findByText("HOME$ADD_GITHUB_REPOS");
+  });
+
+  it("should not render the 'add github repos' link if github provider is not set", async () => {
+    const getConfiSpy = vi.spyOn(OpenHands, "getConfig");
+    // @ts-expect-error - only return the APP_MODE
+    getConfiSpy.mockResolvedValue({
+      APP_MODE: "saas",
+    });
+
+    const getSettingsSpy = vi.spyOn(OpenHands, "getSettings");
+    getSettingsSpy.mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      provider_tokens_set: {
+        gitlab: "some-token",
+        github: null,
+      },
+    });
+
+    renderRepoConnector();
+
+    expect(screen.queryByText("HOME$ADD_GITHUB_REPOS")).not.toBeInTheDocument();
   });
 
   it("should not render the 'add git(hub|lab) repos' links if oss mode", async () => {

--- a/frontend/src/components/features/home/repo-provider-links.tsx
+++ b/frontend/src/components/features/home/repo-provider-links.tsx
@@ -1,20 +1,26 @@
 import { useTranslation } from "react-i18next";
 import { useConfig } from "#/hooks/query/use-config";
 import { I18nKey } from "#/i18n/declaration";
+import { useUserProviders } from "#/hooks/use-user-providers";
 
 export function RepoProviderLinks() {
   const { t } = useTranslation();
   const { data: config } = useConfig();
+  const { providers } = useUserProviders();
 
   const githubHref = config
     ? `https://github.com/apps/${config.APP_SLUG}/installations/new`
     : "";
 
+  const hasGithubProvider = providers.includes("github");
+
   return (
     <div className="flex flex-col text-sm underline underline-offset-2 text-content-2 gap-4 w-fit">
-      <a href={githubHref} target="_blank" rel="noopener noreferrer">
-        {t(I18nKey.HOME$ADD_GITHUB_REPOS)}
-      </a>
+      {hasGithubProvider && (
+        <a href={githubHref} target="_blank" rel="noopener noreferrer">
+          {t(I18nKey.HOME$ADD_GITHUB_REPOS)}
+        </a>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This change ensures that the "Add GitHub repos" link in the repository connector page is only displayed when GitHub is set as a provider. Previously, this link was always displayed regardless of the selected provider, which could be confusing for users who are using GitLab or Bitbucket.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

1. Modified the `RepoProviderLinks` component to check if GitHub is included in the user's providers list
2. Only renders the "Add GitHub repos" link when GitHub is a configured provider
3. Added tests to verify the conditional rendering behavior:
   - Test that the link appears when GitHub is set as a provider
   - Test that the link doesn't appear when GitHub is not set as a provider

The implementation uses the existing `useUserProviders` hook to determine which providers are configured, making it a clean and maintainable solution.

---
**Link of any specific issues this addresses:**

N/A

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/436d2057260844e08031e1295d579beb)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8b571c3-nikolaik   --name openhands-app-8b571c3   docker.all-hands.dev/all-hands-ai/openhands:8b571c3
```