### PR TITLE
Fix dictionary changed size during iteration error in override_provider_tokens_with_custom_secret

### DIFF
--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -290,12 +290,16 @@ class AgentSession:
         custom_secrets: CUSTOM_SECRETS_TYPE | None,
     ):
         if git_provider_tokens and custom_secrets:
-            tokens = dict(git_provider_tokens)
-            for provider, _ in tokens.items():
-                token_name = ProviderHandler.get_provider_env_key(provider)
-                if token_name in custom_secrets or token_name.upper() in custom_secrets:
-                    del tokens[provider]
-
+            # Use dictionary comprehension to avoid modifying dictionary during iteration
+            tokens = {
+                provider: token
+                for provider, token in git_provider_tokens.items()
+                if not (
+                    ProviderHandler.get_provider_env_key(provider) in custom_secrets
+                    or ProviderHandler.get_provider_env_key(provider).upper()
+                    in custom_secrets
+                )
+            }
             return MappingProxyType(tokens)
         return git_provider_tokens
 

--- a/tests/unit/test_agent_session.py
+++ b/tests/unit/test_agent_session.py
@@ -8,6 +8,7 @@ from openhands.controller.state.state import State
 from openhands.core.config import LLMConfig, OpenHandsConfig
 from openhands.core.config.agent_config import AgentConfig
 from openhands.events import EventStream, EventStreamSubscriber
+from openhands.integrations.service_types import ProviderType
 from openhands.llm import LLM
 from openhands.llm.metrics import Metrics
 from openhands.memory.memory import Memory
@@ -402,3 +403,110 @@ async def test_budget_control_flag_syncs_with_metrics(mock_agent):
 
         # Budget control flag should still reflect the accumulated cost after reset
         assert session.controller.state.budget_flag.current_value == test_cost + 0.1
+
+
+def test_override_provider_tokens_with_custom_secret():
+    """Test that override_provider_tokens_with_custom_secret works correctly.
+
+    This test verifies that the method properly removes provider tokens when
+    corresponding custom secrets exist, without causing dictionary iteration errors.
+    """
+    # Setup
+    file_store = InMemoryFileStore({})
+    session = AgentSession(
+        sid='test-session',
+        file_store=file_store,
+    )
+
+    # Create test data
+    git_provider_tokens = {
+        ProviderType.GITHUB: 'github_token_123',
+        ProviderType.GITLAB: 'gitlab_token_456',
+        ProviderType.BITBUCKET: 'bitbucket_token_789',
+    }
+
+    # Custom secrets that will cause some providers to be removed
+    # The get_provider_env_key method returns lowercase, but the method also checks uppercase
+    custom_secrets = {
+        'github_token': 'custom_github_token',
+        'gitlab_token': 'custom_gitlab_token',
+    }
+
+    # This should work without raising any errors
+    result = session.override_provider_tokens_with_custom_secret(
+        git_provider_tokens, custom_secrets
+    )
+
+    # Verify that GitHub and GitLab tokens were removed (they have custom secrets)
+    assert ProviderType.GITHUB not in result
+    assert ProviderType.GITLAB not in result
+
+    # Verify that Bitbucket token remains (no custom secret for it)
+    assert ProviderType.BITBUCKET in result
+    assert result[ProviderType.BITBUCKET] == 'bitbucket_token_789'
+
+
+def test_override_provider_tokens_with_custom_secret_uppercase():
+    """Test that the method works with uppercase custom secret keys."""
+    # Setup
+    file_store = InMemoryFileStore({})
+    session = AgentSession(
+        sid='test-session',
+        file_store=file_store,
+    )
+
+    # Create test data
+    git_provider_tokens = {
+        ProviderType.GITHUB: 'github_token_123',
+        ProviderType.GITLAB: 'gitlab_token_456',
+    }
+
+    # Custom secrets with uppercase keys
+    custom_secrets = {
+        'GITHUB_TOKEN': 'custom_github_token',
+    }
+
+    result = session.override_provider_tokens_with_custom_secret(
+        git_provider_tokens, custom_secrets
+    )
+
+    # Verify that GitHub token was removed (uppercase custom secret)
+    assert ProviderType.GITHUB not in result
+
+    # Verify that GitLab token remains (no custom secret for it)
+    assert ProviderType.GITLAB in result
+    assert result[ProviderType.GITLAB] == 'gitlab_token_456'
+
+
+def test_override_provider_tokens_with_custom_secret_edge_cases():
+    """Test edge cases for override_provider_tokens_with_custom_secret."""
+    # Setup
+    file_store = InMemoryFileStore({})
+    session = AgentSession(
+        sid='test-session',
+        file_store=file_store,
+    )
+
+    # Test with None inputs
+    result = session.override_provider_tokens_with_custom_secret(None, None)
+    assert result is None
+
+    # Test with empty provider tokens
+    result = session.override_provider_tokens_with_custom_secret(
+        {}, {'github_token': 'token'}
+    )
+    assert result == {}
+
+    # Test with empty custom secrets
+    git_provider_tokens = {ProviderType.GITHUB: 'github_token_123'}
+    result = session.override_provider_tokens_with_custom_secret(
+        git_provider_tokens, {}
+    )
+    assert result == git_provider_tokens
+
+    # Test with no matching custom secrets
+    custom_secrets = {'other_token': 'value'}
+    result = session.override_provider_tokens_with_custom_secret(
+        git_provider_tokens, custom_secrets
+    )
+    assert result == git_provider_tokens


