### PR TITLE
Fix clickable area issue in Settings/Integrations buttons

### DIFF
--- a/frontend/src/routes/git-settings.tsx
+++ b/frontend/src/routes/git-settings.tsx
@@ -175,7 +175,7 @@ function GitSettingsScreen() {
 
       <div className="flex gap-6 p-6 justify-end border-t border-t-tertiary">
         {!shouldRenderExternalConfigureButtons && (
-          <>
+          <div className="flex gap-6">
             <BrandButton
               testId="disconnect-tokens-button"
               name="disconnect-tokens-button"
@@ -196,7 +196,7 @@ function GitSettingsScreen() {
               {!isPending && t("SETTINGS$SAVE_CHANGES")}
               {isPending && t("SETTINGS$SAVING")}
             </BrandButton>
-          </>
+          </div>
         )}
       </div>
     </form>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue in the Settings/Integrations page where buttons were clickable across their entire horizontal area, including padding. Now buttons only respond to clicks on the actual button content, providing a more intuitive user experience.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes a UI issue where the "Disconnect Tokens" and "Save Changes" buttons in the Settings/Integrations page had an extended clickable area that spanned the full width of their container, including padding areas.

**Changes made:**
- Wrapped the buttons in a proper `div` container with `flex gap-6` classes instead of using a React Fragment (`<>`)
- This ensures the buttons are properly contained and only clickable within their actual visual boundaries

**Technical details:**
- The issue was caused by the React Fragment wrapper which didn't provide proper containment for the flexbox layout
- The fix is minimal and maintains the existing visual styling while correcting the interaction behavior
- All existing functionality remains unchanged

---
**Link of any specific issues this addresses:**

Addresses user-reported UI issue where buttons in Settings/Integrations were clickable across the entire horizontal area including padding.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ffbd0ce2e9c04e14a117d3ea37edcf71)