### PR TITLE
hotfix(ui): Agent message that includes codeblocks overflows

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -85,21 +85,19 @@ export function ChatMessage({
         />
       </div>
 
-      <div className="text-sm break-words flex">
-        <div>
-          <Markdown
-            components={{
-              code,
-              ul,
-              ol,
-              a: anchor,
-              p: paragraph,
-            }}
-            remarkPlugins={[remarkGfm]}
-          >
-            {message}
-          </Markdown>
-        </div>
+      <div className="text-sm break-words">
+        <Markdown
+          components={{
+            code,
+            ul,
+            ol,
+            a: anchor,
+            p: paragraph,
+          }}
+          remarkPlugins={[remarkGfm]}
+        >
+          {message}
+        </Markdown>
       </div>
       {children}
     </article>

--- a/frontend/src/components/features/chat/event-message.tsx
+++ b/frontend/src/components/features/chat/event-message.tsx
@@ -164,7 +164,7 @@ export function EventMessage({
     const message = parseMessageFromEvent(event);
 
     return (
-      <div className="flex flex-col self-end">
+      <>
         <ChatMessage type={event.source} message={message} actions={actions}>
           {event.args.image_urls && event.args.image_urls.length > 0 && (
             <ImageCarousel size="small" images={event.args.image_urls} />
@@ -184,7 +184,7 @@ export function EventMessage({
         {isAssistantMessage(event) &&
           event.action === "message" &&
           renderLikertScale()}
-      </div>
+      </>
     );
   }
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Agent markdown messages that included  code blocks would overflow:
<img width="360" height="287" alt="image" src="https://github.com/user-attachments/assets/dfd03a56-8dfd-4e09-b6d9-167682039eb3" />


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
<img width="532" height="405" alt="image" src="https://github.com/user-attachments/assets/0ebf6c6c-7845-429e-adea-e85889d23fb7" />

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ebefafe-nikolaik   --name openhands-app-ebefafe   docker.all-hands.dev/all-hands-ai/openhands:ebefafe
```