### PR TITLE
Fix: Prevent LLM settings from being accessible in SaaS mode via double-click

### DIFF
--- a/frontend/src/components/shared/buttons/settings-button.tsx
+++ b/frontend/src/components/shared/buttons/settings-button.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import SettingsIcon from "#/icons/settings.svg?react";
 import { TooltipButton } from "./tooltip-button";
 import { I18nKey } from "#/i18n/declaration";
+import { useConfig } from "#/hooks/query/use-config";
 
 interface SettingsButtonProps {
   onClick?: () => void;
@@ -13,6 +14,12 @@ export function SettingsButton({
   disabled = false,
 }: SettingsButtonProps) {
   const { t } = useTranslation();
+  const { data: config } = useConfig();
+  
+  // Determine the correct settings path based on app mode
+  // In SaaS mode, navigate directly to user settings to avoid the LLM settings page
+  const settingsPath = 
+    config?.APP_MODE === "saas" ? "/settings/user" : "/settings";
 
   return (
     <TooltipButton
@@ -20,7 +27,7 @@ export function SettingsButton({
       tooltip={t(I18nKey.SETTINGS$TITLE)}
       ariaLabel={t(I18nKey.SETTINGS$TITLE)}
       onClick={onClick}
-      navLinkTo="/settings"
+      navLinkTo={settingsPath}
       disabled={disabled}
     >
       <SettingsIcon width={28} height={28} />

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { AxiosError } from "axios";
+import { useNavigate } from "react-router";
 import { ModelSelector } from "#/components/shared/modals/settings/model-selector";
 import { organizeModelsAndProviders } from "#/utils/organize-models-and-providers";
 import { useAIConfigOptions } from "#/hooks/query/use-ai-config-options";
@@ -28,12 +29,21 @@ import { DEFAULT_OPENHANDS_MODEL } from "#/utils/verified-models";
 
 function LlmSettingsScreen() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const { mutate: saveSettings, isPending } = useSaveSettings();
 
   const { data: resources } = useAIConfigOptions();
   const { data: settings, isLoading, isFetching } = useSettings();
   const { data: config } = useConfig();
+  
+  // Safety check: If in SaaS mode, redirect to user settings
+  // This provides an additional layer of protection
+  React.useEffect(() => {
+    if (config?.APP_MODE === "saas") {
+      navigate("/settings/user");
+    }
+  }, [config?.APP_MODE, navigate]);
 
   const [view, setView] = React.useState<"basic" | "advanced">("basic");
   const [securityAnalyzerInputIsVisible, setSecurityAnalyzerInputIsVisible] =


### PR DESCRIPTION
## Description
When using OpenHands in SaaS mode, clicking the settings button twice in quick succession could reveal the hidden LLM settings page, which should not be accessible in SaaS mode.

## Changes
1. Modified the `SettingsButton` component to directly navigate to `/settings/user` in SaaS mode instead of relying on the redirect from `/settings` to `/settings/user`
2. Added a safety check in the `LlmSettingsScreen` component to redirect to user settings if the app is in SaaS mode

## Testing
- Verified that the build completes successfully with the changes
- The changes ensure that even with rapid double-clicking, users in SaaS mode will always be directed to the user settings page instead of the LLM settings page

## Related Issues
Fixes the issue where double-clicking the settings button in SaaS mode reveals hidden LLM settings.

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/69083c8ec7a94ba88cd55eab878d88c5)