### PR TITLE
[CLI] Fix errno 21 warning when reading directory

### DIFF
--- a/openhands/runtime/impl/cli/cli_runtime.py
+++ b/openhands/runtime/impl/cli/cli_runtime.py
@@ -533,10 +533,6 @@ class CLIRuntime(Runtime):
 
         file_path = self._sanitize_filename(action.path)
 
-        # Cannot read binary files
-        if os.path.exists(file_path) and is_binary(file_path):
-            return ErrorObservation('ERROR_BINARY_FILE')
-
         # Use OHEditor for OH_ACI implementation source
         if action.impl_source == FileReadSource.OH_ACI:
             result_str, _ = self._execute_file_editor(
@@ -559,6 +555,10 @@ class CLIRuntime(Runtime):
             # Check if it's a directory
             if os.path.isdir(file_path):
                 return ErrorObservation(f'Cannot read directory: {action.path}')
+
+            # Cannot read binary files
+            if is_binary(file_path):
+                return ErrorObservation('ERROR_BINARY_FILE')
 
             # Read the file
             with open(file_path, 'r', encoding='utf-8', errors='replace') as f:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Fix the warning when the agent attempts to perform read actions on a directory path, it seems to come from the `is_binary` check:
```
Agent running... (Press Ctrl-P to pause)
[Errno 21] Is a directory: '/home/hoang/OpenHands/microagents'

I'll use the editor to explore the microagents folder and show you its contents.

┌────────────────────────| File Read |─────────────────────────┐
```

---
**Link of any specific issues this addresses:**
