### PR TITLE
Add Cerebras Code provider documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -72,6 +72,7 @@
                       "group": "Providers",
                       "pages": [
                         "usage/llms/azure-llms",
+                        "usage/llms/cerebras",
                         "usage/llms/google-llms",
                         "usage/llms/groq",
                         "usage/llms/local-llms",

--- a/docs/usage/llms/cerebras.mdx
+++ b/docs/usage/llms/cerebras.mdx
@@ -1,0 +1,79 @@
+---
+title: Cerebras
+description: OpenHands uses LiteLLM to make calls to chat models on Cerebras. You can find their documentation on using Cerebras as a provider [here](https://docs.litellm.ai/docs/providers/cerebras).
+---
+
+## Overview
+
+Cerebras Code provides ultra-fast inference for large language models, offering speeds up to 2,600 tokens per second. Cerebras specializes in high-performance AI inference with their custom hardware designed specifically for AI workloads.
+
+## Configuration
+
+When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
+
+- `LLM Provider` to `Cerebras`
+- `LLM Model` to the model you will be using. Popular models include:
+  - `cerebras/llama-4-scout` - Latest Llama 4 Scout model (~2600 tokens/s)
+  - `cerebras/llama-3.3-70b` - Llama 3.3 70B model (~2100 tokens/s)
+  - `cerebras/llama-3.1-8b` - Llama 3.1 8B model (~2200 tokens/s)
+  - `cerebras/qwen-3-32b` - Qwen 3 32B model (~2600 tokens/s)
+  - `cerebras/deepseek-r1-distill-llama-70b` - DeepSeek R1 distilled model (~2600 tokens/s)
+
+If the model is not in the list, enable `Advanced` options, and enter it in `Custom Model` (e.g. `cerebras/<model-name>`).
+
+- `API Key` to your Cerebras API key. To get your Cerebras API Key, visit [Cerebras Cloud](https://cloud.cerebras.ai/) and sign up for an account.
+
+## Pricing
+
+Cerebras offers three pricing tiers:
+
+### Exploration (Pay-as-you-go)
+Perfect for prototyping, testing, and small-scale applications:
+- **No minimum commitment** – pay only for what you use
+- **Instant access** to popular Cerebras-supported models
+- **Community support** via Discord
+- Available through [Hugging Face](https://huggingface.co/cerebras) and [OpenRouter](https://openrouter.ai/provider/cerebras)
+
+**Sample pricing for popular models:**
+- **Llama 4 Scout**: $0.65/M input tokens, $0.85/M output tokens (~2600 tokens/s)
+- **Llama 3.3 70B**: $0.85/M input tokens, $1.20/M output tokens (~2100 tokens/s)
+- **Llama 3.1 8B**: $0.10/M input tokens, $0.10/M output tokens (~2200 tokens/s)
+- **Qwen 3 32B**: $0.40/M input tokens, $0.80/M output tokens (~2600 tokens/s)
+- **DeepSeek R1 Distill Llama 70B**: $2.20/M input tokens, $2.50/M output tokens (~2600 tokens/s)
+
+### Growth (Monthly Subscription)
+Scale your production workloads with confidence:
+- **Monthly subscription starting at $1,500/month**
+- **Higher rate limits** (300+ RPM)
+- **Higher request priority** (lower latency at high traffic times)
+- **Early access** to upcoming models and API features
+- **Prioritized support** via Slack
+
+### Enterprise
+Mission-critical performance with white-glove support:
+- **Custom pricing** tailored to your usage
+- **Highest rate limits** for production workloads
+- **Lowest latency** with dedicated queue priority
+- **Extended context length** support
+- **Dedicated deployment** options
+- **Model fine-tuning** and training services available
+- **Dedicated support team** with response time guarantees
+
+For Enterprise pricing, [contact Cerebras sales](https://www.cerebras.ai/build-with-us).
+
+## Key Features
+
+- **Ultra-fast inference**: Up to 2,600 tokens per second
+- **Latest models**: Access to Llama 4, Qwen 3, and other cutting-edge models
+- **High throughput**: Optimized for production workloads
+- **Competitive pricing**: Cost-effective for both development and production use
+- **Multiple access methods**: Direct API, Hugging Face, and OpenRouter integration
+
+## Getting Started
+
+1. Sign up for a Cerebras account at [cloud.cerebras.ai](https://cloud.cerebras.ai/)
+2. Get your API key from the Cerebras dashboard
+3. Configure OpenHands with your Cerebras API key and chosen model
+4. Start building with ultra-fast AI inference!
+
+For more detailed information about Cerebras models and capabilities, visit the [Cerebras documentation](https://inference-docs.cerebras.ai/api-reference/chat-completions).

--- a/docs/usage/llms/cerebras.mdx
+++ b/docs/usage/llms/cerebras.mdx
@@ -3,77 +3,11 @@ title: Cerebras
 description: OpenHands uses LiteLLM to make calls to chat models on Cerebras. You can find their documentation on using Cerebras as a provider [here](https://docs.litellm.ai/docs/providers/cerebras).
 ---
 
-## Overview
-
-Cerebras Code provides ultra-fast inference for large language models, offering speeds up to 2,600 tokens per second. Cerebras specializes in high-performance AI inference with their custom hardware designed specifically for AI workloads.
-
 ## Configuration
 
 When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
-
 - `LLM Provider` to `Cerebras`
-- `LLM Model` to the model you will be using. Popular models include:
-  - `cerebras/llama-4-scout` - Latest Llama 4 Scout model (~2600 tokens/s)
-  - `cerebras/llama-3.3-70b` - Llama 3.3 70B model (~2100 tokens/s)
-  - `cerebras/llama-3.1-8b` - Llama 3.1 8B model (~2200 tokens/s)
-  - `cerebras/qwen-3-32b` - Qwen 3 32B model (~2600 tokens/s)
-  - `cerebras/deepseek-r1-distill-llama-70b` - DeepSeek R1 distilled model (~2600 tokens/s)
+- `LLM Model` to the model you will be using. [Visit here to see the list of models that Cerebras hosts](https://cloud.cerebras.ai/). If the model is not in the list, enable `Advanced` options, and enter it in `Custom Model` (e.g. `cerebras/<model-name>`).
+- `API Key` to your Cerebras API key. To find or create your Cerebras API Key, visit [Cerebras Cloud](https://cloud.cerebras.ai/) and sign up for an account.
 
-If the model is not in the list, enable `Advanced` options, and enter it in `Custom Model` (e.g. `cerebras/<model-name>`).
-
-- `API Key` to your Cerebras API key. To get your Cerebras API Key, visit [Cerebras Cloud](https://cloud.cerebras.ai/) and sign up for an account.
-
-## Pricing
-
-Cerebras offers three pricing tiers:
-
-### Exploration (Pay-as-you-go)
-Perfect for prototyping, testing, and small-scale applications:
-- **No minimum commitment** – pay only for what you use
-- **Instant access** to popular Cerebras-supported models
-- **Community support** via Discord
-- Available through [Hugging Face](https://huggingface.co/cerebras) and [OpenRouter](https://openrouter.ai/provider/cerebras)
-
-**Sample pricing for popular models:**
-- **Llama 4 Scout**: $0.65/M input tokens, $0.85/M output tokens (~2600 tokens/s)
-- **Llama 3.3 70B**: $0.85/M input tokens, $1.20/M output tokens (~2100 tokens/s)
-- **Llama 3.1 8B**: $0.10/M input tokens, $0.10/M output tokens (~2200 tokens/s)
-- **Qwen 3 32B**: $0.40/M input tokens, $0.80/M output tokens (~2600 tokens/s)
-- **DeepSeek R1 Distill Llama 70B**: $2.20/M input tokens, $2.50/M output tokens (~2600 tokens/s)
-
-### Growth (Monthly Subscription)
-Scale your production workloads with confidence:
-- **Monthly subscription starting at $1,500/month**
-- **Higher rate limits** (300+ RPM)
-- **Higher request priority** (lower latency at high traffic times)
-- **Early access** to upcoming models and API features
-- **Prioritized support** via Slack
-
-### Enterprise
-Mission-critical performance with white-glove support:
-- **Custom pricing** tailored to your usage
-- **Highest rate limits** for production workloads
-- **Lowest latency** with dedicated queue priority
-- **Extended context length** support
-- **Dedicated deployment** options
-- **Model fine-tuning** and training services available
-- **Dedicated support team** with response time guarantees
-
-For Enterprise pricing, [contact Cerebras sales](https://www.cerebras.ai/build-with-us).
-
-## Key Features
-
-- **Ultra-fast inference**: Up to 2,600 tokens per second
-- **Latest models**: Access to Llama 4, Qwen 3, and other cutting-edge models
-- **High throughput**: Optimized for production workloads
-- **Competitive pricing**: Cost-effective for both development and production use
-- **Multiple access methods**: Direct API, Hugging Face, and OpenRouter integration
-
-## Getting Started
-
-1. Sign up for a Cerebras account at [cloud.cerebras.ai](https://cloud.cerebras.ai/)
-2. Get your API key from the Cerebras dashboard
-3. Configure OpenHands with your Cerebras API key and chosen model
-4. Start building with ultra-fast AI inference!
-
-For more detailed information about Cerebras models and capabilities, visit the [Cerebras documentation](https://inference-docs.cerebras.ai/api-reference/chat-completions).
+Cerebras models are also available through third-party providers such as [Hugging Face](https://huggingface.co/cerebras) and [OpenRouter](https://openrouter.ai/provider/cerebras).

--- a/docs/usage/llms/cerebras.mdx
+++ b/docs/usage/llms/cerebras.mdx
@@ -12,29 +12,6 @@ When running OpenHands, you'll need to set the following in the OpenHands UI thr
 
 ## Pricing
 
-Cerebras offers three pricing tiers:
-
-### Exploration
-Pay-as-you-go for prototyping and small-scale applications:
-- No minimum commitment
-- Instant access to models
-- Community support via Discord
-- Available through [Hugging Face](https://huggingface.co/cerebras) and [OpenRouter](https://openrouter.ai/provider/cerebras)
-
-### Growth
-Monthly subscriptions for production workloads:
-- Higher rate limits (300+ RPM)
-- Higher request priority
-- Early access to new models and features
-- Prioritized support via Slack
-
-### Enterprise
-Custom solutions for large-scale deployments:
-- Highest rate limits
-- Lowest latency with dedicated queue priority
-- Extended context length support
-- Dedicated deployment options
-- Model fine-tuning and training services
-- Dedicated support team
+Notably, Cerebras allows for standard API pricing and also a Cerebras Code offering that provides a subscription for $50 or $200 for a larger amount of usage.
 
 For current pricing details, visit the [Cerebras pricing page](https://www.cerebras.ai/pricing) or [contact sales](https://www.cerebras.ai/build-with-us) for Enterprise pricing.

--- a/docs/usage/llms/cerebras.mdx
+++ b/docs/usage/llms/cerebras.mdx
@@ -12,30 +12,29 @@ When running OpenHands, you'll need to set the following in the OpenHands UI thr
 
 ## Pricing
 
-Cerebras Code offers three pricing tiers:
+Cerebras offers three pricing tiers:
 
-### Exploration (Pay-as-you-go)
-Perfect for prototyping, testing, and small-scale applications:
-- **No minimum commitment** – pay only for what you use
-- **Instant access** to popular Cerebras-supported models
-- **Community support** via Discord
+### Exploration
+Pay-as-you-go for prototyping and small-scale applications:
+- No minimum commitment
+- Instant access to models
+- Community support via Discord
 - Available through [Hugging Face](https://huggingface.co/cerebras) and [OpenRouter](https://openrouter.ai/provider/cerebras)
 
-### Growth (Monthly Subscription)
-Scale your production workloads with confidence:
-- **Monthly subscription** with higher rate limits
-- **Higher request priority** (lower latency at high traffic times)
-- **Early access** to upcoming models and API features
-- **Prioritized support** via Slack
+### Growth
+Monthly subscriptions for production workloads:
+- Higher rate limits (300+ RPM)
+- Higher request priority
+- Early access to new models and features
+- Prioritized support via Slack
 
 ### Enterprise
-Mission-critical performance with white-glove support:
-- **Custom pricing** tailored to your usage
-- **Highest rate limits** for production workloads
-- **Lowest latency** with dedicated queue priority
-- **Extended context length** support
-- **Dedicated deployment** options
-- **Model fine-tuning** and training services available
-- **Dedicated support team** with response time guarantees
+Custom solutions for large-scale deployments:
+- Highest rate limits
+- Lowest latency with dedicated queue priority
+- Extended context length support
+- Dedicated deployment options
+- Model fine-tuning and training services
+- Dedicated support team
 
-For current pricing details and Enterprise pricing, visit the [Cerebras pricing page](https://www.cerebras.ai/pricing) or [contact Cerebras sales](https://www.cerebras.ai/build-with-us).
+For current pricing details, visit the [Cerebras pricing page](https://www.cerebras.ai/pricing) or [contact sales](https://www.cerebras.ai/build-with-us) for Enterprise pricing.

--- a/docs/usage/llms/cerebras.mdx
+++ b/docs/usage/llms/cerebras.mdx
@@ -10,4 +10,32 @@ When running OpenHands, you'll need to set the following in the OpenHands UI thr
 - `LLM Model` to the model you will be using. [Visit here to see the list of models that Cerebras hosts](https://cloud.cerebras.ai/). If the model is not in the list, enable `Advanced` options, and enter it in `Custom Model` (e.g. `cerebras/<model-name>`).
 - `API Key` to your Cerebras API key. To find or create your Cerebras API Key, visit [Cerebras Cloud](https://cloud.cerebras.ai/) and sign up for an account.
 
-Cerebras models are also available through third-party providers such as [Hugging Face](https://huggingface.co/cerebras) and [OpenRouter](https://openrouter.ai/provider/cerebras).
+## Pricing
+
+Cerebras Code offers three pricing tiers:
+
+### Exploration (Pay-as-you-go)
+Perfect for prototyping, testing, and small-scale applications:
+- **No minimum commitment** – pay only for what you use
+- **Instant access** to popular Cerebras-supported models
+- **Community support** via Discord
+- Available through [Hugging Face](https://huggingface.co/cerebras) and [OpenRouter](https://openrouter.ai/provider/cerebras)
+
+### Growth (Monthly Subscription)
+Scale your production workloads with confidence:
+- **Monthly subscription** with higher rate limits
+- **Higher request priority** (lower latency at high traffic times)
+- **Early access** to upcoming models and API features
+- **Prioritized support** via Slack
+
+### Enterprise
+Mission-critical performance with white-glove support:
+- **Custom pricing** tailored to your usage
+- **Highest rate limits** for production workloads
+- **Lowest latency** with dedicated queue priority
+- **Extended context length** support
+- **Dedicated deployment** options
+- **Model fine-tuning** and training services available
+- **Dedicated support team** with response time guarantees
+
+For current pricing details and Enterprise pricing, visit the [Cerebras pricing page](https://www.cerebras.ai/pricing) or [contact Cerebras sales](https://www.cerebras.ai/build-with-us).

--- a/docs/usage/llms/llms.mdx
+++ b/docs/usage/llms/llms.mdx
@@ -74,6 +74,7 @@ using `-e`:
 We have a few guides for running OpenHands with specific model providers:
 
 - [Azure](/usage/llms/azure-llms)
+- [Cerebras](/usage/llms/cerebras)
 - [Google](/usage/llms/google-llms)
 - [Groq](/usage/llms/groq)
 - [Local LLMs with SGLang or vLLM](/usage/llms/local-llms)


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR adds comprehensive documentation for using Cerebras Code with OpenHands. Users can now easily configure and use Cerebras' ultra-fast AI inference models (up to 2,600 tokens/second) with OpenHands by following the new documentation guide.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds documentation for the Cerebras provider to help users integrate Cerebras Code with OpenHands:

- **New documentation file**: `docs/usage/llms/cerebras.mdx` with comprehensive setup instructions
- **Configuration guidance**: Step-by-step instructions for setting up Cerebras in the OpenHands UI
- **Pricing information**: Detailed breakdown of all three Cerebras pricing tiers (Exploration, Growth, Enterprise)
- **Model details**: Popular models with their speeds and pricing (Llama 4 Scout, Llama 3.3 70B, Qwen 3, etc.)
- **Navigation updates**: Added Cerebras to the documentation navigation and main LLMs overview page
- **LiteLLM integration**: References to LiteLLM documentation for technical implementation details

The documentation follows the same structure and format as existing provider documentation (Groq, OpenRouter, etc.) for consistency.

---
**Link of any specific issues this addresses:**

Fixes #10093

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8d8fccc-nikolaik   --name openhands-app-8d8fccc   docker.all-hands.dev/all-hands-ai/openhands:8d8fccc
```