### PR DESCRIPTION
## Problem

The `override_provider_tokens_with_custom_secret` method in `AgentSession` was causing a `RuntimeError: dictionary changed size during iteration` when custom secrets matched provider tokens. This occurred because the code was modifying a dictionary while iterating over it.

**Error location**: `/app/openhands/server/session/agent_session.py` line 294-297

**Root cause**: The method iterates over `tokens.items()` but deletes from the same dictionary inside the loop:
```python
for provider, _ in tokens.items():  # Line 294 - iterating over dictionary
    token_name = ProviderHandler.get_provider_env_key(provider)
    if token_name in custom_secrets or token_name.upper() in custom_secrets:
        del tokens[provider]  # Line 297 - modifying dictionary during iteration
```

**Bug introduced in**: Commit `890796cc9d94aa4d19e51784d869b5a9ef4cd447` by Rohit Malhotra in PR #8348

## Solution

Replace the dictionary modification during iteration with a dictionary comprehension that creates a new dictionary containing only the providers that don't have corresponding custom secrets:

```python
tokens = {
    provider: token
    for provider, token in git_provider_tokens.items()
    if not (
        ProviderHandler.get_provider_env_key(provider) in custom_secrets
        or ProviderHandler.get_provider_env_key(provider).upper() in custom_secrets
    )
}
```

## Changes

- **Fixed the bug**: Replaced dictionary modification during iteration with dictionary comprehension
- **Added comprehensive tests**: Created tests for the method including:
  - Basic functionality test
  - Uppercase custom secret keys test  
  - Edge cases (None inputs, empty dictionaries, no matches)
- **Maintained functionality**: The method still correctly removes provider tokens when corresponding custom secrets exist

## Testing

All new tests pass and existing tests continue to work:
- `test_override_provider_tokens_with_custom_secret` - Tests basic functionality
- `test_override_provider_tokens_with_custom_secret_uppercase` - Tests uppercase keys
- `test_override_provider_tokens_with_custom_secret_edge_cases` - Tests edge cases

The fix resolves the runtime error while preserving the intended behavior of prioritizing custom secrets over provider tokens.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/23625978a8944d58842d5c96c16bd2bd)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ef65786-nikolaik   --name openhands-app-ef65786   docker.all-hands.dev/all-hands-ai/openhands:ef65786
```