### PR TITLE
Introduced config field to determine whether to init a git repo

### DIFF
--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -89,6 +89,7 @@ class OpenHandsConfig(BaseModel):
     run_as_openhands: bool = Field(default=True)
     max_iterations: int = Field(default=OH_MAX_ITERATIONS)
     max_budget_per_task: float | None = Field(default=None)
+    always_init_git: bool = Field(default=False)
 
     disable_color: bool = Field(default=False)
     jwt_secret: SecretStr | None = Field(default=None)

--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -89,7 +89,7 @@ class OpenHandsConfig(BaseModel):
     run_as_openhands: bool = Field(default=True)
     max_iterations: int = Field(default=OH_MAX_ITERATIONS)
     max_budget_per_task: float | None = Field(default=None)
-    always_init_git: bool = Field(default=False)
+    init_git_in_empty_workspace: bool = Field(default=False)
 
     disable_color: bool = Field(default=False)
     jwt_secret: SecretStr | None = Field(default=None)

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -367,7 +367,7 @@ class Runtime(FileEditRuntimeMixin):
         selected_branch: str | None,
     ) -> str:
         if not selected_repository:
-            if self.config.always_init_git:
+            if self.config.init_git_in_empty_workspace:
                 logger.debug(
                     'No repository selected. Initializing a new git repository in the workspace.'
                 )

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -367,9 +367,7 @@ class Runtime(FileEditRuntimeMixin):
         selected_branch: str | None,
     ) -> str:
         if not selected_repository:
-            # In SaaS mode (indicated by user_id being set), always run git init
-            # In OSS mode, only run git init if workspace_base is not set
-            if self.user_id or not self.config.workspace_base:
+            if self.config.always_init_git:
                 logger.debug(
                     'No repository selected. Initializing a new git repository in the workspace.'
                 )
@@ -1062,7 +1060,8 @@ fi
 
     def get_git_changes(self, cwd: str) -> list[dict[str, str]] | None:
         self.git_handler.set_cwd(cwd)
-        return self.git_handler.get_git_changes()
+        changes = self.git_handler.get_git_changes()
+        return changes
 
     def get_git_diff(self, file_path: str, cwd: str) -> dict[str, str]:
         self.git_handler.set_cwd(cwd)

--- a/tests/unit/test_runtime_git_tokens.py
+++ b/tests/unit/test_runtime_git_tokens.py
@@ -219,10 +219,10 @@ async def test_export_latest_git_provider_tokens_token_update(runtime):
 
 
 @pytest.mark.asyncio
-async def test_clone_or_init_repo_no_repo_always_init_git(temp_dir):
-    """Test that git init is run when no repository is selected and always_init_git"""
+async def test_clone_or_init_repo_no_repo_init_git_in_empty_workspace(temp_dir):
+    """Test that git init is run when no repository is selected and init_git_in_empty_workspace"""
     config = OpenHandsConfig()
-    config.always_init_git = True
+    config.init_git_in_empty_workspace = True
     file_store = get_file_store('local', temp_dir)
     event_stream = EventStream('abc', file_store)
     runtime = TestRuntime(

--- a/tests/unit/test_runtime_git_tokens.py
+++ b/tests/unit/test_runtime_git_tokens.py
@@ -219,33 +219,10 @@ async def test_export_latest_git_provider_tokens_token_update(runtime):
 
 
 @pytest.mark.asyncio
-async def test_clone_or_init_repo_no_repo_with_user_id(temp_dir):
-    """Test that git init is run when no repository is selected and user_id is set"""
+async def test_clone_or_init_repo_no_repo_always_init_git(temp_dir):
+    """Test that git init is run when no repository is selected and always_init_git"""
     config = OpenHandsConfig()
-    file_store = get_file_store('local', temp_dir)
-    event_stream = EventStream('abc', file_store)
-    runtime = TestRuntime(
-        config=config, event_stream=event_stream, sid='test', user_id='test_user'
-    )
-
-    # Call the function with no repository
-    result = await runtime.clone_or_init_repo(None, None, None)
-
-    # Verify that git init was called
-    assert len(runtime.run_action_calls) == 1
-    assert isinstance(runtime.run_action_calls[0], CmdRunAction)
-    assert (
-        runtime.run_action_calls[0].command
-        == f'git init && git config --global --add safe.directory {runtime.workspace_root}'
-    )
-    assert result == ''
-
-
-@pytest.mark.asyncio
-async def test_clone_or_init_repo_no_repo_no_user_id_no_workspace_base(temp_dir):
-    """Test that git init is run when no repository is selected, no user_id, and no workspace_base"""
-    config = OpenHandsConfig()
-    config.workspace_base = None  # Ensure workspace_base is not set
+    config.always_init_git = True
     file_store = get_file_store('local', temp_dir)
     event_stream = EventStream('abc', file_store)
     runtime = TestRuntime(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Introduced config field to determine whether to init a git repo

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
The logic here was weird - trying to figure out whether we are in SAAS mode indirectly and then base the decision of whether to initialize a git repository on that. Let's just make this an config field

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:46380c8-nikolaik   --name openhands-app-46380c8   docker.all-hands.dev/all-hands-ai/openhands:46380c8
```