### PR TITLE
Remove redundant pytest-asyncio dependency and unnecessary reset_terminal=False parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ e2b = { version = ">=1.0.5,<1.6.0", optional = true }
 modal = { version = ">=0.66.26,<1.1.0", optional = true }
 runloop-api-client = { version = "0.43.0", optional = true }
 daytona = { version = "0.22.0", optional = true }
-pytest-asyncio = "^1.1.0"
 
 [tool.poetry.extras]
 third_party_runtimes = [ "e2b", "modal", "runloop-api-client", "daytona" ]

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -140,7 +140,7 @@ async def test_cmd(cmd, expected_risk, temp_dir: str):
         analyzer = InvariantAnalyzer(event_stream, policy)
         data = [
             (MessageAction('Hello world!'), EventSource.USER),
-            (CmdRunAction(command=cmd, reset_terminal=False), EventSource.USER),
+            (CmdRunAction(cmd), EventSource.USER),
         ]
 
         # Call on_event directly for each event
@@ -286,7 +286,7 @@ async def test_unsafe_bash_command(temp_dir: str):
         analyzer = InvariantAnalyzer(event_stream)
         data = [
             (MessageAction('Hello world!'), EventSource.USER),
-            (CmdRunAction(command=code, reset_terminal=False), EventSource.AGENT),
+            (CmdRunAction(code), EventSource.AGENT),
         ]
 
         # Call on_event directly for each event


### PR DESCRIPTION
This PR addresses two issues:

1. Removes the redundant pytest-asyncio dependency from pyproject.toml as it's not necessary for the async tests in this codebase.

2. Removes unnecessary explicit `reset_terminal=False` parameters from test files since `False` is already the default value.

These changes simplify the code without changing functionality.