### PR TITLE
Fix system prompts to exclude tests for documentation changes

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -51,6 +51,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 3. TESTING:
    * For bug fixes: Create tests to verify issues before implementing fixes
    * For new features: Consider test-driven development when appropriate
+   * Do NOT write tests for documentation changes, README updates, configuration files, or other non-functionality changes
    * If the repository lacks testing infrastructure and implementing tests would require extensive setup, consult with the user before investing time in building testing infrastructure
    * If the environment is not set up to run tests, consult with the user first before investing time to install all dependencies
 4. IMPLEMENTATION:

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
@@ -45,6 +45,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 3. TESTING:
    * For bug fixes: Create tests to verify issues before implementing fixes
    * For new features: Consider test-driven development when appropriate
+   * Do NOT write tests for documentation changes, README updates, configuration files, or other non-functionality changes
    * If the repository lacks testing infrastructure and implementing tests would require extensive setup, consult with the user before investing time in building testing infrastructure
    * If the environment is not set up to run tests, consult with the user first before investing time to install all dependencies
 4. IMPLEMENTATION: Make focused, minimal changes to address the problem

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
@@ -44,6 +44,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 3. TESTING:
    * For bug fixes: Create tests to verify issues before implementing fixes
    * For new features: Consider test-driven development when appropriate
+   * Do NOT write tests for documentation changes, README updates, configuration files, or other non-functionality changes
    * If the repository lacks testing infrastructure and implementing tests would require extensive setup, consult with the user before investing time in building testing infrastructure
    * If the environment is not set up to run tests, consult with the user first before investing time to install all dependencies
 4. IMPLEMENTATION: Make focused, minimal changes to address the problem


### PR DESCRIPTION
## Summary

This PR fixes the system prompts to prevent OpenHands from writing tests for documentation and other non-functionality changes, addressing the issue of wasting tokens/cycles on unnecessary test creation.

## Changes Made

- Added explicit instruction to **NOT** write tests for:
  - Documentation changes
  - README updates  
  - Configuration files
  - Other non-functionality changes

- Updated all three CodeAct agent system prompt variants:
  - `system_prompt.j2`
  - `system_prompt_interactive.j2`
  - `system_prompt_long_horizon.j2`

## Problem Addressed

Previously, OpenHands would automatically attempt to write tests for documentation work, which is unnecessary and wastes computational resources. This change provides clear guidance to the agent to skip test creation for non-functional changes while maintaining the testing workflow for actual code changes.

## Testing

- Verified that the new instruction appears in all system prompt variants
- Confirmed that existing testing instructions for bug fixes and new features remain intact
- Pre-commit hooks pass successfully

## Impact

- Reduces unnecessary token consumption during documentation tasks
- Maintains proper testing practices for functional code changes
- Provides clearer guidance to the agent on when tests are appropriate

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7030eb212f5f47318cde94a1e54c0d85)