### PR TITLE
[Fix]: instruct agent to use token when accessing provider apis

### DIFF
--- a/openhands/integrations/templates/resolver/github/issue_comment_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/github/issue_comment_conversation_instructions.j2
@@ -4,7 +4,7 @@ A comment on the issue has been addressed to you.
 
 # Steps to Handle the Comment
 
-1. Address the comment. Use the GitHub API to read issue title, body, and comments if you need more context
+1. Address the comment. Use the $GITHUB_TOKEN and GitHub API to read issue title, body, and comments if you need more context
 2. For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed
 3. Run the tests, and if they pass you are done!
 4. You do NOT need to write new tests if there are only changes to documentation or configuration files.

--- a/openhands/integrations/templates/resolver/github/issue_labeled_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/github/issue_labeled_conversation_instructions.j2
@@ -1,6 +1,6 @@
 Your tasking is to fix an issue in your repository. Do the following
 
-1. Read the issue body and comments using the Github API
+1. Read the issue body and comments using the $GITHUB_TOKEN and Github API
 2. For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed
 3. Run the tests, and if they pass you are done!
 4. You do NOT need to write new tests if there are only changes to documentation or configuration files.

--- a/openhands/integrations/templates/resolver/github/pr_update_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/github/pr_update_conversation_instructions.j2
@@ -6,7 +6,7 @@ A comment on the PR has been addressed to you. Do NOT respond to this comment vi
 # Steps to Handle the Comment
 
 ## Understand the PR Context
-Use the GitHub API to:
+Use the $GITHUB_TOKEN and GitHub API to:
     1. Retrieve the diff against main to understand the changes
     2. Fetch the PR body and the linked issue for context
 

--- a/openhands/integrations/templates/resolver/gitlab/issue_comment_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/gitlab/issue_comment_conversation_instructions.j2
@@ -4,7 +4,7 @@ A comment on the issue has been addressed to you.
 
 # Steps to Handle the Comment
 
-1. Address the comment. Use the GitLab API to read issue title, body, and comments if you need more context
+1. Address the comment. Use the $GITLAB_TOKEN and GitLab API to read issue title, body, and comments if you need more context
 2. For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed
 3. Run the tests, and if they pass you are done!
 4. You do NOT need to write new tests if there are only changes to documentation or configuration files.

--- a/openhands/integrations/templates/resolver/gitlab/issue_labeled_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/gitlab/issue_labeled_conversation_instructions.j2
@@ -1,6 +1,6 @@
 Your tasking is to fix an issue in your repository. Do the following
 
-1. Read the issue body and comments using the GitLab API
+1. Read the issue body and comments using the $GITLAB_TOKEN and GitLab API
 2. For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed
 3. Run the tests, and if they pass you are done!
 4. You do NOT need to write new tests if there are only changes to documentation or configuration files.

--- a/openhands/integrations/templates/resolver/gitlab/mr_update_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/gitlab/mr_update_conversation_instructions.j2
@@ -6,7 +6,7 @@ A comment on the MR has been addressed to you. Do NOT respond to this comment vi
 # Steps to Handle the Comment
 
 ## Understand the MR Context
-Use the GitLab API to:
+Use the $GITLAB_TOKEN and GitLab API to:
     1. Retrieve the diff against main to understand the changes
     2. Fetch the MR body and the linked issue for context
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Fix cases where cloud resolver won't use provider token + provider APIs to read issue descriptions.
 
---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR explicitly asks to agent to use the provider tokens when calling APIs. This isn't a problem in public repos because the contents of the issue are public. But in private repos the agent fails to collect context because it pings public apis and doesn't use the provider token. 

---
**Link of any specific issues this addresses:**
https://github.com/All-Hands-AI/OpenHands-Cloud/issues/102