### PR TITLE
Fix deprecation message to reference SANDBOX_VOLUMES instead of non-existent RUNTIME_MOUNT

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -337,7 +337,7 @@ def finalize_config(cfg: OpenHandsConfig) -> None:
     if cfg.workspace_base is not None or cfg.workspace_mount_path is not None:
         logger.openhands_logger.warning(
             'DEPRECATED: The WORKSPACE_BASE and WORKSPACE_MOUNT_PATH environment variables are deprecated. '
-            "Please use RUNTIME_MOUNT instead, e.g. 'RUNTIME_MOUNT=/my/host/dir:/workspace:rw'"
+            "Please use SANDBOX_VOLUMES instead, e.g. 'SANDBOX_VOLUMES=/my/host/dir:/workspace:rw'"
         )
     if cfg.sandbox.volumes is not None:
         # Split by commas to handle multiple mounts


### PR DESCRIPTION
## Problem

The deprecation warning in `openhands/core/config/utils.py` was incorrectly telling users to migrate from the deprecated `WORKSPACE_BASE` and `WORKSPACE_MOUNT_PATH` environment variables to `RUNTIME_MOUNT`. However, `RUNTIME_MOUNT` is not implemented anywhere in the codebase - it only exists in this deprecation message.

## Solution

Updated the deprecation warning to reference `SANDBOX_VOLUMES` instead, which is:
- Properly implemented in the `SandboxConfig` class
- Documented in the server README
- Used throughout the codebase
- Has the same format: `host_path:container_path:mode`

## Changes

- Changed the deprecation warning message from `RUNTIME_MOUNT` to `SANDBOX_VOLUMES`
- This ensures users get correct guidance when migrating from deprecated variables

## Testing

The change is minimal and only affects a warning message. Users following the updated guidance will now use the correct environment variable that actually works.

Fixes a documentation/implementation mismatch that would confuse users trying to migrate from deprecated workspace variables.