### PR TITLE
Remove task completion status message from finish action display

### DIFF
--- a/frontend/__tests__/components/event-message.test.tsx
+++ b/frontend/__tests__/components/event-message.test.tsx
@@ -28,7 +28,6 @@ describe("EventMessage", () => {
       action: "finish" as const,
       args: {
         final_thought: "Task completed successfully",
-        task_completed: "success" as const,
         outputs: {},
         thought: "Task completed successfully",
       },
@@ -114,7 +113,6 @@ describe("EventMessage", () => {
       action: "finish" as const,
       args: {
         final_thought: "Task completed successfully",
-        task_completed: "success" as const,
         outputs: {},
         thought: "Task completed successfully",
       },

--- a/frontend/src/components/features/chat/event-content-helpers/get-action-content.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/get-action-content.ts
@@ -77,25 +77,9 @@ const getMcpActionContent = (event: MCPAction): string => {
 const getThinkActionContent = (event: ThinkAction): string =>
   event.args.thought;
 
-const getFinishActionContent = (event: FinishAction): string => {
-  let content = event.args.final_thought;
-
-  switch (event.args.task_completed) {
-    case "success":
-      content += `\n\n\n${i18n.t("FINISH$TASK_COMPLETED_SUCCESSFULLY")}`;
-      break;
-    case "failure":
-      content += `\n\n\n${i18n.t("FINISH$TASK_NOT_COMPLETED")}`;
-      break;
-    case "partial":
-    default:
-      content += `\n\n\n${i18n.t("FINISH$TASK_COMPLETED_PARTIALLY")}`;
-      break;
-  }
-
-  return content.trim();
-};
-
+const getFinishActionContent = (event: FinishAction): string =>
+  // Return only the final thought without appending the task completion status message
+  event.args.final_thought.trim();
 const getNoContentActionContent = (): string => "";
 
 export const getActionContent = (event: OpenHandsAction): string => {

--- a/frontend/src/components/features/chat/event-content-helpers/get-action-content.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/get-action-content.ts
@@ -78,7 +78,6 @@ const getThinkActionContent = (event: ThinkAction): string =>
   event.args.thought;
 
 const getFinishActionContent = (event: FinishAction): string =>
-  // Return only the final thought without appending the task completion status message
   event.args.final_thought.trim();
 const getNoContentActionContent = (): string => "";
 

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -64,7 +64,6 @@ export interface FinishAction extends OpenHandsActionEvent<"finish"> {
   source: "agent";
   args: {
     final_thought: string;
-    task_completed: "success" | "failure" | "partial";
     outputs: Record<string, unknown>;
     thought: string;
   };

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -123,7 +123,6 @@ def response_to_actions(
             elif tool_call.function.name == FinishTool['function']['name']:
                 action = AgentFinishAction(
                     final_thought=arguments.get('message', ''),
-                    task_completed=arguments.get('task_completed', None),
                 )
 
             # ================================================

--- a/openhands/agenthub/codeact_agent/tools/finish.py
+++ b/openhands/agenthub/codeact_agent/tools/finish.py
@@ -13,8 +13,6 @@ The message should include:
 - Any next steps for the user
 - Explanation if you're unable to complete the task
 - Any follow-up questions if more information is needed
-
-The task_completed field should be set to True if you believed you have completed the task, and False otherwise.
 """
 
 FinishTool = ChatCompletionToolParam(
@@ -24,16 +22,11 @@ FinishTool = ChatCompletionToolParam(
         description=_FINISH_DESCRIPTION,
         parameters={
             'type': 'object',
-            'required': ['message', 'task_completed'],
+            'required': ['message'],
             'properties': {
                 'message': {
                     'type': 'string',
                     'description': 'Final message to send to the user',
-                },
-                'task_completed': {
-                    'type': 'string',
-                    'enum': ['true', 'false', 'partial'],
-                    'description': 'Whether you have completed the task.',
                 },
             },
         },

--- a/openhands/agenthub/loc_agent/function_calling.py
+++ b/openhands/agenthub/loc_agent/function_calling.py
@@ -81,7 +81,6 @@ def response_to_actions(
             elif tool_call.function.name == FinishTool['function']['name']:
                 action = AgentFinishAction(
                     final_thought=arguments.get('message', ''),
-                    task_completed=arguments.get('task_completed', None),
                 )
             else:
                 raise FunctionCallNotExistsError(

--- a/openhands/agenthub/readonly_agent/function_calling.py
+++ b/openhands/agenthub/readonly_agent/function_calling.py
@@ -141,7 +141,6 @@ def response_to_actions(
             if tool_call.function.name == FinishTool['function']['name']:
                 action = AgentFinishAction(
                     final_thought=arguments.get('message', ''),
-                    task_completed=arguments.get('task_completed', None),
                 )
 
             # ================================================

--- a/openhands/events/action/agent.py
+++ b/openhands/events/action/agent.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any
 
 from openhands.core.schema import ActionType
@@ -20,26 +19,18 @@ class ChangeAgentStateAction(Action):
         return f'Agent state changed to {self.agent_state}'
 
 
-class AgentFinishTaskCompleted(Enum):
-    FALSE = 'false'
-    PARTIAL = 'partial'
-    TRUE = 'true'
-
-
 @dataclass
 class AgentFinishAction(Action):
     """An action where the agent finishes the task.
 
     Attributes:
         final_thought (str): The message to send to the user.
-        task_completed (enum): Whether the agent believes the task has been completed.
         outputs (dict): The other outputs of the agent, for instance "content".
         thought (str): The agent's explanation of its actions.
         action (str): The action type, namely ActionType.FINISH.
     """
 
     final_thought: str = ''
-    task_completed: AgentFinishTaskCompleted | None = None
     outputs: dict[str, Any] = field(default_factory=dict)
     thought: str = ''
     action: str = ActionType.FINISH

--- a/openhands/events/serialization/action.py
+++ b/openhands/events/serialization/action.py
@@ -56,6 +56,10 @@ def handle_action_deprecated_args(args: dict[str, Any]) -> dict[str, Any]:
     if 'keep_prompt' in args:
         args.pop('keep_prompt')
 
+    # task_completed has been deprecated - remove it from args to maintain backward compatibility
+    if 'task_completed' in args:
+        args.pop('task_completed')
+
     # Handle translated_ipython_code deprecation
     if 'translated_ipython_code' in args:
         code = args.pop('translated_ipython_code')

--- a/openhands/events/serialization/event.py
+++ b/openhands/events/serialization/event.py
@@ -121,6 +121,9 @@ def event_to_dict(event: 'Event') -> dict:
         props.pop(key, None)
     if 'security_risk' in props and props['security_risk'] is None:
         props.pop('security_risk')
+    # Remove task_completed from serialization when it's None (backward compatibility)
+    if 'task_completed' in props and props['task_completed'] is None:
+        props.pop('task_completed')
     if 'action' in d:
         d['args'] = props
         if event.timeout is not None:

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -306,7 +306,7 @@ Review the changes and make sure they are as expected. Edit the file again if ne
 """,
     },
     'finish': {
-        'task_completed': """
+        'example': """
 ASSISTANT:
 The server is running on port 5000 with PID 126. You can access the list of numbers in a table format by visiting http://127.0.0.1:5000. Let me know if you have any further requests!
 <function=finish>
@@ -372,7 +372,7 @@ USER: Create a list of numbers from 1 to 10, and display them in a web page at p
         example += TOOL_EXAMPLES['execute_bash']['run_server_again']
 
     if 'finish' in available_tools:
-        example += TOOL_EXAMPLES['finish']['task_completed']
+        example += TOOL_EXAMPLES['finish']['example']
 
     example += """
 --------------------- END OF EXAMPLE ---------------------

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -311,7 +311,6 @@ ASSISTANT:
 The server is running on port 5000 with PID 126. You can access the list of numbers in a table format by visiting http://127.0.0.1:5000. Let me know if you have any further requests!
 <function=finish>
 <parameter=message>The task has been completed. The web server is running and displaying numbers 1-10 in a table format at http://127.0.0.1:5000.</parameter>
-<parameter=task_completed>true</parameter>
 </function>
 """
     },

--- a/tests/unit/test_action_serialization.py
+++ b/tests/unit/test_action_serialization.py
@@ -97,7 +97,8 @@ def test_agent_finish_action_legacy_task_completed_serialization():
     assert isinstance(event, Action)
     assert isinstance(event, AgentFinishAction)
     assert event.final_thought == 'Task completed'
-    assert event.task_completed is None  # Should be None since it's not set
+    # task_completed attribute should not exist anymore
+    assert not hasattr(event, 'task_completed')
 
     # When serialized back, task_completed should not be present
     event_dict = event_to_dict(event)

--- a/tests/unit/test_action_serialization.py
+++ b/tests/unit/test_action_serialization.py
@@ -75,11 +75,33 @@ def test_agent_finish_action_serialization_deserialization():
         'args': {
             'outputs': {},
             'thought': '',
-            'task_completed': None,
             'final_thought': '',
         },
     }
     serialization_deserialization(original_action_dict, AgentFinishAction)
+
+
+def test_agent_finish_action_legacy_task_completed_serialization():
+    """Test that old conversations with task_completed can still be loaded."""
+    original_action_dict = {
+        'action': 'finish',
+        'args': {
+            'outputs': {},
+            'thought': '',
+            'final_thought': 'Task completed',
+            'task_completed': 'true',  # This should be ignored during deserialization
+        },
+    }
+    # This should work without errors - task_completed should be stripped out
+    event = event_from_dict(original_action_dict)
+    assert isinstance(event, Action)
+    assert isinstance(event, AgentFinishAction)
+    assert event.final_thought == 'Task completed'
+    assert event.task_completed is None  # Should be None since it's not set
+    
+    # When serialized back, task_completed should not be present
+    event_dict = event_to_dict(event)
+    assert 'task_completed' not in event_dict['args']
 
 
 def test_agent_reject_action_serialization_deserialization():

--- a/tests/unit/test_action_serialization.py
+++ b/tests/unit/test_action_serialization.py
@@ -98,7 +98,7 @@ def test_agent_finish_action_legacy_task_completed_serialization():
     assert isinstance(event, AgentFinishAction)
     assert event.final_thought == 'Task completed'
     assert event.task_completed is None  # Should be None since it's not set
-    
+
     # When serialized back, task_completed should not be present
     event_dict = event_to_dict(event)
     assert 'task_completed' not in event_dict['args']

--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -183,7 +183,7 @@ def test_get_example_for_tools_single_tool():
     assert TOOL_EXAMPLES['execute_bash']['kill_server'] in example
     assert TOOL_EXAMPLES['str_replace_editor']['create_file'] not in example
     assert TOOL_EXAMPLES['browser']['view_page'] not in example
-    assert TOOL_EXAMPLES['finish']['task_completed'] not in example
+    assert TOOL_EXAMPLES['finish']['example'] not in example
 
 
 def test_get_example_for_tools_single_tool_is_finish():
@@ -205,7 +205,7 @@ def test_get_example_for_tools_single_tool_is_finish():
         'USER: Create a list of numbers from 1 to 10, and display them in a web page at port 5000.'
         in example
     )
-    assert TOOL_EXAMPLES['finish']['task_completed'] in example
+    assert TOOL_EXAMPLES['finish']['example'] in example
     assert TOOL_EXAMPLES['execute_bash']['check_dir'] not in example
     assert TOOL_EXAMPLES['str_replace_editor']['create_file'] not in example
     assert TOOL_EXAMPLES['browser']['view_page'] not in example
@@ -274,7 +274,7 @@ def test_get_example_for_tools_multiple_tools():
     assert TOOL_EXAMPLES['str_replace_editor']['create_file'] in example
     assert TOOL_EXAMPLES['str_replace_editor']['edit_file'] in example
     assert TOOL_EXAMPLES['browser']['view_page'] not in example
-    assert TOOL_EXAMPLES['finish']['task_completed'] not in example
+    assert TOOL_EXAMPLES['finish']['example'] not in example
 
 
 def test_get_example_for_tools_multiple_tools_with_finish():
@@ -374,7 +374,7 @@ def test_get_example_for_tools_multiple_tools_with_finish():
     assert TOOL_EXAMPLES['browser']['view_page'] in example
 
     # Check for finish part
-    assert TOOL_EXAMPLES['finish']['task_completed'] in example
+    assert TOOL_EXAMPLES['finish']['example'] in example
 
 
 def test_get_example_for_tools_all_tools():
@@ -393,7 +393,7 @@ def test_get_example_for_tools_all_tools():
     assert TOOL_EXAMPLES['execute_bash']['kill_server'] in example
     assert TOOL_EXAMPLES['str_replace_editor']['create_file'] in example
     assert TOOL_EXAMPLES['str_replace_editor']['edit_file'] in example
-    assert TOOL_EXAMPLES['finish']['task_completed'] in example
+    assert TOOL_EXAMPLES['finish']['example'] in example
 
     # These are not in global FNCALL_TOOLS
     # assert TOOL_EXAMPLES['web_read']['read_docs'] not in example # web_read is removed

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -349,7 +349,6 @@ async def test_unsafe_bash_command(temp_dir: str):
                         name=ActionType.FINISH,
                         arguments={
                             'outputs': {'content': 'outputs content'},
-                            'task_completed': None,
                             'final_thought': '',
                         },
                     ),


### PR DESCRIPTION
## Description
This PR removes the "I believe that the task was completed partially/successfully/not completed" message that appears at the end of conversations. These messages are based on the `task_completed` parameter from the agent's finish action.

## Changes
- Modified `getFinishActionContent` function in `get-action-content.ts` to only return the final thought without appending the task completion status message.

## Testing
- Built the frontend successfully
- Verified that the changes work as expected

## Related Issues
Addresses user request to stop displaying "I believe the task was XX" in the frontend UI based on the agent's finish action argument.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/31124f9624aa496984c60bbd4ae68e9f)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:be93017-nikolaik   --name openhands-app-be93017   docker.all-hands.dev/all-hands-ai/openhands:be93017
```