### PR TITLE
fix(frontend): The conversation page cannot be used on mobile devices and tablets.

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -274,22 +274,24 @@ export function ConversationCard({
               variant={variant}
             />
           )}
-          <p className="text-xs text-neutral-400">
-            <span>{t(I18nKey.CONVERSATION$CREATED)} </span>
-            <time>
-              {formatTimeDelta(new Date(createdAt || lastUpdatedAt))}{" "}
-              {t(I18nKey.CONVERSATION$AGO)}
-            </time>
-            {showUpdateTime && (
-              <>
-                <span>{t(I18nKey.CONVERSATION$UPDATED)} </span>
-                <time>
-                  {formatTimeDelta(new Date(lastUpdatedAt))}{" "}
-                  {t(I18nKey.CONVERSATION$AGO)}
-                </time>
-              </>
-            )}
-          </p>
+          {(createdAt || lastUpdatedAt) && (
+            <p className="text-xs text-neutral-400">
+              <span>{t(I18nKey.CONVERSATION$CREATED)} </span>
+              <time>
+                {formatTimeDelta(new Date(createdAt || lastUpdatedAt))}{" "}
+                {t(I18nKey.CONVERSATION$AGO)}
+              </time>
+              {showUpdateTime && (
+                <>
+                  <span>{t(I18nKey.CONVERSATION$UPDATED)} </span>
+                  <time>
+                    {formatTimeDelta(new Date(lastUpdatedAt))}{" "}
+                    {t(I18nKey.CONVERSATION$AGO)}
+                  </time>
+                </>
+              )}
+            </p>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Description:**  
On the **Conversation** page, the text `NaN` is occasionally displayed on the conversation card.

---

### ✅ Expected Behavior
- The conversation card should never display `NaN`.

---

### ❌ Current Behavior
- In some cases, `NaN` appears on the conversation card.

---

### 🔁 Steps to Reproduce
1. Create a new conversation.
2. If the network is slow or the system takes time to initialize the runtime environment, `NaN` may be shown on the conversation card.

---

### 📸 Additional Context
A screenshot illustrating the issue:

<img width="1432" alt="Image" src="https://github.com/user-attachments/assets/04f55538-10cc-4284-b02a-cd1463be8fa4" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes an issue where `NaN` was displayed on the conversation card by ensuring proper handling of the data before rendering.

You can refer to the image below to see the result of this PR:

<img width="1432" alt="output" src="https://github.com/user-attachments/assets/a79dee80-20d6-497f-b856-bcd8a454ddfd" />

---
**Link of any specific issues this addresses:**

Resolves #9580 
