### PR TITLE
fix(frontend): The terminal is still shown when connecting to an agent.

### DIFF
--- a/frontend/src/components/features/terminal/terminal.tsx
+++ b/frontend/src/components/features/terminal/terminal.tsx
@@ -22,7 +22,7 @@ function Terminal() {
           {t("DIFF_VIEWER$WAITING_FOR_RUNTIME")}
         </div>
       )}
-      <div ref={ref} className="h-full w-full" />
+      {!isRuntimeInactive && <div ref={ref} className="h-full w-full" />}
     </div>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

### **Description**
When creating a new conversation, the terminal is displayed immediately—even before the agent is fully connected.

---

### ✅ Expected Behavior
- The terminal should only appear **after** the agent is ready and fully connected.

---

### ❌ Current Behavior
- The terminal is shown **while** the agent is still connecting.

---

### 🔁 Steps to Reproduce
1. Start a new conversation.
2. Watch the **Terminal** tab as the agent connects.
3. Notice that the terminal appears before the agent is ready.

---

### 📹 Additional Context
A video demonstrating the issue is available here: 

https://github.com/user-attachments/assets/91ef18df-12aa-4cd1-85cf-1e2b58c6b3cf

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- A PR is available that resolves this issue by ensuring the terminal is only shown after the agent is ready.

---
**Link of any specific issues this addresses:**

Resolves #9602 
