### PR TITLE
Update Slack OAuth URL for the 'Install OpenHands Slack App' button

### DIFF
--- a/frontend/src/components/features/settings/git-settings/install-slack-app-anchor.tsx
+++ b/frontend/src/components/features/settings/git-settings/install-slack-app-anchor.tsx
@@ -8,7 +8,7 @@ export function InstallSlackAppAnchor() {
   return (
     <a
       data-testid="install-slack-app-button"
-      href="https://slack.com/oauth/v2/authorize?client_id=7477886716822.8729519890534&scope=app_mentions:read,chat:write,users:read,channels:history,groups:history,mpim:history,im:history&user_scope=channels:history,groups:history,im:history,mpim:history"
+      href="https://slack.com/oauth/v2/authorize?client_id=7477886716822.8729519890534&scope=app_mentions:read,channels:history,chat:write,groups:history,im:history,mpim:history,users:read&user_scope="
       target="_blank"
       rel="noreferrer noopener"
       className="py-9"


### PR DESCRIPTION
This PR updates the Slack OAuth URL for the 'Install OpenHands Slack App' button in the frontend component.

The update changes the scope parameters and removes the user_scope values as requested.

**Changes:**
- Updated the OAuth URL in `frontend/src/components/features/settings/git-settings/install-slack-app-anchor.tsx`
- Reordered the scope parameters alphabetically
- Removed the user_scope values

**Note:** Only the frontend component was updated as requested, leaving the documentation file unchanged.

Related to [ALL-2386](https://linear.app/all-hands-ai/issue/ALL-2386/publish-slack-app-to-marketplace)

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/90838768f6bb4796bf2cf7f568f6b05c)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5f3f6a6-nikolaik   --name openhands-app-5f3f6a6   docker.all-hands.dev/all-hands-ai/openhands:5f3f6a6
```