### PR TITLE
Fix Jupyter tab not showing input commands

### DIFF
--- a/frontend/__tests__/services/actions.test.tsx
+++ b/frontend/__tests__/services/actions.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ActionType from "#/types/action-type";
+import { ActionMessage } from "#/types/message";
+
+// Mock the store and actions
+const mockDispatch = vi.fn();
+const mockAppendInput = vi.fn();
+const mockAppendJupyterInput = vi.fn();
+
+vi.mock("#/store", () => ({
+  default: {
+    dispatch: mockDispatch,
+  },
+}));
+
+vi.mock("#/state/command-slice", () => ({
+  appendInput: mockAppendInput,
+}));
+
+vi.mock("#/state/jupyter-slice", () => ({
+  appendJupyterInput: mockAppendJupyterInput,
+}));
+
+describe("handleActionMessage", () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.clearAllMocks();
+  });
+
+  it("should handle RUN actions by adding input to terminal", async () => {
+    const { handleActionMessage } = await import("#/services/actions");
+    
+    const runAction: ActionMessage = {
+      action: ActionType.RUN,
+      args: {
+        command: "ls -la",
+      },
+      message: "Running command: ls -la",
+      timestamp: "2023-01-01T00:00:00Z",
+    };
+
+    // Handle the action
+    handleActionMessage(runAction);
+
+    // Check that appendInput was called with the command
+    expect(mockDispatch).toHaveBeenCalledWith(mockAppendInput("ls -la"));
+    expect(mockAppendJupyterInput).not.toHaveBeenCalled();
+  });
+
+  it("should handle RUN_IPYTHON actions by adding input to Jupyter", async () => {
+    const { handleActionMessage } = await import("#/services/actions");
+    
+    const ipythonAction: ActionMessage = {
+      action: ActionType.RUN_IPYTHON,
+      args: {
+        code: "print('Hello from Jupyter!')",
+      },
+      message: "Running Python code interactively: print('Hello from Jupyter!')",
+      timestamp: "2023-01-01T00:00:00Z",
+    };
+
+    // Handle the action
+    handleActionMessage(ipythonAction);
+
+    // Check that appendJupyterInput was called with the code
+    expect(mockDispatch).toHaveBeenCalledWith(mockAppendJupyterInput("print('Hello from Jupyter!')"));
+    expect(mockAppendInput).not.toHaveBeenCalled();
+  });
+
+  it("should not process hidden actions", async () => {
+    const { handleActionMessage } = await import("#/services/actions");
+    
+    const hiddenAction: ActionMessage = {
+      action: ActionType.RUN,
+      args: {
+        command: "secret command",
+        hidden: true,
+      },
+      message: "Running command: secret command",
+      timestamp: "2023-01-01T00:00:00Z",
+    };
+
+    // Handle the action
+    handleActionMessage(hiddenAction);
+
+    // Check that nothing was dispatched
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/actions.ts
+++ b/frontend/src/services/actions.ts
@@ -11,6 +11,7 @@ import {
 } from "#/types/message";
 import { handleObservationMessage } from "./observations";
 import { appendInput } from "#/state/command-slice";
+import { appendJupyterInput } from "#/state/jupyter-slice";
 import { queryClient } from "#/query-client-config";
 
 export function handleActionMessage(message: ActionMessage) {
@@ -30,6 +31,10 @@ export function handleActionMessage(message: ActionMessage) {
 
   if (message.action === ActionType.RUN) {
     store.dispatch(appendInput(message.args.command));
+  }
+
+  if (message.action === ActionType.RUN_IPYTHON) {
+    store.dispatch(appendJupyterInput(message.args.code));
   }
 
   if ("args" in message && "security_risk" in message.args) {


### PR DESCRIPTION
# Fix Jupyter Tab Not Showing Input Commands

## Summary

Fixes the Jupyter tab not displaying input commands, only showing outputs. This made the Jupyter experience appear broken or incomplete.

## Root Cause

The issue was in the frontend action handling logic in `frontend/src/services/actions.ts`. While the system properly handled:

- ✅ **RUN actions** → Added input to terminal via `appendInput()`
- ✅ **RUN_IPYTHON observations** → Added output to Jupyter via `appendJupyterOutput()`

It was missing:

- ❌ **RUN_IPYTHON actions** → Should add input to Jupyter via `appendJupyterInput()`

## Changes Made

1. **Added missing import** in `frontend/src/services/actions.ts`:
   ```typescript
   import { appendJupyterInput } from "#/state/jupyter-slice";
   ```

2. **Added action handling** for `RUN_IPYTHON` actions:
   ```typescript
   if (message.action === ActionType.RUN_IPYTHON) {
     store.dispatch(appendJupyterInput(message.args.code));
   }
   ```

3. **Added comprehensive unit tests** in `frontend/__tests__/services/actions.test.tsx`

## Impact

**Before Fix:**
- Terminal Tab: Complete experience (input + output) ✅
- Jupyter Tab: Incomplete experience (output only) ❌

**After Fix:**
- Terminal Tab: Complete experience (input + output) ✅  
- Jupyter Tab: Complete experience (input + output) ✅

## Testing

- ✅ Unit tests pass: `npm test -- actions.test.tsx`
- ✅ Pre-commit hooks pass
- ✅ Comprehensive test coverage for action handling

## Files Changed

- `frontend/src/services/actions.ts` - Added RUN_IPYTHON action handling
- `frontend/__tests__/services/actions.test.tsx` - Added unit tests

This fix ensures that the Jupyter tab provides a complete and functional notebook experience for users doing data analysis and interactive Python development.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/029826d899894b6284b8c341bcb3cebb)