### PR TITLE
feat(backend): Include owner_type in the Get Repositories API response.

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1827,6 +1827,11 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "owner_type": {
+            "type": "string",
+            "enum": ["user", "organization"],
+            "nullable": true
           }
         }
       },

--- a/openhands/integrations/bitbucket/bitbucket_service.py
+++ b/openhands/integrations/bitbucket/bitbucket_service.py
@@ -9,6 +9,7 @@ from openhands.integrations.service_types import (
     BaseGitService,
     Branch,
     GitService,
+    OwnerType,
     ProviderType,
     Repository,
     RequestMethod,
@@ -246,6 +247,11 @@ class BitBucketService(BaseGitService, GitService):
                         is_public=repo.get('is_private', True) is False,
                         stargazers_count=None,  # Bitbucket doesn't have stars
                         pushed_at=repo.get('updated_on'),
+                        owner_type=(
+                            OwnerType.ORGANIZATION
+                            if repo.get('workspace', {}).get('is_private') is False
+                            else OwnerType.USER
+                        ),
                     )
                 )
 
@@ -287,6 +293,11 @@ class BitBucketService(BaseGitService, GitService):
             is_public=data.get('is_private', True) is False,
             stargazers_count=None,  # Bitbucket doesn't have stars
             pushed_at=data.get('updated_on'),
+            owner_type=(
+                OwnerType.ORGANIZATION
+                if data.get('workspace', {}).get('is_private') is False
+                else OwnerType.USER
+            ),
         )
 
     async def get_branches(self, repository: str) -> list[Branch]:

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -15,6 +15,7 @@ from openhands.integrations.service_types import (
     BaseGitService,
     Branch,
     GitService,
+    OwnerType,
     ProviderType,
     Repository,
     RequestMethod,
@@ -236,6 +237,11 @@ class GitHubService(BaseGitService, GitService):
                 stargazers_count=repo.get('stargazers_count'),
                 git_provider=ProviderType.GITHUB,
                 is_public=not repo.get('private', True),
+                owner_type=(
+                    OwnerType.ORGANIZATION
+                    if repo.get('owner', {}).get('type') == 'Organization'
+                    else OwnerType.USER
+                ),
             )
             for repo in all_repos
         ]
@@ -269,6 +275,11 @@ class GitHubService(BaseGitService, GitService):
                 stargazers_count=repo.get('stargazers_count'),
                 git_provider=ProviderType.GITHUB,
                 is_public=True,
+                owner_type=(
+                    OwnerType.ORGANIZATION
+                    if repo.get('owner', {}).get('type') == 'Organization'
+                    else OwnerType.USER
+                ),
             )
             for repo in repo_items
         ]
@@ -414,6 +425,11 @@ class GitHubService(BaseGitService, GitService):
             stargazers_count=repo.get('stargazers_count'),
             git_provider=ProviderType.GITHUB,
             is_public=not repo.get('private', True),
+            owner_type=(
+                OwnerType.ORGANIZATION
+                if repo.get('owner', {}).get('type') == 'Organization'
+                else OwnerType.USER
+            ),
         )
 
     async def get_branches(self, repository: str) -> list[Branch]:

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -8,6 +8,7 @@ from openhands.integrations.service_types import (
     BaseGitService,
     Branch,
     GitService,
+    OwnerType,
     ProviderType,
     Repository,
     RequestMethod,
@@ -214,6 +215,11 @@ class GitLabService(BaseGitService, GitService):
                 stargazers_count=repo.get('star_count'),
                 git_provider=ProviderType.GITLAB,
                 is_public=True,
+                owner_type=(
+                    OwnerType.ORGANIZATION
+                    if repo.get('namespace', {}).get('kind') == 'group'
+                    else OwnerType.USER
+                ),
             )
             for repo in response
         ]
@@ -265,6 +271,11 @@ class GitLabService(BaseGitService, GitService):
                 stargazers_count=repo.get('star_count'),
                 git_provider=ProviderType.GITLAB,
                 is_public=repo.get('visibility') == 'public',
