### PR TITLE
Add IP whitelisting information for Bitbucket Cloud integration

### DIFF
--- a/docs/usage/cloud/bitbucket-installation.mdx
+++ b/docs/usage/cloud/bitbucket-installation.mdx
@@ -8,6 +8,28 @@ description: This guide walks you through the process of installing OpenHands Cl
 
 - Signed in to [OpenHands Cloud](https://app.all-hands.dev) with [a Bitbucket account](/usage/cloud/openhands-cloud).
 
+## IP Whitelisting
+
+If your Bitbucket Cloud instance has IP restrictions, you'll need to whitelist the following IP addresses to allow OpenHands to access your repositories:
+
+### Core App IP
+```
+34.68.58.200
+```
+
+### Runtime IPs
+```
+34.10.175.217
+34.45.0.142
+34.28.69.126
+35.224.240.213
+34.70.174.52
+34.42.4.87
+35.222.133.153
+34.29.175.97
+34.60.55.59
+```
+
 ## Adding Bitbucket Repository Access
 
 Upon signing into OpenHands Cloud with a Bitbucket account, OpenHands will have access to your repositories.


### PR DESCRIPTION
This PR adds IP whitelisting information to the Bitbucket Cloud integration documentation. It includes:

- Core app IP address
- Runtime IP addresses

These IPs need to be whitelisted for organizations that have IP restrictions on their Bitbucket Cloud instance to allow OpenHands to access their repositories.

The information is added to the existing Bitbucket integration documentation file at `docs/usage/cloud/bitbucket-installation.mdx`.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/113f6bb4833f432a998edeb603b940f4)