### PR TITLE
Fix type hint: add | None to first element of create_default_mcp_server_config return tuple

### DIFF
--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -190,7 +190,7 @@ class OpenHandsMCPConfig:
     @staticmethod
     def create_default_mcp_server_config(
         host: str, config: 'OpenHandsConfig', user_id: str | None = None
-    ) -> tuple[MCPSHTTPServerConfig, list[MCPStdioServerConfig]]:
+    ) -> tuple[MCPSHTTPServerConfig | None, list[MCPStdioServerConfig]]:
         """
         Create a default MCP server configuration.
 
@@ -198,7 +198,7 @@ class OpenHandsMCPConfig:
             host: Host string
             config: OpenHandsConfig
         Returns:
-            tuple[MCPSSEServerConfig, list[MCPStdioServerConfig]]: A tuple containing the default SSE server configuration and a list of MCP stdio server configurations
+            tuple[MCPSHTTPServerConfig | None, list[MCPStdioServerConfig]]: A tuple containing the default SHTTP server configuration (or None) and a list of MCP stdio server configurations
         """
         stdio_servers = []
         search_engine_stdio_server = OpenHandsMCPConfig.add_search_engine(config)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This is a type hint improvement that makes the code more type-safe by accurately reflecting that the first element of the tuple returned by `create_default_mcp_server_config` can be `None`. This change improves developer experience with better IDE support and type checking.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR updates the type annotation for the `create_default_mcp_server_config` method in `openhands/core/config/mcp_config.py`:

1. **Updated return type annotation**: Changed from `tuple[MCPSHTTPServerConfig, list[MCPStdioServerConfig]]` to `tuple[MCPSHTTPServerConfig | None, list[MCPStdioServerConfig]]`

2. **Fixed docstring**: Updated the return type documentation to reflect the correct class name (`MCPSHTTPServerConfig` instead of `MCPSSEServerConfig`) and added the `| None` annotation

**Design rationale**: The existing code in `session.py` already checks `if openhands_mcp_server:` before using the first element of the tuple, indicating that it can indeed be `None`. This type hint change makes the annotation accurate and improves type safety without changing any logic.

**No functional changes**: This is purely a type annotation improvement - no runtime behavior is modified.

---
**Link of any specific issues this addresses:**

N/A - This is a type hint improvement requested for better code quality and type safety.

@raymyers can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ae3bf0486f4741d6a29ab241173da7cb)