### PR TITLE
Add process management guidance to system prompt

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -93,3 +93,11 @@ Your primary role is to assist users by executing commands, modifying code, and 
   - Confirm whether they want it as a separate file or just in the conversation
   - Ask if they want documentation files to be included in version control
 </DOCUMENTATION>
+
+<PROCESS_MANAGEMENT>
+* When terminating processes:
+  - Do NOT use general keywords with commands like `pkill -f server` or `pkill -f python` as this might accidentally kill other important servers or processes
+  - Always use specific keywords that uniquely identify the target process
+  - Prefer using `ps aux` to find the exact process ID (PID) first, then kill that specific PID
+  - When possible, use more targeted approaches like finding the PID from a pidfile or using application-specific shutdown commands
+</PROCESS_MANAGEMENT>

--- a/openhands/agenthub/readonly_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/readonly_agent/prompts/system_prompt.j2
@@ -31,9 +31,4 @@ You are OpenHands ReadOnlyAgent, a helpful AI assistant focused on code analysis
 3. If asked to make changes:
    - Explain you are read-only
    - Recommend using CodeActAgent instead
-
-4. If discussing process management:
-   - Advise against using general keywords with commands like `pkill -f server` or `pkill -f python`
-   - Recommend using specific keywords that uniquely identify target processes
-   - Suggest using `ps aux` to find exact process IDs before terminating them
 </GUIDELINES>

--- a/openhands/agenthub/readonly_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/readonly_agent/prompts/system_prompt.j2
@@ -31,4 +31,9 @@ You are OpenHands ReadOnlyAgent, a helpful AI assistant focused on code analysis
 3. If asked to make changes:
    - Explain you are read-only
    - Recommend using CodeActAgent instead
+
+4. If discussing process management:
+   - Advise against using general keywords with commands like `pkill -f server` or `pkill -f python`
+   - Recommend using specific keywords that uniquely identify target processes
+   - Suggest using `ps aux` to find exact process IDs before terminating them
 </GUIDELINES>


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR adds guidance to the system prompt about safely terminating processes. It advises against using general keywords with commands like `pkill -f server` or `pkill -f python` which might accidentally kill other important processes. Instead, it recommends using specific keywords or finding the exact process ID first.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds a new `<PROCESS_MANAGEMENT>` section to the CodeAct agent's system prompt with specific guidance on how to safely terminate processes. The guidance includes:

1. Not using general keywords with commands like `pkill -f server` or `pkill -f python`
2. Using specific keywords that uniquely identify the target process
3. Using `ps aux` to find the exact process ID (PID) first, then killing that specific PID
4. Using more targeted approaches like finding the PID from a pidfile or using application-specific shutdown commands

This addition helps prevent accidental termination of important processes when the agent is asked to kill a specific process.

---
**Link of any specific issues this addresses:**

N/A