### PR TITLE
Separate commit and push into distinct tools for better agent control

### DIFF
--- a/docs/git_actions.md
+++ b/docs/git_actions.md
@@ -1,0 +1,162 @@
+# Git Actions in OpenHands
+
+This document describes the new git commit and push actions that provide better control over git operations in OpenHands.
+
+## Overview
+
+Previously, agents would use `CmdRunAction` to execute git commands like `git commit` and `git push`. This approach had limitations:
+
+- Combined operations made it difficult to control when code was committed vs pushed
+- Less granular error handling
+- Harder to debug git-related issues
+- Limited workflow flexibility
+
+The new git actions separate these operations into distinct tools:
+
+- `GitCommitAction`: Handles local git commits only
+- `GitPushAction`: Handles pushing to remote repositories
+
+## GitCommitAction
+
+Commits changes to the local git repository.
+
+### Parameters
+
+- `commit_message` (str): The commit message
+- `files` (list[str] | None): Specific files to commit. If None, commits all staged files
+- `add_all` (bool): If True, stages all changes before committing (equivalent to `git add -A`)
+- `thought` (str): Optional thought/reasoning for the action
+
+### Example Usage
+
+```python
+from openhands.events.action.git import GitCommitAction
+
+# Commit all staged files
+action = GitCommitAction(
+    commit_message="Fix bug in user authentication"
+)
+
+# Commit specific files
+action = GitCommitAction(
+    commit_message="Update documentation",
+    files=["README.md", "docs/api.md"]
+)
+
+# Stage all changes and commit
+action = GitCommitAction(
+    commit_message="Complete feature implementation",
+    add_all=True
+)
+```
+
+### Response
+
+Returns a `GitCommitObservation` with:
+- `content`: Output from the git commit command
+- `commit_hash`: Hash of the created commit
+- `files_committed`: List of files that were committed
+- `success`: Boolean indicating if the commit was successful
+- `error`: Boolean indicating if there was an error
+
+## GitPushAction
+
+Pushes commits to a remote git repository.
+
+### Parameters
+
+- `remote` (str): Remote name to push to (default: "origin")
+- `branch` (str | None): Branch to push. If None, pushes current branch
+- `force` (bool): If True, performs a force push (default: False)
+- `set_upstream` (bool): If True, sets upstream tracking (default: False)
+- `thought` (str): Optional thought/reasoning for the action
+
+### Example Usage
+
+```python
+from openhands.events.action.git import GitPushAction
+
+# Push to origin/main
+action = GitPushAction(
+    remote="origin",
+    branch="main"
+)
+
+# Push current branch and set upstream
+action = GitPushAction(
+    set_upstream=True
+)
+
+# Force push to a specific branch
+action = GitPushAction(
+    remote="origin",
+    branch="feature-branch",
+    force=True
+)
+```
+
+### Response
+
+Returns a `GitPushObservation` with:
+- `content`: Output from the git push command
+- `remote`: The remote that was pushed to
+- `branch`: The branch that was pushed
+- `success`: Boolean indicating if the push was successful
+- `error`: Boolean indicating if there was an error
+
+## Benefits
+
+### Better Control
+Agents can commit work locally without immediately pushing to remote, allowing for:
+- Multiple commits before pushing
+- Local testing and validation
+- Better commit history management
+
+### Reduced Conflicts
+Prevents automatic pushing that may conflict with other work or require authentication.
+
+### User Intent
+Users have better control over when their work is shared remotely.
+
+### Debugging
+Easier to debug and review changes before they are pushed to remote repositories.
+
+### Workflow Flexibility
+Supports different git workflows and branching strategies:
+- Feature branch workflows
+- Git flow
+- GitHub flow
+- Custom workflows
+
+## Error Handling
+
+Both actions provide detailed error information:
+
+- **Commit errors**: No staged changes, permission issues, invalid repository
+- **Push errors**: Authentication failures, network issues, rejected pushes, conflicts
+
+Errors are returned as `ErrorObservation` objects with descriptive messages.
+
+## Migration from CmdRunAction
+
+### Before
+```python
+# Old approach - combined operation
+action = CmdRunAction(command='git add . && git commit -m "Fix bug" && git push origin main')
+```
+
+### After
+```python
+# New approach - separate operations
+commit_action = GitCommitAction(
+    commit_message="Fix bug",
+    add_all=True
+)
+
+push_action = GitPushAction(
+    remote="origin",
+    branch="main"
+)
+```
+
+This separation allows for better error handling, more granular control, and improved workflow flexibility.

