### PR TITLE
fix(docker-runtime): adjust default port ranges to avoid Windows ephemeral ports

### DIFF
--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -44,6 +44,12 @@ VSCODE_PORT_RANGE = (40000, 49999)
 APP_PORT_RANGE_1 = (50000, 54999)
 APP_PORT_RANGE_2 = (55000, 59999)
 
+if os.name == 'nt':
+    EXECUTION_SERVER_PORT_RANGE = (30000, 34999)
+    VSCODE_PORT_RANGE = (35000, 39999)
+    APP_PORT_RANGE_1 = (40000, 44999)
+    APP_PORT_RANGE_2 = (45000, 49151)
+
 
 def _is_retryablewait_until_alive_error(exception: Exception) -> bool:
     if isinstance(exception, tenacity.RetryError):

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import typing
 from functools import lru_cache
 from typing import Callable
@@ -44,7 +45,7 @@ VSCODE_PORT_RANGE = (40000, 49999)
 APP_PORT_RANGE_1 = (50000, 54999)
 APP_PORT_RANGE_2 = (55000, 59999)
 
-if os.name == 'nt':
+if os.name == 'nt' or platform.release().endswith('microsoft-standard-WSL2'):
     EXECUTION_SERVER_PORT_RANGE = (30000, 34999)
     VSCODE_PORT_RANGE = (35000, 39999)
     APP_PORT_RANGE_1 = (40000, 44999)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes "ports are not available" error message on Windows

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Changes default port ranges on Windows to avoid overlap with ephemeral ports (49152 - 65535)

---
**Link of any specific issues this addresses:**
Closes #9202