### PR TITLE
Fix VSCode extension installation in remote environments

### DIFF
--- a/openhands/cli/vscode_extension.py
+++ b/openhands/cli/vscode_extension.py
@@ -71,6 +71,34 @@ def attempt_vscode_extension_install():
             if isinstance(val, str)
         )
     )
+
+    # Skip installation if we're in a VSCode remote terminal
+    # When running in a VSCode terminal on a remote machine via VSCode Remote:
+    # - TERM_PROGRAM might be 'tmux' or something else, not 'vscode'
+    # - OPENVSCODE_SERVER_ROOT might be set, indicating we're in a remote VSCode server
+    # - VSCODE_PORT might be set, indicating we're in a remote VSCode server
+    # - We might be in a container or remote environment where extension installation doesn't make sense
+    #
+    # Detection logic:
+    # 1. If OPENVSCODE_SERVER_ROOT is set, we're definitely in a remote VSCode server
+    # 2. If TERM_PROGRAM is 'vscode' AND VSCODE_PORT is set, we're likely in a remote VSCode terminal
+    #    (local VSCode doesn't typically set VSCODE_PORT in the terminal environment)
+    is_remote_vscode = os.environ.get('OPENVSCODE_SERVER_ROOT') is not None or (
+        is_vscode_like and os.environ.get('VSCODE_PORT') is not None
+    )
+
+    if is_remote_vscode:
+        logger.debug(
+            'Detected VSCode remote environment. Skipping extension installation.'
+        )
+        print(
+            'INFO: VSCode remote environment detected. Extension installation is skipped when running in a remote terminal.'
+        )
+        print(
+            'INFO: To install the OpenHands extension, please use the Extensions view in your local VSCode instance.'
+        )
+        return
+
     if not (is_vscode_like or is_windsurf):
         return
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the automatic VSCode extension installation doesn't work when launching the CLI inside a VSCode terminal on a remote machine (via VSCode Remote).

## Changes

- Added detection logic to identify when OpenHands is running in a VSCode remote environment
- Skip the extension installation when running in a remote environment
- Added user-friendly messages explaining why the installation is skipped and how to install the extension manually

## Testing

Tested by checking environment variables in a VSCode remote environment and verifying the detection logic.

## Related Issues

Fixes the issue where automatic VSCode extension installation doesn't work in remote environments.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/de59dcd21d674fa0832305d3f371f8ce)