--- a/openhands/core/schema/action.py
+++ b/openhands/core/schema/action.py
@@ -80,6 +80,9 @@ class ActionType(str, Enum):
 
     CHANGE_AGENT_STATE = 'change_agent_state'
 
+    COMMIT = 'commit'
+    """Commit changes to the local git repository."""
+
     PUSH = 'push'
     """Push a branch to github."""
 

--- a/openhands/core/schema/observation.py
+++ b/openhands/core/schema/observation.py
@@ -22,6 +22,14 @@ class ObservationType(str, Enum):
     """Runs a IPython cell.
     """
 
+    COMMIT = 'commit'
+    """The result of a git commit operation.
+    """
+
+    PUSH = 'push'
+    """The result of a git push operation.
+    """
+
     CHAT = 'chat'
     """A message from the user
     """

--- a/openhands/events/action/__init__.py
+++ b/openhands/events/action/__init__.py
@@ -15,6 +15,7 @@ from openhands.events.action.files import (
     FileReadAction,
     FileWriteAction,
 )
+from openhands.events.action.git import GitCommitAction, GitPushAction
 from openhands.events.action.mcp import MCPAction
 from openhands.events.action.message import MessageAction, SystemMessageAction
 
@@ -27,6 +28,8 @@ __all__ = [
     'FileReadAction',
     'FileWriteAction',
     'FileEditAction',
+    'GitCommitAction',
+    'GitPushAction',
     'AgentFinishAction',
     'AgentRejectAction',
     'AgentDelegateAction',

--- a/openhands/events/action/git.py
+++ b/openhands/events/action/git.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+from openhands.core.schema import ActionType
+from openhands.events.action.action import (
+    Action,
+    ActionConfirmationStatus,
+    ActionSecurityRisk,
+)
+
+
+@dataclass
+class GitCommitAction(Action):
+    """Action for committing changes to the local git repository."""
+
+    commit_message: str  # Commit message
+    files: list[str] | None = (
+        None  # Specific files to commit, if None commits all staged files
+    )
+    add_all: bool = False  # If True, stages all changes before committing (git add -A)
+    thought: str = ''
+    action: str = ActionType.COMMIT
+    runnable: ClassVar[bool] = True
+    confirmation_state: ActionConfirmationStatus = ActionConfirmationStatus.CONFIRMED
+    security_risk: ActionSecurityRisk | None = None
+
+    @property
+    def message(self) -> str:
+        return f'Committing changes: {self.commit_message}'
+
+    def __str__(self) -> str:
+        ret = f'**GitCommitAction (source={self.source})**\n'
+        if self.thought:
+            ret += f'THOUGHT: {self.thought}\n'
+        ret += f'COMMIT MESSAGE: {self.commit_message}\n'
+        if self.files:
+            ret += f'FILES: {", ".join(self.files)}\n'
+        if self.add_all:
+            ret += 'ADD ALL: True\n'
+        return ret
+
+
+@dataclass
+class GitPushAction(Action):
+    """Action for pushing commits to a remote git repository."""
+
+    remote: str = 'origin'  # Remote name to push to
+    branch: str | None = None  # Branch to push, if None pushes current branch
+    force: bool = False  # If True, performs a force push (git push --force)
+    set_upstream: bool = False  # If True, sets upstream tracking (git push -u)
+    thought: str = ''
+    action: str = ActionType.PUSH
+    runnable: ClassVar[bool] = True
+    confirmation_state: ActionConfirmationStatus = ActionConfirmationStatus.CONFIRMED
+    security_risk: ActionSecurityRisk | None = None
+
+    @property
+    def message(self) -> str:
+        branch_info = f' to {self.branch}' if self.branch else ''
+        return f'Pushing changes to {self.remote}{branch_info}'
+
+    def __str__(self) -> str:
+        ret = f'**GitPushAction (source={self.source})**\n'
+        if self.thought:
+            ret += f'THOUGHT: {self.thought}\n'
+        ret += f'REMOTE: {self.remote}\n'
+        if self.branch:
+            ret += f'BRANCH: {self.branch}\n'
+        if self.force:
+            ret += 'FORCE: True\n'
+        if self.set_upstream:
+            ret += 'SET UPSTREAM: True\n'
+        return ret

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -22,6 +22,7 @@ from openhands.events.observation.files import (
     FileReadObservation,
     FileWriteObservation,
 )
+from openhands.events.observation.git import GitCommitObservation, GitPushObservation
 from openhands.events.observation.mcp import MCPObservation
 from openhands.events.observation.observation import Observation
 from openhands.events.observation.reject import UserRejectObservation
@@ -38,6 +39,8 @@ __all__ = [
     'FileReadObservation',
     'FileWriteObservation',
     'FileEditObservation',
+    'GitCommitObservation',
+    'GitPushObservation',
     'ErrorObservation',
     'AgentStateChangedObservation',
     'AgentDelegateObservation',

--- a/openhands/events/observation/git.py
+++ b/openhands/events/observation/git.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass
+
+from openhands.core.schema import ObservationType
+from openhands.events.observation.observation import Observation
+
+
+@dataclass
+class GitCommitObservation(Observation):
+    """This data class represents the result of a git commit operation."""
+
+    commit_hash: str | None = None  # The hash of the created commit
+    files_committed: list[str] | None = None  # List of files that were committed
+    observation: str = ObservationType.COMMIT
+
+    @property
+    def error(self) -> bool:
+        return self.commit_hash is None
+
+    @property
+    def success(self) -> bool:
+        return not self.error
+
+    @property
+    def message(self) -> str:
+        if self.success:
+            return f'Successfully committed changes. Commit hash: {self.commit_hash}'
+        else:
+            return 'Failed to commit changes'
+
+    def __str__(self) -> str:
+        ret = f'**GitCommitObservation (source={self.source})**\n'
+        if self.commit_hash:
+            ret += f'COMMIT HASH: {self.commit_hash}\n'
+        if self.files_committed:
+            ret += f'FILES COMMITTED: {", ".join(self.files_committed)}\n'
+        ret += f'CONTENT:\n{self.content}'
+        return ret
+
+
+@dataclass
+class GitPushObservation(Observation):
+    """This data class represents the result of a git push operation."""
+
+    remote: str | None = None  # The remote that was pushed to
+    branch: str | None = None  # The branch that was pushed
+    observation: str = ObservationType.PUSH
+
+    @property
+    def error(self) -> bool:
+        # Check if the content contains common error indicators
+        error_indicators = [
+            'error:',
+            'fatal:',
+            'rejected',
+            'failed to push',
+            'permission denied',
+            'authentication failed',
+        ]
+        return any(indicator in self.content.lower() for indicator in error_indicators)
+
+    @property
+    def success(self) -> bool:
+        return not self.error
+
+    @property
+    def message(self) -> str:
+        if self.success:
+            branch_info = f' to {self.branch}' if self.branch else ''
+            remote_info = f' on {self.remote}' if self.remote else ''
+            return f'Successfully pushed changes{branch_info}{remote_info}'
+        else:
+            return 'Failed to push changes'
+
+    def __str__(self) -> str:
+        ret = f'**GitPushObservation (source={self.source})**\n'
+        if self.remote:
+            ret += f'REMOTE: {self.remote}\n'
+        if self.branch:
+            ret += f'BRANCH: {self.branch}\n'
+        ret += f'CONTENT:\n{self.content}'
+        return ret

--- a/openhands/events/serialization/action.py
+++ b/openhands/events/serialization/action.py
@@ -23,6 +23,7 @@ from openhands.events.action.files import (
     FileReadAction,
     FileWriteAction,
 )
+from openhands.events.action.git import GitCommitAction, GitPushAction
 from openhands.events.action.mcp import MCPAction
 from openhands.events.action.message import MessageAction, SystemMessageAction
 
@@ -35,6 +36,8 @@ actions = (
     FileReadAction,
     FileWriteAction,
     FileEditAction,
+    GitCommitAction,
+    GitPushAction,
     AgentThinkAction,
     AgentFinishAction,
     AgentRejectAction,

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -26,6 +26,7 @@ from openhands.events.observation.files import (
     FileReadObservation,
     FileWriteObservation,
 )
+from openhands.events.observation.git import GitCommitObservation, GitPushObservation
 from openhands.events.observation.mcp import MCPObservation
 from openhands.events.observation.observation import Observation
 from openhands.events.observation.reject import UserRejectObservation
@@ -39,6 +40,8 @@ observations = (
     FileReadObservation,
     FileWriteObservation,
     FileEditObservation,
+    GitCommitObservation,
+    GitPushObservation,
     AgentDelegateObservation,
     SuccessObservation,
     ErrorObservation,

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -28,6 +28,8 @@ from openhands.events.action import (
     FileEditAction,
     FileReadAction,
     FileWriteAction,
+    GitCommitAction,
+    GitPushAction,
     IPythonRunCellAction,
 )
 from openhands.events.action.action import Action
@@ -352,6 +354,12 @@ class ActionExecutionClient(Runtime):
         return self.send_action_for_execution(action)
 
     def browse_interactive(self, action: BrowseInteractiveAction) -> Observation:
+        return self.send_action_for_execution(action)
+
+    def commit(self, action: GitCommitAction) -> Observation:
+        return self.send_action_for_execution(action)
+
+    def push(self, action: GitPushAction) -> Observation:
         return self.send_action_for_execution(action)
 
     def get_mcp_config(

--- a/tests/unit/test_git_actions.py
+++ b/tests/unit/test_git_actions.py
@@ -1,0 +1,273 @@
+"""Tests for git commit and push actions."""
+
+from unittest.mock import Mock
+
+from openhands.events.action.git import GitCommitAction, GitPushAction
+from openhands.events.observation.git import GitCommitObservation, GitPushObservation
+from openhands.runtime.utils.git_handler import CommandResult, GitHandler
+
+
+class TestGitActions:
+    """Test git commit and push actions."""
+
+    def test_git_commit_action_creation(self):
+        """Test creating a GitCommitAction."""
+        action = GitCommitAction(
+            commit_message='Test commit message',
+            files=['file1.py', 'file2.py'],
+            add_all=False,
+        )
+
+        assert action.commit_message == 'Test commit message'
+        assert action.files == ['file1.py', 'file2.py']
+        assert action.add_all is False
+        assert action.action == 'commit'
+
+    def test_git_push_action_creation(self):
+        """Test creating a GitPushAction."""
+        action = GitPushAction(
+            remote='origin',
+            branch='main',
+            force=False,
+            set_upstream=True,
+        )
+
+        assert action.remote == 'origin'
+        assert action.branch == 'main'
+        assert action.force is False
+        assert action.set_upstream is True
+        assert action.action == 'push'
+
+    def test_git_commit_observation_creation(self):
+        """Test creating a GitCommitObservation."""
+        obs = GitCommitObservation(
+            content='Commit successful',
+            commit_hash='abc123',
+            files_committed=['file1.py', 'file2.py'],
+        )
+
+        assert obs.content == 'Commit successful'
+        assert obs.commit_hash == 'abc123'
+        assert obs.files_committed == ['file1.py', 'file2.py']
+        assert obs.observation == 'commit'
+        assert obs.success is True
+        assert obs.error is False
+
+    def test_git_push_observation_creation(self):
+        """Test creating a GitPushObservation."""
+        obs = GitPushObservation(
+            content='Push successful',
+            remote='origin',
+            branch='main',
+        )
+
+        assert obs.content == 'Push successful'
+        assert obs.remote == 'origin'
+        assert obs.branch == 'main'
+        assert obs.observation == 'push'
+        assert obs.success is True
+        assert obs.error is False
+
+    def test_git_commit_observation_error_detection(self):
+        """Test GitCommitObservation error detection."""
+        obs = GitCommitObservation(
+            content='Commit failed',
+            commit_hash=None,
+        )
+
+        assert obs.success is False
+        assert obs.error is True
+
+    def test_git_push_observation_error_detection(self):
+        """Test GitPushObservation error detection."""
+        obs = GitPushObservation(
+            content='error: failed to push some refs',
+        )
+
+        assert obs.success is False
+        assert obs.error is True
+
+
+class TestGitHandler:
+    """Test GitHandler functionality."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_execute = Mock()
+        self.mock_create_file = Mock()
+        self.git_handler = GitHandler(
+            execute_shell_fn=self.mock_execute,
+            create_file_fn=self.mock_create_file,
+        )
+        self.git_handler.set_cwd('/test/workspace')
+
+    def test_commit_changes_success(self):
+        """Test successful git commit."""
+        # Mock the command executions
+        self.mock_execute.side_effect = [
+            CommandResult(
+                content='M  file1.py\nA  file2.py', exit_code=0
+            ),  # git status --porcelain --cached
+            CommandResult(
+                content='file1.py\nfile2.py', exit_code=0
+            ),  # git diff --cached --name-only
+            CommandResult(
+                content='[main abc123] Test commit', exit_code=0
+            ),  # git commit
+            CommandResult(content='abc123def456', exit_code=0),  # git rev-parse HEAD
+        ]
+
+        result = self.git_handler.commit_changes(
+            message='Test commit',
+            add_all=True,
+        )
+
+        assert result['success'] is True
+        assert result['commit_hash'] == 'abc123def456'
+        assert result['files_committed'] == ['file1.py', 'file2.py']
+
+        # Verify the commands were called
+        calls = self.mock_execute.call_args_list
+        assert len(calls) == 4
+        assert calls[0][0][0] == 'git add -A'
+        assert calls[1][0][0] == 'git status --porcelain --cached'
+        assert calls[2][0][0] == 'git diff --cached --name-only'
+        assert calls[3][0][0] == 'git commit -m "Test commit"'
+
+    def test_commit_changes_no_staged_changes(self):
+        """Test git commit with no staged changes."""
+        self.mock_execute.side_effect = [
+            CommandResult(
+                content='', exit_code=0
+            ),  # git status --porcelain --cached (empty)
+        ]
+
+        result = self.git_handler.commit_changes(
+            message='Test commit',
+        )
+
+        assert result['success'] is False
+        assert 'No staged changes to commit' in result['error']
+
+    def test_commit_changes_specific_files(self):
+        """Test git commit with specific files."""
+        self.mock_execute.side_effect = [
+            CommandResult(content='', exit_code=0),  # git add file1.py
+            CommandResult(content='', exit_code=0),  # git add file2.py
+            CommandResult(
+                content='M  file1.py\nA  file2.py', exit_code=0
+            ),  # git status --porcelain --cached
+            CommandResult(
+                content='file1.py\nfile2.py', exit_code=0
+            ),  # git diff --cached --name-only
+            CommandResult(
+                content='[main abc123] Test commit', exit_code=0
+            ),  # git commit
+            CommandResult(content='abc123def456', exit_code=0),  # git rev-parse HEAD
+        ]
+
+        result = self.git_handler.commit_changes(
+            message='Test commit',
+            files=['file1.py', 'file2.py'],
+        )
+
+        assert result['success'] is True
+        assert result['files_committed'] == ['file1.py', 'file2.py']
+
+    def test_push_changes_success(self):
+        """Test successful git push."""
+        self.mock_execute.side_effect = [
+            CommandResult(content='main', exit_code=0),  # git branch --show-current
+            CommandResult(
+                content='To origin\n   abc123..def456  main -> main', exit_code=0
+            ),  # git push
+        ]
+
+        result = self.git_handler.push_changes(
+            remote='origin',
+        )
+
+        assert result['success'] is True
+        assert result['remote'] == 'origin'
+        assert result['branch'] == 'main'
+
+        # Verify the commands were called
+        calls = self.mock_execute.call_args_list
+        assert len(calls) == 2
+        assert calls[0][0][0] == 'git branch --show-current'
+        assert calls[1][0][0] == 'git push origin main'
+
+    def test_push_changes_with_upstream(self):
+        """Test git push with upstream setting."""
+        self.mock_execute.side_effect = [
+            CommandResult(
+                content='feature-branch', exit_code=0
+            ),  # git branch --show-current
+            CommandResult(
+                content="Branch 'feature-branch' set up to track remote branch",
+                exit_code=0,
+            ),  # git push -u
+        ]
+
+        result = self.git_handler.push_changes(
+            remote='origin',
+            set_upstream=True,
+        )
+
+        assert result['success'] is True
+
+        # Verify the push command includes -u flag
+        calls = self.mock_execute.call_args_list
+        assert calls[1][0][0] == 'git push -u origin feature-branch'
+
+    def test_push_changes_force(self):
+        """Test git push with force flag."""
+        self.mock_execute.side_effect = [
+            CommandResult(content='main', exit_code=0),  # git branch --show-current
+            CommandResult(
+                content='+ abc123...def456 main -> main (forced update)', exit_code=0
+            ),  # git push --force
+        ]
+
+        result = self.git_handler.push_changes(
+            remote='origin',
+            force=True,
+        )
+
+        assert result['success'] is True
+
+        # Verify the push command includes --force flag
+        calls = self.mock_execute.call_args_list
+        assert calls[1][0][0] == 'git push --force origin main'
+
+    def test_push_changes_error(self):
+        """Test git push with error."""
+        self.mock_execute.side_effect = [
+            CommandResult(content='main', exit_code=0),  # git branch --show-current
+            CommandResult(
+                content='error: failed to push some refs', exit_code=1
+            ),  # git push (error)
+        ]
+
+        result = self.git_handler.push_changes(
+            remote='origin',
+        )
+
+        assert result['success'] is False
+        assert 'failed to push some refs' in result['error']
+
+    def test_push_changes_authentication_error(self):
+        """Test git push with authentication error."""
+        self.mock_execute.side_effect = [
+            CommandResult(content='main', exit_code=0),  # git branch --show-current
+            CommandResult(
+                content='remote: Permission denied', exit_code=0
+            ),  # git push (auth error)
+        ]
+
+        result = self.git_handler.push_changes(
+            remote='origin',
+        )
+
+        assert result['success'] is False
+        assert 'Permission denied' in result['error']


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Separates commit and push actions.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Add GitCommitAction and GitPushAction for granular git operations
- Add corresponding GitCommitObservation and GitPushObservation
- Extend GitHandler with commit_changes() and push_changes() methods
- Update runtime implementations to support new git actions
- Add comprehensive tests for git actions and handlers
- Add documentation for new git actions


---
**Link of any specific issues this addresses:**
This addresses issue #9999 by providing agents with better control over when code is committed vs pushed, reducing conflicts and improving workflow flexibility.