### PR TITLE
docs: Add CLI installation options with shell aliases and local installation

### DIFF
--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -33,6 +33,62 @@ pip install openhands-ai
 uvx --python 3.12 --from openhands-ai openhands
 ```
 
+<AccordionGroup>
+
+<Accordion title="Setting up OpenHands CLI for easy access">
+
+### Create shell aliases for easy access across environments
+
+Add the following to your shell configuration file (`.bashrc`, `.zshrc`, etc.):
+
+```bash
+# Add OpenHands aliases
+alias openhands="uvx --python 3.12 --from openhands-ai openhands"
+alias oh="uvx --python 3.12 --from openhands-ai openhands"
+```
+
+After adding these lines, reload your shell configuration with `source ~/.bashrc` or `source ~/.zshrc` (depending on your shell).
+
+### Install OpenHands in home directory without global installation
+
+You can install OpenHands in a virtual environment in your home directory using `uv`:
+
+```bash
+# Create a virtual environment in your home directory
+cd ~
+uv venv .openhands-venv --python 3.12
+
+# Install OpenHands in the virtual environment
+uv pip install -t ~/.openhands-venv/lib/python3.12/site-packages openhands-ai
+
+# Add the bin directory to your PATH in your shell configuration file
+echo 'export PATH="$PATH:$HOME/.openhands-venv/bin"' >> ~/.bashrc  # or ~/.zshrc
+
+# Reload your shell configuration
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+Alternatively, you can create a simple script in your `~/.local/bin` directory:
+
+```bash
+mkdir -p ~/.local/bin
+
+cat << 'EOF' > ~/.local/bin/openhands
+#!/bin/bash
+exec uvx --python 3.12 --from openhands-ai openhands "$@"
+EOF
+
+chmod +x ~/.local/bin/openhands
+
+# Make sure ~/.local/bin is in your PATH
+echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc  # or ~/.zshrc
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+</Accordion>
+
+</AccordionGroup>
+
 2. Launch an interactive OpenHands conversation from the command line:
 ```bash
 openhands


### PR DESCRIPTION
This PR adds documentation for setting up OpenHands CLI for easy access across different environments:

1. Added an Accordion section in the CLI mode documentation showing how to:
   - Create shell aliases for easy access to OpenHands CLI across different environments
   - Install OpenHands in the home directory using uv without installing it globally

These additions will help users more easily access OpenHands CLI from their terminal without requiring global installation.

The documentation includes:
- Shell alias examples for both `openhands` and `oh` shortcuts
- Instructions for installing in a virtual environment in the home directory
- Alternative approach using a script in `~/.local/bin`

Fixes the request to document these installation options in the CLI documentation.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7cb706c6eda74b13955b116f46c3d281)