### PR TITLE
docs: Add MCP Cloud availability note and improve document structure

### DIFF
--- a/docs/usage/mcp.mdx
+++ b/docs/usage/mcp.mdx
@@ -10,9 +10,9 @@ Model Context Protocol (MCP) is a mechanism that allows OpenHands to communicate
 servers can provide additional functionality to the agent, such as specialized data processing, external API access,
 or custom tools. MCP is based on the open standard defined at [modelcontextprotocol.io](https://modelcontextprotocol.io).
 
-:::note
+<Note>
 MCP is currently not available on OpenHands Cloud. This feature is only available when running OpenHands locally.
-:::
+</Note>
 
 ### How MCP Works
 

--- a/docs/usage/mcp.mdx
+++ b/docs/usage/mcp.mdx
@@ -10,6 +10,25 @@ Model Context Protocol (MCP) is a mechanism that allows OpenHands to communicate
 servers can provide additional functionality to the agent, such as specialized data processing, external API access,
 or custom tools. MCP is based on the open standard defined at [modelcontextprotocol.io](https://modelcontextprotocol.io).
 
+:::note
+MCP is currently not available on OpenHands Cloud. This feature is only available when running OpenHands locally or in self-hosted environments.
+:::
+
+### How MCP Works
+
+When OpenHands starts, it:
+
+1. Reads the MCP configuration.
+2. Connects to any configured SSE and SHTTP servers.
+3. Starts any configured stdio servers.
+4. Registers the tools provided by these servers with the agent.
+
+The agent can then use these tools just like any built-in tool. When the agent calls an MCP tool:
+
+1. OpenHands routes the call to the appropriate MCP server.
+2. The server processes the request and returns a response.
+3. OpenHands converts the response to an observation and presents it to the agent.
+
 ## Configuration
 
 MCP configuration can be defined in:
@@ -103,21 +122,6 @@ Stdio servers are configured using an object with the following properties:
   - Type: `dict of str to str`
   - Default: `{}`
   - Description: Environment variables to set for the server process
-
-## How MCP Works
-
-When OpenHands starts, it:
-
-1. Reads the MCP configuration.
-2. Connects to any configured SSE and SHTTP servers.
-3. Starts any configured stdio servers.
-4. Registers the tools provided by these servers with the agent.
-
-The agent can then use these tools just like any built-in tool. When the agent calls an MCP tool:
-
-1. OpenHands routes the call to the appropriate MCP server.
-2. The server processes the request and returns a response.
-3. OpenHands converts the response to an observation and presents it to the agent.
 
 ## Transport Protocols
 

--- a/docs/usage/mcp.mdx
+++ b/docs/usage/mcp.mdx
@@ -11,7 +11,7 @@ servers can provide additional functionality to the agent, such as specialized d
 or custom tools. MCP is based on the open standard defined at [modelcontextprotocol.io](https://modelcontextprotocol.io).
 
 :::note
-MCP is currently not available on OpenHands Cloud. This feature is only available when running OpenHands locally or in self-hosted environments.
+MCP is currently not available on OpenHands Cloud. This feature is only available when running OpenHands locally.
 :::
 
 ### How MCP Works


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Added a clear note in the MCP documentation indicating that Model Context Protocol (MCP) is currently not available on OpenHands Cloud and is only available when running OpenHands locally or in self-hosted environments. This helps users understand the availability limitations of MCP features.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR makes two improvements to the MCP documentation (`docs/usage/mcp.mdx`):

1. **Added Cloud availability note**: Added a prominent note in the Overview section clarifying that MCP is currently not available on OpenHands Cloud and is only available when running OpenHands locally or in self-hosted environments.

2. **Improved document structure**: Moved the "How MCP Works" content from its original location (after Configuration Options) to be a subsection at the end of the Overview section. This creates better document flow by explaining how MCP works immediately after introducing what it is.

The note uses the standard `:::note` syntax consistent with other documentation and follows the proper terminology ("OpenHands Cloud") used throughout the docs.

---
**Link of any specific issues this addresses:**

This addresses user feedback about the need to clarify MCP availability on OpenHands Cloud.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/25275030d0384353935a4a73c925be21)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:865c7b9-nikolaik   --name openhands-app-865c7b9   docker.all-hands.dev/all-hands-ai/openhands:865c7b9
```