### PR TITLE
Fixes for docker nested runtime

### DIFF
--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -499,7 +499,6 @@ class DockerNestedConversationManager(ConversationManager):
         env_vars['ALLOW_SET_CONVERSATION_ID'] = '1'
         env_vars['SANDBOX_CLOSE_DELAY'] = '0'
         env_vars['SKIP_DEPENDENCY_CHECK'] = '1'
-        # Not useed yet but will be when warm local servers are merged
         env_vars['INITIAL_NUM_WARM_SERVERS'] = '1'
 
         # Set up mounted volume for conversation directory within workspace

--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -511,7 +511,9 @@ class DockerNestedConversationManager(ConversationManager):
         # Set up mounted volume for conversation directory within workspace
         if config.file_store == 'local':
             # Resolve ~ from path as the docker container does not work otherwise
-            file_store_path = os.path.realpath(os.path.expanduser(config.file_store_path))
+            file_store_path = os.path.realpath(
+                os.path.expanduser(config.file_store_path)
+            )
 
             volumes.append(
                 f'{file_store_path}/{conversation_dir}:/root/.openhands/{conversation_dir}:rw'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
* Removed deprecated WORKSPACE_BASE environment variable
* Fixed broken file store path mapping when path contains a ~

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes several issues with the Docker nested runtime:

1. Removed the deprecated WORKSPACE_BASE environment variable that is no longer needed
2. Fixed file path handling when the file store path contains a tilde (~) character:
   - Added proper path resolution using os.path.expanduser and os.path.realpath
   - This ensures Docker can properly mount volumes with home directory references
3. Simplified the volume mount path structure:
   - Changed the target path from /root/.openhands/file_store/{conversation_dir} to /root/.openhands/{conversation_dir}
4. Added a check to only set up the mounted volume if config.file_store == 'local'
5. Added INITIAL_NUM_WARM_SERVERS environment variable set to '1' to ensure there's at least one warm server available

These changes improve the reliability of the Docker nested runtime, particularly when using file paths that contain home directory references.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5eb0b94-nikolaik   --name openhands-app-5eb0b94   docker.all-hands.dev/all-hands-ai/openhands:5eb0b94
```