### PR TITLE
Always install Docker with MTU 1450 configuration

### DIFF
--- a/microagents/docker.md
+++ b/microagents/docker.md
@@ -15,10 +15,6 @@ triggers:
 To start Docker in a container environment:
 
 ```bash
-# Configure Docker daemon with MTU 1450 to prevent packet fragmentation issues
-sudo mkdir -p /etc/docker
-echo '{"mtu": 1450}' | sudo tee /etc/docker/daemon.json > /dev/null
-
 # Start Docker daemon in the background
 sudo dockerd > /tmp/docker.log 2>&1 &
 

--- a/microagents/docker.md
+++ b/microagents/docker.md
@@ -8,37 +8,17 @@ triggers:
 - container
 ---
 
-# Docker Installation and Usage Guide
-
-## Installation on Debian/Ubuntu Systems
-
-To install Docker on a Debian/Ubuntu system, follow these steps:
-
-```bash
-# Update package index
-sudo apt-get update
-
-# Install prerequisites
-sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
-
-# Add Docker's official GPG key
-curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-
-# Set up the stable repository
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-# Update package index again
-sudo apt-get update
-
-# Install Docker Engine
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-```
+# Docker Usage Guide
 
 ## Starting Docker in Container Environments
 
-If you're in a container environment without systemd (like this workspace), start Docker with:
+To start Docker in a container environment:
 
 ```bash
+# Configure Docker daemon with MTU 1450 to prevent packet fragmentation issues
+sudo mkdir -p /etc/docker
+echo '{"mtu": 1450}' | sudo tee /etc/docker/daemon.json > /dev/null
+
 # Start Docker daemon in the background
 sudo dockerd > /tmp/docker.log 2>&1 &
 

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -33,6 +33,7 @@ def _generate_dockerfile(
     build_from: BuildFromImageType = BuildFromImageType.SCRATCH,
     extra_deps: str | None = None,
     enable_browser: bool = True,
+    install_docker: bool = False,
 ) -> str:
     """Generate the Dockerfile content for the runtime image based on the base image.
 
@@ -41,6 +42,7 @@ def _generate_dockerfile(
     - build_from (BuildFromImageType): The build method for the runtime image.
     - extra_deps (str):
     - enable_browser (bool): Whether to enable browser support (install Playwright)
+    - install_docker (bool): Whether to install Docker in the image
 
     Returns:
     - str: The resulting Dockerfile content
@@ -58,6 +60,7 @@ def _generate_dockerfile(
         build_from_versioned=build_from == BuildFromImageType.VERSIONED,
         extra_deps=extra_deps if extra_deps is not None else '',
         enable_browser=enable_browser,
+        install_docker=install_docker,
     )
     return dockerfile_content
 
@@ -115,6 +118,7 @@ def build_runtime_image(
     force_rebuild: bool = False,
     extra_build_args: list[str] | None = None,
     enable_browser: bool = True,
+    install_docker: bool = False,
 ) -> str:
     """Prepares the final docker build folder.
 
