### PR TITLE
Fix UI regression: prevent action titles from getting cut off

### DIFF
--- a/frontend/src/components/features/chat/expandable-message.tsx
+++ b/frontend/src/components/features/chat/expandable-message.tsx
@@ -135,7 +135,7 @@ export function ExpandableMessage({
         <div className="flex flex-row justify-between items-center w-full">
           <span
             className={cn(
-              "font-bold",
+              "font-bold flex-1 min-w-0 break-words",
               type === "error" ? "text-danger" : "text-neutral-300",
             )}
           >

--- a/frontend/src/components/features/chat/generic-event-message.tsx
+++ b/frontend/src/components/features/chat/generic-event-message.tsx
@@ -24,7 +24,7 @@ export function GenericEventMessage({
   return (
     <div className="flex flex-col gap-2 border-l-2 pl-2 my-2 py-2 border-neutral-300 text-sm w-full">
       <div className="flex items-center justify-between font-bold text-neutral-300">
-        <div>
+        <div className="flex-1 min-w-0 break-words">
           {title}
           {details && (
             <button


### PR DESCRIPTION
## Problem
Action titles in the chat interface were getting cut off when they contained long commands or file paths. This was particularly noticeable with:
- Long npm install commands with multiple packages  
- Long file paths in read/write operations
- Any action with lengthy text content

## Root Cause
The issue was in the flex layout of action title containers in two components:
1. `GenericEventMessage` component
2. `ExpandableMessage` component

Both components used `justify-between` flex layout but didn't properly handle text wrapping for long content.

## Solution
Added CSS classes to the title containers in both components:
- `flex-1`: Allows the title to take up available space
- `min-w-0`: Allows flex item to shrink below its content size  
- `break-words`: Enables word breaking for long text

## Result
- ✅ Long commands now wrap properly instead of being cut off
- ✅ Long file paths display completely with proper line breaks
- ✅ Success indicators remain visible on the right side
- ✅ Text breaks at word boundaries for better readability
- ✅ No impact on existing functionality or layout

## Testing
- All existing frontend tests pass
- Manual testing confirmed the fix works for various long text scenarios
- Pre-commit hooks and linting pass successfully

## Files Changed
- `frontend/src/components/features/chat/generic-event-message.tsx`
- `frontend/src/components/features/chat/expandable-message.tsx`

Only 2 lines changed total - minimal, targeted fix.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/03d4fedc8eb9405a88711380ded95bd3)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8d0e292-nikolaik   --name openhands-app-8d0e292   docker.all-hands.dev/all-hands-ai/openhands:8d0e292
```