### PR TITLE
fix: use poetry run for pre-commit in husky hook

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -8,4 +8,4 @@ npx lint-staged
 # Run backend pre-commit
 echo "Running backend pre-commit..."
 cd ..
-pre-commit run --files openhands/**/* evaluation/**/* tests/**/* --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+poetry run pre-commit run --files openhands/**/* evaluation/**/* tests/**/* --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml


### PR DESCRIPTION
## Description
Fixes the pre-commit hook failure that occurs when following the development setup instructions.

## Problem
The husky pre-commit hook was calling `pre-commit` directly, but pre-commit is installed in the poetry virtual environment and not available in the system PATH. This caused commits to fail with:
```
husky - pre-commit script failed (code 127)
husky - command not found in PATH=...
```

## Solution
Changed the pre-commit hook to use `poetry run pre-commit` instead of `pre-commit` directly, ensuring it runs within the correct virtual environment.

## Changes
- Modified `frontend/.husky/pre-commit` line 11 to use `poetry run pre-commit`

## Testing
- Verified the fix works by successfully committing changes
- Pre-commit hooks now run properly and validate code before commits

## Related Issue
Fixes #9933

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally