### PR TITLE
Fix for issue where some cases use `WORK_PORT` and some use `APP_PORT`

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -623,8 +623,16 @@ def _create_server(
         os.getenv('VSCODE_PORT') or str(find_available_tcp_port(*VSCODE_PORT_RANGE))
     )
     app_ports = [
-        int(os.getenv('WORK_PORT_1') or os.getenv('WORK_PORT_1') or str(find_available_tcp_port(*APP_PORT_RANGE_1))),
-        int(os.getenv('WORK_PORT_2') or os.getenv('WORK_PORT_2') or str(find_available_tcp_port(*APP_PORT_RANGE_2))),
+        int(
+             os.getenv('WORK_PORT_1')
+             or os.getenv('APP_PORT_1')
+             or str(find_available_tcp_port(*APP_PORT_RANGE_1))
+         ),
+         int(
+             os.getenv('WORK_PORT_2')
+             or os.getenv('APP_PORT_2')
+             or str(find_available_tcp_port(*APP_PORT_RANGE_2))
+        ),
     ]
 
     # Get user info

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -624,14 +624,14 @@ def _create_server(
     )
     app_ports = [
         int(
-             os.getenv('WORK_PORT_1')
-             or os.getenv('APP_PORT_1')
-             or str(find_available_tcp_port(*APP_PORT_RANGE_1))
+            os.getenv('WORK_PORT_1')
+            or os.getenv('APP_PORT_1')
+            or str(find_available_tcp_port(*APP_PORT_RANGE_1))
          ),
          int(
-             os.getenv('WORK_PORT_2')
-             or os.getenv('APP_PORT_2')
-             or str(find_available_tcp_port(*APP_PORT_RANGE_2))
+            os.getenv('WORK_PORT_2')
+            or os.getenv('APP_PORT_2')
+            or str(find_available_tcp_port(*APP_PORT_RANGE_2))
         ),
     ]
 

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -627,8 +627,8 @@ def _create_server(
             os.getenv('WORK_PORT_1')
             or os.getenv('APP_PORT_1')
             or str(find_available_tcp_port(*APP_PORT_RANGE_1))
-         ),
-         int(
+        ),
+        int(
             os.getenv('WORK_PORT_2')
             or os.getenv('APP_PORT_2')
             or str(find_available_tcp_port(*APP_PORT_RANGE_2))

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -623,8 +623,8 @@ def _create_server(
         os.getenv('VSCODE_PORT') or str(find_available_tcp_port(*VSCODE_PORT_RANGE))
     )
     app_ports = [
-        int(os.getenv('APP_PORT_1') or str(find_available_tcp_port(*APP_PORT_RANGE_1))),
-        int(os.getenv('APP_PORT_2') or str(find_available_tcp_port(*APP_PORT_RANGE_2))),
+        int(os.getenv('WORK_PORT_1') or os.getenv('WORK_PORT_1') or str(find_available_tcp_port(*APP_PORT_RANGE_1))),
+        int(os.getenv('WORK_PORT_2') or os.getenv('WORK_PORT_2') or str(find_available_tcp_port(*APP_PORT_RANGE_2))),
     ]
 
     # Get user info


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Added check for work ports

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e7f1550-nikolaik   --name openhands-app-e7f1550   docker.all-hands.dev/all-hands-ai/openhands:e7f1550
```