### PR TITLE
Fix newline display in frontend UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
         "react-router": "^7.6.3",
         "react-syntax-highlighter": "^15.6.1",
         "react-textarea-autosize": "^8.5.9",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sirv-cli": "^3.0.1",
         "socket.io-client": "^4.8.1",
@@ -12592,6 +12593,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -15052,6 +15067,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "react-router": "^7.6.3",
     "react-syntax-highlighter": "^15.6.1",
     "react-textarea-autosize": "^8.5.9",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sirv-cli": "^3.0.1",
     "socket.io-client": "^4.8.1",

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.10.2'
+const PACKAGE_VERSION = '2.10.3'
 const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import { code } from "../markdown/code";
 import { cn } from "#/utils/utils";
 import { ul, ol } from "../markdown/list";
@@ -94,7 +95,7 @@ export function ChatMessage({
             a: anchor,
             p: paragraph,
           }}
-          remarkPlugins={[remarkGfm]}
+          remarkPlugins={[remarkGfm, remarkBreaks]}
         >
           {message}
         </Markdown>

--- a/frontend/src/components/features/chat/error-message.tsx
+++ b/frontend/src/components/features/chat/error-message.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import { useTranslation } from "react-i18next";
 import { code } from "../markdown/code";
 import { ol, ul } from "../markdown/list";
@@ -46,7 +47,7 @@ export function ErrorMessage({ errorId, defaultMessage }: ErrorMessageProps) {
             ul,
             ol,
           }}
-          remarkPlugins={[remarkGfm]}
+          remarkPlugins={[remarkGfm, remarkBreaks]}
         >
           {defaultMessage}
         </Markdown>

--- a/frontend/src/components/features/chat/expandable-message.tsx
+++ b/frontend/src/components/features/chat/expandable-message.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
 import { Link } from "react-router";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import { useConfig } from "#/hooks/query/use-config";
 import { I18nKey } from "#/i18n/declaration";
 import ArrowDown from "#/icons/angle-down-solid.svg?react";
@@ -199,7 +200,7 @@ export function ExpandableMessage({
                 ol,
                 p: paragraph,
               }}
-              remarkPlugins={[remarkGfm]}
+              remarkPlugins={[remarkGfm, remarkBreaks]}
             >
               {details}
             </Markdown>

--- a/frontend/src/components/features/chat/generic-event-message.tsx
+++ b/frontend/src/components/features/chat/generic-event-message.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import { code } from "../markdown/code";
 import { ol, ul } from "../markdown/list";
 import ArrowDown from "#/icons/angle-down-solid.svg?react";
@@ -52,7 +53,7 @@ export function GenericEventMessage({
               ul,
               ol,
             }}
-            remarkPlugins={[remarkGfm]}
+            remarkPlugins={[remarkGfm, remarkBreaks]}
           >
             {details}
           </Markdown>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where single newlines (`\n`) in chat messages and other text content were not being displayed properly in the frontend UI. Previously, single newlines would be collapsed into spaces, making multi-line text difficult to read. Now single newlines are preserved as line breaks while double newlines continue to work as paragraph breaks, improving text readability throughout the application.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes the newline display issue by adding the `remark-breaks` plugin to all markdown rendering components in the frontend. The plugin converts single newlines (`\n`) into HTML line breaks (`<br>`) while preserving the existing behavior for double newlines (`\n\n`) as paragraph breaks.

**Changes made:**
- Added `remark-breaks` dependency to package.json
- Updated 4 chat components to include the `remark-breaks` plugin:
  - `ChatMessage` - main chat messages
  - `GenericEventMessage` - event details
  - `ExpandableMessage` - expandable content
  - `ErrorMessage` - error details

**Design decisions:**
- Used `remark-breaks` plugin instead of custom text processing to maintain consistency with existing markdown rendering
- Applied the fix to all components that use `react-markdown` with `remarkPlugins` to ensure consistent behavior
- Maintained backward compatibility - double newlines continue to work as paragraph breaks


Screenshot confirms this fix the issue:
<img width="573" height="771" alt="image" src="https://github.com/user-attachments/assets/54eee13a-61a3-4959-945b-266fbb907dbb" />


---
**Link of any specific issues this addresses:**

This addresses a user-reported issue where single newlines in chat messages were not being displayed properly in the frontend UI, causing poor text readability.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3409c79d7bbb42d796c20263ffd3c820)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:01e35c0-nikolaik   --name openhands-app-01e35c0   docker.all-hands.dev/all-hands-ai/openhands:01e35c0
```