### PR TITLE
fix: prevent maintenance banner from causing page overflow

### DIFF
--- a/frontend/src/routes/root-layout.tsx
+++ b/frontend/src/routes/root-layout.tsx
@@ -202,16 +202,17 @@ export default function MainApp() {
     >
       <Sidebar />
 
-      <div
-        id="root-outlet"
-        className="h-[calc(100%-50px)] md:h-full w-full relative overflow-auto"
-      >
+      <div className="flex flex-col w-full h-[calc(100%-50px)] md:h-full gap-3">
         {config.data?.MAINTENANCE && (
-          <MaintenanceBanner startTime={config.data.MAINTENANCE.startTime} />
+          <div className="flex-shrink-0">
+            <MaintenanceBanner startTime={config.data.MAINTENANCE.startTime} />
+          </div>
         )}
-        <EmailVerificationGuard>
-          <Outlet />
-        </EmailVerificationGuard>
+        <div id="root-outlet" className="flex-1 relative overflow-auto">
+          <EmailVerificationGuard>
+            <Outlet />
+          </EmailVerificationGuard>
+        </div>
       </div>
 
       {renderAuthModal && (


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where the maintenance banner would cause the page content to overflow, requiring users to scroll to see all content. Now when a maintenance banner is displayed, all page content remains visible without scrolling.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes a layout issue where the maintenance banner was consuming space within the fixed-height main content area, causing the page content to overflow and require scrolling.

**Key changes:**
- Restructured the layout in `root-layout.tsx` to move the maintenance banner outside the fixed-height content container
- Implemented a flex column layout where:
  - The maintenance banner uses `flex-shrink-0` to maintain its size
  - The main content area uses `flex-1` to take up remaining available space
- Added proper gap spacing between elements
- Maintained existing responsive behavior across all viewport sizes

**Design decisions:**
- Used CSS flexbox for optimal space distribution
- Kept the maintenance banner at the top of the content area for visibility
- Preserved all existing functionality and styling
- Ensured the fix works across mobile and desktop viewports


<img width="2926" height="1756" alt="image" src="https://github.com/user-attachments/assets/3abf152d-dcc2-4c00-8fbd-27b8a7464646" />

---
**Link of any specific issues this addresses:**

This addresses a user-reported issue where the maintenance banner addition caused page content to require scrolling to view completely.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b90780696da3491883e4e895e8c4906b)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f7f194f-nikolaik   --name openhands-app-f7f194f   docker.all-hands.dev/all-hands-ai/openhands:f7f194f
```