@@ -130,6 +134,7 @@ def build_runtime_image(
     - force_rebuild (bool): if True, it will create the Dockerfile which uses the base_image
     - extra_build_args (List[str]): Additional build arguments to pass to the builder
     - enable_browser (bool): Whether to enable browser support (install Playwright)
+    - install_docker (bool): Whether to install Docker in the image
 
     Returns:
     - str: <image_repo>:<MD5 hash>. Where MD5 hash is the hash of the docker build folder
@@ -148,6 +153,7 @@ def build_runtime_image(
                 platform=platform,
                 extra_build_args=extra_build_args,
                 enable_browser=enable_browser,
+                install_docker=install_docker,
             )
             return result
 
@@ -161,6 +167,7 @@ def build_runtime_image(
         platform=platform,
         extra_build_args=extra_build_args,
         enable_browser=enable_browser,
+        install_docker=install_docker,
     )
     return result
 
@@ -175,6 +182,7 @@ def build_runtime_image_in_folder(
     platform: str | None = None,
     extra_build_args: list[str] | None = None,
     enable_browser: bool = True,
+    install_docker: bool = False,
 ) -> str:
     runtime_image_repo, _ = get_runtime_image_repo_and_tag(base_image)
     lock_tag = f'oh_v{oh_version}_{get_hash_for_lock_files(base_image, enable_browser)}'
@@ -197,6 +205,7 @@ def build_runtime_image_in_folder(
             build_from=BuildFromImageType.SCRATCH,
             extra_deps=extra_deps,
             enable_browser=enable_browser,
+            install_docker=install_docker,
         )
         if not dry_run:
             _build_sandbox_image(
@@ -235,7 +244,9 @@ def build_runtime_image_in_folder(
     else:
         logger.debug(f'Build [{hash_image_name}] from scratch')
 
-    prep_build_folder(build_folder, base_image, build_from, extra_deps, enable_browser)
+    prep_build_folder(
+        build_folder, base_image, build_from, extra_deps, enable_browser, install_docker
+    )
     if not dry_run:
         _build_sandbox_image(
             build_folder,
@@ -261,6 +272,7 @@ def prep_build_folder(
     build_from: BuildFromImageType,
     extra_deps: str | None,
     enable_browser: bool = True,
+    install_docker: bool = False,
 ) -> None:
     # Copy the source code to directory. It will end up in build_folder/code
     # If package is not found, build from source code
@@ -293,6 +305,7 @@ def prep_build_folder(
         build_from=build_from,
         extra_deps=extra_deps,
         enable_browser=enable_browser,
+        install_docker=install_docker,
     )
     dockerfile_path = Path(build_folder, 'Dockerfile')
     with open(str(dockerfile_path), 'w') as f:
@@ -396,6 +409,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--no_enable_browser', dest='enable_browser', action='store_false'
     )
+    parser.add_argument('--install_docker', action='store_true', default=False)
     args = parser.parse_args()
 
     if args.build_folder is not None:
@@ -428,6 +442,7 @@ if __name__ == '__main__':
                 force_rebuild=args.force_rebuild,
                 platform=args.platform,
                 enable_browser=args.enable_browser,
+                install_docker=args.install_docker,
             )
 
             _runtime_image_repo, runtime_image_source_tag = (

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -33,7 +33,6 @@ def _generate_dockerfile(
     build_from: BuildFromImageType = BuildFromImageType.SCRATCH,
     extra_deps: str | None = None,
     enable_browser: bool = True,
-    install_docker: bool = False,
 ) -> str:
     """Generate the Dockerfile content for the runtime image based on the base image.
 
@@ -42,7 +41,6 @@ def _generate_dockerfile(
     - build_from (BuildFromImageType): The build method for the runtime image.
     - extra_deps (str):
     - enable_browser (bool): Whether to enable browser support (install Playwright)
-    - install_docker (bool): Whether to install Docker in the image
 
     Returns:
     - str: The resulting Dockerfile content
@@ -60,7 +58,6 @@ def _generate_dockerfile(
         build_from_versioned=build_from == BuildFromImageType.VERSIONED,
         extra_deps=extra_deps if extra_deps is not None else '',
         enable_browser=enable_browser,
-        install_docker=install_docker,
     )
     return dockerfile_content
 
@@ -118,7 +115,6 @@ def build_runtime_image(
     force_rebuild: bool = False,
     extra_build_args: list[str] | None = None,
     enable_browser: bool = True,
-    install_docker: bool = False,
 ) -> str:
     """Prepares the final docker build folder.
 
@@ -134,7 +130,6 @@ def build_runtime_image(
     - force_rebuild (bool): if True, it will create the Dockerfile which uses the base_image
     - extra_build_args (List[str]): Additional build arguments to pass to the builder
     - enable_browser (bool): Whether to enable browser support (install Playwright)
-    - install_docker (bool): Whether to install Docker in the image
 
     Returns:
     - str: <image_repo>:<MD5 hash>. Where MD5 hash is the hash of the docker build folder
@@ -153,7 +148,6 @@ def build_runtime_image(
                 platform=platform,
                 extra_build_args=extra_build_args,
                 enable_browser=enable_browser,
-                install_docker=install_docker,
             )
             return result
 
@@ -167,7 +161,6 @@ def build_runtime_image(
         platform=platform,
         extra_build_args=extra_build_args,
         enable_browser=enable_browser,
-        install_docker=install_docker,
     )
     return result
 
@@ -182,7 +175,6 @@ def build_runtime_image_in_folder(
     platform: str | None = None,
     extra_build_args: list[str] | None = None,
     enable_browser: bool = True,
-    install_docker: bool = False,
 ) -> str:
     runtime_image_repo, _ = get_runtime_image_repo_and_tag(base_image)
     lock_tag = f'oh_v{oh_version}_{get_hash_for_lock_files(base_image, enable_browser)}'
@@ -205,7 +197,6 @@ def build_runtime_image_in_folder(
             build_from=BuildFromImageType.SCRATCH,
             extra_deps=extra_deps,
             enable_browser=enable_browser,
-            install_docker=install_docker,
         )
         if not dry_run:
             _build_sandbox_image(
@@ -245,7 +236,7 @@ def build_runtime_image_in_folder(
         logger.debug(f'Build [{hash_image_name}] from scratch')
 
     prep_build_folder(
-        build_folder, base_image, build_from, extra_deps, enable_browser, install_docker
+        build_folder, base_image, build_from, extra_deps, enable_browser
     )
     if not dry_run:
         _build_sandbox_image(
@@ -272,7 +263,6 @@ def prep_build_folder(
     build_from: BuildFromImageType,
     extra_deps: str | None,
     enable_browser: bool = True,
-    install_docker: bool = False,
 ) -> None:
     # Copy the source code to directory. It will end up in build_folder/code
     # If package is not found, build from source code
@@ -305,7 +295,6 @@ def prep_build_folder(
         build_from=build_from,
         extra_deps=extra_deps,
         enable_browser=enable_browser,
-        install_docker=install_docker,
     )
     dockerfile_path = Path(build_folder, 'Dockerfile')
     with open(str(dockerfile_path), 'w') as f:
@@ -409,7 +398,6 @@ if __name__ == '__main__':
     parser.add_argument(
         '--no_enable_browser', dest='enable_browser', action='store_false'
     )
-    parser.add_argument('--install_docker', action='store_true', default=False)
     args = parser.parse_args()
 
     if args.build_folder is not None:
@@ -442,7 +430,6 @@ if __name__ == '__main__':
                 force_rebuild=args.force_rebuild,
                 platform=args.platform,
                 enable_browser=args.enable_browser,
-                install_docker=args.install_docker,
             )
 
             _runtime_image_repo, runtime_image_source_tag = (

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -193,9 +193,7 @@ COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 # ================================================================
 {% endif %}
 
-{% if install_docker %}
 {{ setup_docker() }}
-{% endif %}
 
 {{ setup_vscode_server() }}
 
@@ -216,9 +214,7 @@ RUN chmod a+rwx /openhands/code/openhands/__init__.py
 {% if build_from_versioned %}
 {{ install_dependencies() }}
 {{ install_vscode_extensions() }}
-{% if install_docker %}
 {{ setup_docker() }}
-{% endif %}
 {% endif %}
 
 # Install extra dependencies if specified

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -68,6 +68,23 @@ RUN mkdir -p /openhands && \
 
 {% endmacro %}
 
+{% macro setup_docker() %}
+# Install Docker
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https ca-certificates curl gnupg lsb-release && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure Docker daemon with MTU 1450 to prevent packet fragmentation issues
+RUN mkdir -p /etc/docker && \
+    echo '{"mtu": 1450}' > /etc/docker/daemon.json
+{% endmacro %}
+
 {% macro setup_vscode_server() %}
 # Reference:
 # 1. https://github.com/gitpod-io/openvscode-server
@@ -176,6 +193,10 @@ COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 # ================================================================
 {% endif %}
 
+{% if install_docker %}
+{{ setup_docker() }}
+{% endif %}
+
 {{ setup_vscode_server() }}
 
 # ================================================================
@@ -195,6 +216,9 @@ RUN chmod a+rwx /openhands/code/openhands/__init__.py
 {% if build_from_versioned %}
 {{ install_dependencies() }}
 {{ install_vscode_extensions() }}
+{% if install_docker %}
+{{ setup_docker() }}
+{% endif %}
 {% endif %}
 
 # Install extra dependencies if specified


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR adds Docker installation with MTU 1450 configuration to all runtime images by default. This helps prevent network connectivity issues in container environments where the default MTU size causes packet fragmentation.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

1. Modified `Dockerfile.j2` to always include Docker installation with MTU 1450 configuration
2. Updated `runtime_build.py` to remove the optional `install_docker` parameter since Docker is now installed by default
3. Simplified the `docker.md` microagent to only include instructions for starting the Docker daemon (MTU configuration is now handled automatically during image build)

Design decisions:
- Always install Docker in runtime images rather than making it optional
- Set MTU to 1450 by default to prevent packet fragmentation issues in various container environments
- Configure MTU at build time rather than runtime to ensure consistent behavior

---
**Link of any specific issues this addresses:**

N/A