### PR TITLE
Add support for organization-level setup.sh

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -425,7 +425,127 @@ class Runtime(FileEditRuntimeMixin):
         return dir_name
 
     def maybe_run_setup_script(self):
-        """Run .openhands/setup.sh if it exists in the workspace or repository."""
+        """
+        Run setup.sh scripts if they exist in the workspace or repository.
+
+        Order of execution:
+        1. Organization-level setup.sh (from org/.openhands or org/openhands-config)
+        2. Repository-level setup.sh (from .openhands/setup.sh)
+        """
+        # Get the repository name from the workspace
+        repo_dir = None
+        for item in self.workspace_root.iterdir():
+            if item.is_dir() and (item / '.git').exists():
+                repo_dir = item
+                break
+
+        if repo_dir:
+            # Try to get the remote URL to extract the organization
+            action = CmdRunAction(f'cd {repo_dir} && git remote get-url origin')
+            obs = self.run_action(action)
+
+            if isinstance(obs, CmdOutputObservation) and obs.exit_code == 0:
+                remote_url = obs.content.strip()
+                repo_parts = remote_url.split('/')
+
+                if len(repo_parts) >= 2:
+                    # Extract the organization name
+                    org_name = repo_parts[-2]
+
+                    # Determine if this is a GitLab repository
+                    is_gitlab = self._is_gitlab_repository(remote_url)
+
+                    # For GitLab, use openhands-config (since .openhands is not a valid repo name)
+                    # For other providers, use .openhands
+                    if is_gitlab:
+                        org_openhands_repo = f'{org_name}/openhands-config'
+                    else:
+                        org_openhands_repo = f'{org_name}/.openhands'
+
+                    # Create a temporary directory for the org-level repo
+                    org_repo_dir = self.workspace_root / f'org_openhands_{org_name}'
+
+                    # Try to clone the org-level repo
+                    try:
+                        # Get authenticated URL and do a shallow clone (--depth 1) for efficiency
+                        try:
+                            remote_url = call_async_from_sync(
+                                self._get_authenticated_git_url,
+                                GENERAL_TIMEOUT,
+                                org_openhands_repo,
+                                self.git_provider_tokens,
+                            )
+
+                            clone_cmd = f'GIT_TERMINAL_PROMPT=0 git clone --depth 1 {remote_url} {org_repo_dir}'
+
+                            self.log(
+                                'info',
+                                'Executing clone command for org-level repo',
+                            )
+
+                            action = CmdRunAction(command=clone_cmd)
+                            obs = self.run_action(action)
+
+                            if (
+                                isinstance(obs, CmdOutputObservation)
+                                and obs.exit_code == 0
+                            ):
+                                self.log(
+                                    'info',
+                                    f'Successfully cloned org-level repo from {org_openhands_repo}',
+                                )
+
+                                # Check for org-level setup.sh
+                                org_setup_script = org_repo_dir / 'setup.sh'
+                                org_setup_read_obs = self.read(
+                                    FileReadAction(path=str(org_setup_script))
+                                )
+                                if not isinstance(org_setup_read_obs, ErrorObservation):
+                                    self.log(
+                                        'info',
+                                        f'Found org-level setup.sh at {org_setup_script}',
+                                    )
+
+                                    if self.status_callback:
+                                        self.status_callback(
+                                            'info',
+                                            RuntimeStatus.SETTING_UP_WORKSPACE,
+                                            'Running organization-level setup script...',
+                                        )
+
+                                    # Run the org-level setup script
+                                    org_setup_action = CmdRunAction(
+                                        f'chmod +x {org_setup_script} && source {org_setup_script}',
+                                        blocking=True,
+                                        hidden=True,
+                                    )
+                                    org_setup_action.set_hard_timeout(600)
+
+                                    # Add the action to the event stream as an ENVIRONMENT event
+                                    source = EventSource.ENVIRONMENT
+                                    self.event_stream.add_event(
+                                        org_setup_action, source
+                                    )
+
+                                    # Execute the action
+                                    self.run_action(org_setup_action)
+
+                                # Clean up the org repo directory
+                                action = CmdRunAction(f'rm -rf {org_repo_dir}')
+                                self.run_action(action)
+
+                        except Exception as e:
+                            self.log(
+                                'warning',
+                                f'Failed to get authenticated URL for {org_openhands_repo}: {str(e)}',
+                            )
+                    except Exception as e:
+                        self.log(
+                            'warning',
+                            f'Error while trying to run org-level setup script: {str(e)}',
+                        )
+
+        # Now run the repository-level setup script
         setup_script = '.openhands/setup.sh'
         read_obs = self.read(FileReadAction(path=setup_script))
         if isinstance(read_obs, ErrorObservation):


### PR DESCRIPTION
## Description

This PR adds support for organization-level setup.sh scripts. The organization-level setup.sh is executed before the repository-level setup.sh, allowing organizations to set up common environment configurations across all repositories.

## Implementation Details

- Modified the `maybe_run_setup_script` method in `openhands/runtime/base.py` to:
  1. Check if a git repository exists in the workspace
  2. Extract the organization name from the remote URL
  3. Clone the organization's `.openhands` repository (or `openhands-config` for GitLab)
  4. Check if a `setup.sh` file exists in the organization repository
  5. If found, execute the organization-level setup.sh before the repository-level setup.sh
  6. Clean up the temporary organization repository after execution

## Testing

The implementation follows the same pattern as the existing organization-level microagents loading, ensuring consistent behavior.

## Related Issues

N/A

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9311714400234f2d9a657220d60e0930)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a6e91d1-nikolaik   --name openhands-app-a6e91d1   docker.all-hands.dev/all-hands-ai/openhands:a6e91d1
```