### PR TITLE
Revert "Add experiment for agent config"

### DIFF
--- a/openhands/experiments/experiment_manager.py
+++ b/openhands/experiments/experiment_manager.py
@@ -1,7 +1,5 @@
 import os
 
-from openhands.core.config.agent_config import AgentConfig
-from openhands.core.logger import openhands_logger as logger
 from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.utils.import_utils import get_impl
 
@@ -12,15 +10,6 @@ class ExperimentManager:
         user_id: str, conversation_id: str, conversation_settings: ConversationInitData
     ) -> ConversationInitData:
         return conversation_settings
-
-    @staticmethod
-    def run_agent_config_variant_test(
-        user_id: str, conversation_id: str, agent_config: AgentConfig
-    ) -> AgentConfig:
-        logger.debug(
-            f'Running agent config variant test for user_id={user_id}, conversation_id={conversation_id}'
-        )
-        return agent_config
 
 
 experiment_manager_cls = os.environ.get(

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -28,7 +28,6 @@ from openhands.events.observation.agent import RecallObservation
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.serialization import event_from_dict, event_to_dict
 from openhands.events.stream import EventStreamSubscriber
-from openhands.experiments.experiment_manager import ExperimentManagerImpl
 from openhands.llm.llm import LLM
 from openhands.runtime.runtime_status import RuntimeStatus
 from openhands.server.session.agent_session import AgentSession
@@ -157,10 +156,6 @@ class Session:
 
         llm = self._create_llm(agent_cls)
         agent_config = self.config.get_agent_config(agent_cls)
-
-        agent_config = ExperimentManagerImpl.run_agent_config_variant_test(
-            self.user_id, self.sid, agent_config
-        )
 
         if settings.enable_default_condenser:
             # Default condenser chains three condensers together:


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#9861

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5803503-nikolaik   --name openhands-app-5803503   docker.all-hands.dev/all-hands-ai/openhands:5803503
```