### PR TITLE
Add core config to disable browser environment

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -49,6 +49,9 @@
 # Maximum file size for uploads, in megabytes
 #file_uploads_max_file_size_mb = 0
 
+# Enable the browser environment
+#enable_browser = true
+
 # Maximum budget per task, 0.0 means no limit
 #max_budget_per_task = 0.0
 
@@ -226,6 +229,7 @@ model = "gpt-4o"
 [agent]
 
 # Whether the browsing tool is enabled
+# Note: when this is set to true, enable_browser in the core config must also be true
 enable_browsing = true
 
 # Whether the LLM draft editor is enabled

--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -34,6 +34,7 @@ class OpenHandsConfig(BaseModel):
         file_store_path: Path to the file store.
         file_store_web_hook_url: Optional url for file store web hook
         file_store_web_hook_headers: Optional headers for file_store web hook
+        enable_browser: Whether to enable the browser environment
         save_trajectory_path: Either a folder path to store trajectories with auto-generated filenames, or a designated trajectory file path.
         save_screenshots_in_trajectory: Whether to save screenshots in trajectory (in encoded image format).
         replay_trajectory_path: Path to load trajectory and replay. If provided, trajectory would be replayed first before user's instruction.
@@ -68,6 +69,7 @@ class OpenHandsConfig(BaseModel):
     file_store_path: str = Field(default='~/.openhands')
     file_store_web_hook_url: str | None = Field(default=None)
     file_store_web_hook_headers: dict | None = Field(default=None)
+    enable_browser: bool = Field(default=True)
     save_trajectory_path: str | None = Field(default=None)
     save_screenshots_in_trajectory: bool = Field(default=False)
     replay_trajectory_path: str | None = Field(default=None)

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -172,6 +172,7 @@ class ActionExecutor:
         work_dir: str,
         username: str,
         user_id: int,
+        enable_browser: bool,
         browsergym_eval_env: str | None,
     ) -> None:
         self.plugins_to_load = plugins_to_load
@@ -188,9 +189,15 @@ class ActionExecutor:
         self.lock = asyncio.Lock()
         self.plugins: dict[str, Plugin] = {}
         self.file_editor = OHEditor(workspace_root=self._initial_cwd)
+        self.enable_browser = enable_browser
         self.browser: BrowserEnv | None = None
         self.browser_init_task: asyncio.Task | None = None
         self.browsergym_eval_env = browsergym_eval_env
+
+        if (not self.enable_browser) and self.browsergym_eval_env:
+            raise BrowserUnavailableException(
+                'Browser environment is not enabled in config, but browsergym_eval_env is set'
+            )
 
         self.start_time = time.time()
         self.last_execution_time = self.start_time
@@ -219,6 +226,10 @@ class ActionExecutor:
 
     async def _init_browser_async(self):
         """Initialize the browser asynchronously."""
+        if not self.enable_browser:
+            logger.info('Browser environment is not enabled in config')
+            return
+
         if sys.platform == 'win32':
             logger.warning('Browser environment not supported on windows')
             return
@@ -596,7 +607,7 @@ class ActionExecutor:
     async def browse(self, action: BrowseURLAction) -> Observation:
         if self.browser is None:
             return ErrorObservation(
-                'Browser functionality is not supported on Windows.'
+                'Browser functionality is not supported or disabled.'
             )
         await self._ensure_browser_ready()
         return await browse(action, self.browser, self.initial_cwd)
@@ -604,7 +615,7 @@ class ActionExecutor:
     async def browse_interactive(self, action: BrowseInteractiveAction) -> Observation:
         if self.browser is None:
             return ErrorObservation(
-                'Browser functionality is not supported on Windows.'
+                'Browser functionality is not supported or disabled.'
             )
         await self._ensure_browser_ready()
         browser_observation = await browse(action, self.browser, self.initial_cwd)
@@ -667,6 +678,12 @@ if __name__ == '__main__':
     )
     parser.add_argument('--user-id', type=int, help='User ID to run as', default=1000)
     parser.add_argument(
+        '--enable-browser',
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help='Enable the browser environment',
+    )
+    parser.add_argument(
         '--browsergym-eval-env',
         type=str,
         help='BrowserGym environment used for browser evaluation',
@@ -703,6 +720,7 @@ if __name__ == '__main__':
             work_dir=args.working_dir,
             username=args.username,
             user_id=args.user_id,
+            enable_browser=args.enable_browser,
             browsergym_eval_env=args.browsergym_eval_env,
         )
         await client.ainit()

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -680,7 +680,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--enable-browser',
         action=argparse.BooleanOptionalAction,
-        default=False,
+        default=True,
         help='Enable the browser environment',
     )
     parser.add_argument(

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -360,6 +360,8 @@ class DockerRuntime(ActionExecutionClient):
         )
 
         command = self.get_action_execution_server_startup_command()
+        self.log('info', f'Starting server with command: {command}')
+
         if self.config.sandbox.enable_gpu:
             gpu_ids = self.config.sandbox.cuda_visible_devices
             if gpu_ids is None:

--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -60,7 +60,7 @@ def get_action_execution_server_startup_command(
         *browsergym_args,
     ]
 
-    if app_config.enable_browser:
-        base_cmd.append('--enable-browser')
+    if not app_config.enable_browser:
+        base_cmd.append('--no-enable-browser')
 
     return base_cmd

--- a/openhands/runtime/utils/command.py
+++ b/openhands/runtime/utils/command.py
@@ -60,4 +60,7 @@ def get_action_execution_server_startup_command(
         *browsergym_args,
     ]
 
+    if app_config.enable_browser:
+        base_cmd.append('--enable-browser')
+
     return base_cmd

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -212,6 +212,7 @@ def _load_runtime(
     runtime_startup_env_vars: dict[str, str] | None = None,
     docker_runtime_kwargs: dict[str, str] | None = None,
     override_mcp_config: MCPConfig | None = None,
+    enable_browser: bool = True,
 ) -> tuple[Runtime, OpenHandsConfig]:
     sid = 'rt_' + str(random.randint(100000, 999999))
 
@@ -221,6 +222,7 @@ def _load_runtime(
 
     config = load_openhands_config()
     config.run_as_openhands = run_as_openhands
+    config.enable_browser = enable_browser
     config.sandbox.force_rebuild_runtime = force_rebuild_runtime
     config.sandbox.keep_runtime_alive = False
     config.sandbox.docker_runtime_kwargs = docker_runtime_kwargs


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Right now, there's no way to disable browser environment, even if you disable browsing feature in a specific or all agents' configs. When there's no need to use browser, it is costly and unnecessary to start playwright environment. Moreover, when using openhands as a python library, playwright dependencies are not available without manual installation.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Add a config to enable/disable browser environment. Default behavior is enabled.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:456ab02-nikolaik   --name openhands-app-456ab02   docker.all-hands.dev/all-hands-ai/openhands:456ab02
```