### PR TITLE
Build from vsix first

### DIFF
--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -107,13 +107,13 @@ def attempt_vscode_extension_install():
         f'INFO: First-time setup: attempting to install the OpenHands {editor_name} extension...'
     )
 
-    # Attempt 1: Download from GitHub Releases
-    if _attempt_github_install(editor_command, editor_name):
+    # Attempt 1: Install from bundled .vsix
+    if _attempt_bundled_install(editor_command, editor_name):
         _mark_installation_successful(flag_file, editor_name)
         return  # Success! We are done.
 
-    # Attempt 2: Install from bundled .vsix
-    if _attempt_bundled_install(editor_command, editor_name):
+    # Attempt 2: Download from GitHub Releases
+    if _attempt_github_install(editor_command, editor_name):
         _mark_installation_successful(flag_file, editor_name)
         return  # Success! We are done.
 

--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -107,13 +107,13 @@ def attempt_vscode_extension_install():
         f'INFO: First-time setup: attempting to install the OpenHands {editor_name} extension...'
     )
 
-    # Attempt 1: Download from GitHub Releases (the new primary method)
-    if _attempt_github_install(editor_command, editor_name):
+    # Attempt 1: Install from bundled .vsix
+    if _attempt_bundled_install(editor_command, editor_name):
         _mark_installation_successful(flag_file, editor_name)
         return  # Success! We are done.
 
-    # Attempt 2: Install from bundled .vsix
-    if _attempt_bundled_install(editor_command, editor_name):
+    # Attempt 2: Download from GitHub Releases
+    if _attempt_github_install(editor_command, editor_name):
         _mark_installation_successful(flag_file, editor_name)
         return  # Success! We are done.
 
@@ -267,6 +267,8 @@ def _attempt_bundled_install(editor_command: str, editor_name: str) -> bool:
                     logger.debug(
                         f'Bundled .vsix installation failed: {process.stderr.strip()}'
                     )
+            else:
+                logger.debug(f'Bundled .vsix not found at {vsix_path}.')
     except Exception as e:
         logger.debug(f'Could not locate bundled .vsix: {e}.')
 

--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -107,13 +107,13 @@ def attempt_vscode_extension_install():
         f'INFO: First-time setup: attempting to install the OpenHands {editor_name} extension...'
     )
 
-    # Attempt 1: Install from bundled .vsix
-    if _attempt_bundled_install(editor_command, editor_name):
+    # Attempt 1: Download from GitHub Releases
+    if _attempt_github_install(editor_command, editor_name):
         _mark_installation_successful(flag_file, editor_name)
         return  # Success! We are done.
 
-    # Attempt 2: Download from GitHub Releases
-    if _attempt_github_install(editor_command, editor_name):
+    # Attempt 2: Install from bundled .vsix
+    if _attempt_bundled_install(editor_command, editor_name):
         _mark_installation_successful(flag_file, editor_name)
         return  # Success! We are done.
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Fix order in which we build, since we've settled on auto install from bundled .vsix first.

@mamoodi I didn't actually replicate the skip you saw, but this might help?
```
2025-07-10 19:39 - openhands_aci:DEBUG - Logger initialized
2025-07-10 19:39 - openhands_aci.editor.file_cache:DEBUG - Current size updated: 0
2025-07-10 19:39 - openhands_aci.editor.file_cache:DEBUG - FileCache initialized with directory: /var/folders/15/pyrd6jhs3tnd259qd39xsplm0000gn/T/oh_editor_history_qoyt3egp, size_limit: None, current_size: 0
19:39:45 - openhands:DEBUG: utils.py:257 - Default condenser configuration loaded from config toml and assigned to default agent
19:39:45 - openhands:WARNING: utils.py:324 - DEPRECATED: The WORKSPACE_BASE and WORKSPACE_MOUNT_PATH environment variables are deprecated. Please use RUNTIME_MOUNT instead, e.g. 'RUNTIME_MOUNT=/my/host/dir:/workspace:rw'
19:39:45 - openhands:DEBUG: utils.py:410 - Automatically disabled Jupyter plugin and browsing for all agents because CLIRuntime is selected and does not support IPython execution.
INFO: First-time setup: attempting to install the OpenHands Windsurf extension...
INFO: Bundled Windsurf extension installed successfully.
19:39:45 - openhands:DEBUG: vscode_extension.py:144 - Windsurf extension installation marked as successful.
```

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7c56f12-nikolaik   --name openhands-app-7c56f12   docker.all-hands.dev/all-hands-ai/openhands:7c56f12
```