+                owner_type=(
+                    OwnerType.ORGANIZATION
+                    if repo.get('namespace', {}).get('kind') == 'group'
+                    else OwnerType.USER
+                ),
             )
             for repo in all_repos
         ]
@@ -415,6 +426,11 @@ class GitLabService(BaseGitService, GitService):
             stargazers_count=repo.get('star_count'),
             git_provider=ProviderType.GITLAB,
             is_public=repo.get('visibility') == 'public',
+            owner_type=(
+                OwnerType.ORGANIZATION
+                if repo.get('namespace', {}).get('kind') == 'group'
+                else OwnerType.USER
+            ),
         )
 
     async def get_branches(self, repository: str) -> list[Branch]:

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -24,6 +24,11 @@ class TaskType(str, Enum):
     OPEN_PR = 'OPEN_PR'
 
 
+class OwnerType(str, Enum):
+    USER = 'user'
+    ORGANIZATION = 'organization'
+
+
 class SuggestedTask(BaseModel):
     git_provider: ProviderType
     task_type: TaskType
@@ -32,17 +37,7 @@ class SuggestedTask(BaseModel):
     title: str
 
     def get_provider_terms(self) -> dict:
-        if self.git_provider == ProviderType.GITLAB:
-            return {
-                'requestType': 'Merge Request',
-                'requestTypeShort': 'MR',
-                'apiName': 'GitLab API',
-                'tokenEnvVar': 'GITLAB_TOKEN',
-                'ciSystem': 'CI pipelines',
-                'ciProvider': 'GitLab',
-                'requestVerb': 'merge request',
-            }
-        elif self.git_provider == ProviderType.GITHUB:
+        if self.git_provider == ProviderType.GITHUB:
             return {
                 'requestType': 'Pull Request',
                 'requestTypeShort': 'PR',
@@ -51,6 +46,16 @@ class SuggestedTask(BaseModel):
                 'ciSystem': 'GitHub Actions',
                 'ciProvider': 'GitHub',
                 'requestVerb': 'pull request',
+            }
+        elif self.git_provider == ProviderType.GITLAB:
+            return {
+                'requestType': 'Merge Request',
+                'requestTypeShort': 'MR',
+                'apiName': 'GitLab API',
+                'tokenEnvVar': 'GITLAB_TOKEN',
+                'ciSystem': 'CI pipelines',
+                'ciProvider': 'GitLab',
+                'requestVerb': 'merge request',
             }
         elif self.git_provider == ProviderType.BITBUCKET:
             return {
@@ -117,6 +122,9 @@ class Repository(BaseModel):
     stargazers_count: int | None = None
     link_header: str | None = None
     pushed_at: str | None = None  # ISO 8601 format date string
+    owner_type: OwnerType | None = (
+        None  # Whether the repository is owned by a user or organization
+    )
 
 
 class AuthenticationError(ValueError):

--- a/tests/unit/test_github_service.py
+++ b/tests/unit/test_github_service.py
@@ -5,7 +5,13 @@ import pytest
 from pydantic import SecretStr
 
 from openhands.integrations.github.github_service import GitHubService
-from openhands.integrations.service_types import AuthenticationError
+from openhands.integrations.service_types import (
+    AuthenticationError,
+    OwnerType,
+    ProviderType,
+    Repository,
+)
+from openhands.server.types import AppMode
 
 
 @pytest.mark.asyncio
@@ -79,3 +85,162 @@ async def test_github_service_fetch_data():
 
         with pytest.raises(AuthenticationError):
             _ = await service._make_request('https://api.github.com/user')
+
+
+@pytest.mark.asyncio
+async def test_github_get_repositories_with_user_owner_type():
+    """Test that get_repositories correctly sets owner_type field for user repositories."""
+    service = GitHubService(user_id=None, token=SecretStr('test-token'))
+
+    # Mock repository data for user repositories
+    mock_repo_data = [
+        {
+            'id': 123,
+            'full_name': 'test-user/test-repo',
+            'private': False,
+            'stargazers_count': 10,
+            'owner': {'type': 'User'},  # User repository
+        },
+        {
+            'id': 456,
+            'full_name': 'test-user/another-repo',
+            'private': True,
+            'stargazers_count': 5,
+            'owner': {'type': 'User'},  # User repository
+        },
+    ]
+
+    with (
+        patch.object(service, '_fetch_paginated_repos', return_value=mock_repo_data),
+        patch.object(service, 'get_installation_ids', return_value=[123]),
+    ):
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify we got the expected number of repositories
+        assert len(repositories) == 2
+
+        # Verify owner_type is correctly set for user repositories
+        for repo in repositories:
+            assert repo.owner_type == OwnerType.USER
+            assert isinstance(repo, Repository)
+            assert repo.git_provider == ProviderType.GITHUB
+
+
+@pytest.mark.asyncio
+async def test_github_get_repositories_with_organization_owner_type():
+    """Test that get_repositories correctly sets owner_type field for organization repositories."""
+    service = GitHubService(user_id=None, token=SecretStr('test-token'))
+
+    # Mock repository data for organization repositories
+    mock_repo_data = [
+        {
+            'id': 789,
+            'full_name': 'test-org/org-repo',
+            'private': False,
+            'stargazers_count': 25,
+            'owner': {'type': 'Organization'},  # Organization repository
+        },
+        {
+            'id': 101,
+            'full_name': 'test-org/another-org-repo',
+            'private': True,
+            'stargazers_count': 15,
+            'owner': {'type': 'Organization'},  # Organization repository
+        },
+    ]
+
+    with (
+        patch.object(service, '_fetch_paginated_repos', return_value=mock_repo_data),
+        patch.object(service, 'get_installation_ids', return_value=[123]),
+    ):
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify we got the expected number of repositories
+        assert len(repositories) == 2
+
+        # Verify owner_type is correctly set for organization repositories
+        for repo in repositories:
+            assert repo.owner_type == OwnerType.ORGANIZATION
+            assert isinstance(repo, Repository)
+            assert repo.git_provider == ProviderType.GITHUB
+
+
+@pytest.mark.asyncio
+async def test_github_get_repositories_mixed_owner_types():
+    """Test that get_repositories correctly handles mixed user and organization repositories."""
+    service = GitHubService(user_id=None, token=SecretStr('test-token'))
+
+    # Mock repository data with mixed owner types
+    mock_repo_data = [
+        {
+            'id': 123,
+            'full_name': 'test-user/user-repo',
+            'private': False,
+            'stargazers_count': 10,
+            'owner': {'type': 'User'},  # User repository
+        },
+        {
+            'id': 456,
+            'full_name': 'test-org/org-repo',
+            'private': True,
+            'stargazers_count': 25,
+            'owner': {'type': 'Organization'},  # Organization repository
+        },
+    ]
+
+    with (
+        patch.object(service, '_fetch_paginated_repos', return_value=mock_repo_data),
+        patch.object(service, 'get_installation_ids', return_value=[123]),
+    ):
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify we got the expected number of repositories
+        assert len(repositories) == 2
+
+        # Verify owner_type is correctly set for each repository
+        user_repo = next(repo for repo in repositories if 'user-repo' in repo.full_name)
+        org_repo = next(repo for repo in repositories if 'org-repo' in repo.full_name)
+
+        assert user_repo.owner_type == OwnerType.USER
+        assert org_repo.owner_type == OwnerType.ORGANIZATION
+
+
+@pytest.mark.asyncio
+async def test_github_get_repositories_owner_type_fallback():
+    """Test that owner_type defaults to USER when owner type is not 'Organization'."""
+    service = GitHubService(user_id=None, token=SecretStr('test-token'))
+
+    # Mock repository data with missing or unexpected owner type
+    mock_repo_data = [
+        {
+            'id': 123,
+            'full_name': 'test-user/test-repo',
+            'private': False,
+            'stargazers_count': 10,
+            'owner': {'type': 'User'},  # Explicitly User
+        },
+        {
+            'id': 456,
+            'full_name': 'test-user/another-repo',
+            'private': True,
+            'stargazers_count': 5,
+            'owner': {'type': 'Bot'},  # Unexpected type
+        },
+        {
+            'id': 789,
+            'full_name': 'test-user/third-repo',
+            'private': False,
+            'stargazers_count': 15,
+            'owner': {},  # Missing type
+        },
+    ]
+
+    with (
+        patch.object(service, '_fetch_paginated_repos', return_value=mock_repo_data),
+        patch.object(service, 'get_installation_ids', return_value=[123]),
+    ):
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify all repositories default to USER owner_type
+        for repo in repositories:
+            assert repo.owner_type == OwnerType.USER

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -1,0 +1,169 @@
+"""Tests for GitLab integration."""
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.integrations.gitlab.gitlab_service import GitLabService
+from openhands.integrations.service_types import OwnerType, ProviderType, Repository
+from openhands.server.types import AppMode
+
+
+@pytest.mark.asyncio
+async def test_gitlab_get_repositories_with_user_owner_type():
+    """Test that get_repositories correctly sets owner_type field for user repositories."""
+    service = GitLabService(token=SecretStr('test-token'))
+
+    # Mock repository data for user repositories (namespace kind = 'user')
+    mock_repos = [
+        {
+            'id': 123,
+            'path_with_namespace': 'test-user/user-repo1',
+            'star_count': 10,
+            'visibility': 'public',
+            'namespace': {'kind': 'user'},  # User namespace
+        },
+        {
+            'id': 456,
+            'path_with_namespace': 'test-user/user-repo2',
+            'star_count': 5,
+            'visibility': 'private',
+            'namespace': {'kind': 'user'},  # User namespace
+        },
+    ]
+
+    with patch.object(service, '_make_request') as mock_request:
+        # Mock the pagination response
+        mock_request.side_effect = [(mock_repos, {'Link': ''})]  # No next page
+
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify we got the expected number of repositories
+        assert len(repositories) == 2
+
+        # Verify owner_type is correctly set for user repositories
+        for repo in repositories:
+            assert repo.owner_type == OwnerType.USER
+            assert isinstance(repo, Repository)
+            assert repo.git_provider == ProviderType.GITLAB
+
+
+@pytest.mark.asyncio
+async def test_gitlab_get_repositories_with_organization_owner_type():
+    """Test that get_repositories correctly sets owner_type field for organization repositories."""
+    service = GitLabService(token=SecretStr('test-token'))
+
+    # Mock repository data for organization repositories (namespace kind = 'group')
+    mock_repos = [
+        {
+            'id': 789,
+            'path_with_namespace': 'test-org/org-repo1',
+            'star_count': 25,
+            'visibility': 'public',
+            'namespace': {'kind': 'group'},  # Organization/Group namespace
+        },
+        {
+            'id': 101,
+            'path_with_namespace': 'test-org/org-repo2',
+            'star_count': 15,
+            'visibility': 'private',
+            'namespace': {'kind': 'group'},  # Organization/Group namespace
+        },
+    ]
+
+    with patch.object(service, '_make_request') as mock_request:
+        # Mock the pagination response
+        mock_request.side_effect = [(mock_repos, {'Link': ''})]  # No next page
+
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify we got the expected number of repositories
+        assert len(repositories) == 2
+
+        # Verify owner_type is correctly set for organization repositories
+        for repo in repositories:
+            assert repo.owner_type == OwnerType.ORGANIZATION
+            assert isinstance(repo, Repository)
+            assert repo.git_provider == ProviderType.GITLAB
+
+
+@pytest.mark.asyncio
+async def test_gitlab_get_repositories_mixed_owner_types():
+    """Test that get_repositories correctly handles mixed user and organization repositories."""
+    service = GitLabService(token=SecretStr('test-token'))
+
+    # Mock repository data with mixed namespace types
+    mock_repos = [
+        {
+            'id': 123,
+            'path_with_namespace': 'test-user/user-repo',
+            'star_count': 10,
+            'visibility': 'public',
+            'namespace': {'kind': 'user'},  # User namespace
+        },
+        {
+            'id': 456,
+            'path_with_namespace': 'test-org/org-repo',
+            'star_count': 25,
+            'visibility': 'public',
+            'namespace': {'kind': 'group'},  # Organization/Group namespace
+        },
+    ]
+
+    with patch.object(service, '_make_request') as mock_request:
+        # Mock the pagination response
+        mock_request.side_effect = [(mock_repos, {'Link': ''})]  # No next page
+
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify we got the expected number of repositories
+        assert len(repositories) == 2
+
+        # Verify owner_type is correctly set for each repository
+        user_repo = next(repo for repo in repositories if 'user-repo' in repo.full_name)
+        org_repo = next(repo for repo in repositories if 'org-repo' in repo.full_name)
+
+        assert user_repo.owner_type == OwnerType.USER
+        assert org_repo.owner_type == OwnerType.ORGANIZATION
+
+
+@pytest.mark.asyncio
+async def test_gitlab_get_repositories_owner_type_fallback():
+    """Test that owner_type defaults to USER when namespace kind is not 'group'."""
+    service = GitLabService(token=SecretStr('test-token'))
+
+    # Mock repository data with missing or unexpected namespace kind
+    mock_repos = [
+        {
+            'id': 123,
+            'path_with_namespace': 'test-user/user-repo1',
+            'star_count': 10,
+            'visibility': 'public',
+            'namespace': {'kind': 'user'},  # Explicitly user
+        },
+        {
+            'id': 456,
+            'path_with_namespace': 'test-user/user-repo2',
+            'star_count': 5,
+            'visibility': 'private',
+            'namespace': {'kind': 'unknown'},  # Unexpected kind
+        },
+        {
+            'id': 789,
+            'path_with_namespace': 'test-user/user-repo3',
+            'star_count': 15,
+            'visibility': 'public',
+            'namespace': {},  # Missing kind
+        },
+    ]
+
+    with patch.object(service, '_make_request') as mock_request:
+        # Mock the pagination response
+        mock_request.side_effect = [(mock_repos, {'Link': ''})]  # No next page
+
+        repositories = await service.get_repositories('pushed', AppMode.SAAS)
+
+        # Verify all repositories default to USER owner_type
+        for repo in repositories:
+            assert repo.owner_type == OwnerType.USER


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

To properly display repositories in the UI, we need to differentiate between personal and organization-level repositories.

For example, a user might have multiple repositories with the same name:
- hieptl/.openhands — personal repository
- hieptl-org1/openhands — organization 1
- hieptl-org2/openhands — organization 2

From the frontend, it’s important to distinguish these cases to provide accurate context to the user.

To enable this, the Get Repositories API should return an owner_type field for each repository, indicating whether it’s associated with a user or an organization.

**Acceptance Criteria:**
- The Get Repositories API includes an owner_type field in the response.
- The owner_type should clearly indicate whether the repository belongs to a user or an organization.

<img width="694" height="722" alt="microagent-management" src="https://github.com/user-attachments/assets/38ba924b-d3f2-45c5-9169-ac0567dd411f" />


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR includes owner_type in the Get Repositories API response.

We can refer to the video below for the output of the PR:

https://github.com/user-attachments/assets/21579835-6cfb-4642-8f3b-548aa1d66871

---
**Link of any specific issues this addresses:**

Resolves [ALL-2762](https://linear.app/all-hands-ai/issue/ALL-2762/microagent-management-include-owner-type-in-the-get-repositories-api).