### PR TITLE
refactor(frontend): The Jupyter tab is not showing "Waiting for runtime to start..." when connecting to an agent

### DIFF
--- a/frontend/src/components/features/jupyter/jupyter.tsx
+++ b/frontend/src/components/features/jupyter/jupyter.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
 import { RootState } from "#/store";
 import { useScrollToBottom } from "#/hooks/use-scroll-to-bottom";
 import { JupyterCell } from "./jupyter-cell";
 import { ScrollToBottomButton } from "#/components/shared/buttons/scroll-to-bottom-button";
+import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
 
 interface JupyterEditorProps {
   maxWidth: number;
@@ -11,28 +13,43 @@ interface JupyterEditorProps {
 
 export function JupyterEditor({ maxWidth }: JupyterEditorProps) {
   const cells = useSelector((state: RootState) => state.jupyter?.cells ?? []);
+  const { curAgentState } = useSelector((state: RootState) => state.agent);
+
   const jupyterRef = React.useRef<HTMLDivElement>(null);
+
+  const { t } = useTranslation();
+
+  const isRuntimeInactive = RUNTIME_INACTIVE_STATES.includes(curAgentState);
 
   const { hitBottom, scrollDomToBottom, onChatBodyScroll } =
     useScrollToBottom(jupyterRef);
 
   return (
-    <div className="flex-1 h-full flex flex-col" style={{ maxWidth }}>
-      <div
-        data-testid="jupyter-container"
-        className="flex-1 overflow-y-auto fast-smooth-scroll"
-        ref={jupyterRef}
-        onScroll={(e) => onChatBodyScroll(e.currentTarget)}
-      >
-        {cells.map((cell, index) => (
-          <JupyterCell key={index} cell={cell} />
-        ))}
-      </div>
-      {!hitBottom && (
-        <div className="sticky bottom-2 flex items-center justify-center">
-          <ScrollToBottomButton onClick={scrollDomToBottom} />
+    <>
+      {isRuntimeInactive && (
+        <div className="w-full h-full flex items-center text-center justify-center text-2xl text-tertiary-light">
+          {t("DIFF_VIEWER$WAITING_FOR_RUNTIME")}
         </div>
       )}
-    </div>
+      {!isRuntimeInactive && (
+        <div className="flex-1 h-full flex flex-col" style={{ maxWidth }}>
+          <div
+            data-testid="jupyter-container"
+            className="flex-1 overflow-y-auto fast-smooth-scroll"
+            ref={jupyterRef}
+            onScroll={(e) => onChatBodyScroll(e.currentTarget)}
+          >
+            {cells.map((cell, index) => (
+              <JupyterCell key={index} cell={cell} />
+            ))}
+          </div>
+          {!hitBottom && (
+            <div className="sticky bottom-2 flex items-center justify-center">
+              <ScrollToBottomButton onClick={scrollDomToBottom} />
+            </div>
+          )}
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

### **Description**

When initiating a new conversation, users expect to see a loading state in the **Jupyter** tab while the agent is connecting. Currently, no such feedback is shown, which may confuse users or make the app feel unresponsive.

The **Jupyter** tab does not display the message **"Waiting for runtime to start..."** during the agent connection phase.

---

### ✅ Expected Behavior
- The **Jupyter** tab should display the message:  
  **"Waiting for runtime to start..."**  
  when connecting to an agent.
---

### ❌ Current Behavior
- The **Jupyter** tab remains blank or static and does **not** display any loading message while waiting for the agent runtime to initialize.

---

### 🔁 Steps to Reproduce
1. Create a new conversation.
2. Navigate to the **Jupyter** tab.
3. Observe the tab while the agent is connecting.

---

### 📹 Additional Context
A video demonstrating the issue is available below:

https://github.com/user-attachments/assets/a4ac1ba7-559e-4e6f-b6bd-ea17263f2285

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Display the message **"Waiting for runtime to start..."** in the Jupyter tab during the agent connection phase to provide clear visual feedback.

A video demonstrating the output is available below:

https://github.com/user-attachments/assets/ec19a7db-c87c-4882-9cdf-9e6ee6a671d0

---
**Link of any specific issues this addresses:**

Resolves #9625 
