### PR TITLE
fix: keep tabs visible when agent is stopped

### DIFF
--- a/frontend/src/types/agent-state.tsx
+++ b/frontend/src/types/agent-state.tsx
@@ -17,6 +17,6 @@ export enum AgentState {
 export const RUNTIME_INACTIVE_STATES = [
   AgentState.INIT,
   AgentState.LOADING,
-  AgentState.STOPPED,
+  // Removed AgentState.STOPPED to allow tabs to remain visible when agent is stopped
   AgentState.ERROR,
 ];


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where the terminal, VSCode, Jupyter, and other tabs would show a "Waiting for runtime to start..." message when the agent was stopped, instead of displaying their actual content. Now when you stop the agent, these tabs remain accessible and continue to show their content (terminal history, code editor, notebooks, file changes, etc.), making it easier to review work and continue where you left off.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR removes `AgentState.STOPPED` from the `RUNTIME_INACTIVE_STATES` array in `/frontend/src/types/agent-state.tsx`. 

The issue was that when an agent is stopped by the user, the UI components (Terminal, VSCode, Jupyter, Changes tabs) were checking if the current agent state was in the `RUNTIME_INACTIVE_STATES` array, and if so, they would hide their content and show a "Waiting for runtime to start..." message instead.

However, when an agent is stopped, the runtime environment and its data should still be accessible. The agent being stopped doesn't mean the runtime data is unavailable - it just means the agent isn't actively running tasks. Users should still be able to view terminal history, browse code in VSCode, see Jupyter notebooks, and review file changes.

The fix is minimal and focused: we simply remove `AgentState.STOPPED` from the inactive states array, while keeping the other truly inactive states (`INIT`, `LOADING`, `ERROR`) that genuinely indicate the runtime isn't ready.

---
**Link of any specific issues this addresses:**

This addresses the user-reported issue where tabs show a pending message when the agent is stopped, instead of displaying their content.

@amanape can click here to [continue refining the PR](https://app.all-hands.dev/conversations/322a62fc67a5474898013ebe04cc1191)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ab5d90c-nikolaik   --name openhands-app-ab5d90c   docker.all-hands.dev/all-hands-ai/openhands:ab5d90c
```