### PR TITLE
fix(tests): fix tests missed by failing frontend test workflow and other flaky tests

### DIFF
--- a/frontend/__tests__/components/features/home/home-header.test.tsx
+++ b/frontend/__tests__/components/features/home/home-header.test.tsx
@@ -72,6 +72,7 @@ describe("HomeHeader", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
 
     // expect to be redirected to /conversations/:conversationId

--- a/frontend/__tests__/components/features/home/repo-connector.test.tsx
+++ b/frontend/__tests__/components/features/home/repo-connector.test.tsx
@@ -209,6 +209,7 @@ describe("RepoConnector", () => {
       undefined,
       "main",
       undefined,
+      undefined,
     );
   });
 

--- a/frontend/__tests__/components/features/home/task-card.test.tsx
+++ b/frontend/__tests__/components/features/home/task-card.test.tsx
@@ -97,6 +97,7 @@ describe("TaskCard", () => {
         },
         undefined,
         undefined,
+        undefined,
       );
     });
   });

--- a/frontend/__tests__/routes/home-screen.test.tsx
+++ b/frontend/__tests__/routes/home-screen.test.tsx
@@ -222,10 +222,12 @@ describe("HomeScreen", () => {
       // All other buttons should be disabled when the header button is clicked
       await userEvent.click(headerLaunchButton);
 
-      expect(headerLaunchButton).toBeDisabled();
-      expect(repoLaunchButton).toBeDisabled();
-      tasksLaunchButtonsAfter.forEach((button) => {
-        expect(button).toBeDisabled();
+      await waitFor(() => {
+        expect(headerLaunchButton).toBeDisabled();
+        expect(repoLaunchButton).toBeDisabled();
+        tasksLaunchButtonsAfter.forEach((button) => {
+          expect(button).toBeDisabled();
+        });
       });
     });
 
@@ -240,10 +242,12 @@ describe("HomeScreen", () => {
       // All other buttons should be disabled when the repo button is clicked
       await userEvent.click(repoLaunchButton);
 
-      expect(headerLaunchButton).toBeDisabled();
-      expect(repoLaunchButton).toBeDisabled();
-      tasksLaunchButtonsAfter.forEach((button) => {
-        expect(button).toBeDisabled();
+      await waitFor(() => {
+        expect(headerLaunchButton).toBeDisabled();
+        expect(repoLaunchButton).toBeDisabled();
+        tasksLaunchButtonsAfter.forEach((button) => {
+          expect(button).toBeDisabled();
+        });
       });
     });
 
@@ -258,10 +262,12 @@ describe("HomeScreen", () => {
       // All other buttons should be disabled when the task button is clicked
       await userEvent.click(tasksLaunchButtons[0]);
 
-      expect(headerLaunchButton).toBeDisabled();
-      expect(repoLaunchButton).toBeDisabled();
-      tasksLaunchButtonsAfter.forEach((button) => {
-        expect(button).toBeDisabled();
+      await waitFor(() => {
+        expect(headerLaunchButton).toBeDisabled();
+        expect(repoLaunchButton).toBeDisabled();
+        tasksLaunchButtonsAfter.forEach((button) => {
+          expect(button).toBeDisabled();
+        });
       });
     });
   });

--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -366,17 +366,17 @@ describe("Form submission", () => {
 
     renderLlmSettingsScreen();
     await screen.findByTestId("llm-settings-screen");
-    screen.getByTestId("llm-settings-form-advanced");
+    await screen.findByTestId("llm-settings-form-advanced");
 
-    const submitButton = screen.getByTestId("submit-button");
+    const submitButton = await screen.findByTestId("submit-button");
     expect(submitButton).toBeDisabled();
 
-    const model = screen.getByTestId("llm-custom-model-input");
-    const baseUrl = screen.getByTestId("base-url-input");
-    const apiKey = screen.getByTestId("llm-api-key-input");
-    const agent = screen.getByTestId("agent-input");
-    const confirmation = screen.getByTestId("enable-confirmation-mode-switch");
-    const condensor = screen.getByTestId("enable-memory-condenser-switch");
+    const model = await screen.findByTestId("llm-custom-model-input");
+    const baseUrl = await screen.findByTestId("base-url-input");
+    const apiKey = await screen.findByTestId("llm-api-key-input");
+    const agent = await screen.findByTestId("agent-input");
+    const confirmation = await screen.findByTestId("enable-confirmation-mode-switch");
+    const condensor = await screen.findByTestId("enable-memory-condenser-switch");
 
     // enter custom model
     await userEvent.type(model, "-mini");
@@ -449,7 +449,7 @@ describe("Form submission", () => {
     expect(submitButton).toBeDisabled();
 
     // select security analyzer
-    const securityAnalyzer = screen.getByTestId("security-analyzer-input");
+    const securityAnalyzer = await screen.findByTestId("security-analyzer-input");
     await userEvent.click(securityAnalyzer);
     const securityAnalyzerOption = screen.getByText("mock-invariant");
     await userEvent.click(securityAnalyzerOption);

--- a/frontend/tests/repo-selection-form.test.tsx
+++ b/frontend/tests/repo-selection-form.test.tsx
@@ -43,7 +43,7 @@ describe("RepositorySelectionForm", () => {
     });
 
     (useCreateConversation as any).mockReturnValue({
-      mutate: vi.fn(),
+      mutate: vi.fn(() => (useIsCreatingConversation as any).mockReturnValue(true)),
       isPending: false,
       isSuccess: false,
     });


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**



---
**Summarize what the PR does, explaining any non-trivial design decisions.**

### Tests related to PR #9821
`__tests__/components/features/home/home-header.test.tsx`
`__tests__/components/features/home/repo-connector.test.tsx`
`__tests__/components/features/home/task-card.test.tsx`
- included missing trailing `undefined` in createConversation args

### Other flaky tests
`frontend/tests/repo-selection-form.test.tsx`
`__tests__/routes/home-screen.test.tsx`
- wrapped disabled buttons assertions in a `waitFor`
- mocked `mutate `to update `useIsCreatingConversation` immediately

`__tests__/routes/llm-settings.test.tsx`
- used awaited `findByTestId `to await async renders

---
**Link of any specific issues this addresses:**
