### PR TITLE
fix: Properly propagate AgentRuntimeTimeoutError to evaluation loop

### DIFF
--- a/evaluation/benchmarks/swe_bench/run_infer.py
+++ b/evaluation/benchmarks/swe_bench/run_infer.py
@@ -641,7 +641,9 @@ def process_instance(
             )
         )
 
-        # if fatal error, throw EvalError to trigger re-run
+        # if state is None or has a fatal error, throw EvalError to trigger re-run
+        if state is None:
+            raise EvalException('State is None, likely due to a runtime error')
         if is_fatal_evaluation_error(state.last_error):
             raise EvalException('Fatal error detected: ' + state.last_error)
 
@@ -671,8 +673,9 @@ def process_instance(
 
     # If you are working on some simpler benchmark that only evaluates the final model output (e.g., in a MessageAction)
     # You can simply get the LAST `MessageAction` from the returned `state.history` and parse it for evaluation.
+    # This check is redundant since we already check above, but keeping it for safety
     if state is None:
-        raise ValueError('State should not be None.')
+        raise EvalException('State is None, likely due to a runtime error')
 
     # NOTE: this is NO LONGER the event stream, but an agent history that includes delegate agent's events
     histories = [event_to_dict(event) for event in state.history]


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR fixes an issue where `AgentRuntimeTimeoutError` was not being properly propagated to the evaluation loop, causing evaluations to hang indefinitely when a timeout occurred. Now, when a runtime timeout happens, the error will be properly detected and handled, allowing the evaluation to either retry or report the error appropriately.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

1. Modified `openhands/core/main.py` to:
   - Add imports for runtime exception classes
   - Set the error in the controller state when an exception occurs
   - Re-raise fatal runtime errors so they can be properly handled by the evaluation loop

2. Modified `evaluation/benchmarks/swe_bench/run_infer.py` to:
   - Add a check for when the state is None (which can happen when a runtime error occurs)
   - Change the error type from `ValueError` to `EvalException` to trigger the retry mechanism

The key design decision was to re-raise specific runtime errors in the `run_controller` function rather than catching and suppressing them. This ensures that the evaluation loop can detect and handle these errors appropriately.

---
**Link of any specific issues this addresses:**

N/A

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5ec45a5bdb5b4aee93a9f96dc5757f6d)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c92f71c-nikolaik   --name openhands-app-c92f71c   docker.all-hands.dev/all-hands-ai/openhands:c92f71c
```