### PR TITLE
fix: add missing '#' path alias to vite.config.ts to fix frontend build errors

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ import svgr from "vite-plugin-svgr";
 import { reactRouter } from "@react-router/dev/vite";
 import { configDefaults } from "vitest/config";
 import tailwindcss from "@tailwindcss/vite";
+import path from "path";
 
 export default defineConfig(({ mode }) => {
   const {
@@ -31,6 +32,11 @@ export default defineConfig(({ mode }) => {
       svgr(),
       tailwindcss(),
     ],
+    resolve: {
+      alias: {
+        "#": path.resolve(__dirname, "src"),
+      },
+    },
     server: {
       port: FE_PORT,
       host: true,


### PR DESCRIPTION
This PR adds the missing '#' path alias configuration to the Vite config file, which is needed to properly resolve imports using the '#' alias (e.g., `import { AgentState } from "#/types/agent-state";`).

The alias is already defined in tsconfig.json but was missing in vite.config.ts, causing build errors when using the '#' alias in imports.

## Changes
- Added the path alias configuration to vite.config.ts
- Imported the path module to resolve the alias path

## Testing
- Successfully built the frontend with `npm run build`

Fixes #10052

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a013034-nikolaik   --name openhands-app-a013034   docker.all-hands.dev/all-hands-ai/openhands:a013034
```