### PR TITLE
Bump conversation history limit from 20 to 100

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -281,7 +281,7 @@ class OpenHands {
 
   static async getUserConversations(): Promise<Conversation[]> {
     const { data } = await openHands.get<ResultSet<Conversation>>(
-      "/api/conversations?limit=20",
+      "/api/conversations?limit=100",
     );
     return data.results;
   }
@@ -289,7 +289,7 @@ class OpenHands {
   static async searchConversations(
     selectedRepository?: string,
     conversationTrigger?: string,
-    limit: number = 20,
+    limit: number = 100,
   ): Promise<Conversation[]> {
     const params = new URLSearchParams();
     params.append("limit", limit.toString());

--- a/frontend/src/hooks/query/use-search-conversations.ts
+++ b/frontend/src/hooks/query/use-search-conversations.ts
@@ -4,7 +4,7 @@ import OpenHands from "#/api/open-hands";
 export const useSearchConversations = (
   selectedRepository?: string,
   conversationTrigger?: string,
-  limit: number = 20,
+  limit: number = 100,
   cacheDisabled: boolean = false,
 ) =>
   useQuery({


### PR DESCRIPTION
## Summary

This PR increases the conversation history limit from 20 to 100 conversations, allowing users to see more of their conversation history without pagination.

## Changes

- **Frontend API calls**: Updated `getUserConversations()` to request `limit=100` instead of `limit=20`
- **Search conversations**: Updated `searchConversations()` default parameter from 20 to 100
- **React hook**: Updated `useSearchConversations` default limit parameter from 20 to 100

## Implementation Details

This is a frontend-only change that works by:
1. Frontend explicitly requests `limit=100` in API calls
2. Backend receives the explicit limit and passes it through to the conversation store
3. Conversation store uses the provided limit (100) instead of any default values

This approach is cleaner than changing backend defaults because:
- The frontend controls the user experience
- Backend defaults are only used when no explicit limit is provided
- No changes needed to backend logic or database queries

## Testing

- ✅ Verified API calls now include `limit=100` parameter
- ✅ Confirmed backend properly handles the increased limit
- ✅ No breaking changes to existing functionality

## Impact

Users will now see up to 100 conversations in their history instead of 20, providing better visibility into their past work without requiring pagination for most use cases.