### PR TITLE
Update llm constants to match on unpinned `claude-sonnet-4`

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -59,6 +59,7 @@ CACHE_PROMPT_SUPPORTED_MODELS = [
     'claude-3-haiku-20240307',
     'claude-3-opus-20240229',
     'claude-sonnet-4-20250514',
+    'claude-sonnet-4',
     'claude-opus-4-20250514',
 ]
 
@@ -72,6 +73,7 @@ FUNCTION_CALLING_SUPPORTED_MODELS = [
     'claude-3.5-haiku',
     'claude-3-5-haiku-20241022',
     'claude-sonnet-4-20250514',
+    'claude-sonnet-4',
     'claude-opus-4-20250514',
     'gpt-4o-mini',
     'gpt-4o',


### PR DESCRIPTION
We were matching only on the full pinned version but some providers (like anthropic) do not offer the pinned model name.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Match both the pinned and unpinned claude sonnet 4 model name.

---
**Link of any specific issues this addresses:**
