### PR TITLE
fix workspace repo can not be set by -d/--directory

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -850,4 +850,8 @@ def setup_config_from_args(args: argparse.Namespace) -> OpenHandsConfig:
     if args.selected_repo is not None:
         config.sandbox.selected_repo = args.selected_repo
 
+    # Set workspace base folder if provided
+    if args.directory is not None:
+        config.workspace_base = args.directory
+
     return config


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below
---
**Summarize what the PR does, explaining any non-trivial design decisions.**
   fix workspace repo can not be set by -d/--directory
