### PR TITLE
feat: [CLI] 9392 cli improve confirmation ux - revisited

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -239,7 +239,7 @@ async def run_session(
                         ChangeAgentStateAction(AgentState.USER_CONFIRMED),
                         EventSource.USER,
                     )
-                else: # 'no' or alternative instructions
+                else:  # 'no' or alternative instructions
                     # Tell the agent the proposed action was rejected
                     event_stream.add_event(
                         ChangeAgentStateAction(AgentState.USER_REJECTED),

--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -239,7 +239,7 @@ async def run_session(
                         ChangeAgentStateAction(AgentState.USER_CONFIRMED),
                         EventSource.USER,
                     )
-                elif confirmation_status == 'edit':
+                else: # 'no' or alternative instructions
                     # Tell the agent the proposed action was rejected
                     event_stream.add_event(
                         ChangeAgentStateAction(AgentState.USER_REJECTED),
@@ -248,15 +248,8 @@ async def run_session(
                     # Notify the user
                     print_formatted_text(
                         HTML(
-                            '<skyblue>Okay, please tell me what I should do instead.</skyblue>'
+                            '<skyblue>Okay, please tell me what I should do next/instead.</skyblue>'
                         )
-                    )
-                    # Solicit replacement isntructions
-                    await prompt_for_next_task(AgentState.AWAITING_USER_INPUT)
-                else:  # 'no' or fallback
-                    event_stream.add_event(
-                        ChangeAgentStateAction(AgentState.USER_REJECTED),
-                        EventSource.USER,
                     )
 
                 # Set the always_confirm_mode flag if the user wants to always confirm

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -705,7 +705,7 @@ async def read_confirmation_input(config: OpenHandsConfig) -> str:
         choices = [
             'Yes, proceed',
             'No (and allow to enter instructions)',
-            "Always proceed (don't ask again)"
+            "Always proceed (don't ask again)",
         ]
 
         # keep the outer coroutine responsive by using asyncio.to_thread which puts the blocking call app.run() of cli_confirm() in a separate thread

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -714,7 +714,7 @@ async def read_confirmation_input(config: OpenHandsConfig) -> str:
             cli_confirm, config, 'Choose an option:', choices
         )
 
-        return {0: 'yes', 1: 'no', 2: 'always', 3: 'edit'}.get(index, 'no')
+        return {0: 'yes', 1: 'no', 2: 'always', 3: 'no'}.get(index, 'no')
 
     except (KeyboardInterrupt, EOFError):
         return 'no'

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -704,9 +704,8 @@ async def read_confirmation_input(config: OpenHandsConfig) -> str:
     try:
         choices = [
             'Yes, proceed',
-            'No, skip this action',
-            "Always proceed (don't ask again)",
-            'Let me provide different instructions',
+            'No (and allow to enter instructions)',
+            "Always proceed (don't ask again)"
         ]
 
         # keep the outer coroutine responsive by using asyncio.to_thread which puts the blocking call app.run() of cli_confirm() in a separate thread
@@ -714,7 +713,7 @@ async def read_confirmation_input(config: OpenHandsConfig) -> str:
             cli_confirm, config, 'Choose an option:', choices
         )
 
-        return {0: 'yes', 1: 'no', 2: 'always', 3: 'no'}.get(index, 'no')
+        return {0: 'yes', 1: 'no', 2: 'always'}.get(index, 'no')
 
     except (KeyboardInterrupt, EOFError):
         return 'no'


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
User gets a multiple choice menu which can be navigated using the arrow keys instead of a simple prompt to which he was asked to answer with a single char 'y', 'n' or 'a'. Additionally a new option that was not previously available is provided that gives the user the possibility to give alternative instructions for the next operation the agent shall perfom instead of what the agent currently was planning.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Conditionally grouped 'n' and (former) 'edit' option in main.py and tui.py since the edit option did not have any difference as to how the agent was handling it compared to the 'n'. At the moment the user sees a 4th option but this is just mapped on the 'n' option aswell. If we prefer to leave the 'illusion' of a 4th option or add some text to the 2nd ('n') option to indicate to the user that he can continue providing instructions is still to be decided. 
Removed await prompt_for_next_task(AgentState.AWAITING_USER_INPUT) which potentially leading to double handling the USER_REJECTED state (during my tests I did not have any blocks but what I did notice before removing it is that I got the '>' agent awaiting input twice after selecting the 'edit' option, this is fixed now).
Removed test for 'edit' option since no longer relevant!


---
**Link of any specific issues this addresses:**
former 9392 - now closed
<img width="1679" height="1476" alt="grafik" src="https://github.com/user-attachments/assets/2248fd78-b983-47a5-aa6c-0ce6909db432" />
