### PR TITLE
fix(ci): fix fe unit tests workflow failure due to invalid node-version value

### DIFF
--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       matrix:
-        node-version: 22
+        node-version: [22]
       fail-fast: true
     steps:
       - name: Checkout


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Fixes frontend unit tests workflow failure caused by invalid node-version matrix value.

Error from failed workflow run:
```
Check failure on line 27 in .github/workflows/fe-unit-tests.yml
The workflow is not valid. .github/workflows/fe-unit-tests.yml (Line: 27, Col: 23): Unexpected value '22'
```
Screenshot:
<img width="758" height="307" alt="image" src="https://github.com/user-attachments/assets/d1686530-42a8-40a6-962d-44e702d1f7c3" />

---
**Link of any specific issues this addresses:**
