### PR TITLE
(Hotfix): Microagent won't load depending on version number format

### DIFF
--- a/openhands/microagent/microagent.py
+++ b/openhands/microagent/microagent.py
@@ -78,6 +78,10 @@ class BaseMicroagent(BaseModel):
         # Handle case where there's no frontmatter or empty frontmatter
         metadata_dict = loaded.metadata or {}
 
+        # Ensure version is always a string (YAML may parse numeric versions as integers)
+        if 'version' in metadata_dict and not isinstance(metadata_dict['version'], str):
+            metadata_dict['version'] = str(metadata_dict['version'])
+
         try:
             metadata = MicroagentMetadata(**metadata_dict)
 

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -591,6 +591,8 @@ fi
 
             loaded_microagents.extend(repo_agents.values())
             loaded_microagents.extend(knowledge_agents.values())
+        except Exception as e:
+            self.log('error', f'Failed to load agents from {source_description}: {e}')
         finally:
             shutil.rmtree(microagent_folder)
 

--- a/tests/unit/test_microagent_utils.py
+++ b/tests/unit/test_microagent_utils.py
@@ -223,6 +223,97 @@ Add proper error handling."""
     assert agent.source == str(cursorrules_path)
 
 
+def test_microagent_version_as_integer():
+    """Test loading a microagent with version as integer (reproduces the bug)."""
+    # Create a microagent with version as an unquoted integer
+    # This should be parsed as an integer by YAML but converted to string by our code
+    microagent_content = """---
+name: test_agent
+type: knowledge
+version: 2512312
+agent: CodeActAgent
+triggers:
+  - test
+---
+
+# Test Agent
+
+This is a test agent with integer version.
+"""
+
+    test_path = Path('test_agent.md')
+
+    # This should not raise an error even though version is an integer in YAML
+    agent = BaseMicroagent.load(test_path, file_content=microagent_content)
+
+    # Verify the agent was loaded correctly
+    assert isinstance(agent, KnowledgeMicroagent)
+    assert agent.name == 'test_agent'
+    assert agent.metadata.version == '2512312'  # Should be converted to string
+    assert isinstance(agent.metadata.version, str)  # Ensure it's actually a string
+    assert agent.type == MicroagentType.KNOWLEDGE
+
+
+def test_microagent_version_as_float():
+    """Test loading a microagent with version as float."""
+    # Create a microagent with version as an unquoted float
+    microagent_content = """---
+name: test_agent_float
+type: knowledge
+version: 1.5
+agent: CodeActAgent
+triggers:
+  - test
+---
+
+# Test Agent Float
+
+This is a test agent with float version.
+"""
+
+    test_path = Path('test_agent_float.md')
+
+    # This should not raise an error even though version is a float in YAML
+    agent = BaseMicroagent.load(test_path, file_content=microagent_content)
+
+    # Verify the agent was loaded correctly
+    assert isinstance(agent, KnowledgeMicroagent)
+    assert agent.name == 'test_agent_float'
+    assert agent.metadata.version == '1.5'  # Should be converted to string
+    assert isinstance(agent.metadata.version, str)  # Ensure it's actually a string
+    assert agent.type == MicroagentType.KNOWLEDGE
+
+
+def test_microagent_version_as_string_unchanged():
+    """Test loading a microagent with version as string (should remain unchanged)."""
+    # Create a microagent with version as a quoted string
+    microagent_content = """---
+name: test_agent_string
+type: knowledge
+version: "1.0.0"
+agent: CodeActAgent
+triggers:
+  - test
+---
+
+# Test Agent String
+
+This is a test agent with string version.
+"""
+
+    test_path = Path('test_agent_string.md')
+
+    # This should work normally
+    agent = BaseMicroagent.load(test_path, file_content=microagent_content)
+
+    # Verify the agent was loaded correctly
+    assert isinstance(agent, KnowledgeMicroagent)
+    assert agent.name == 'test_agent_string'
+    assert agent.metadata.version == '1.0.0'  # Should remain as string
+    assert isinstance(agent.metadata.version, str)  # Ensure it's actually a string
+    assert agent.type == MicroagentType.KNOWLEDGE
+
+
 @pytest.fixture
 def temp_microagents_dir_with_cursorrules():
     """Create a temporary directory with test microagents and .cursorrules file."""


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Fix microgents not loading when the version number is an int 

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

When defining a knowledge microagent, we require a version number in the metadata. Sometimes the version number is loaded in as an int (e.g version number that contains `234232`) instead of a string (e.g instead of `1.0.0`)


This PR ensures that when the yaml is loaded, the version number is always cast to a string 

---
**Link of any specific issues this addresses:**
