### PR TITLE
Fix #9511: Reduce noisy logging for Gemini tool modifications

### DIFF
--- a/openhands/llm/llm_utils.py
+++ b/openhands/llm/llm_utils.py
@@ -7,6 +7,9 @@ from openhands.core.logger import openhands_logger as logger
 if TYPE_CHECKING:
     from litellm import ChatCompletionToolParam
 
+# Track whether we've already logged the Gemini tool modification message
+_gemini_tool_modification_logged = set()
+
 
 def check_tools(
     tools: list['ChatCompletionToolParam'], llm_config: LLMConfig
@@ -14,12 +17,21 @@ def check_tools(
     """Checks and modifies tools for compatibility with the current LLM."""
     # Special handling for Gemini models which don't support default fields and have limited format support
     if 'gemini' in llm_config.model.lower():
-        logger.info(
-            f'Removing default fields and unsupported formats from tools for Gemini model {llm_config.model} '
-            "since Gemini models have limited format support (only 'enum' and 'date-time' for STRING types)."
-        )
+        # Only log the main message once per model to reduce noise
+        if llm_config.model not in _gemini_tool_modification_logged:
+            logger.debug(
+                f'Removing default fields and unsupported formats from tools for Gemini model {llm_config.model} '
+                "since Gemini models have limited format support (only 'enum' and 'date-time' for STRING types)."
+            )
+            _gemini_tool_modification_logged.add(llm_config.model)
+
         # prevent mutation of input tools
         checked_tools = copy.deepcopy(tools)
+
+        # Track if we actually modify anything to provide useful feedback
+        defaults_removed = 0
+        formats_removed = 0
+
         # Strip off default fields and unsupported formats that cause errors with gemini-preview
         for tool in checked_tools:
             if 'function' in tool and 'parameters' in tool['function']:
@@ -30,15 +42,26 @@ def check_tools(
                         # Remove default fields
                         if 'default' in prop:
                             del prop['default']
+                            defaults_removed += 1
 
                         # Remove format fields for STRING type parameters if the format is unsupported
                         # Gemini only supports 'enum' and 'date-time' formats for STRING type
                         if prop.get('type') == 'string' and 'format' in prop:
                             supported_formats = ['enum', 'date-time']
                             if prop['format'] not in supported_formats:
-                                logger.info(
-                                    f'Removing unsupported format "{prop["format"]}" for STRING parameter "{prop_name}"'
+                                logger.debug(
+                                    f'Removing unsupported format "{prop["format"]}" for STRING parameter "{prop_name}" '
+                                    f'in tool "{tool.get("function", {}).get("name", "unknown")}"'
                                 )
                                 del prop['format']
+                                formats_removed += 1
+
+        # Log a summary if we actually modified anything, but only at debug level to reduce noise
+        if defaults_removed > 0 or formats_removed > 0:
+            logger.debug(
+                f'Modified {len(checked_tools)} tools for Gemini compatibility: '
+                f'removed {defaults_removed} default fields and {formats_removed} unsupported formats'
+            )
+
         return checked_tools
     return tools


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Reduces noisy INFO-level logging when using Gemini models with tools. Previously, every time tools were processed for Gemini compatibility, an INFO message was logged, which could clutter the logs during normal operation. Now these messages are logged at DEBUG level and only once per model to provide a cleaner user experience.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR addresses issue #9511 by improving the logging behavior in the `check_tools` function for Gemini models:

1. **Reduced log verbosity**: Changed the main log message from INFO to DEBUG level to prevent log clutter during normal operation
2. **One-time logging per model**: Added tracking to log the main compatibility message only once per unique model name, preventing repetitive messages
3. **Enhanced logging context**: Improved format removal logging to include tool names for better debugging
4. **Summary logging**: Added detailed tracking and summary of modifications (number of default fields and formats removed)

The core functionality remains unchanged - the function still correctly removes default fields and unsupported string formats for Gemini models as required by the LiteLLM/Gemini API limitations. The changes only affect the logging behavior to make it more appropriate for production use.

**Design decisions:**
- Used a module-level set to track logged models rather than a more complex caching mechanism for simplicity
- Kept all logging at DEBUG level to maintain consistency and avoid mixed log levels
- Added counters to provide useful summary information for debugging when needed

---
**Link of any specific issues this addresses:**

Fixes #9511

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/642a4f5a8204452882c135dade63e152)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:882184f-nikolaik   --name openhands-app-882184f   docker.all-hands.dev/all-hands-ai/openhands:882184f
```