### PR TITLE
Fix: Silence FastMCP SSE connection closure assertion error

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -777,7 +777,17 @@ if __name__ == '__main__':
     # Are these something we should keep?
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception):
-        logger.exception('Unhandled exception occurred:')
+        # Check if this is the specific assertion error from Starlette middleware
+        if (
+            isinstance(exc, AssertionError)
+            and str(exc) == 'message["type"] == "http.response.body"'
+        ):
+            # This is the known FastMCP SSE connection closure error - log at debug level only
+            logger.debug('FastMCP SSE connection closed: %s', exc)
+        else:
+            # For all other exceptions, log at error level as before
+            logger.exception('Unhandled exception occurred:')
+
         return JSONResponse(
             status_code=500,
             content={'detail': 'An unexpected error occurred. Please try again later.'},


### PR DESCRIPTION
## Description

This PR addresses the issue where an assertion error is being logged when FastMCP SSE connections are closed. The error occurs in the Starlette middleware with the message `assert message["type"] == "http.response.body"`.

## Changes

- Modified the global exception handler in `action_execution_server.py` to detect this specific assertion error and log it at the DEBUG level instead of ERROR level
- This change will reduce noise in the logs while still maintaining proper error handling for other exceptions

## Related Issues

Fixes #9705

## Testing

The change has been tested by running pre-commit hooks and ensuring the code passes all linting checks.

## Additional Notes

This is a known issue with FastMCP when SSE connections are closed abruptly. The error is harmless but was causing noise in the logs. This change silences only this specific error while maintaining proper error handling for all other exceptions.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/65a1d53a844140f680979464bf50db5e)