### PR TITLE
refactor: make /events endpoint lightweight without requiring active conversation

### DIFF
--- a/openhands/server/utils.py
+++ b/openhands/server/utils.py
@@ -3,9 +3,14 @@ import uuid
 from fastapi import Depends, HTTPException, Request, status
 
 from openhands.core.logger import openhands_logger as logger
-from openhands.server.shared import ConversationStoreImpl, config, conversation_manager
+from openhands.server.shared import (
+    ConversationStoreImpl,
+    config,
+    conversation_manager,
+)
 from openhands.server.user_auth import get_user_id
 from openhands.storage.conversation.conversation_store import ConversationStore
+from openhands.storage.data_models.conversation_metadata import ConversationMetadata
 
 
 async def get_conversation_store(request: Request) -> ConversationStore | None:
@@ -27,6 +32,47 @@ async def generate_unique_conversation_id(
     while await conversation_store.exists(conversation_id):
         conversation_id = uuid.uuid4().hex
     return conversation_id
+
+
+async def get_conversation_metadata(
+    conversation_id: str, user_id: str | None = Depends(get_user_id)
+) -> ConversationMetadata:
+    """Get conversation metadata and validate user access without requiring an active conversation."""
+    conversation_store = await ConversationStoreImpl.get_instance(config, user_id)
+
+    # Check if conversation exists
+    if not await conversation_store.exists(conversation_id):
+        logger.warning(
+            f'get_conversation_metadata: conversation {conversation_id} not found',
+            extra={'session_id': conversation_id, 'user_id': user_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Conversation {conversation_id} not found',
+        )
+
+    # Get metadata and validate user access
+    try:
+        metadata = await conversation_store.get_metadata(conversation_id)
+        if not await conversation_store.validate_metadata(conversation_id, user_id):
+            logger.warning(
+                f'get_conversation_metadata: user {user_id} does not have access to conversation {conversation_id}',
+                extra={'session_id': conversation_id, 'user_id': user_id},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f'Access denied to conversation {conversation_id}',
+            )
+        return metadata
+    except Exception as e:
+        logger.error(
+            f'get_conversation_metadata: error getting metadata for conversation {conversation_id}: {e}',
+            extra={'session_id': conversation_id, 'user_id': user_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f'Error accessing conversation {conversation_id}',
+        )
 
 
 async def get_conversation(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Improves the performance of the `/events` endpoint by making it more lightweight. The endpoint now accesses conversation events without requiring a full active conversation with runtime, while maintaining all existing security and functionality.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR refactors the `/events` endpoint (`search_events`) in `conversation.py` to not require an active conversation in order to run. 

**Key Changes:**

1. **New dependency function**: Added `get_conversation_metadata()` in `utils.py` that:
   - Gets conversation metadata and validates user access without requiring an active conversation
   - Uses `ConversationStore` to check existence and validate user permissions
   - Returns appropriate HTTP errors (404 for not found, 403 for access denied)

2. **Modified `/events` endpoint**: 
   - **Before**: Depended on `ServerConversation` via `get_conversation` dependency (requires full conversation with runtime, event stream, etc.)
   - **After**: Uses `get_conversation_metadata` dependency and creates `EventStore` directly
   - Creates `EventStore` with just `sid`, `file_store`, and `user_id`
   - Maintains all existing functionality (filtering, pagination, reverse ordering, limit validation)

**Design Decisions:**
- Used the same `EventStore.search_events()` method that was previously accessed through `conversation.event_stream.search_events()`
- Preserved all existing API parameters and response format for backward compatibility
- Maintained proper user access validation through conversation metadata validation
- Kept the same error handling and HTTP status codes

**Benefits:**
- **Performance**: More lightweight since it doesn't need to create/attach to a full conversation with runtime
- **Security**: Still maintains proper user access validation
- **Functionality**: Preserves all existing features including event filtering and pagination

---
**Link of any specific issues this addresses:**

This addresses the requirement to make the `/events` endpoint not require an active conversation while maintaining user access validation and all existing functionality.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/da84858222a249b1a29eda7c23d110ea)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:812d81c-nikolaik   --name openhands-app-812d81c   docker.all-hands.dev/all-hands-ai/openhands:812d81c
```