### PR TITLE
Fix(backend): correctly forward AWS Bedrock aws_access_key_id / aws_secret_access_key / aws_region_name to litellm

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -191,6 +191,17 @@ class LLM(RetryMixin, DebugMixin):
         elif 'gemini' in self.config.model.lower() and self.config.safety_settings:
             kwargs['safety_settings'] = self.config.safety_settings
 
+        # support AWS Bedrock provider
+        kwargs['aws_region_name'] = self.config.aws_region_name
+        if self.config.aws_access_key_id:
+            kwargs['aws_access_key_id'] = (
+                self.config.aws_access_key_id.get_secret_value()
+            )
+        if self.config.aws_secret_access_key:
+            kwargs['aws_secret_access_key'] = (
+                self.config.aws_secret_access_key.get_secret_value()
+            )
+
         self._completion = partial(
             litellm_completion,
             model=self.config.model,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Small bug-fix—credentials in config were not reaching litellm; now injected before each Bedrock call and verified locally.
---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
