### PR TITLE
Fix git-related test failures by making tests environment-independent

### DIFF
--- a/tests/unit/resolver/gitlab/test_gitlab_pr_title_escaping.py
+++ b/tests/unit/resolver/gitlab/test_gitlab_pr_title_escaping.py
@@ -13,6 +13,15 @@ def test_commit_message_with_quotes():
     with tempfile.TemporaryDirectory() as temp_dir:
         subprocess.run(['git', 'init', temp_dir], check=True)
 
+        # Set git configuration locally for this repository
+        subprocess.run(
+            ['git', '-C', temp_dir, 'config', 'user.email', 'test@example.com'],
+            check=True,
+        )
+        subprocess.run(
+            ['git', '-C', temp_dir, 'config', 'user.name', 'Test User'], check=True
+        )
+
         # Create a test file and add it to git
         test_file = os.path.join(temp_dir, 'test.txt')
         with open(test_file, 'w') as f:
@@ -37,8 +46,20 @@ def test_commit_message_with_quotes():
             thread_ids=None,
         )
 
-        # Make the commit
-        make_commit(temp_dir, issue, 'issue')
+        # Make the commit with author information
+        # First, modify the environment to include GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL
+        old_environ = os.environ.copy()
+        os.environ['GIT_AUTHOR_NAME'] = 'Test User'
+        os.environ['GIT_AUTHOR_EMAIL'] = 'test@example.com'
+        os.environ['GIT_COMMITTER_NAME'] = 'Test User'
+        os.environ['GIT_COMMITTER_EMAIL'] = 'test@example.com'
+
+        try:
+            make_commit(temp_dir, issue, 'issue')
+        finally:
+            # Restore the original environment
+            os.environ.clear()
+            os.environ.update(old_environ)
 
         # Get the commit message
         result = subprocess.run(
@@ -101,6 +122,14 @@ def test_pr_title_with_quotes(monkeypatch):
     def mock_run(*args, **kwargs):
         logger.info(f'Running command: {args[0] if args else kwargs.get("args", [])}')
         if isinstance(args[0], list) and args[0][0] == 'git':
+            # Set git environment variables for all git commands
+            env = kwargs.get('env', os.environ.copy())
+            env['GIT_AUTHOR_NAME'] = 'Test User'
+            env['GIT_AUTHOR_EMAIL'] = 'test@example.com'
+            env['GIT_COMMITTER_NAME'] = 'Test User'
+            env['GIT_COMMITTER_EMAIL'] = 'test@example.com'
+            kwargs['env'] = env
+
             if 'push' in args[0]:
                 return subprocess.CompletedProcess(
                     args[0], returncode=0, stdout='', stderr=''
@@ -156,11 +185,23 @@ def test_pr_title_with_quotes(monkeypatch):
         # Try to send a PR - this will fail if the title is incorrectly escaped
         logger.info('Sending PR...')
 
-        send_pull_request(
-            issue=issue,
-            token='dummy-token',
-            username='test-user',
-            platform=ProviderType.GITHUB,
-            patch_dir=temp_dir,
-            pr_type='ready',
-        )
+        # Set git environment variables
+        old_environ = os.environ.copy()
+        os.environ['GIT_AUTHOR_NAME'] = 'Test User'
+        os.environ['GIT_AUTHOR_EMAIL'] = 'test@example.com'
+        os.environ['GIT_COMMITTER_NAME'] = 'Test User'
+        os.environ['GIT_COMMITTER_EMAIL'] = 'test@example.com'
+
+        try:
+            send_pull_request(
+                issue=issue,
+                token='dummy-token',
+                username='test-user',
+                platform=ProviderType.GITHUB,
+                patch_dir=temp_dir,
+                pr_type='ready',
+            )
+        finally:
+            # Restore the original environment
+            os.environ.clear()
+            os.environ.update(old_environ)


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
This PR fixes git-related test failures that were occurring due to missing git user configuration in test environments. The tests now set the necessary git environment variables directly, making them more robust and environment-independent.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This PR addresses test failures in git-related tests that were failing with "Author identity unknown" errors. The changes include:

1. Modified `TestGitHandler` to set git environment variables (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`) directly in the test environment
2. Updated PR title escaping tests in GitHub and GitLab modules to set the same environment variables
3. Changed git config commands to use specific config files with `-f .git/config` to avoid conflicts with global git configuration

These changes make the tests more robust and independent of the environment they run in, ensuring they pass regardless of whether global git user configuration is present.

---
**Link of any specific issues this addresses:**
N/A