### PR TITLE
Sort conversations by last activity time instead of creation time

### DIFF
--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -115,6 +115,11 @@ class FileConversationStore(ConversationStore):
 
 
 def _sort_key(conversation: ConversationMetadata) -> str:
+    # Sort by last_updated_at if available, otherwise fall back to created_at
+    last_updated_at = conversation.last_updated_at
+    if last_updated_at:
+        return last_updated_at.isoformat()  # YYYY-MM-DDTHH:MM:SS for sorting
+
     created_at = conversation.created_at
     if created_at:
         return created_at.isoformat()  # YYYY-MM-DDTHH:MM:SS for sorting


### PR DESCRIPTION
## Summary

This PR implements the requested feature to sort conversations by how recently they were active (`last_updated_at`) instead of how recently they were created (`created_at`). This provides a better user experience as users typically want to see their most recently worked-on conversations at the top.

## Changes Made

### Core Implementation
- **Modified `_sort_key` function** in `openhands/storage/conversation/file_conversation_store.py`:
  - Now prioritizes `last_updated_at` over `created_at` for sorting
  - Added fallback to `created_at` when `last_updated_at` is None for backward compatibility
  - Maintains the same ISO format sorting for consistency

### Testing
- **Updated existing tests** to reflect new sorting behavior
- **Added comprehensive test coverage**:
  - `test_search_sort_by_last_updated_at`: Verifies sorting by `last_updated_at` when available
  - `test_search_mixed_last_updated_at`: Verifies fallback behavior for conversations without `last_updated_at`

## Key Benefits

✅ **Better UX**: Conversations now appear in order of recent activity rather than creation time  
✅ **Backward Compatible**: Conversations without `last_updated_at` still work (fallback to `created_at`)  
✅ **Consistent**: Uses the same sorting pattern as other conversation managers in the codebase  
✅ **Well Tested**: Comprehensive test coverage for all scenarios  

## Testing

- All existing unit tests continue to pass
- New tests verify correct sorting behavior in all scenarios
- Pre-commit hooks pass with proper formatting
- Manual testing confirmed expected sorting behavior

## Technical Details

- The change is minimal and focused - only the `_sort_key` function was modified
- No breaking changes to existing functionality
- Follows existing code patterns and conventions
- The `last_updated_at` field is already properly maintained by the conversation system

This change aligns the file conversation store sorting behavior with the user's expectation that recently active conversations should appear first, improving the overall user experience.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f639f9a47b8a43e69f82c07837d4d4d8)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:57c787f-nikolaik   --name openhands-app-57c787f   docker.all-hands.dev/all-hands-ai/openhands:57c787f
```