### PR TITLE
refactor(frontend): Remove the border bottom of the last element on the suggested tasks.

### DIFF
--- a/frontend/src/components/features/home/tasks/task-card.tsx
+++ b/frontend/src/components/features/home/tasks/task-card.tsx
@@ -19,9 +19,10 @@ const getTaskTypeMap = (
 
 interface TaskCardProps {
   task: SuggestedTask;
+  isLastTask?: boolean;
 }
 
-export function TaskCard({ task }: TaskCardProps) {
+export function TaskCard({ task, isLastTask }: TaskCardProps) {
   const { setOptimisticUserMessage } = useOptimisticUserMessage();
   const { data: repositories } = useUserRepositories();
   const { mutate: createConversation, isPending } = useCreateConversation();
@@ -64,7 +65,12 @@ export function TaskCard({ task }: TaskCardProps) {
   }
 
   return (
-    <li className="py-3 border-b border-[#717888] flex items-center pr-6">
+    <li
+      className={cn(
+        "py-3 border-b border-[#717888] flex items-center pr-6",
+        isLastTask && "border-b-0",
+      )}
+    >
       <TaskIssueNumber issueNumber={task.issue_number} href={href} />
 
       <div className="w-full pl-8">

--- a/frontend/src/components/features/home/tasks/task-group.tsx
+++ b/frontend/src/components/features/home/tasks/task-group.tsx
@@ -5,17 +5,27 @@ import { SuggestedTask } from "./task.types";
 interface TaskGroupProps {
   title: string;
   tasks: SuggestedTask[];
+  isLastTaskGroup?: boolean;
 }
 
-export function TaskGroup({ title, tasks }: TaskGroupProps) {
+export function TaskGroup({ title, tasks, isLastTaskGroup }: TaskGroupProps) {
+  const numberOfTasks = tasks.length;
+
   return (
     <div className="text-content-2">
       <TaskItemTitle>{title}</TaskItemTitle>
 
       <ul className="text-sm">
-        {tasks.map((task) => (
-          <TaskCard key={task.issue_number} task={task} />
-        ))}
+        {tasks.map((task, index) => {
+          const isLastTask = index === numberOfTasks - 1;
+          return (
+            <TaskCard
+              key={task.issue_number}
+              task={task}
+              isLastTask={isLastTaskGroup && isLastTask}
+            />
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

### **Description**
The bottom border is used to visually separate tasks and task groups within the **Suggested Tasks** section. However, the **last element** in the list currently displays a bottom border, which is unnecessary and visually inconsistent.

---

### ✅ Expected Behavior
- The **last element** in the Suggested Tasks list **should not** have a bottom border.

---

### ❌ Current Behavior
- The **last element** currently **has** a bottom border, which is visually redundant.

---

### 🔁 Steps to Reproduce
1. Navigate to the **Suggested Tasks** section.
2. Scroll to the last item in the list.
3. Observe that a bottom border is still rendered on the last element.

---

### 📹 Additional Context
An image demonstrating the issue is available below:

<img width="1432" height="737" alt="Image" src="https://github.com/user-attachments/assets/a25e44a2-c8b1-404b-907f-f82a80ef4de0" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

A PR has been submitted that removes the bottom border from the **last element** in the Suggested Tasks list.

An image showing the corrected UI after the PR has been applied is available below:

<img width="1432" alt="output" src="https://github.com/user-attachments/assets/9c22eb9b-1728-4567-a6ab-e6a7bf34cbfb" />

---
**Link of any specific issues this addresses:**

Resolves #9609 
