### PR TITLE
fix(frontend): Jupyter tab requires page refresh to display content

### DIFF
--- a/frontend/src/routes/jupyter-tab.tsx
+++ b/frontend/src/routes/jupyter-tab.tsx
@@ -5,17 +5,36 @@ function Jupyter() {
   const parentRef = React.useRef<HTMLDivElement>(null);
   const [parentWidth, setParentWidth] = React.useState(0);
 
-  // This is a hack to prevent the editor from overflowing
-  // Should be removed after revising the parent and containers
+  // Use ResizeObserver to properly track parent width changes
   React.useEffect(() => {
+    let resizeObserver: ResizeObserver | null = null;
+
+    resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        // Use contentRect.width for more accurate measurements
+        const { width } = entry.contentRect;
+        if (width > 0) {
+          setParentWidth(width);
+        }
+      }
+    });
+
     if (parentRef.current) {
-      setParentWidth(parentRef.current.offsetWidth);
+      resizeObserver.observe(parentRef.current);
     }
+
+    return () => {
+      resizeObserver?.disconnect();
+    };
   }, []);
+
+  // Provide a fallback width to prevent the editor from being hidden
+  // Use parentWidth if available, otherwise use a large default
+  const maxWidth = parentWidth > 0 ? parentWidth : 9999;
 
   return (
     <div ref={parentRef} className="h-full">
-      <JupyterEditor maxWidth={parentWidth} />
+      <JupyterEditor maxWidth={maxWidth} />
     </div>
   );
 }

--- a/frontend/src/routes/jupyter-tab.tsx
+++ b/frontend/src/routes/jupyter-tab.tsx
@@ -5,6 +5,8 @@ function Jupyter() {
   const parentRef = React.useRef<HTMLDivElement>(null);
   const [parentWidth, setParentWidth] = React.useState(0);
 
+  // This is a hack to prevent the editor from overflowing
+  // Should be removed after revising the parent and containers
   // Use ResizeObserver to properly track parent width changes
   React.useEffect(() => {
     let resizeObserver: ResizeObserver | null = null;


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

### **Description**

When a user executes IPython commands through OpenHands, the Jupyter tab should immediately display the content without requiring any manual intervention.

---

### ✅ Expected Behavior
- The Jupyter tab should display the content.

---

### ❌ Current Behavior
- The Jupyter tab does not display the content.

---

### 🔁 Steps to Reproduce
1. Start a new conversation with OpenHands
2. Ask it to execute a Python command using IPython, e.g., "Run print("Hello, World!") in IPython"
3. Navigate to the Jupyter tab
4. Observe that the tab is empty
5. Refresh the page
6. Navigate to the Jupyter tab again
7. Observe that now the input and output are visible

---

### 📹 Additional Context
A video demonstrating the issue is available below:

https://github.com/user-attachments/assets/107da0ec-1ada-4dee-84c6-0637e1c37ac7

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- The `parentWidth` is initially `0`, resulting in `maxWidth: 0`.
- This causes the Jupyter content to be hidden or not displayed at all.
- The associated PR resolves this issue by correctly handling the initial measurement of `parentWidth`.

A video showing the resolved behavior after applying the PR is available below:  

https://github.com/user-attachments/assets/0b70947f-90a2-4ca3-a045-c615fa69ad20

---
**Link of any specific issues this addresses:**

Resolves #9578 
