### PR TITLE
feat(frontend): improve conversation card context menu

### DIFF
--- a/frontend/src/components/features/context-menu/context-menu-list-item.tsx
+++ b/frontend/src/components/features/context-menu/context-menu-list-item.tsx
@@ -19,7 +19,7 @@ export function ContextMenuListItem({
       onClick={onClick}
       disabled={isDisabled}
       className={cn(
-        "text-sm px-4 py-2 w-full text-start hover:bg-white/10 first-of-type:rounded-t-md last-of-type:rounded-b-md",
+        "text-sm px-4 h-10 w-full text-start hover:bg-white/10",
         "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent text-nowrap",
       )}
     >

--- a/frontend/src/components/features/context-menu/context-menu.tsx
+++ b/frontend/src/components/features/context-menu/context-menu.tsx
@@ -18,7 +18,7 @@ export function ContextMenu({
     <ul
       data-testid={testId}
       ref={ref}
-      className={cn("bg-tertiary rounded-md", className)}
+      className={cn("bg-tertiary rounded-md overflow-hidden", className)}
     >
       {children}
     </ul>

--- a/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
@@ -1,8 +1,18 @@
+import {
+  Trash,
+  Power,
+  Pencil,
+  Download,
+  Wallet,
+  Wrench,
+  Bot,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { cn } from "#/utils/utils";
 import { ContextMenu } from "../context-menu/context-menu";
 import { ContextMenuListItem } from "../context-menu/context-menu-list-item";
+import { ContextMenuSeparator } from "../context-menu/context-menu-separator";
 import { I18nKey } from "#/i18n/declaration";
 
 interface ConversationCardContextMenuProps {
@@ -31,6 +41,12 @@ export function ConversationCardContextMenu({
   const { t } = useTranslation();
   const ref = useClickOutsideElement<HTMLUListElement>(onClose);
 
+  const hasEdit = Boolean(onEdit);
+  const hasDownload = Boolean(onDownloadViaVSCode);
+  const hasTools = Boolean(onShowAgentTools || onShowMicroagents);
+  const hasInfo = Boolean(onDisplayCost);
+  const hasControl = Boolean(onStop || onDelete);
+
   return (
     <ContextMenu
       ref={ref}
@@ -41,51 +57,90 @@ export function ConversationCardContextMenu({
         position === "bottom" && "top-full",
       )}
     >
-      {onDelete && (
-        <ContextMenuListItem testId="delete-button" onClick={onDelete}>
-          {t(I18nKey.BUTTON$DELETE)}
-        </ContextMenuListItem>
-      )}
-      {onStop && (
-        <ContextMenuListItem testId="stop-button" onClick={onStop}>
-          {t(I18nKey.BUTTON$STOP)}
-        </ContextMenuListItem>
-      )}
       {onEdit && (
         <ContextMenuListItem testId="edit-button" onClick={onEdit}>
-          {t(I18nKey.BUTTON$EDIT_TITLE)}
+          <div className="flex items-center gap-3 px-1">
+            <Pencil className="w-4 h-4 shrink-0" />
+            {t(I18nKey.BUTTON$EDIT_TITLE)}
+          </div>
         </ContextMenuListItem>
       )}
+
+      {hasEdit && (hasDownload || hasTools || hasInfo || hasControl) && (
+        <ContextMenuSeparator />
+      )}
+
       {onDownloadViaVSCode && (
         <ContextMenuListItem
           testId="download-vscode-button"
           onClick={onDownloadViaVSCode}
         >
-          {t(I18nKey.BUTTON$DOWNLOAD_VIA_VSCODE)}
+          <div className="flex items-center gap-3 px-1">
+            <Download className="w-4 h-4 shrink-0" />
+            {t(I18nKey.BUTTON$DOWNLOAD_VIA_VSCODE)}
+          </div>
         </ContextMenuListItem>
       )}
-      {onDisplayCost && (
-        <ContextMenuListItem
-          testId="display-cost-button"
-          onClick={onDisplayCost}
-        >
-          {t(I18nKey.BUTTON$DISPLAY_COST)}
-        </ContextMenuListItem>
+
+      {hasDownload && (hasTools || hasInfo || hasControl) && (
+        <ContextMenuSeparator />
       )}
+
       {onShowAgentTools && (
         <ContextMenuListItem
           testId="show-agent-tools-button"
           onClick={onShowAgentTools}
         >
-          {t(I18nKey.BUTTON$SHOW_AGENT_TOOLS_AND_METADATA)}
+          <div className="flex items-center gap-3 px-1">
+            <Wrench className="w-4 h-4 shrink-0" />
+            {t(I18nKey.BUTTON$SHOW_AGENT_TOOLS_AND_METADATA)}
+          </div>
         </ContextMenuListItem>
       )}
+
       {onShowMicroagents && (
         <ContextMenuListItem
           testId="show-microagents-button"
           onClick={onShowMicroagents}
         >
-          {t(I18nKey.CONVERSATION$SHOW_MICROAGENTS)}
+          <div className="flex items-center gap-3 px-1">
+            <Bot className="w-4 h-4 shrink-0" />
+            {t(I18nKey.CONVERSATION$SHOW_MICROAGENTS)}
+          </div>
+        </ContextMenuListItem>
+      )}
+
+      {hasTools && (hasInfo || hasControl) && <ContextMenuSeparator />}
+
+      {onDisplayCost && (
+        <ContextMenuListItem
+          testId="display-cost-button"
+          onClick={onDisplayCost}
+        >
+          <div className="flex items-center gap-3 px-1">
+            <Wallet className="w-4 h-4 shrink-0" />
+            {t(I18nKey.BUTTON$DISPLAY_COST)}
+          </div>
+        </ContextMenuListItem>
+      )}
+
+      {hasInfo && hasControl && <ContextMenuSeparator />}
+
+      {onStop && (
+        <ContextMenuListItem testId="stop-button" onClick={onStop}>
+          <div className="flex items-center gap-3 px-1">
+            <Power className="w-4 h-4 shrink-0" />
+            {t(I18nKey.BUTTON$STOP)}
+          </div>
+        </ContextMenuListItem>
+      )}
+
+      {onDelete && (
+        <ContextMenuListItem testId="delete-button" onClick={onDelete}>
+          <div className="flex items-center gap-3 px-1">
+            <Trash className="w-4 h-4 shrink-0" />
+            {t(I18nKey.BUTTON$DELETE)}
+          </div>
         </ContextMenuListItem>
       )}
     </ContextMenu>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Improved conversation context menu UI with icons and separators

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Updated the conversation context menu:
- Added icons to the menu items
- Sorted and grouped the menu items, with separators
- Added logic for the separators so they remain consistent no matter what menu items are active

Screenshot - all icons visible (all menu items force-enabled):
<img width="413" height="344" alt="image" src="https://github.com/user-attachments/assets/a3a51960-525e-4b9b-a4f8-43742d28acdc" />

Screenshots - normal usage (before):
<img width="424" height="173" alt="image" src="https://github.com/user-attachments/assets/6f094397-87c4-4c18-b2c0-70f10a9f157a" />
<img width="244" height="175" alt="image" src="https://github.com/user-attachments/assets/512c6cef-21e1-450f-b119-4a99f4dbfe45" />

Screenshots - normal usage (after):
<img width="414" height="186" alt="image" src="https://github.com/user-attachments/assets/0be2542b-3644-42b6-bdfa-838c0a2d9d28" />
<img width="278" height="186" alt="image" src="https://github.com/user-attachments/assets/ee717eb6-7df7-4309-8379-e3e88cb91934" />

---
**Link of any specific issues this addresses:**
