### PR TITLE
refactor(frontend): Show the git providers on the suggested tasks

### DIFF
--- a/frontend/src/components/features/home/tasks/task-group.tsx
+++ b/frontend/src/components/features/home/tasks/task-group.tsx
@@ -1,3 +1,4 @@
+import { FaBitbucket, FaGithub, FaGitlab } from "react-icons/fa6";
 import { TaskCard } from "./task-card";
 import { TaskItemTitle } from "./task-item-title";
 import { SuggestedTask } from "./task.types";
@@ -8,9 +9,16 @@ interface TaskGroupProps {
 }
 
 export function TaskGroup({ title, tasks }: TaskGroupProps) {
+  const gitProvider = tasks.length > 0 ? tasks[0].git_provider : null;
+
   return (
     <div className="text-content-2">
-      <TaskItemTitle>{title}</TaskItemTitle>
+      <div className="flex items-center gap-2 border-b-1 border-[#717888]">
+        {gitProvider === "github" && <FaGithub size={14} />}
+        {gitProvider === "gitlab" && <FaGitlab />}
+        {gitProvider === "bitbucket" && <FaBitbucket />}
+        <TaskItemTitle>{title}</TaskItemTitle>
+      </div>
 
       <ul className="text-sm">
         {tasks.map((task) => (

--- a/frontend/src/components/features/home/tasks/task-item-title.tsx
+++ b/frontend/src/components/features/home/tasks/task-item-title.tsx
@@ -1,6 +1,6 @@
 export function TaskItemTitle({ children: title }: React.PropsWithChildren) {
   return (
-    <div className="py-3 border-b-1 border-[#717888]">
+    <div className="py-3">
       <h3 className="text-[16px] leading-6 font-[500]">{title}</h3>
     </div>
   );


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

### **Description**
Currently, the **Suggested Tasks** section displays only the repository titles. This makes it difficult to quickly identify which Git provider a repository belongs to—especially when multiple repositories share the same name but originate from different Git providers.

---

### ✅ Expected Behavior
- Show Git provider **icons** alongside repository titles in the **Suggested Tasks** section.  
- This enhancement would improve scannability and user experience, allowing users to quickly differentiate between repositories.

---

### ❌ Current Behavior
- Only the repository title is shown, making it hard to distinguish between similarly named repositories from different providers.

---

### 🔁 Steps to Reproduce
1. Connect multiple repositories with the same title from different Git providers.
2. Open the **Suggested Tasks** section.
3. Try to identify which repository belongs to which provider at a glance.

---

### 📹 Additional Context
An image demonstrating the current issue is available below:

<img width="1432" height="737" alt="Image" src="https://github.com/user-attachments/assets/677d763a-f14c-420d-b1e8-1218cc63676c" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Display Git provider icons (e.g., GitHub, GitLab, Bitbucket) next to each repository title in the Suggested Tasks list.
- This will help users skim through repositories faster and improve overall UX.

An image demonstrating the output is available below:

<img width="1432" alt="output" src="https://github.com/user-attachments/assets/8bff041a-986a-49e8-b54f-7709c7e8cf81" />

---
**Link of any specific issues this addresses:**

Resolves #9607 