### PR TITLE
fix(frontend): [OpenHands Cloud] The API keys table does not display properly if the API key name is too long.

### DIFF
--- a/frontend/src/components/features/settings/api-keys-manager.tsx
+++ b/frontend/src/components/features/settings/api-keys-manager.tsx
@@ -108,7 +108,12 @@ export function ApiKeysManager() {
               <tbody>
                 {apiKeys.map((key) => (
                   <tr key={key.id} className="border-t border-tertiary">
-                    <td className="p-3 text-sm">{key.name}</td>
+                    <td
+                      className="p-3 text-sm truncate max-w-[160px]"
+                      title={key.name}
+                    >
+                      {key.name}
+                    </td>
                     <td className="p-3 text-sm">
                       {formatDate(key.created_at)}
                     </td>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Description:**  
In **OpenHands Cloud**, the API Keys table does not display correctly when an API key has an excessively long name.

---

### ✅ Expected Behavior
- The API Keys table should render properly, regardless of the length of the API key name.

---

### ❌ Current Behavior
- The table layout breaks or displays incorrectly when an API key has a long name.

---

### 🔁 Steps to Reproduce
1. Navigate to the **API Keys** page.
2. Create a new API key with a very long name.
3. Observe the table layout.

---

### 📹 Additional Context
An image demonstrating the issue can be found here:  

<img width="1432" alt="Image" src="https://github.com/user-attachments/assets/1183a2bd-5f6d-4037-b2d0-d207f8583e55" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR truncates the API key name if the text is too long, if the users hover over the API key name, they can see the full content.

We can refer to the image below for the output of the PR:


<img width="1432" alt="output" src="https://github.com/user-attachments/assets/0b13a6fd-225c-43c2-bdfa-2cb7f6c2ae92" />

---
**Link of any specific issues this addresses:**

Resolves #9553 