### PR TITLE
Add CLI alias setup for first-time users

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -16,6 +16,7 @@ from openhands.cli.commands import (
 from openhands.cli.settings import modify_llm_settings_basic
 from openhands.cli.tui import (
     UsageMetrics,
+    cli_confirm,
     display_agent_running_message,
     display_banner,
     display_event,
@@ -30,6 +31,10 @@ from openhands.cli.tui import (
     update_streaming_output,
 )
 from openhands.cli.utils import (
+    add_aliases_to_bash_profile,
+    has_alias_setup_been_completed,
+    is_first_time_user,
+    mark_alias_setup_completed,
     update_usage_metrics,
 )
 from openhands.cli.vscode_extension import attempt_vscode_extension_install
@@ -360,6 +365,81 @@ async def run_setup_flow(config: OpenHandsConfig, settings_store: FileSettingsSt
     await modify_llm_settings_basic(config, settings_store)
 
 
+def run_alias_setup_flow(config: OpenHandsConfig) -> None:
+    """Run the alias setup flow to configure shell aliases.
+
+    Prompts the user to set up aliases for 'openhands' and 'oh' commands.
+    """
+    print_formatted_text('')
+    print_formatted_text(HTML('<gold>🚀 Welcome to OpenHands CLI!</gold>'))
+    print_formatted_text('')
+    print_formatted_text(
+        HTML('<grey>Would you like to set up convenient shell aliases?</grey>')
+    )
+    print_formatted_text('')
+    print_formatted_text(
+        HTML('<grey>This will add the following aliases to your bash profile:</grey>')
+    )
+    print_formatted_text(
+        HTML(
+            '<grey>  • <b>openhands</b> → uvx --python 3.12 --from openhands-ai openhands</grey>'
+        )
+    )
+    print_formatted_text(
+        HTML(
+            '<grey>  • <b>oh</b> → uvx --python 3.12 --from openhands-ai openhands</grey>'
+        )
+    )
+    print_formatted_text('')
+    print_formatted_text(
+        HTML(
+            '<ansiyellow>⚠️  Note: This requires uv to be installed first.</ansiyellow>'
+        )
+    )
+    print_formatted_text(
+        HTML(
+            '<ansiyellow>   Installation guide: https://docs.astral.sh/uv/getting-started/installation</ansiyellow>'
+        )
+    )
+    print_formatted_text('')
+
+    # Use cli_confirm to get user choice
+    choice = cli_confirm(
+        config, 'Set up shell aliases?', ['Yes, set up aliases', 'No, skip this step']
+    )
+
+    if choice == 0:  # User chose "Yes"
+        success = add_aliases_to_bash_profile()
+        if success:
+            print_formatted_text('')
+            print_formatted_text(
+                HTML('<ansigreen>✅ Aliases added successfully!</ansigreen>')
+            )
+            print_formatted_text(
+                HTML(
+                    '<grey>Run <b>source ~/.bashrc</b> (or restart your terminal) to use the new aliases.</grey>'
+                )
+            )
+        else:
+            print_formatted_text('')
+            print_formatted_text(
+                HTML(
+                    '<ansired>❌ Failed to add aliases. You can set them up manually later.</ansired>'
+                )
+            )
+    else:  # User chose "No"
+        print_formatted_text('')
+        print_formatted_text(
+            HTML(
+                '<grey>Skipped alias setup. You can run this setup again anytime.</grey>'
+            )
+        )
+
+    # Mark that we've shown the alias setup (regardless of user choice)
+    mark_alias_setup_completed()
+    print_formatted_text('')
+
+
 async def main_with_loop(loop: asyncio.AbstractEventLoop) -> None:
     """Runs the agent in CLI mode."""
     args = parse_arguments()
@@ -441,6 +521,16 @@ async def main_with_loop(loop: asyncio.AbstractEventLoop) -> None:
         # Need to finalize config again after setting runtime to 'cli'
         # This ensures Jupyter plugin is disabled for CLI runtime
         finalize_config(config)
+
+    # Check if we should show the alias setup flow
+    # Only show it if this is the first time or if the user hasn't seen it before
+    if is_first_time_user() or not has_alias_setup_been_completed():
+        # Clear the terminal if we haven't shown a banner yet
+        if not banner_shown:
+            clear()
+
+        run_alias_setup_flow(config)
+        banner_shown = True
 
     # TODO: Set working directory from config or use current working directory?
     current_dir = config.workspace_base

--- a/openhands/cli/utils.py
+++ b/openhands/cli/utils.py
@@ -224,3 +224,85 @@ def read_file(file_path: str | Path) -> str:
 def write_to_file(file_path: str | Path, content: str) -> None:
     with open(file_path, 'w') as f:
         f.write(content)
+
+
+def is_first_time_user() -> bool:
+    """Check if this is the first time the user is running OpenHands CLI.
+
+    Returns:
+        True if the ~/.openhands directory doesn't exist, False otherwise.
+    """
+    openhands_dir = Path.home() / '.openhands'
+    return not openhands_dir.exists()
+
+
+def get_bash_profile_path() -> Path:
+    """Get the path to the user's bash profile file.
+
+    Returns:
+        Path to the bash profile file (prefers .bashrc, falls back to .bash_profile).
+    """
+    home = Path.home()
+    bashrc = home / '.bashrc'
+    bash_profile = home / '.bash_profile'
+
+    # Prefer .bashrc if it exists, otherwise use .bash_profile
+    if bashrc.exists():
+        return bashrc
+    return bash_profile
+
+
+def add_aliases_to_bash_profile() -> bool:
+    """Add OpenHands aliases to the user's bash profile.
+
+    Returns:
+        True if aliases were added successfully, False otherwise.
+    """
+    try:
+        profile_path = get_bash_profile_path()
+
+        # Define the aliases to add
+        alias_lines = [
+            '',
+            '# OpenHands CLI aliases',
+            'alias openhands="uvx --python 3.12 --from openhands-ai openhands"',
+            'alias oh="uvx --python 3.12 --from openhands-ai openhands"',
+            '',
+        ]
+
+        # Check if aliases already exist
+        if profile_path.exists():
+            with open(profile_path, 'r') as f:
+                content = f.read()
+                if 'alias openhands=' in content or 'alias oh=' in content:
+                    return True  # Aliases already exist
+
+        # Append aliases to the profile
+        with open(profile_path, 'a') as f:
+            f.write('\n'.join(alias_lines))
+
+        return True
+    except Exception:
+        return False
+
+
+def mark_alias_setup_completed() -> None:
+    """Mark that the alias setup has been completed by creating a marker file."""
+    try:
+        openhands_dir = Path.home() / '.openhands'
+        openhands_dir.mkdir(parents=True, exist_ok=True)
+
+        marker_file = openhands_dir / '.alias_setup_completed'
+        marker_file.touch()
+    except Exception:
+        pass  # Silently fail if we can't create the marker
+
+
+def has_alias_setup_been_completed() -> bool:
+    """Check if the alias setup has been completed before.
+
+    Returns:
+        True if the alias setup marker file exists, False otherwise.
+    """
+    marker_file = Path.home() / '.openhands' / '.alias_setup_completed'
+    return marker_file.exists()

--- a/tests/unit/test_cli_alias_setup.py
+++ b/tests/unit/test_cli_alias_setup.py
@@ -1,0 +1,121 @@
+"""Unit tests for CLI alias setup functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from openhands.cli.utils import (
+    add_aliases_to_bash_profile,
+    get_bash_profile_path,
+    has_alias_setup_been_completed,
+    is_first_time_user,
+    mark_alias_setup_completed,
+)
+
+
+class TestAliasSetup:
+    """Test cases for alias setup functionality."""
+
+    def test_is_first_time_user_no_config_dir(self):
+        """Test first time user detection when .openhands doesn't exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                assert is_first_time_user() is True
+
+    def test_is_first_time_user_with_config_dir(self):
+        """Test first time user detection when .openhands exists."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                # Create .openhands directory
+                openhands_dir = Path(temp_dir) / '.openhands'
+                openhands_dir.mkdir()
+
+                assert is_first_time_user() is False
+
+    def test_alias_setup_completion_tracking(self):
+        """Test alias setup completion tracking."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                # Should not be completed initially
+                assert has_alias_setup_been_completed() is False
+
+                # Mark as completed
+                mark_alias_setup_completed()
+
+                # Should be completed now
+                assert has_alias_setup_been_completed() is True
+
+    def test_get_bash_profile_path_no_files(self):
+        """Test bash profile path when neither .bashrc nor .bash_profile exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                profile_path = get_bash_profile_path()
+                assert profile_path.name == '.bash_profile'
+
+    def test_get_bash_profile_path_prefers_bashrc(self):
+        """Test bash profile path prefers .bashrc when it exists."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                # Create .bashrc
+                bashrc = Path(temp_dir) / '.bashrc'
+                bashrc.touch()
+
+                profile_path = get_bash_profile_path()
+                assert profile_path.name == '.bashrc'
+
+    def test_add_aliases_to_bash_profile(self):
+        """Test adding aliases to bash profile."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                # Add aliases
+                success = add_aliases_to_bash_profile()
+                assert success is True
+
+                # Check that the aliases were added
+                profile_path = get_bash_profile_path()
+                with open(profile_path, 'r') as f:
+                    content = f.read()
+                    assert 'alias openhands=' in content
+                    assert 'alias oh=' in content
+                    assert 'uvx --python 3.12 --from openhands-ai openhands' in content
+
+    def test_add_aliases_handles_existing_aliases(self):
+        """Test that adding aliases handles existing aliases correctly."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                # Add aliases first time
+                success = add_aliases_to_bash_profile()
+                assert success is True
+
+                # Try adding again - should detect existing aliases
+                success = add_aliases_to_bash_profile()
+                assert success is True
+
+                # Check that aliases weren't duplicated
+                profile_path = get_bash_profile_path()
+                with open(profile_path, 'r') as f:
+                    content = f.read()
+                    # Count occurrences of the alias
+                    openhands_count = content.count('alias openhands=')
+                    oh_count = content.count('alias oh=')
+                    assert openhands_count == 1
+                    assert oh_count == 1
+
+    def test_mark_alias_setup_completed_creates_directory(self):
+        """Test that marking alias setup completed creates the .openhands directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch('openhands.cli.utils.Path.home', return_value=Path(temp_dir)):
+                # Directory shouldn't exist initially
+                openhands_dir = Path(temp_dir) / '.openhands'
+                assert not openhands_dir.exists()
+
+                # Mark as completed
+                mark_alias_setup_completed()
+
+                # Directory should exist now
+                assert openhands_dir.exists()
+                assert openhands_dir.is_dir()
+
+                # Marker file should exist
+                marker_file = openhands_dir / '.alias_setup_completed'
+                assert marker_file.exists()


### PR DESCRIPTION
## Summary

This PR implements a feature to prompt first-time users about setting up convenient shell aliases when they first use OpenHands CLI.

## Features

- **First-time user detection**: Checks if the `~/.openhands` directory exists
- **Interactive prompt**: Allows users to confirm or reject alias setup
- **Shell aliases**: Sets up `openhands` and `oh` aliases using `uvx --python 3.12 --from openhands-ai openhands`
- **UV installation warning**: Displays warning with link to UV installation guide
- **Bash profile integration**: Automatically adds aliases to `.bashrc` or `.bash_profile`
- **Completion tracking**: Only shows the prompt once per user
- **Duplicate prevention**: Checks for existing aliases before adding new ones

## User Experience

When a first-time user runs OpenHands CLI, they see:

```
🚀 Welcome to OpenHands CLI!

Would you like to set up convenient shell aliases?

This will add the following aliases to your bash profile:
  • openhands → uvx --python 3.12 --from openhands-ai openhands
  • oh → uvx --python 3.12 --from openhands-ai openhands

⚠️  Note: This requires uv to be installed first.
   Installation guide: https://docs.astral.sh/uv/getting-started/installation

Set up shell aliases? [Yes, set up aliases / No, skip this step]
```

## Implementation

### Files Modified
- `openhands/cli/utils.py`: Added utility functions for alias setup
- `openhands/cli/main.py`: Added interactive flow and integration
- `tests/unit/test_cli_alias_setup.py`: Comprehensive unit tests

### Technical Details
- Uses existing `cli_confirm` for user interaction
- Prefers `.bashrc` over `.bash_profile` when both exist
- Creates `.alias_setup_completed` marker to track completion
- Handles file system errors gracefully
- Idempotent operation (safe to run multiple times)

## Testing

- ✅ 8 comprehensive unit tests covering all functionality
- ✅ Integration tests verified end-to-end flow
- ✅ All pre-commit hooks pass (linting, formatting, type checking)

## Requirements

- UV must be installed for the aliases to work
- Bash shell (or compatible shell that sources bash profile files)
- Write permissions to home directory

Fixes the requirement to help users set up convenient aliases for OpenHands CLI.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7664a692d4f14a7cb839a2504c23fc8e)