### PR TITLE
Do not override user's git config in CLI mode or local machine

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -31,9 +31,9 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* You MUST keep the same git config in place, if it already exists. Only if git has not been configured on the machine, then you are permitted to configure it with "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* When committing changes, you MUST use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. This ensures all commits are attributed to the OpenHands agent, regardless of the local git config.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
-* When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
+* When committing, use `git status` to see all modified files, and stage all files necessary for the commit.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
 * If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
 </VERSION_CONTROL>

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -33,7 +33,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 <VERSION_CONTROL>
 * When committing changes, you MUST use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. This ensures all commits are attributed to the OpenHands agent, regardless of the local git config.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
-* When committing, use `git status` to see all modified files, and stage all files necessary for the commit.
+* When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
 * If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
 </VERSION_CONTROL>

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -31,7 +31,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* When configuring git credentials, use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* You MUST keep the same git config in place, if it already exists. Only if git has not been configured on the machine, then you are permitted to configure it with "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
 * When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
@@ -27,7 +27,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 <VERSION_CONTROL>
 * When committing changes, you MUST use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. This ensures all commits are attributed to the OpenHands agent, regardless of the local git config.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
-* When committing, use `git status` to see all modified files, and stage all files necessary for the commit.
+* When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
 * If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
 </VERSION_CONTROL>

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
@@ -25,7 +25,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* When configuring git credentials, use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* You MUST keep the same git config in place, if it already exists. Only if git has not been configured on the machine, then you are permitted to configure it with "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
 * When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
@@ -25,9 +25,9 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* You MUST keep the same git config in place, if it already exists. Only if git has not been configured on the machine, then you are permitted to configure it with "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* When committing changes, you MUST use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. This ensures all commits are attributed to the OpenHands agent, regardless of the local git config.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
-* When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
+* When committing, use `git status` to see all modified files, and stage all files necessary for the commit.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
 * If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
 </VERSION_CONTROL>

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
@@ -27,7 +27,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 <VERSION_CONTROL>
 * When committing changes, you MUST use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. This ensures all commits are attributed to the OpenHands agent, regardless of the local git config.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
-* When committing, use `git status` to see all modified files, and stage all files necessary for the commit.
+* When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
 * If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
 </VERSION_CONTROL>

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
@@ -25,7 +25,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* When configuring git credentials, use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* You MUST keep the same git config in place, if it already exists. Only if git has not been configured on the machine, then you are permitted to configure it with "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
 * When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
@@ -25,9 +25,9 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* You MUST keep the same git config in place, if it already exists. Only if git has not been configured on the machine, then you are permitted to configure it with "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* When committing changes, you MUST use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. This ensures all commits are attributed to the OpenHands agent, regardless of the local git config.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
-* When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
+* When committing, use `git status` to see all modified files, and stage all files necessary for the commit.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
 * If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
 </VERSION_CONTROL>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Fix the system prompt to keep the user's git config in place. We have reports on slack about it overriding the local user, thus people have to spend time re-configuring it.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c9368ea-nikolaik   --name openhands-app-c9368ea   docker.all-hands.dev/all-hands-ai/openhands:c9368ea
```