### PR TITLE
Add base experiment manager infrastructure

### DIFF
--- a/openhands/experiments/experiment_manager.py
+++ b/openhands/experiments/experiment_manager.py
@@ -1,5 +1,6 @@
 import os
 
+from openhands.core.config.agent_config import AgentConfig
 from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.utils.import_utils import get_impl
 
@@ -10,6 +11,12 @@ class ExperimentManager:
         user_id: str, conversation_id: str, conversation_settings: ConversationInitData
     ) -> ConversationInitData:
         return conversation_settings
+
+    @staticmethod
+    def run_agent_config_variant_test(
+        user_id: str, conversation_id: str, agent_config: AgentConfig
+    ) -> AgentConfig:
+        return agent_config
 
 
 experiment_manager_cls = os.environ.get(

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -28,6 +28,7 @@ from openhands.events.observation.agent import RecallObservation
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.serialization import event_from_dict, event_to_dict
 from openhands.events.stream import EventStreamSubscriber
+from openhands.experiments.experiment_manager import ExperimentManagerImpl
 from openhands.llm.llm import LLM
 from openhands.runtime.runtime_status import RuntimeStatus
 from openhands.server.session.agent_session import AgentSession
@@ -156,6 +157,10 @@ class Session:
 
         llm = self._create_llm(agent_cls)
         agent_config = self.config.get_agent_config(agent_cls)
+
+        agent_config = ExperimentManagerImpl.run_agent_config_variant_test(
+            self.user_id, self.sid, agent_config
+        )
 
         if settings.enable_default_condenser:
             # Default condenser chains three condensers together:


### PR DESCRIPTION
## Description

This PR adds an experiment manager that allows customizing the system prompt used by agents in OpenHands. This is particularly useful for testing different system prompts to improve agent performance or for specializing agents for specific tasks.

## Changes

- Added `run_agent_config_variant_test` method to `ExperimentManager` class in `experiment_manager.py` that can modify the agent config used by agents
- Updated `session.py` to call the experiment manager when initializing agents
- Added import for `AgentConfig` in `experiment_manager.py`
- Added import for `ExperimentManagerImpl` in `session.py`

## How to Use

The experiment manager provides a hook point for customizing agent configuration during initialization. Custom experiment managers can be implemented by extending the `ExperimentManager` class and overriding the `run_agent_config_variant_test` method.

## Testing

- [x] Pre-commit hooks pass
- [x] Code follows existing patterns and conventions
- [x] Changes are minimal and focused

This implementation provides the base infrastructure for experiment management while maintaining backward compatibility.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a977d34938a43fd8095bcc46ed0cf09)