### PR TITLE
feat: show export trajectory button in SaaS mode for debugging

### DIFF
--- a/frontend/__tests__/components/feedback-actions.test.tsx
+++ b/frontend/__tests__/components/feedback-actions.test.tsx
@@ -86,11 +86,11 @@ describe("TrajectoryActions", () => {
       );
 
       const actions = screen.getByTestId("feedback-actions");
-      
+
       // Should not render feedback buttons in SaaS mode
       expect(within(actions).queryByTestId("positive-feedback")).toBeNull();
       expect(within(actions).queryByTestId("negative-feedback")).toBeNull();
-      
+
       // Should still render export button
       within(actions).getByTestId("export-trajectory");
     });

--- a/frontend/__tests__/components/feedback-actions.test.tsx
+++ b/frontend/__tests__/components/feedback-actions.test.tsx
@@ -73,4 +73,73 @@ describe("TrajectoryActions", () => {
 
     expect(onExportTrajectory).toHaveBeenCalled();
   });
+
+  describe("SaaS mode", () => {
+    it("should only render export button when isSaasMode is true", () => {
+      renderWithProviders(
+        <TrajectoryActions
+          onPositiveFeedback={onPositiveFeedback}
+          onNegativeFeedback={onNegativeFeedback}
+          onExportTrajectory={onExportTrajectory}
+          isSaasMode={true}
+        />,
+      );
+
+      const actions = screen.getByTestId("feedback-actions");
+      
+      // Should not render feedback buttons in SaaS mode
+      expect(within(actions).queryByTestId("positive-feedback")).toBeNull();
+      expect(within(actions).queryByTestId("negative-feedback")).toBeNull();
+      
+      // Should still render export button
+      within(actions).getByTestId("export-trajectory");
+    });
+
+    it("should render all buttons when isSaasMode is false", () => {
+      renderWithProviders(
+        <TrajectoryActions
+          onPositiveFeedback={onPositiveFeedback}
+          onNegativeFeedback={onNegativeFeedback}
+          onExportTrajectory={onExportTrajectory}
+          isSaasMode={false}
+        />,
+      );
+
+      const actions = screen.getByTestId("feedback-actions");
+      within(actions).getByTestId("positive-feedback");
+      within(actions).getByTestId("negative-feedback");
+      within(actions).getByTestId("export-trajectory");
+    });
+
+    it("should render all buttons when isSaasMode is undefined (default behavior)", () => {
+      renderWithProviders(
+        <TrajectoryActions
+          onPositiveFeedback={onPositiveFeedback}
+          onNegativeFeedback={onNegativeFeedback}
+          onExportTrajectory={onExportTrajectory}
+        />,
+      );
+
+      const actions = screen.getByTestId("feedback-actions");
+      within(actions).getByTestId("positive-feedback");
+      within(actions).getByTestId("negative-feedback");
+      within(actions).getByTestId("export-trajectory");
+    });
+
+    it("should call onExportTrajectory when export button is clicked in SaaS mode", async () => {
+      renderWithProviders(
+        <TrajectoryActions
+          onPositiveFeedback={onPositiveFeedback}
+          onNegativeFeedback={onNegativeFeedback}
+          onExportTrajectory={onExportTrajectory}
+          isSaasMode={true}
+        />,
+      );
+
+      const exportButton = screen.getByTestId("export-trajectory");
+      await user.click(exportButton);
+
+      expect(onExportTrajectory).toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -232,17 +232,16 @@ export function ChatInterface() {
 
         <div className="flex flex-col gap-[6px] px-4 pb-4">
           <div className="flex justify-between relative">
-            {config?.APP_MODE !== "saas" && (
-              <TrajectoryActions
-                onPositiveFeedback={() =>
-                  onClickShareFeedbackActionButton("positive")
-                }
-                onNegativeFeedback={() =>
-                  onClickShareFeedbackActionButton("negative")
-                }
-                onExportTrajectory={() => onClickExportTrajectoryButton()}
-              />
-            )}
+            <TrajectoryActions
+              onPositiveFeedback={() =>
+                onClickShareFeedbackActionButton("positive")
+              }
+              onNegativeFeedback={() =>
+                onClickShareFeedbackActionButton("negative")
+              }
+              onExportTrajectory={() => onClickExportTrajectoryButton()}
+              isSaasMode={config?.APP_MODE === "saas"}
+            />
 
             <div className="absolute left-1/2 transform -translate-x-1/2 bottom-0">
               {curAgentState === AgentState.RUNNING && <TypingIndicator />}

--- a/frontend/src/components/features/trajectory/trajectory-actions.tsx
+++ b/frontend/src/components/features/trajectory/trajectory-actions.tsx
@@ -9,29 +9,35 @@ interface TrajectoryActionsProps {
   onPositiveFeedback: () => void;
   onNegativeFeedback: () => void;
   onExportTrajectory: () => void;
+  isSaasMode?: boolean;
 }
 
 export function TrajectoryActions({
   onPositiveFeedback,
   onNegativeFeedback,
   onExportTrajectory,
+  isSaasMode = false,
 }: TrajectoryActionsProps) {
   const { t } = useTranslation();
 
   return (
     <div data-testid="feedback-actions" className="flex gap-1">
-      <TrajectoryActionButton
-        testId="positive-feedback"
-        onClick={onPositiveFeedback}
-        icon={<ThumbsUpIcon width={15} height={15} />}
-        tooltip={t(I18nKey.BUTTON$MARK_HELPFUL)}
-      />
-      <TrajectoryActionButton
-        testId="negative-feedback"
-        onClick={onNegativeFeedback}
-        icon={<ThumbDownIcon width={15} height={15} />}
-        tooltip={t(I18nKey.BUTTON$MARK_NOT_HELPFUL)}
-      />
+      {!isSaasMode && (
+        <>
+          <TrajectoryActionButton
+            testId="positive-feedback"
+            onClick={onPositiveFeedback}
+            icon={<ThumbsUpIcon width={15} height={15} />}
+            tooltip={t(I18nKey.BUTTON$MARK_HELPFUL)}
+          />
+          <TrajectoryActionButton
+            testId="negative-feedback"
+            onClick={onNegativeFeedback}
+            icon={<ThumbDownIcon width={15} height={15} />}
+            tooltip={t(I18nKey.BUTTON$MARK_NOT_HELPFUL)}
+          />
+        </>
+      )}
       <TrajectoryActionButton
         testId="export-trajectory"
         onClick={onExportTrajectory}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

In SaaS mode, users can now export conversation trajectories for debugging purposes. Previously, all trajectory action buttons (including export) were completely hidden in SaaS mode, making it difficult to debug issues. Now, the export button remains visible while feedback buttons are appropriately hidden.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR modifies the `TrajectoryActions` component to conditionally render buttons based on the app mode:

### Changes Made
- **Added `isSaasMode` prop** to `TrajectoryActions` component to control button visibility
- **Modified rendering logic** to hide feedback buttons (thumbs up/down) in SaaS mode while keeping the export trajectory button visible
- **Updated `ChatInterface`** to always render `TrajectoryActions` but pass the appropriate mode flag
- **Enhanced test coverage** with comprehensive tests for SaaS mode functionality

### Design Decisions
- Used a boolean prop rather than checking config directly in the component to maintain separation of concerns and testability
- Maintained backward compatibility by making the prop optional with a default value of `false`
- Kept the export functionality available in SaaS mode specifically for debugging purposes as requested

### Behavior Changes
- **Before**: In SaaS mode, no trajectory action buttons were visible
- **After**: In SaaS mode, only the "Export trajectory" button is visible for debugging
- **OSS mode**: No changes - all buttons remain visible

---
**Link of any specific issues this addresses:**

Addresses internal request to enable trajectory export functionality in SaaS mode for debugging purposes.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b0643e6-nikolaik   --name openhands-app-b0643e6   docker.all-hands.dev/all-hands-ai/openhands:b0643e6
```