### PR TITLE
hotfix(frontend): Fix context menu closing

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -35,6 +35,8 @@ interface ConversationCardProps {
   conversationStatus?: ConversationStatus;
   variant?: "compact" | "default";
   conversationId?: string; // Optional conversation ID for VS Code URL
+  contextMenuOpen?: boolean;
+  onContextMenuToggle?: (isOpen: boolean) => void;
 }
 
 const MAX_TIME_BETWEEN_CREATION_AND_UPDATE = 1000 * 60 * 30; // 30 minutes
@@ -55,10 +57,11 @@ export function ConversationCard({
   conversationStatus = "STOPPED",
   variant = "default",
   conversationId,
+  contextMenuOpen = false,
+  onContextMenuToggle,
 }: ConversationCardProps) {
   const { t } = useTranslation();
   const { parsedEvents } = useWsClient();
-  const [contextMenuVisible, setContextMenuVisible] = React.useState(false);
   const [titleMode, setTitleMode] = React.useState<"view" | "edit">("view");
   const [metricsModalVisible, setMetricsModalVisible] = React.useState(false);
   const [systemModalVisible, setSystemModalVisible] = React.useState(false);
@@ -101,21 +104,21 @@ export function ConversationCard({
     event.preventDefault();
     event.stopPropagation();
     onDelete?.();
-    setContextMenuVisible(false);
+    onContextMenuToggle?.(false);
   };
 
   const handleStop = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
     onStop?.();
-    setContextMenuVisible(false);
+    onContextMenuToggle?.(false);
   };
 
   const handleEdit = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
     setTitleMode("edit");
-    setContextMenuVisible(false);
+    onContextMenuToggle?.(false);
   };
 
   const handleDownloadViaVSCode = async (
@@ -141,7 +144,7 @@ export function ConversationCard({
       }
     }
 
-    setContextMenuVisible(false);
+    onContextMenuToggle?.(false);
   };
 
   const handleDisplayCost = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -224,15 +227,15 @@ export function ConversationCard({
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    setContextMenuVisible((prev) => !prev);
+                    onContextMenuToggle?.(!contextMenuOpen);
                   }}
                 />
               </div>
             )}
             <div className="relative">
-              {contextMenuVisible && (
+              {contextMenuOpen && (
                 <ConversationCardContextMenu
-                  onClose={() => setContextMenuVisible(false)}
+                  onClose={() => onContextMenuToggle?.(false)}
                   onDelete={onDelete && handleDelete}
                   onStop={
                     conversationStatus !== "STOPPED"

--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -36,6 +36,9 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
   const [selectedConversationId, setSelectedConversationId] = React.useState<
     string | null
   >(null);
+  const [openContextMenuId, setOpenContextMenuId] = React.useState<
+    string | null
+  >(null);
 
   const { data: conversations, isFetching, error } = useUserConversations();
 
@@ -144,6 +147,10 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
               createdAt={project.created_at}
               conversationStatus={project.status}
               conversationId={project.conversation_id}
+              contextMenuOpen={openContextMenuId === project.conversation_id}
+              onContextMenuToggle={(isOpen) =>
+                setOpenContextMenuId(isOpen ? project.conversation_id : null)
+              }
             />
           )}
         </NavLink>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
If the user clicks the 3 dots on multiple conversation cards, they will all remain open.
<img width="256" height="297" alt="image" src="https://github.com/user-attachments/assets/5393a1f2-2b88-4012-91e9-663c318034a0" />


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Only keep one open at a time.
- update tests

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d1eb793-nikolaik   --name openhands-app-d1eb793   docker.all-hands.dev/all-hands-ai/openhands:d1eb793
```