### PR TITLE
fix(frontend):

### DIFF
--- a/frontend/src/components/features/settings/delete-api-key-modal.tsx
+++ b/frontend/src/components/features/settings/delete-api-key-modal.tsx
@@ -73,7 +73,7 @@ export function DeleteApiKeyModal({
       footer={modalFooter}
     >
       <div data-testid="delete-api-key-modal">
-        <p className="text-sm">
+        <p className="text-sm break-all">
           {t(I18nKey.SETTINGS$DELETE_API_KEY_CONFIRMATION, {
             name: keyToDelete.name,
           })}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

In **OpenHands Cloud**, the Delete API Key modal does not display correctly when an API key has an excessively long name.

---

### ✅ Expected Behavior
- the Delete API Key modal should render properly, regardless of the length of the API key name.

---

### ❌ Current Behavior
- the Delete API Key modal layout breaks or displays incorrectly when an API key has a long name.

---

### 🔁 Steps to Reproduce
1. Navigate to the **API Keys** page.
2. Create a new API key with a very long name.
3. Click on the **Delete** action.
4. Observe the Delete API Key modal layout.
---

### 📹 Additional Context
An image demonstrating the issue can be found here:  


<img width="1432" alt="Image" src="https://github.com/user-attachments/assets/a3d7fed4-117f-432e-b802-ec4c28a89ccb" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates CSS to make the Delete API Key modal display correctly.

We can refer to the image below for the output of the PR:

<img width="1432" alt="output" src="https://github.com/user-attachments/assets/1b071ad0-c466-4efd-aa24-d93e4c4d70f6" />

---
**Link of any specific issues this addresses:**

Resolves #9555 
