### PR TITLE
Add CLI argument for LLM timeout configuration

### DIFF
--- a/docs/usage/configuration-options.mdx
+++ b/docs/usage/configuration-options.mdx
@@ -259,9 +259,9 @@ For development setups, you can also define custom named LLM configurations. See
   - Description: Temperature for the API
 
 - `timeout`
-  - Type: `int`
-  - Default: `0`
-  - Description: Timeout for the API
+  - Type: `int | None`
+  - Default: `None`
+  - Description: Timeout for the LLM API in seconds. If None, uses the provider's default timeout. Can also be set via CLI argument `--llm-timeout`.
 
 - `top_p`
   - Type: `float`

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -765,6 +765,12 @@ def get_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
     )
+    parser.add_argument(
+        '--llm-timeout',
+        help='Set the LLM timeout in seconds (default: None, uses provider default)',
+        type=int,
+        default=None,
+    )
     return parser
 
 
@@ -851,6 +857,12 @@ def setup_config_from_args(args: argparse.Namespace) -> OpenHandsConfig:
         config.max_iterations = args.max_iterations
     if args.max_budget_per_task is not None:
         config.max_budget_per_task = args.max_budget_per_task
+
+    # Set LLM timeout if provided
+    if args.llm_timeout is not None:
+        llm_config = config.get_llm_config()
+        llm_config.timeout = args.llm_timeout
+        config.set_llm_config(llm_config)
 
     # Read selected repository in config for use by CLI and main.py
     if args.selected_repo is not None:


### PR DESCRIPTION
## Summary

This PR adds CLI support for configuring LLM timeout and fixes documentation issues related to the timeout field.

## Changes

1. **Add CLI argument**: Added `--llm-timeout` CLI argument to set LLM timeout in seconds
2. **Fix documentation**: Corrected the timeout field documentation:
   - Fixed default value from `0` to `None`
   - Fixed type from `int` to `int | None`
   - Added mention of CLI argument availability
3. **Implementation**: Added proper mapping from CLI argument to LLM configuration

## Usage

```bash
# Set LLM timeout to 30 seconds via CLI
python -m openhands.core.main --llm-timeout 30 "Your task here"

# Or via environment variable (existing functionality)
export LLM_TIMEOUT=30
python -m openhands.core.main "Your task here"

# Or via config.toml (existing functionality)
[llm]
timeout = 30
```

## Testing

- [x] CLI argument appears in help output
- [x] Pre-commit hooks pass
- [x] mypy type checking passes

## Related Issues

This addresses the need for easier LLM timeout configuration via CLI, which is particularly useful for users who want to adjust timeout settings without modifying configuration files.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f1d46a206c4142e49ca335ad83ad0c44)