### PR TITLE
[Bug]: Jupyter tab requires page refresh to display content

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-jupyter-tab-refresh-issue.md
+++ b/.github/ISSUE_TEMPLATE/bug-jupyter-tab-refresh-issue.md
@@ -1,0 +1,66 @@
+---
+name: Bug - Jupyter Tab Refresh Issue
+about: Jupyter tab requires page refresh to display content
+title: "[Bug]: Jupyter tab requires page refresh to display content"
+labels: bug, frontend
+assignees: ''
+---
+
+# Bug: Jupyter tab requires page refresh to display content
+
+## Summary
+
+While PR #9533 fixed the issue of Jupyter tab not showing input commands, there remains a problem where the Jupyter tab doesn't display any content (input or output) until the user manually refreshes the page.
+
+## Environment
+
+- OpenHands version: Latest main branch
+- Browser: All major browsers (Chrome, Firefox, Safari)
+- Deployment: Both local and cloud deployments
+
+## Bug Description
+
+### Expected Behavior
+
+When a user executes IPython commands through OpenHands, the Jupyter tab should immediately display both the input commands and their outputs without requiring any manual intervention.
+
+### Actual Behavior
+
+Currently, when IPython commands are executed, the Jupyter tab remains blank until the user manually refreshes the page. Only after refreshing does the tab display the input commands and their outputs.
+
+### Impact
+
+This issue significantly disrupts the user experience when working with Jupyter notebooks in OpenHands:
+- Users might think the Jupyter functionality is broken when they don't see any content
+- The need for manual refreshing breaks the flow of interactive data analysis
+- It creates confusion about whether commands were actually executed
+
+## Root Cause
+
+The root cause appears to be related to state management or component rendering in the frontend. PR #9114 attempted to debug this issue by adding console logs to track when actions are dispatched and when the component updates, but it was closed without resolving the problem.
+
+Potential areas to investigate:
+1. State updates not triggering component re-renders
+2. Event handling for Jupyter actions
+3. Redux state management for Jupyter cells
+4. Component lifecycle issues in the Jupyter tab
+
+## Steps to Reproduce
+
+1. Start a new conversation with OpenHands
+2. Ask it to execute a Python command using IPython, e.g., "Run `print('Hello, World!')` in IPython"
+3. Navigate to the Jupyter tab
+4. Observe that the tab is empty
+5. Refresh the page
+6. Navigate to the Jupyter tab again
+7. Observe that now the input and output are visible
+
+## Related Issues
+
+- PR #9533 fixed the related issue of Jupyter tab not showing input commands
+- PR #9114 was an attempt to debug this issue by adding console logs
+
+## Additional Context
+
+As noted by Muhammad in a comment on PR #9533:
+> In process, Jupyter tab doesn't show the content until we refresh the page, I see there is a PR for it as well but marked as closed, yet issue remains unresolved.


### PR DESCRIPTION
## Summary

While PR #9533 fixed the issue of Jupyter tab not showing input commands, there remains a problem where the Jupyter tab doesn't display any content (input or output) until the user manually refreshes the page.

## Bug Description

### Expected Behavior

When a user executes IPython commands through OpenHands, the Jupyter tab should immediately display both the input commands and their outputs without requiring any manual intervention.

### Actual Behavior

Currently, when IPython commands are executed, the Jupyter tab remains blank until the user manually refreshes the page. Only after refreshing does the tab display the input commands and their outputs.

### Impact

This issue significantly disrupts the user experience when working with Jupyter notebooks in OpenHands:
- Users might think the Jupyter functionality is broken when they don't see any content
- The need for manual refreshing breaks the flow of interactive data analysis
- It creates confusion about whether commands were actually executed

## Root Cause

The root cause appears to be related to state management or component rendering in the frontend. PR #9114 attempted to debug this issue by adding console logs to track when actions are dispatched and when the component updates, but it was closed without resolving the problem.

Potential areas to investigate:
1. State updates not triggering component re-renders
2. Event handling for Jupyter actions
3. Redux state management for Jupyter cells
4. Component lifecycle issues in the Jupyter tab

## Related Issues

- PR #9533 fixed the related issue of Jupyter tab not showing input commands
- PR #9114 was an attempt to debug this issue by adding console logs

## Additional Context

As noted by Muhammad in a comment on PR #9533:
> In process, Jupyter tab doesn't show the content until we refresh the page, I see there is a PR for it as well but marked as closed, yet issue remains unresolved.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/53be8bf3224f46c0b82cccf214230b53)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:31cbe65-nikolaik   --name openhands-app-31cbe65   docker.all-hands.dev/all-hands-ai/openhands:31cbe65
```