### PR TITLE
fix(frontend): Add context menu state management to Controls component

### DIFF
--- a/frontend/src/components/features/controls/controls.tsx
+++ b/frontend/src/components/features/controls/controls.tsx
@@ -13,6 +13,7 @@ interface ControlsProps {
 
 export function Controls({ setSecurityOpen, showSecurityLock }: ControlsProps) {
   const { data: conversation } = useActiveConversation();
+  const [contextMenuOpen, setContextMenuOpen] = React.useState(false);
 
   return (
     <div className="flex flex-col gap-2 md:items-center md:justify-between md:flex-row">
@@ -37,6 +38,8 @@ export function Controls({ setSecurityOpen, showSecurityLock }: ControlsProps) {
         }}
         conversationStatus={conversation?.status}
         conversationId={conversation?.conversation_id}
+        contextMenuOpen={contextMenuOpen}
+        onContextMenuToggle={setContextMenuOpen}
       />
     </div>
   );


### PR DESCRIPTION
## Description
This PR fixes the issue where the three dots menu on the conversation card is no longer clickable in the main branch. The problem was introduced in PR #9822 which changed the context menu state management from the ConversationCard component to its parent components.

## Problem
The Controls component in `frontend/src/components/features/controls/controls.tsx` was using the ConversationCard component but didn't provide the new required props:
1. `contextMenuOpen` - A boolean indicating if the context menu is open
2. `onContextMenuToggle` - A callback function to toggle the context menu state

## Solution
Added state management for the context menu in the Controls component and passed the required props to the ConversationCard component, similar to how it's done in the ConversationPanel component.

## Testing
Built and verified that the three dots menu is now clickable again.

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1107d0127db3420996c2abedc8f854c4)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f0c8cf8-nikolaik   --name openhands-app-f0c8cf8   docker.all-hands.dev/all-hands-ai/openhands:f0c8cf8
```