### PR TITLE
docs: update CodeAct agent step method Returns documentation

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -161,6 +161,13 @@ class CodeActAgent(Agent):
         - AgentDelegateAction(agent, inputs) - delegate action for (sub)task
         - MessageAction(content) - Message action to run (e.g. ask for clarification)
         - AgentFinishAction() - end the interaction
+        - CondensationAction(...) - condense conversation history by forgetting specified events and optionally providing a summary
+        - FileReadAction(path, ...) - read file content from specified path
+        - FileEditAction(path, ...) - edit file using LLM-based (deprecated) or ACI-based editing
+        - AgentThinkAction(thought) - log agent's thought/reasoning process
+        - CondensationRequestAction() - request condensation of conversation history
+        - BrowseInteractiveAction(browser_actions) - interact with browser using specified actions
+        - MCPAction(name, arguments) - interact with MCP server tools
         """
         # Continue with pending actions if any
         if self.pending_actions:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Update the `step` method documentation in CodeActAgent to include all possible Action types that can be returned. Added 7 missing Action types to the Returns section.

**Where these Actions are introduced.**
- `CondensationAction`: Returned directly at line 184 when condenser returns a Condensation object
- `FileReadAction`, `FileEditAction`, `AgentThinkAction`, `CondensationRequestAction`, `BrowseInteractiveAction`, `MCPAction`: Generated in `function_calling.py:response_to_actions()` method (lines 168-230) and returned via `pending_actions.popleft()` at lines 167 or 207

**Why this matters.**
The previous documentation was incomplete and could mislead developers/AI about what Action types the `step` method can return. All these Actions are already implemented in the codebase but were missing from the documentation.


---
**Link of any specific issues this addresses:** N/A
