### PR TITLE
Add make lint to pre-commit hook

### DIFF
--- a/.openhands/pre-commit.sh
+++ b/.openhands/pre-commit.sh
@@ -1,28 +1,31 @@
 #!/bin/bash
 
 echo "Running OpenHands pre-commit hook..."
+echo "This hook runs 'make lint' to ensure code quality before committing."
 
 # Store the exit code to return at the end
 # This allows us to be additive to existing pre-commit hooks
 EXIT_CODE=0
 
+# Run make lint to check both frontend and backend code
+echo "Running linting checks with 'make lint'..."
+make lint
+if [ $? -ne 0 ]; then
+    echo "Linting failed. Please fix the issues before committing."
+    EXIT_CODE=1
+else
+    echo "Linting checks passed!"
+fi
+
 # Check if frontend directory has changed
 frontend_changes=$(git diff --cached --name-only | grep "^frontend/")
 if [ -n "$frontend_changes" ]; then
-    echo "Frontend changes detected. Running frontend checks..."
+    echo "Frontend changes detected. Running additional frontend checks..."
 
     # Check if frontend directory exists
     if [ -d "frontend" ]; then
         # Change to frontend directory
         cd frontend || exit 1
-
-        # Run lint:fix
-        echo "Running npm lint:fix..."
-        npm run lint:fix
-        if [ $? -ne 0 ]; then
-            echo "Frontend linting failed. Please fix the issues before committing."
-            EXIT_CODE=1
-        fi
 
         # Run build
         echo "Running npm build..."
@@ -50,7 +53,7 @@ if [ -n "$frontend_changes" ]; then
         echo "Frontend directory not found. Skipping frontend checks."
     fi
 else
-    echo "No frontend changes detected. Skipping frontend checks."
+    echo "No frontend changes detected. Skipping additional frontend checks."
 fi
 
 # Run any existing pre-commit hooks that might have been installed by the user


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
This change enhances the pre-commit hook to run `make lint` before committing code, ensuring that code passes all linting checks before being committed. This helps prevent linting errors from being caught only in CI, saving time and reducing failed CI builds.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This PR modifies the `.openhands/pre-commit.sh` script to run `make lint` as part of the pre-commit process. The `make lint` command runs both frontend and backend linting checks.

I removed the separate `npm run lint:fix` step from the frontend checks section because:
1. It is now redundant since `make lint` already includes frontend linting via `make lint-frontend`
2. Running linting twice (once via `make lint` and again directly) would be inefficient
3. The consolidated approach ensures consistent linting behavior across the codebase

The changes are minimal and focused on the specific request to add `make lint` to the pre-commit hook.

---
**Link of any specific issues this addresses:**
N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2022c84-nikolaik   --name openhands-app-2022c84   docker.all-hands.dev/all-hands-ai/openhands:2022c84
```