### PR TITLE
Fix conversation not starting on revisited pages by clearing query cache

### DIFF
--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -2,6 +2,7 @@ import { useDisclosure } from "@heroui/react";
 import React from "react";
 import { useNavigate } from "react-router";
 import { useDispatch } from "react-redux";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { Controls } from "#/components/features/controls/controls";
@@ -39,6 +40,7 @@ function AppContent() {
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   // Set the document title to the conversation title when available
   useDocumentTitleFromState();
@@ -68,6 +70,15 @@ function AppContent() {
     dispatch(clearTerminal());
     dispatch(clearJupyter());
   });
+
+  // Clear conversation query cache when route loads to ensure fresh data
+  React.useEffect(() => {
+    if (conversationId) {
+      queryClient.invalidateQueries({
+        queryKey: ["user", "conversation", conversationId],
+      });
+    }
+  }, [conversationId, queryClient]);
 
   function handleResize() {
     setWidth(window.innerWidth);


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes an issue where conversations would not start automatically when visiting a conversation page that had been visited within the last 5 minutes. This was caused by TanStack Query's caching mechanism serving stale conversation data, which prevented the conversation start logic from triggering properly.

Users will now experience more reliable conversation initialization when navigating between conversation pages, especially when revisiting pages quickly.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds query cache invalidation to the conversation route component to ensure fresh conversation data is always fetched when the route loads.

**Key changes:**
- Added `useQueryClient` hook to the conversation route component
- Added a `useEffect` that invalidates the conversation query cache whenever the `conversationId` changes
- This ensures that cached conversation status doesn't prevent the conversation start logic from running

**Technical details:**
The root cause was TanStack Query's `staleTime` configuration of 5 minutes in `useUserConversation`. When users revisited a conversation page within 5 minutes, the cached conversation data was served without refetching from the server. If the cached conversation showed a status other than "STOPPED" (e.g., "STARTING" or "RUNNING"), the conversation start logic wouldn't trigger, even if the backend conversation had actually stopped.

By invalidating the query cache on route load, we force a fresh fetch of conversation data, ensuring the conversation start logic has accurate information to work with.

---
**Link of any specific issues this addresses:**

This addresses the user-reported issue where conversations fail to start when visiting pages that have been visited within the last few minutes.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2410c4b-nikolaik   --name openhands-app-2410c4b   docker.all-hands.dev/all-hands-ai/openhands:2410c4b
```