### PR TITLE
Add gray circle background to pause button for better visibility

### DIFF
--- a/frontend/src/components/features/controls/agent-control-bar.tsx
+++ b/frontend/src/components/features/controls/agent-control-bar.tsx
@@ -39,6 +39,11 @@ export function AgentControlBar() {
             : AgentState.PAUSED
         }
         handleAction={handleAction}
+        className={
+          curAgentState === AgentState.RUNNING
+            ? "bg-gray-500/20 ring-2 ring-gray-400/30"
+            : ""
+        }
       >
         {curAgentState === AgentState.PAUSED ? <PlayIcon /> : <PauseIcon />}
       </ActionButton>

--- a/frontend/src/components/features/controls/agent-control-bar.tsx
+++ b/frontend/src/components/features/controls/agent-control-bar.tsx
@@ -41,7 +41,7 @@ export function AgentControlBar() {
         handleAction={handleAction}
         className={
           curAgentState === AgentState.RUNNING
-            ? "bg-gray-500/20 ring-2 ring-gray-400/30"
+            ? "bg-blue-500/20 ring-2 ring-blue-400/50"
             : ""
         }
       >

--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -6,6 +6,7 @@ interface ActionButtonProps {
   content: string;
   action: AgentState;
   handleAction: (action: AgentState) => void;
+  className?: string;
 }
 
 export function ActionButton({
@@ -13,6 +14,7 @@ export function ActionButton({
   content,
   action,
   handleAction,
+  className = "",
   children,
 }: React.PropsWithChildren<ActionButtonProps>) {
   return (
@@ -20,7 +22,7 @@ export function ActionButton({
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-colors duration-300 ease-in-out border border-transparent hover:border-red-400/40 rounded-full p-1"
+        className={`relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-colors duration-300 ease-in-out border border-transparent hover:border-red-400/40 rounded-full p-1 ${className}`}
         type="button"
       >
         <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">


### PR DESCRIPTION
## Summary

This PR improves the visibility of the pause button by adding a gray circle background when the agent is in the running state.

## Changes Made

- **Modified `ActionButton` component** to accept an optional `className` prop for additional styling
- **Updated `AgentControlBar` component** to apply gray background styling specifically to the pause button when the agent is running
- Added `bg-gray-500/20 ring-2 ring-gray-400/30` classes to create a subtle gray circle with a ring border

## Visual Impact

- The pause button now has a gray circular background that makes it more noticeable
- The styling is applied only when the agent is running (showing the pause button)
- When paused (showing the play button), no additional background is applied
- Maintains the existing hover effects and accessibility features

## Testing

- ✅ Frontend linting and formatting checks pass
- ✅ Backend pre-commit hooks pass
- ✅ Build completes successfully
- ✅ No breaking changes to existing functionality

## Screenshots

The pause button now has a subtle gray circle background that makes it easier to notice while maintaining the existing design aesthetic.

## Related Issues

Addresses user feedback about the pause button being too hard to notice.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e0244f2074d94b809ffd816c9c82a187)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4dde750-nikolaik   --name openhands-app-4dde750   docker.all-hands.dev/all-hands-ai/openhands:4dde750
```