### PR TITLE
fix(frontend): The secret settings layout will be broken if the secret name is too long.

### DIFF
--- a/frontend/src/components/features/settings/secrets-settings/secret-list-item.tsx
+++ b/frontend/src/components/features/settings/secrets-settings/secret-list-item.tsx
@@ -40,9 +40,9 @@ export function SecretListItem({
 
       <td
         className="w-1/2 truncate overflow-hidden whitespace-nowrap text-sm text-content-2 opacity-80 italic"
-        title={description || "-"}
+        title={description || ""}
       >
-        {description || "-"}
+        {description || ""}
       </td>
 
       <td className="w-1/4 flex items-center justify-end gap-4">

--- a/frontend/src/components/features/settings/secrets-settings/secret-list-item.tsx
+++ b/frontend/src/components/features/settings/secrets-settings/secret-list-item.tsx
@@ -34,9 +34,14 @@ export function SecretListItem({
       data-testid="secret-item"
       className="border-t border-[#717888] last-of-type:border-b max-w-[830px] py-[13px] flex w-full items-center"
     >
-      <td className="w-1/4 text-sm text-content-2">{title}</td>
+      <td className="w-1/4 text-sm text-content-2 truncate" title={title}>
+        {title}
+      </td>
 
-      <td className="w-1/2 truncate overflow-hidden whitespace-nowrap text-sm text-content-2 opacity-80 italic">
+      <td
+        className="w-1/2 truncate overflow-hidden whitespace-nowrap text-sm text-content-2 opacity-80 italic"
+        title={description || "-"}
+      >
         {description || "-"}
       </td>
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Description:**

The layout of the Secret Settings page breaks when a secret with an excessively long name is added.

---

**Steps to Reproduce:**

1. Navigate to the **Secret Settings** page.  
2. Create a new secret with a **very long name**.

---

**Current Behavior:**

- The layout of the Secret Settings page becomes distorted or broken when displaying the long secret name.

---

**Expected Behavior:**

- The layout should remain intact and responsive, regardless of the length of the secret name.

---

**Additional Information:**

- 📹 A video demonstrating the issue:  
 
https://github.com/user-attachments/assets/7926a4d1-e94c-46e1-bb74-f9cfd7cb0e28

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR addresses an issue where the Secret Settings layout breaks if a secret has an excessively long name.

**Output Preview:**

📹 A video demonstrating the result of this fix:  

https://github.com/user-attachments/assets/0a9aff64-86a9-4c0e-b2a8-4646f310be4c

---
**Link of any specific issues this addresses:**

Resolves #9521 
