### PR TITLE
fix(frontend): The suggested tasks section only filters the tasks by the repository’s title.

### DIFF
--- a/frontend/__tests__/components/features/home/repo-selection-form.test.tsx
+++ b/frontend/__tests__/components/features/home/repo-selection-form.test.tsx
@@ -252,8 +252,6 @@ describe("RepositorySelectionForm", () => {
     expect(searchedRepo).toBeInTheDocument();
 
     await userEvent.click(searchedRepo);
-    expect(mockOnRepoSelection).toHaveBeenCalledWith(
-      MOCK_SEARCH_REPOS[0].full_name,
-    );
+    expect(mockOnRepoSelection).toHaveBeenCalledWith(MOCK_SEARCH_REPOS[0]);
   });
 });

--- a/frontend/src/components/features/home/repo-connector.tsx
+++ b/frontend/src/components/features/home/repo-connector.tsx
@@ -4,9 +4,10 @@ import { RepositorySelectionForm } from "./repo-selection-form";
 import { useConfig } from "#/hooks/query/use-config";
 import { RepoProviderLinks } from "./repo-provider-links";
 import { useUserProviders } from "#/hooks/use-user-providers";
+import { GitRepository } from "#/types/git";
 
 interface RepoConnectorProps {
-  onRepoSelection: (repoTitle: string | null) => void;
+  onRepoSelection: (repo: GitRepository | null) => void;
 }
 
 export function RepoConnector({ onRepoSelection }: RepoConnectorProps) {

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -19,7 +19,7 @@ import {
 } from "./repository-selection";
 
 interface RepositorySelectionFormProps {
-  onRepoSelection: (repoTitle: string | null) => void;
+  onRepoSelection: (repo: GitRepository | null) => void;
 }
 
 export function RepositorySelectionForm({
@@ -94,8 +94,7 @@ export function RepositorySelectionForm({
 
   const handleRepoSelection = (key: React.Key | null) => {
     const selectedRepo = allRepositories?.find((repo) => repo.id === key);
-
-    if (selectedRepo) onRepoSelection(selectedRepo.full_name);
+    if (selectedRepo) onRepoSelection(selectedRepo);
     setSelectedRepository(selectedRepo || null);
     setSelectedBranch(null); // Reset branch selection when repo changes
     branchManuallyClearedRef.current = false; // Reset the flag when repo changes

--- a/frontend/src/components/features/home/tasks/task-suggestions.tsx
+++ b/frontend/src/components/features/home/tasks/task-suggestions.tsx
@@ -6,16 +6,24 @@ import { TaskSuggestionsSkeleton } from "./task-suggestions-skeleton";
 import { cn } from "#/utils/utils";
 import { I18nKey } from "#/i18n/declaration";
 import { TooltipButton } from "#/components/shared/buttons/tooltip-button";
+import { GitRepository } from "#/types/git";
 
 interface TaskSuggestionsProps {
-  filterFor?: string | null;
+  filterFor?: GitRepository | null;
 }
 
 export function TaskSuggestions({ filterFor }: TaskSuggestionsProps) {
   const { t } = useTranslation();
   const { data: tasks, isLoading } = useSuggestedTasks();
+
   const suggestedTasks = filterFor
-    ? tasks?.filter((task) => task.title === filterFor)
+    ? tasks?.filter(
+        (element) =>
+          element.title === filterFor.full_name &&
+          !!element.tasks.find(
+            (task) => task.git_provider === filterFor.git_provider,
+          ),
+      )
     : tasks;
 
   const hasSuggestedTasks = suggestedTasks && suggestedTasks.length > 0;

--- a/frontend/src/routes/home.tsx
+++ b/frontend/src/routes/home.tsx
@@ -4,14 +4,15 @@ import { HomeHeader } from "#/components/features/home/home-header";
 import { RepoConnector } from "#/components/features/home/repo-connector";
 import { TaskSuggestions } from "#/components/features/home/tasks/task-suggestions";
 import { useUserProviders } from "#/hooks/use-user-providers";
+import { GitRepository } from "#/types/git";
 
 <PrefetchPageLinks page="/conversations/:conversationId" />;
 
 function HomeScreen() {
   const { providers } = useUserProviders();
-  const [selectedRepoTitle, setSelectedRepoTitle] = React.useState<
-    string | null
-  >(null);
+  const [selectedRepo, setSelectedRepo] = React.useState<GitRepository | null>(
+    null,
+  );
 
   const providersAreSet = providers.length > 0;
 
@@ -25,11 +26,9 @@ function HomeScreen() {
       <hr className="border-[#717888]" />
 
       <main className="flex flex-col lg:flex-row justify-between gap-8">
-        <RepoConnector
-          onRepoSelection={(title) => setSelectedRepoTitle(title)}
-        />
+        <RepoConnector onRepoSelection={(repo) => setSelectedRepo(repo)} />
         <hr className="md:hidden border-[#717888]" />
-        {providersAreSet && <TaskSuggestions filterFor={selectedRepoTitle} />}
+        {providersAreSet && <TaskSuggestions filterFor={selectedRepo} />}
       </main>
     </div>
   );


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

### **Description**
The **Suggested Tasks** section currently filters tasks based solely on the repository’s title. This causes incorrect behavior when multiple repositories share the same title but come from different Git providers—filtering becomes unreliable or incorrect in such cases.

---

### ✅ Expected Behavior
- Filtering should correctly consider **both** the repository title **and** its Git provider to uniquely identify repositories.

---

### ❌ Current Behavior
- Filtering is based **only** on the repository title, leading to incorrect or ambiguous results when duplicate titles exist across providers.

---

### 🔁 Steps to Reproduce
1. Create or connect multiple repositories that share the same title but are hosted on different Git providers.
2. Open the **Suggested Tasks** section.
3. Try filtering by selecting one of the repositories.
4. Observe that tasks from other repositories with the same title may appear.

---

### 📹 Additional Context
A video demonstrating the issue is available here:  

https://github.com/user-attachments/assets/b7b7893c-926e-4940-8ec6-059e167ad0eb

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The associated PR updates the filtering logic to include **both** the repository title and Git provider, resolving the issue.

The output after applying the fix in the PR can be seen in this video:

https://github.com/user-attachments/assets/fb8965ec-b58e-4eeb-8ce9-0c7116226d00

---
**Link of any specific issues this addresses:**

Resolves #9605 
