### PR TITLE
Add kimi-k2-0711-preview model to OpenHands provider

### DIFF
--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -20,6 +20,7 @@ export const VERIFIED_MODELS = [
   "devstral-small-2505",
   "devstral-small-2507",
   "devstral-medium-2507",
+  "kimi-k2-0711-preview",
 ];
 
 // LiteLLM does not return OpenAI models with the provider, so we list them here to set them ourselves for consistency
@@ -66,6 +67,7 @@ export const VERIFIED_OPENHANDS_MODELS = [
   "devstral-small-2507",
   "devstral-medium-2507",
   "devstral-small-2505",
+  "kimi-k2-0711-preview",
 ];
 
 // Default model for OpenHands provider

--- a/openhands/cli/utils.py
+++ b/openhands/cli/utils.py
@@ -189,6 +189,7 @@ VERIFIED_OPENHANDS_MODELS = [
     'o3',
     'o4-mini',
     'gemini-2.5-pro',
+    'kimi-k2-0711-preview',
 ]
 
 

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -63,6 +63,7 @@ def get_supported_llm_models(config: OpenHandsConfig) -> list[str]:
         'openhands/devstral-small-2505',
         'openhands/devstral-small-2507',
         'openhands/devstral-medium-2507',
+        'openhands/kimi-k2-0711-preview',
     ]
     model_list = openhands_models + model_list
 


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR adds support for the new kimi-k2-0711-preview model to the OpenHands provider, allowing users to access this model through the OpenHands interface.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds the kimi-k2-0711-preview model to the following locations:
1. Added to VERIFIED_MODELS array in frontend/src/utils/verified-models.ts
2. Added to VERIFIED_OPENHANDS_MODELS array in frontend/src/utils/verified-models.ts
3. Added to VERIFIED_OPENHANDS_MODELS array in openhands/cli/utils.py
4. Added to openhands_models list in openhands/utils/llm.py

The model was already included in the FUNCTION_CALLING_SUPPORTED_MODELS list in openhands/llm/llm.py, so no changes were needed there.


**UI**
<img width="593" height="352" alt="image" src="https://github.com/user-attachments/assets/39ad443b-6170-4dae-a36a-cc5a8d50511c" />
<img width="837" height="579" alt="image" src="https://github.com/user-attachments/assets/30aef442-57b7-4cea-b28f-e96f0ba342a1" />


**CLI**
<img width="1098" height="664" alt="image" src="https://github.com/user-attachments/assets/459ee2e5-d9a4-4c9b-91b4-6e8f45a8d8f4" />
<img width="1653" height="398" alt="image" src="https://github.com/user-attachments/assets/c43028d1-bf0a-400e-b6cb-31db2a4b7665" />


---
**Link of any specific issues this addresses:**

N/A

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3f5e3c956c314a0eb61b5c2f95736867)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a4ffad6-nikolaik   --name openhands-app-a4ffad6   docker.all-hands.dev/all-hands-ai/openhands:a4ffad6
```