### PR TITLE
Update git configuration instructions in CodeAct agent system prompts

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -31,7 +31,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* When committing changes, you MUST use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. This ensures all commits are attributed to the OpenHands agent, regardless of the local git config.
+* If there are existing git user credentials already configured, use them and add Co-authored-by: openhands <openhands@all-hands.dev> to any commits messages you make. if a git config doesn't exist use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
 * When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
@@ -25,7 +25,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* Use the existing git user credentials when possible. When committing, use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. If a git config doesn't exist, use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* If there are existing git user credentials already configured, use them and add Co-authored-by: openhands <openhands@all-hands.dev> to any commits messages you make. if a git config doesn't exist use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
 * When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_long_horizon.j2
@@ -25,7 +25,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </CODE_QUALITY>
 
 <VERSION_CONTROL>
-* Use the existing git user credentials when possible. When committing, use the `--author` flag to set the author to `"openhands <openhands@all-hands.dev>"`. For example: `git commit --author="openhands <openhands@all-hands.dev>" -m "Fix bug"`. If a git config doesn't exist, use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
+* If there are existing git user credentials already configured, use them and add Co-authored-by: openhands <openhands@all-hands.dev> to any commits messages you make. if a git config doesn't exist use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default, unless explicitly instructed otherwise.
 * Exercise caution with git operations. Do NOT make potentially dangerous changes (e.g., pushing to main, deleting repositories) unless explicitly asked to do so.
 * When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.


### PR DESCRIPTION
This PR updates the git configuration bullet point in all system prompts for the CodeAct agent.

The change replaces the current instruction to always use the `--author` flag with a new instruction to:
1. Use existing git user credentials if configured
2. Add `Co-authored-by: openhands <openhands@all-hands.dev>` to commit messages
3. Use "openhands" as the user.name and "openhands@all-hands.dev" as the user.email by default if no git config exists

This change has been applied to all three system prompt files:
- system_prompt.j2
- system_prompt_interactive.j2
- system_prompt_long_horizon.j2

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f01a03d-nikolaik   --name openhands-app-f01a03d   docker.all-hands.dev/all-hands-ai/openhands:f01a03d
```