### PR TITLE
Fix for issued due to changes in spec for custom secrets

### DIFF
--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -12,7 +12,6 @@ import docker
 import httpx
 import socketio
 from docker.models.containers import Container
-from fastapi import status
 
 from openhands.controller.agent import Agent
 from openhands.core.config import OpenHandsConfig

--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -204,11 +204,11 @@ class DockerNestedConversationManager(ConversationManager):
                 settings_json.pop('git_provider_tokens', None)
                 if settings_json.get('git_provider'):
                     settings_json['git_provider'] = settings_json['git_provider'].value
-                secrets_store = settings_json.pop('secrets_store', None) or {}
+                settings_json.pop('secrets_store', None) or {}
                 response = await client.post(
                     f'{api_url}/api/settings', json=settings_json
                 )
-                assert response.status_code == status.HTTP_200_OK
+                response.raise_for_status()
 
                 # Setup provider tokens
                 provider_handler = self._get_provider_handler(settings)
@@ -229,21 +229,21 @@ class DockerNestedConversationManager(ConversationManager):
                             'provider_tokens': provider_tokens_json,
                         },
                     )
-                    assert response.status_code == status.HTTP_200_OK
+                    response.raise_for_status()
 
                 # Setup custom secrets
-                custom_secrets = secrets_store.get('custom_secrets') or {}
+                custom_secrets = settings.custom_secrets  # type: ignore
                 if custom_secrets:
-                    for key, value in custom_secrets.items():
+                    for key, secret in custom_secrets.items():
                         response = await client.post(
                             f'{api_url}/api/secrets',
                             json={
                                 'name': key,
-                                'description': value.description,
-                                'value': value.value,
+                                'description': secret.description,
+                                'value': secret.secret.get_secret_value(),
                             },
                         )
-                        assert response.status_code == status.HTTP_200_OK
+                        response.raise_for_status()
 
                 init_conversation: dict[str, Any] = {
                     'initial_user_msg': initial_user_msg,
@@ -266,7 +266,7 @@ class DockerNestedConversationManager(ConversationManager):
                 logger.info(
                     f'_start_agent_loop:{response.status_code}:{response.json()}'
                 )
-                assert response.status_code == status.HTTP_200_OK
+                response.raise_for_status()
         finally:
             self._starting_conversation_ids.discard(sid)
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes an issue where custom secrets were not being properly set up in Docker nested conversation manager due to changes in the custom secrets data structure specification.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes the custom secrets handling in the Docker nested conversation manager by:

1. **Updating custom secrets access pattern**: Changed from accessing custom secrets via a dictionary structure (`secrets_store.get('custom_secrets')`) to accessing them directly from the settings object (`settings.custom_secrets`)

2. **Fixing secret value extraction**: Updated the code to use the new CustomSecret object structure:
   - Changed from `value.value` to `secret.secret.get_secret_value()` to properly extract the secret value
   - Changed from `value.description` to `secret.description` for consistency

3. **Improving error handling**: Replaced `assert response.status_code == status.HTTP_200_OK` with `response.raise_for_status()` for better HTTP error handling

4. **Code cleanup**: Removed unused import `from fastapi import status` and cleaned up variable assignment

The changes ensure that custom secrets are properly configured when starting agent conversations in Docker nested environments, addressing compatibility issues with the updated custom secrets specification.

---
**Link of any specific issues this addresses:**

Fixes issues with custom secrets not being properly configured in Docker nested conversation environments due to API specification changes.
<img width="876" height="559" alt="image" src="https://github.com/user-attachments/assets/17c5e419-c081-4dff-9bcc-472076e04dd1" />

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:afc645e-nikolaik   --name openhands-app-afc645e   docker.all-hands.dev/all-hands-ai/openhands:afc645e
```