### PR TITLE
Update summary prompt to avoid repetition in consecutive summaries

### DIFF
--- a/openhands/integrations/templates/resolver/summary_prompt.j2
+++ b/openhands/integrations/templates/resolver/summary_prompt.j2
@@ -5,4 +5,5 @@ If you simply answered a question, this final message should re-state the answer
 If you made changes, please first double-check the git diff, think carefully about the user's request(s), and check:
 1. whether the request has been completely addressed and all of the instructions have been followed faithfully (in checklist format if appropriate).
 2. whether the changes are concise (if there are any extraneous changes not important to addressing the user's request they should be reverted).
+3. focus only on summarizing new changes since your last summary, avoiding repetition of information already covered in previous summaries.
 If the request has been addressed and the changes are concise, then push your changes to the remote branch and send a final message summarizing the changes.


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

- Improves the summary generation by instructing the agent to focus only on new changes since the last summary, preventing repetitive information in consecutive summaries.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR updates the summary instructions template to include a directive for the agent to focus only on summarizing new changes since the last summary, avoiding repetition of information already covered in previous summaries.

The change adds a new item to the checklist that agents should consider when generating summaries, encouraging more concise and relevant summaries that do not repeat information unnecessarily.


Example [slack conversation](https://openhands-ai.slack.com/archives/C086ARSNMGA/p1753128590006579) where repetitive information in summaries makes it time consuming to decipher new changes that were made 

---
**Link of any specific issues this addresses:**

N/A

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c8c64fb-nikolaik   --name openhands-app-c8c64fb   docker.all-hands.dev/all-hands-ai/openhands:c8c64fb
```