### PR TITLE
ADD gemini-2.5 to REASONING_EFFORT_SUPPORTED_MODELS

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -95,6 +95,8 @@ REASONING_EFFORT_SUPPORTED_MODELS = [
     'o3-mini',
     'o4-mini',
     'o4-mini-2025-04-16',
+    'gemini-2.5-flash',
+    'gemini-2.5-pro',
 ]
 
 MODELS_WITHOUT_STOP_WORDS = [


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Support for gemini-2.5 with added thinking feature.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Added gemini-2.5-flash and gemini-2.5-pro to REASONING_EFFORT_SUPPORTED_MODELS.
LiteLLM converts OpenAI's reasoning_effort into Gemini's thinking parameter.

https://docs.litellm.ai/docs/providers/gemini#usage---thinking--reasoning_content
https://ai.google.dev/gemini-api/docs/thinking?hl=ja

---
**Link of any specific issues this addresses:**
