### PR TITLE
Fix for issue where wrong method was called

### DIFF
--- a/openhands/server/routes/conversation.py
+++ b/openhands/server/routes/conversation.py
@@ -158,7 +158,7 @@ async def add_event(
     request: Request, conversation: ServerConversation = Depends(get_conversation)
 ):
     data = request.json()
-    await conversation_manager.send_to_event_stream(conversation.sid, data)
+    await conversation_manager.send_event_to_conversation(conversation.sid, data)
     return JSONResponse({'success': True})
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
The wrong method was being called in the rest API, resulting in an error. The correct method expects the conversation_id as a parameter - the previously invoked method expects a `connection_id` from SocketIO

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4e48cd6-nikolaik   --name openhands-app-4e48cd6   docker.all-hands.dev/all-hands-ai/openhands:4e48cd6
```