### PR TITLE
refactor: modify ExperimentManager to take config instead of agent_config and call before session creation

### DIFF
--- a/openhands/experiments/experiment_manager.py
+++ b/openhands/experiments/experiment_manager.py
@@ -1,6 +1,6 @@
 import os
 
-from openhands.core.config.agent_config import AgentConfig
+from openhands.core.config.openhands_config import OpenHandsConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.utils.import_utils import get_impl
@@ -15,12 +15,12 @@ class ExperimentManager:
 
     @staticmethod
     def run_agent_config_variant_test(
-        user_id: str, conversation_id: str, agent_config: AgentConfig
-    ) -> AgentConfig:
+        user_id: str, conversation_id: str, config: OpenHandsConfig
+    ) -> OpenHandsConfig:
         logger.debug(
             f'Running agent config variant test for user_id={user_id}, conversation_id={conversation_id}'
         )
-        return agent_config
+        return config
 
 
 experiment_manager_cls = os.environ.get(

--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -20,6 +20,7 @@ from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import MessageAction
 from openhands.events.nested_event_store import NestedEventStore
 from openhands.events.stream import EventStream
+from openhands.experiments.experiment_manager import ExperimentManagerImpl
 from openhands.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderHandler
 from openhands.llm.llm import LLM
 from openhands.runtime import get_runtime_cls
@@ -469,24 +470,30 @@ class DockerNestedConversationManager(ConversationManager):
     ) -> DockerRuntime:
         # This session is created here only because it is the easiest way to get a runtime, which
         # is the easiest way to create the needed docker container
+
+        # Run experiment manager variant test before creating session
+        modified_config = ExperimentManagerImpl.run_agent_config_variant_test(
+            user_id, sid, self.config
+        )
+
         session = Session(
             sid=sid,
             file_store=self.file_store,
-            config=self.config,
+            config=modified_config,
             sio=self.sio,
             user_id=user_id,
         )
-        agent_cls = settings.agent or self.config.default_agent
+        agent_cls = settings.agent or modified_config.default_agent
         agent_name = agent_cls if agent_cls is not None else 'agent'
         llm = LLM(
-            config=self.config.get_llm_config_from_agent(agent_name),
+            config=modified_config.get_llm_config_from_agent(agent_name),
             retry_listener=session._notify_on_llm_retry,
         )
         llm = session._create_llm(agent_cls)
-        agent_config = self.config.get_agent_config(agent_cls)
+        agent_config = modified_config.get_agent_config(agent_cls)
         agent = Agent.get_cls(agent_cls)(llm, agent_config)
 
-        config = self.config.model_copy(deep=True)
+        config = modified_config.model_copy(deep=True)
         env_vars = config.sandbox.runtime_startup_env_vars
         env_vars['CONVERSATION_MANAGER_CLASS'] = (
             'openhands.server.conversation_manager.standalone_conversation_manager.StandaloneConversationManager'

--- a/openhands/server/conversation_manager/standalone_conversation_manager.py
+++ b/openhands/server/conversation_manager/standalone_conversation_manager.py
@@ -12,6 +12,7 @@ from openhands.core.logger import openhands_logger as logger
 from openhands.core.schema.agent import AgentState
 from openhands.events.action import MessageAction
 from openhands.events.stream import EventStreamSubscriber, session_exists
+from openhands.experiments.experiment_manager import ExperimentManagerImpl
 from openhands.runtime import get_runtime_cls
 from openhands.server.config.server_config import ServerConfig
 from openhands.server.data_models.agent_loop_info import AgentLoopInfo
@@ -331,10 +332,15 @@ class StandaloneConversationManager(ConversationManager):
                 )
                 await self.close_session(oldest_conversation_id)
 
+        # Run experiment manager variant test before creating session
+        modified_config = ExperimentManagerImpl.run_agent_config_variant_test(
+            user_id, sid, self.config
+        )
+
         session = Session(
             sid=sid,
             file_store=self.file_store,
-            config=self.config,
+            config=modified_config,
             sio=self.sio,
             user_id=user_id,
         )

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -28,7 +28,6 @@ from openhands.events.observation.agent import RecallObservation
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.serialization import event_from_dict, event_to_dict
 from openhands.events.stream import EventStreamSubscriber
-from openhands.experiments.experiment_manager import ExperimentManagerImpl
 from openhands.llm.llm import LLM
 from openhands.runtime.runtime_status import RuntimeStatus
 from openhands.server.session.agent_session import AgentSession
@@ -157,10 +156,6 @@ class Session:
 
         llm = self._create_llm(agent_cls)
         agent_config = self.config.get_agent_config(agent_cls)
-
-        agent_config = ExperimentManagerImpl.run_agent_config_variant_test(
-            self.user_id, self.sid, agent_config
-        )
 
         if settings.enable_default_condenser:
             # Default condenser chains three condensers together:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This change improves the experiment management system by allowing more comprehensive configuration modifications during experiments. The experiment manager now has access to the full OpenHands configuration instead of just the agent configuration, enabling more flexible experimentation capabilities.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR refactors the ExperimentManager to:

1. **Change method signature**: Modified `ExperimentManager.run_agent_config_variant_test` to accept `OpenHandsConfig` instead of `AgentConfig`, providing access to the full configuration for more comprehensive experiment modifications.

2. **Move experiment manager call timing**: Relocated the experiment manager call from `Session.initialize_agent` (after session creation) to the conversation managers' `_start_agent_loop`/`_create_runtime` methods (before session creation). This ensures experiment configurations are applied before any session initialization occurs.

3. **Update both conversation managers**: Applied changes to both `StandaloneConversationManager` and `DockerNestedConversationManager` to ensure consistent behavior across different deployment modes.

**Key design decisions:**
- The experiment manager is now called before `Session` instantiation to ensure all configuration modifications are applied from the start
- The method now returns the potentially modified `OpenHandsConfig` which is then used for session creation
- All subsequent configuration references in the conversation managers use the modified config to maintain consistency

---
**Link of any specific issues this addresses:**

This addresses the requirement to modify ExperimentManager to take the full config instead of just agent_config and ensure it's called before session creation.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c47026edf06b4dfaaa2f3c7713ab06d6)