### PR TITLE
Log vscode error in a visible way

### DIFF
--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -271,7 +271,7 @@ def _attempt_bundled_install(editor_command: str, editor_name: str) -> bool:
                 logger.debug(f'Bundled .vsix not found at {vsix_path}.')
     except Exception as e:
         logger.warning(
-            f'Could not auto-install extension. Please make sure "code" command is in PATH. Error: {e}.'
+            f'Could not auto-install extension. Please make sure "code" command is in PATH. Error: {e}'
         )
 
     return False

--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -270,7 +270,9 @@ def _attempt_bundled_install(editor_command: str, editor_name: str) -> bool:
             else:
                 logger.debug(f'Bundled .vsix not found at {vsix_path}.')
     except Exception as e:
-        logger.warning(f'Could not auto-install extension. Please make sure "code" command is in PATH. Error: {e}.')
+        logger.warning(
+            f'Could not auto-install extension. Please make sure "code" command is in PATH. Error: {e}.'
+        )
 
     return False
 

--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -270,7 +270,7 @@ def _attempt_bundled_install(editor_command: str, editor_name: str) -> bool:
             else:
                 logger.debug(f'Bundled .vsix not found at {vsix_path}.')
     except Exception as e:
-        logger.warning(f'Could not auto-install extension: {e}.')
+        logger.warning(f'Could not auto-install extension. Please make sure "code" command is in PATH. Error: {e}.')
 
     return False
 

--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -270,7 +270,7 @@ def _attempt_bundled_install(editor_command: str, editor_name: str) -> bool:
             else:
                 logger.debug(f'Bundled .vsix not found at {vsix_path}.')
     except Exception as e:
-        logger.debug(f'Could not locate bundled .vsix: {e}.')
+        logger.warning(f'Could not auto-install extension: {e}.')
 
     return False
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Make sure the error on 'code' not available in PATH will be visible in the log (for people to know, and for us to see it if reported)

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:91053dd-nikolaik   --name openhands-app-91053dd   docker.all-hands.dev/all-hands-ai/openhands:91053dd
```