### PR TITLE
fix: 9543

### DIFF
--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -56,6 +56,10 @@ else
   mkdir -p /home/enduser/.cache/huggingface/hub/
 
   usermod -aG $DOCKER_SOCKET_GID enduser
+  # --- FIX:9543 ---
+  if [ -n "$WORKSPACE_MOUNT_PATH" ] && [ -d "$WORKSPACE_MOUNT_PATH" ]; then
+    chown -R $SANDBOX_USER_ID:app "$WORKSPACE_MOUNT_PATH" || true
+  fi
   echo "Running as enduser"
   su enduser /bin/bash -c "${*@Q}" # This magically runs any arguments passed to the script as a command
 fi


### PR DESCRIPTION
Problem

Docker mounts are commonly owned by root by default, which can prevent the non-root user in the container from creating or modifying files as themselves.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds logic to the entrypoint script to ensure that the mounted workspace directory is owned by the non-root sandbox user before starting the main process.
This change is intended to prevent file ownership issues when running as a non-root user inside the container.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below
---
**Link of any specific issues this addresses:** #9543

