### PR TITLE
fix: remove duplicate error message in provider validator

### DIFF
--- a/openhands/cli/settings.py
+++ b/openhands/cli/settings.py
@@ -205,20 +205,11 @@ async def modify_llm_settings_basic(
             provider = verified_providers[choice_index]
         else:
             # User selected "Select another provider" - use manual selection
-            # Define a validator function that prints an error message
-            def provider_validator(x):
-                is_valid = x in organized_models
-                if not is_valid:
-                    print_formatted_text(
-                        HTML('<grey>Invalid provider selected: {}</grey>'.format(x))
-                    )
-                return is_valid
-
             provider = await get_validated_input(
                 session,
                 '(Step 1/3) Select LLM Provider (TAB for options, CTRL-c to cancel): ',
                 completer=provider_completer,
-                validator=provider_validator,
+                validator=lambda x: x in organized_models,
                 error_message='Invalid provider selected',
             )
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Remove duplicate error message in provider validator.
 
The `get_validated_input` function already prints the provided error_message when validation fails, making the custom validator's error printing redundant.

### Before
<img width="1230" height="1226" alt="image" src="https://github.com/user-attachments/assets/c8bcaaf4-d14c-4c01-acb1-32530cb82a9f" />

### Now
<img width="1234" height="1176" alt="image" src="https://github.com/user-attachments/assets/5b591200-fef4-44fe-87c1-34f3923db1a9" />

---
**Link of any specific issues this addresses:** N/A
