### PR TITLE
chore(eslint): Extend eslint rules to error on `i18next/on no-literal-string`

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -13,8 +13,9 @@
     "plugin:react-hooks/recommended",
     "plugin:@tanstack/query/recommended",
   ],
-  "plugins": ["prettier", "unused-imports"],
+  "plugins": ["prettier", "unused-imports", "i18next"],
   "rules": {
+    "i18next/no-literal-string": "error",
     "unused-imports/no-unused-imports": "error",
     "prettier/prettier": ["error"],
     // Resolves https://stackoverflow.com/questions/59265981/typescript-eslint-missing-file-extension-ts-import-extensions/59268871#59268871

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,7 +1,7 @@
 # Run frontend checks
 echo "Running frontend checks..."
 cd frontend
-npm run check-unlocalized-strings
+npm run lint
 npm run check-translation-completeness
 npx lint-staged
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,6 +82,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-i18next": "^6.1.2",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "^5.5.1",
@@ -9121,6 +9122,20 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-i18next": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.1.2.tgz",
+      "integrity": "sha512-hvTmws4kouNHkk314+9MHNj+RQmsqrkejWhTXGlRC0j8H+EXq2qDRLe6UqIjrFZo7/ogyd4btuqsnKCBi8wHbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=18.10.0"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
@@ -15115,6 +15130,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/requires-port": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -107,6 +107,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-i18next": "^6.1.2",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.5.1",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
We are currently using a custom script (https://github.com/All-Hands-AI/OpenHands/blob/main/frontend/scripts/check-unlocalized-strings.cjs) to check whether there are any unlocalized strings in our app.

We also have tests to run this script https://github.com/All-Hands-AI/OpenHands/blob/37cbeb735fcaa45f41e37550cb09c753c682754d/frontend/src/test/localization-fix.test.ts#L7-L23 that was introduced in #9283 due to the unreliability of running the script in the pre-commit only. When this test fails, the error message does not include any feedback on why or where the script failed.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Use [`eslint-plugin-i18next`](https://github.com/edvardchen/eslint-plugin-i18next) to check for string literals and throw when running our lint command

---
**Link of any specific issues this addresses:**
