### PR TITLE
Update Slack integration 'Add to Slack' button link

### DIFF
--- a/docs/usage/cloud/slack-installation.mdx
+++ b/docs/usage/cloud/slack-installation.mdx
@@ -24,7 +24,7 @@ description: This guide walks you through installing the OpenHands Slack app.
   **This step is for Slack admins/owners**
 
   1. Make sure you have permissions to install Apps to your workspace.
-  2. Click the button below to install OpenHands Slack App <a target="_blank" href="https://slack.com/oauth/v2/authorize?client_id=7477886716822.8729519890534&scope=app_mentions:read,chat:write,users:read,channels:history,groups:history,mpim:history,im:history&user_scope=channels:history,groups:history,im:history,mpim:history"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
+  2. Click the button below to install OpenHands Slack App <a target="_blank" href="https://slack.com/oauth/v2/authorize?client_id=7477886716822.8729519890534&scope=app_mentions:read,channels:history,chat:write,groups:history,im:history,mpim:history,users:read&user_scope="><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
   3. In the top right corner, select the workspace to install the OpenHands Slack app.
   4. Review permissions and click allow.
 


### PR DESCRIPTION
## Summary
Updated the "Add to Slack" button link in the Slack integration documentation to use the new OAuth authorization URL with updated scope configuration.

## Changes
- Updated OAuth authorization URL in `/docs/usage/cloud/slack-installation.mdx`
- Changed scope parameter order to: `app_mentions:read,channels:history,chat:write,groups:history,im:history,mpim:history,users:read`
- Removed user_scope parameters (now empty: `user_scope=`)

## Testing
- [x] Verified only the intended documentation file was modified
- [x] Confirmed the new URL format matches the provided specification

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

Related to [ALL-2386](https://linear.app/all-hands-ai/issue/ALL-2386/publish-slack-app-to-marketplace)

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/86128482bf22458ab7996da27ef7d3a4)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7d30ce9-nikolaik   --name openhands-app-7d30ce9   docker.all-hands.dev/all-hands-ai/openhands:7d30ce9
```