### PR TITLE
Fix CLI confirmation input to handle invalid input properly

### DIFF
--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -568,22 +568,32 @@ async def read_confirmation_input(config: OpenHandsConfig) -> str:
     try:
         prompt_session = create_prompt_session(config)
 
-        with patch_stdout():
-            print_formatted_text('')
-            confirmation: str = await prompt_session.prompt_async(
-                HTML('<gold>Proceed with action? (y)es/(n)o/(a)lways > </gold>'),
-            )
+        while True:
+            with patch_stdout():
+                print_formatted_text('')
+                confirmation: str = await prompt_session.prompt_async(
+                    HTML('<gold>Proceed with action? (y)es/(n)o/(a)lways > </gold>'),
+                )
 
-            confirmation = '' if confirmation is None else confirmation.strip().lower()
+                confirmation = (
+                    '' if confirmation is None else confirmation.strip().lower()
+                )
 
-            if confirmation in ['y', 'yes']:
-                return 'yes'
-            elif confirmation in ['n', 'no']:
-                return 'no'
-            elif confirmation in ['a', 'always']:
-                return 'always'
-            else:
-                return 'no'
+                if confirmation in ['y', 'yes']:
+                    return 'yes'
+                elif confirmation in ['n', 'no']:
+                    return 'no'
+                elif confirmation in ['a', 'always']:
+                    return 'always'
+                else:
+                    # Display error message for invalid input
+                    print_formatted_text('')
+                    print_formatted_text(
+                        HTML(
+                            '<ansired>Invalid input. Please enter (y)es, (n)o, or (a)lways.</ansired>'
+                        )
+                    )
+                    # Continue the loop to re-prompt
     except (KeyboardInterrupt, EOFError):
         return 'no'
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where the CLI confirmation prompt would silently default to "no" when users entered invalid input (like random text). Now the system properly validates input and shows an error message, then re-prompts the user until they provide a valid response (yes/no/always).

**Before:** Typing "maybe" or "sure" would silently be treated as "no" and deny the action.
**After:** Typing invalid input shows "Invalid input. Please enter (y)es, (n)o, or (a)lways." and asks again.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR modifies the `read_confirmation_input` function in `openhands/cli/tui.py` to:

1. **Add input validation loop**: Instead of prompting once and defaulting to "no" for invalid input, the function now loops until valid input is received.

2. **Display error messages**: When invalid input is detected, the system shows a clear error message in red text explaining what valid inputs are accepted.

3. **Maintain existing behavior for valid inputs**: All existing valid inputs (y, yes, n, no, a, always) continue to work exactly as before.

4. **Preserve exception handling**: Keyboard interrupts (Ctrl+C) and EOF errors still default to "no" as a safe fallback.

The design decision to use a `while True` loop ensures that users cannot accidentally proceed or cancel actions due to typos or misunderstanding of the prompt. This improves the user experience by providing clear feedback and preventing unintended actions.

**Test updates**: Updated existing tests to reflect the new behavior where invalid input prompts for re-entry rather than defaulting to "no". Added new test cases to verify error message display and multiple invalid input handling.

---
**Link of any specific issues this addresses:**

This addresses the user-reported issue where CLI confirmation prompts would silently default to "no" for invalid input instead of providing feedback and re-prompting for valid input.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/43f917732d5b4c43a6840e0840ba3851)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c557449-nikolaik   --name openhands-app-c557449   docker.all-hands.dev/all-hands-ai/openhands:c557449
```