### PR TITLE
Fix 'Is a directory' error when CLI tries to read a folder

### DIFF
--- a/openhands/cli/utils.py
+++ b/openhands/cli/utils.py
@@ -231,6 +231,26 @@ def split_is_actually_version(split: list[str]) -> bool:
 
 
 def read_file(file_path: str | Path) -> str:
+    """Read content from a file.
+
+    Args:
+        file_path: Path to the file to read
+
+    Returns:
+        str: Content of the file
+
+    Raises:
+        IsADirectoryError: If the path is a directory
+        FileNotFoundError: If the file doesn't exist
+        PermissionError: If there are permission issues
+    """
+    from pathlib import Path
+
+    path = Path(file_path)
+
+    if path.is_dir():
+        raise IsADirectoryError(f"'{file_path}' is a directory, not a file")
+
     with open(file_path, 'r') as f:
         return f.read()
 

--- a/openhands/io/io.py
+++ b/openhands/io/io.py
@@ -18,7 +18,24 @@ def read_input(cli_multiline_input: bool = False) -> str:
 
 
 def read_task_from_file(file_path: str) -> str:
-    """Read task from the specified file."""
+    """Read task from the specified file.
+
+    Args:
+        file_path: Path to the file to read
+
+    Returns:
+        str: Content of the file
+
+    Raises:
+        IsADirectoryError: If the path is a directory
+        FileNotFoundError: If the file doesn't exist
+        PermissionError: If there are permission issues
+    """
+    import os
+
+    if os.path.isdir(file_path):
+        raise IsADirectoryError(f"'{file_path}' is a directory, not a file")
+
     with open(file_path, 'r', encoding='utf-8') as file:
         return file.read()
 
@@ -31,7 +48,20 @@ def read_task(args: argparse.Namespace, cli_multiline_input: bool) -> str:
     # Determine the task
     task_str = ''
     if args.file:
-        task_str = read_task_from_file(args.file)
+        try:
+            task_str = read_task_from_file(args.file)
+        except IsADirectoryError as e:
+            print(f'Error: {e}')
+            sys.exit(1)
+        except FileNotFoundError:
+            print(f"Error: File '{args.file}' not found.")
+            sys.exit(1)
+        except PermissionError:
+            print(f"Error: Permission denied when reading '{args.file}'.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error reading file '{args.file}': {e}")
+            sys.exit(1)
     elif args.task:
         task_str = args.task
     elif not sys.stdin.isatty():

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -461,6 +461,26 @@ class TestFileOperations:
 
         assert result == mock_content
 
+    def test_read_file_directory_error(self):
+        """Test that read_file raises IsADirectoryError when trying to read a directory."""
+        with patch('pathlib.Path.is_dir', return_value=True):
+            try:
+                read_file('/some/directory')
+                raise AssertionError('Expected IsADirectoryError to be raised')
+            except IsADirectoryError as e:
+                assert 'is a directory, not a file' in str(e)
+                assert '/some/directory' in str(e)
+
+    def test_read_file_regular_file(self):
+        """Test that read_file works normally for regular files."""
+        mock_content = 'test file content'
+        with (
+            patch('pathlib.Path.is_dir', return_value=False),
+            patch('builtins.open', mock_open(read_data=mock_content)),
+        ):
+            result = read_file('test.txt')
+            assert result == mock_content
+
     def test_write_to_file(self):
         mock_content = 'test file content'
         mock_file = mock_open()

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,7 +1,7 @@
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 from openhands.core.config import OpenHandsConfig
-from openhands.io import read_input
+from openhands.io import read_input, read_task_from_file
 
 
 def test_single_line_input():
@@ -25,3 +25,26 @@ def test_multiline_input():
     with patch('builtins.input', side_effect=mock_inputs):
         result = read_input(config.cli_multiline_input)
         assert result == 'line 1\nline 2\nline 3'
+
+
+def test_read_task_from_file():
+    """Test that read_task_from_file works correctly for regular files"""
+    mock_content = 'This is a task from a file'
+
+    with (
+        patch('os.path.isdir', return_value=False),
+        patch('builtins.open', mock_open(read_data=mock_content)),
+    ):
+        result = read_task_from_file('task.txt')
+        assert result == mock_content
+
+
+def test_read_task_from_file_directory_error():
+    """Test that read_task_from_file raises IsADirectoryError when trying to read a directory"""
+    with patch('os.path.isdir', return_value=True):
+        try:
+            read_task_from_file('/some/directory')
+            raise AssertionError('Expected IsADirectoryError to be raised')
+        except IsADirectoryError as e:
+            assert 'is a directory, not a file' in str(e)
+            assert '/some/directory' in str(e)


### PR DESCRIPTION
## Problem

Users were encountering confusing raw error messages like `[Errno 21] Is a directory: '/path/to/directory'` when accidentally trying to read a directory as a file in the CLI. This happened because the file reading functions didn't properly validate whether the provided path was a directory before attempting to open it as a file.

## Solution

This PR adds proper directory validation and user-friendly error handling to the file reading functions:

### Changes Made

1. **`openhands/cli/utils.py`** - Enhanced `read_file()` function:
   - Added directory check using `Path.is_dir()` before attempting to open file
   - Raises clear `IsADirectoryError` with descriptive message
   - Added comprehensive docstring with exception documentation

2. **`openhands/io/io.py`** - Enhanced `read_task_from_file()` function:
   - Added directory check using `os.path.isdir()` before attempting to open file
   - Raises clear `IsADirectoryError` with descriptive message
   - Added comprehensive docstring with exception documentation

3. **`openhands/io/io.py`** - Enhanced `read_task()` function:
   - Added comprehensive exception handling for file operations
   - Provides user-friendly error messages for different error types
   - Gracefully exits with appropriate error codes

4. **Added comprehensive unit tests**:
   - Tests for directory error handling in `tests/unit/test_cli_utils.py`
   - Tests for directory error handling in `tests/unit/test_io.py`
   - Ensures normal file reading functionality still works correctly

### Before
```
[Errno 21] Is a directory: '/mnt/data/research/xingyao/2025_prod_data'
```

### After
```
Error: '/mnt/data/research/xingyao/2025_prod_data' is a directory, not a file
```

## Testing

- All existing tests continue to pass
- New unit tests verify directory detection works correctly
- New unit tests verify normal file reading still functions properly
- Pre-commit hooks pass (Python linting and formatting)

## Impact

This change improves user experience by providing clear, actionable error messages when users accidentally try to read directories as files, replacing confusing system error codes with human-readable explanations.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/733c42fd80c04589a35379df7af06784)