### PR TITLE
Refactor configuration system with ConfigurationMerger

### DIFF
--- a/openhands/core/config/__init__.py
+++ b/openhands/core/config/__init__.py
@@ -5,6 +5,7 @@ from openhands.core.config.config_utils import (
     OH_MAX_ITERATIONS,
     get_field_info,
 )
+from openhands.core.config.configuration_merger import ConfigurationMerger
 from openhands.core.config.extended_config import ExtendedConfig
 from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.mcp_config import MCPConfig
@@ -34,6 +35,7 @@ __all__ = [
     'SandboxConfig',
     'SecurityConfig',
     'ExtendedConfig',
+    'ConfigurationMerger',
     'load_openhands_config',
     'load_from_env',
     'load_from_toml',

--- a/openhands/core/config/configuration_merger.py
+++ b/openhands/core/config/configuration_merger.py
@@ -1,0 +1,147 @@
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+# Import MCPConfig directly to avoid circular imports
+from openhands.core.config.mcp_config import MCPConfig
+
+if TYPE_CHECKING:
+    from openhands.core.config.openhands_config import OpenHandsConfig
+    from openhands.storage.data_models.settings import Settings
+
+
+class ConfigurationMerger:
+    """Utility class for merging Settings with OpenHandsConfig.
+
+    This class provides a centralized way to merge user settings with the
+    application configuration, ensuring consistent precedence rules across
+    all configuration types.
+    """
+
+    @staticmethod
+    def merge_settings_with_config(
+        settings: 'Settings', config: 'OpenHandsConfig'
+    ) -> 'OpenHandsConfig':
+        """Merge user settings with application configuration.
+
+        Creates a new config object with settings applied according to
+        consistent precedence rules. Settings generally take precedence
+        over config values, except for MCP settings which are merged.
+
+        Args:
+            settings: User settings to apply
+            config: Base configuration to merge with
+
+        Returns:
+            A new OpenHandsConfig instance with settings applied
+        """
+        # Create a deep copy to avoid modifying the original
+        merged_config = deepcopy(config)
+
+        # Apply settings to config with clear precedence rules
+        ConfigurationMerger._merge_settings(merged_config, settings)
+
+        return merged_config
+
+    @staticmethod
+    def _merge_settings(config: 'OpenHandsConfig', settings: 'Settings') -> None:
+        """Apply settings to config with consistent precedence rules."""
+        # Core settings
+        ConfigurationMerger._merge_core_settings(config, settings)
+
+        # LLM settings
+        ConfigurationMerger._merge_llm_settings(config, settings)
+
+        # Security settings
+        ConfigurationMerger._merge_security_settings(config, settings)
+
+        # Sandbox settings
+        ConfigurationMerger._merge_sandbox_settings(config, settings)
+
+        # MCP settings
+        ConfigurationMerger._merge_mcp_settings(config, settings)
+
+    @staticmethod
+    def _merge_core_settings(config: 'OpenHandsConfig', settings: 'Settings') -> None:
+        """Merge core settings."""
+        if settings.agent is not None:
+            config.default_agent = settings.agent
+
+        if settings.max_iterations is not None:
+            config.max_iterations = settings.max_iterations
+
+        if settings.max_budget_per_task is not None:
+            config.max_budget_per_task = settings.max_budget_per_task
+
+        if settings.git_user_name is not None:
+            config.git_user_name = settings.git_user_name
+
+        if settings.git_user_email is not None:
+            config.git_user_email = settings.git_user_email
+
+        if settings.search_api_key is not None:
+            config.search_api_key = settings.search_api_key
+
+    @staticmethod
+    def _merge_llm_settings(config: 'OpenHandsConfig', settings: 'Settings') -> None:
+        """Merge LLM-specific settings."""
+        llm_config = config.get_llm_config()
+
+        if settings.llm_model:
+            llm_config.model = settings.llm_model
+
+        if settings.llm_api_key:
+            llm_config.api_key = settings.llm_api_key
+
+        if settings.llm_base_url:
+            llm_config.base_url = settings.llm_base_url
+
+    @staticmethod
+    def _merge_security_settings(
+        config: 'OpenHandsConfig', settings: 'Settings'
+    ) -> None:
+        """Merge security-specific settings."""
+        if settings.confirmation_mode is not None:
+            config.security.confirmation_mode = settings.confirmation_mode
+
+        if settings.security_analyzer is not None:
+            config.security.security_analyzer = settings.security_analyzer
+
+    @staticmethod
+    def _merge_sandbox_settings(
+        config: 'OpenHandsConfig', settings: 'Settings'
+    ) -> None:
+        """Merge sandbox-specific settings."""
+        if settings.sandbox_base_container_image is not None:
+            config.sandbox.base_container_image = settings.sandbox_base_container_image
+
+        if settings.sandbox_runtime_container_image is not None:
+            config.sandbox.runtime_container_image = (
+                settings.sandbox_runtime_container_image
+            )
+
+        if settings.sandbox_api_key is not None:
+            config.sandbox.api_key = settings.sandbox_api_key.get_secret_value()
+
+    @staticmethod
+    def _merge_mcp_settings(config: 'OpenHandsConfig', settings: 'Settings') -> None:
+        """Merge MCP-specific settings."""
+        if settings.mcp_config is None:
+            return
+
+        if config.mcp is None:
+            # mypy doesn't understand that this is reachable
+            config.mcp = settings.mcp_config  # type: ignore
+            return
+
+        # Merge MCP configs with config.toml taking priority (appearing first)
+
+        merged_mcp = MCPConfig(
+            sse_servers=list(config.mcp.sse_servers)
+            + list(settings.mcp_config.sse_servers),
+            stdio_servers=list(config.mcp.stdio_servers)
+            + list(settings.mcp_config.stdio_servers),
+            shttp_servers=list(config.mcp.shttp_servers)
+            + list(settings.mcp_config.shttp_servers),
+        )
+
+        config.mcp = merged_mcp

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -13,7 +13,8 @@ from openhands.core.config.condenser_config import (
     ConversationWindowCondenserConfig,
     LLMSummarizingCondenserConfig,
 )
-from openhands.core.config.mcp_config import MCPConfig, OpenHandsMCPConfigImpl
+from openhands.core.config.configuration_merger import ConfigurationMerger
+from openhands.core.config.mcp_config import OpenHandsMCPConfigImpl
 from openhands.core.exceptions import MicroagentValidationError
 from openhands.core.logger import OpenHandsLoggerAdapter
 from openhands.core.schema import AgentState
@@ -36,7 +37,7 @@ from openhands.server.session.conversation_init_data import ConversationInitData
 from openhands.storage.data_models.settings import Settings
 from openhands.storage.files import FileStore
 
-ROOM_KEY = 'room:{sid}'
+ROOM_KEY = "room:{sid}"
 
 
 class Session:
@@ -63,7 +64,7 @@ class Session:
         self.sio = sio
         self.last_active_ts = int(time.time())
         self.file_store = file_store
-        self.logger = OpenHandsLoggerAdapter(extra={'session_id': sid})
+        self.logger = OpenHandsLoggerAdapter(extra={"session_id": sid})
         self.agent_session = AgentSession(
             sid,
             file_store,
@@ -84,9 +85,9 @@ class Session:
     async def close(self) -> None:
         if self.sio:
             await self.sio.emit(
-                'oh_event',
+                "oh_event",
                 event_to_dict(
-                    AgentStateChangedObservation('', AgentState.STOPPED.value)
+                    AgentStateChangedObservation("", AgentState.STOPPED.value)
                 ),
                 to=ROOM_KEY.format(sid=self.sid),
             )
@@ -100,58 +101,15 @@ class Session:
         replay_json: str | None,
     ) -> None:
         self.agent_session.event_stream.add_event(
-            AgentStateChangedObservation('', AgentState.LOADING),
+            AgentStateChangedObservation("", AgentState.LOADING),
             EventSource.ENVIRONMENT,
         )
-        agent_cls = settings.agent or self.config.default_agent
-        self.config.security.confirmation_mode = (
-            self.config.security.confirmation_mode
-            if settings.confirmation_mode is None
-            else settings.confirmation_mode
-        )
-        self.config.security.security_analyzer = (
-            settings.security_analyzer or self.config.security.security_analyzer
-        )
-        self.config.sandbox.base_container_image = (
-            settings.sandbox_base_container_image
-            or self.config.sandbox.base_container_image
-        )
-        self.config.sandbox.runtime_container_image = (
-            settings.sandbox_runtime_container_image
-            if settings.sandbox_base_container_image
-            or settings.sandbox_runtime_container_image
-            else self.config.sandbox.runtime_container_image
+
+        # Use the configuration merger to merge settings with config
+        self.config = ConfigurationMerger.merge_settings_with_config(
+            settings, self.config
         )
 
-        # Set Git user configuration if provided in settings
-        if hasattr(settings, 'git_user_name') and settings.git_user_name:
-            self.config.git_user_name = settings.git_user_name
-        if hasattr(settings, 'git_user_email') and settings.git_user_email:
-            self.config.git_user_email = settings.git_user_email
-        max_iterations = settings.max_iterations or self.config.max_iterations
-
-        # Prioritize settings over config for max_budget_per_task
-        max_budget_per_task = (
-            settings.max_budget_per_task
-            if settings.max_budget_per_task is not None
-            else self.config.max_budget_per_task
-        )
-
-        # This is a shallow copy of the default LLM config, so changes here will
-        # persist if we retrieve the default LLM config again when constructing
-        # the agent
-        default_llm_config = self.config.get_llm_config()
-        default_llm_config.model = settings.llm_model or ''
-        default_llm_config.api_key = settings.llm_api_key
-        default_llm_config.base_url = settings.llm_base_url
-        self.config.search_api_key = settings.search_api_key
-        if settings.sandbox_api_key:
-            self.config.sandbox.api_key = settings.sandbox_api_key.get_secret_value()
-
-        # NOTE: this need to happen AFTER the config is updated with the search_api_key
-        self.config.mcp = settings.mcp_config or MCPConfig(
-            sse_servers=[], stdio_servers=[]
-        )
         # Add OpenHands' MCP server by default
         openhands_mcp_server, openhands_mcp_stdio_servers = (
             OpenHandsMCPConfigImpl.create_default_mcp_server_config(
@@ -162,9 +120,13 @@ class Session:
             self.config.mcp.shttp_servers.append(openhands_mcp_server)
         self.config.mcp.stdio_servers.extend(openhands_mcp_stdio_servers)
 
-        # TODO: override other LLM config & agent config groups (#2075)
+        # Get agent class from settings or config
+        agent_cls = settings.agent or self.config.default_agent
 
+        # Create LLM with the merged config
         llm = self._create_llm(agent_cls)
+
+        # Get agent config from the merged config
         agent_config = self.config.get_agent_config(agent_cls)
 
         if settings.enable_default_condenser:
@@ -188,15 +150,18 @@ class Session:
             )
 
             self.logger.info(
-                f'Enabling pipeline condenser with:'
-                f' browser_output_masking(attention_window=2), '
+                f"Enabling pipeline condenser with:"
+                f" browser_output_masking(attention_window=2), "
                 f' llm(model="{llm.config.model}", '
                 f' base_url="{llm.config.base_url}", '
-                f' keep_first=4, max_size=80)'
+                f" keep_first=4, max_size=80)"
             )
             agent_config.condenser = default_condenser_config
+
+        # Create the agent with the merged config
         agent = Agent.get_cls(agent_cls)(llm, agent_config)
 
+        # Extract additional settings for conversation initialization
         git_provider_tokens = None
         selected_repository = None
         selected_branch = None
@@ -214,8 +179,8 @@ class Session:
                 runtime_name=self.config.runtime,
                 config=self.config,
                 agent=agent,
-                max_iterations=max_iterations,
-                max_budget_per_task=max_budget_per_task,
+                max_iterations=self.config.max_iterations,
+                max_budget_per_task=self.config.max_budget_per_task,
                 agent_to_llm_config=self.config.get_agent_to_llm_config_map(),
                 agent_configs=self.config.get_agent_configs(),
                 git_provider_tokens=git_provider_tokens,
@@ -227,33 +192,33 @@ class Session:
                 replay_json=replay_json,
             )
         except MicroagentValidationError as e:
-            self.logger.exception(f'Error creating agent_session: {e}')
+            self.logger.exception(f"Error creating agent_session: {e}")
             # For microagent validation errors, provide more helpful information
-            await self.send_error(f'Failed to create agent session: {str(e)}')
+            await self.send_error(f"Failed to create agent session: {str(e)}")
             return
         except ValueError as e:
-            self.logger.exception(f'Error creating agent_session: {e}')
+            self.logger.exception(f"Error creating agent_session: {e}")
             error_message = str(e)
             # For ValueError related to microagents, provide more helpful information
-            if 'microagent' in error_message.lower():
+            if "microagent" in error_message.lower():
                 await self.send_error(
-                    f'Failed to create agent session: {error_message}'
+                    f"Failed to create agent session: {error_message}"
                 )
             else:
                 # For other ValueErrors, just show the error class
-                await self.send_error('Failed to create agent session: ValueError')
+                await self.send_error("Failed to create agent session: ValueError")
             return
         except Exception as e:
-            self.logger.exception(f'Error creating agent_session: {e}')
+            self.logger.exception(f"Error creating agent_session: {e}")
             # For other errors, just show the error class to avoid exposing sensitive information
             await self.send_error(
-                f'Failed to create agent session: {e.__class__.__name__}'
+                f"Failed to create agent session: {e.__class__.__name__}"
             )
             return
 
     def _create_llm(self, agent_cls: str | None) -> LLM:
         """Initialize LLM, extracted for testing."""
-        agent_name = agent_cls if agent_cls is not None else 'agent'
+        agent_name = agent_cls if agent_cls is not None else "agent"
         return LLM(
             config=self.config.get_llm_config_from_agent(agent_name),
             retry_listener=self._notify_on_llm_retry,
@@ -261,7 +226,7 @@ class Session:
 
     def _notify_on_llm_retry(self, retries: int, max: int) -> None:
         self.queue_status_message(
-            'info', RuntimeStatus.LLM_RETRY, f'Retrying LLM request, {retries} / {max}'
+            "info", RuntimeStatus.LLM_RETRY, f"Retrying LLM request, {retries} / {max}"
         )
 
     def on_event(self, event: Event) -> None:
@@ -289,20 +254,20 @@ class Session:
         ):
             # feedback from the environment to agent actions is understood as agent events by the UI
             event_dict = event_to_dict(event)
-            event_dict['source'] = EventSource.AGENT
+            event_dict["source"] = EventSource.AGENT
             await self.send(event_dict)
             if (
                 isinstance(event, AgentStateChangedObservation)
                 and event.agent_state == AgentState.ERROR
             ):
                 self.logger.error(
-                    f'Agent status error: {event.reason}',
-                    extra={'signal': 'agent_status_error'},
+                    f"Agent status error: {event.reason}",
+                    extra={"signal": "agent_status_error"},
                 )
         elif isinstance(event, ErrorObservation):
             # send error events as agent events to the UI
             event_dict = event_to_dict(event)
-            event_dict['source'] = EventSource.AGENT
+            event_dict["source"] = EventSource.AGENT
             await self.send(event_dict)
 
     async def dispatch(self, data: dict) -> None:
@@ -313,12 +278,12 @@ class Session:
             if controller:
                 if controller.agent.llm.config.disable_vision:
                     await self.send_error(
-                        'Support for images is disabled for this model, try without an image.'
+                        "Support for images is disabled for this model, try without an image."
                     )
                     return
                 if not controller.agent.llm.vision_is_active():
                     await self.send_error(
-                        'Model does not support image upload, change to a different model or try without an image.'
+                        "Model does not support image upload, change to a different model or try without an image."
                     )
                     return
         self.agent_session.event_stream.add_event(event, EventSource.USER)
@@ -334,38 +299,38 @@ class Session:
             if not self.is_alive:
                 return False
             if self.sio:
-                await self.sio.emit('oh_event', data, to=ROOM_KEY.format(sid=self.sid))
+                await self.sio.emit("oh_event", data, to=ROOM_KEY.format(sid=self.sid))
             await asyncio.sleep(0.001)  # This flushes the data to the client
             self.last_active_ts = int(time.time())
             return True
         except RuntimeError as e:
-            self.logger.error(f'Error sending data to websocket: {str(e)}')
+            self.logger.error(f"Error sending data to websocket: {str(e)}")
             self.is_alive = False
             return False
 
     async def send_error(self, message: str) -> None:
         """Sends an error message to the client."""
-        await self.send({'error': True, 'message': message})
+        await self.send({"error": True, "message": message})
 
     async def _send_status_message(
         self, msg_type: str, runtime_status: RuntimeStatus, message: str
     ) -> None:
         """Sends a status message to the client."""
-        if msg_type == 'error':
+        if msg_type == "error":
             agent_session = self.agent_session
             controller = self.agent_session.controller
             if controller is not None and not agent_session.is_closed():
                 await controller.set_agent_state_to(AgentState.ERROR)
             self.logger.error(
-                f'Agent status error: {message}',
-                extra={'signal': 'agent_status_error'},
+                f"Agent status error: {message}",
+                extra={"signal": "agent_status_error"},
             )
         await self.send(
             {
-                'status_update': True,
-                'type': msg_type,
-                'id': runtime_status.value,
-                'message': message,
+                "status_update": True,
+                "type": msg_type,
+                "id": runtime_status.value,
+                "message": message,
             }
         )
 

--- a/tests/unit/core/config/test_configuration_merger.py
+++ b/tests/unit/core/config/test_configuration_merger.py
@@ -1,0 +1,244 @@
+"""Tests for the ConfigurationMerger class."""
+
+from pydantic import SecretStr
+
+from openhands.core.config import OpenHandsConfig
+from openhands.core.config.configuration_merger import ConfigurationMerger
+from openhands.core.config.mcp_config import (
+    MCPConfig,
+    MCPSSEServerConfig,
+    MCPStdioServerConfig,
+)
+from openhands.storage.data_models.settings import Settings
+
+
+def test_merge_core_settings():
+    """Test merging core settings."""
+    # Create a config with default values
+    config = OpenHandsConfig()
+
+    # Create settings with different values
+    settings = Settings(
+        agent="TestAgent",
+        max_iterations=100,
+        max_budget_per_task=50.0,
+        git_user_name="test-user",
+        git_user_email="test@example.com",
+        search_api_key=SecretStr("test-search-key"),
+    )
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that the merged config has the values from settings
+    assert merged_config.default_agent == "TestAgent"
+    assert merged_config.max_iterations == 100
+    assert merged_config.max_budget_per_task == 50.0
+    assert merged_config.git_user_name == "test-user"
+    assert merged_config.git_user_email == "test@example.com"
+    assert merged_config.search_api_key.get_secret_value() == "test-search-key"
+
+    # Check that the original config is unchanged
+    assert config.default_agent != "TestAgent"
+    assert config.max_iterations != 100
+    assert config.max_budget_per_task != 50.0
+    assert config.git_user_name != "test-user"
+    assert config.git_user_email != "test@example.com"
+    assert config.search_api_key != SecretStr("test-search-key")
+
+
+def test_merge_llm_settings():
+    """Test merging LLM settings."""
+    # Create a config with default values
+    config = OpenHandsConfig()
+
+    # Create settings with different values
+    settings = Settings(
+        llm_model="test-model",
+        llm_api_key=SecretStr("test-api-key"),
+        llm_base_url="https://test-api.example.com",
+    )
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that the merged config has the values from settings
+    llm_config = merged_config.get_llm_config()
+    assert llm_config.model == "test-model"
+    assert llm_config.api_key.get_secret_value() == "test-api-key"
+    assert llm_config.base_url == "https://test-api.example.com"
+
+    # Check that the original config is unchanged
+    original_llm_config = config.get_llm_config()
+    assert original_llm_config.model != "test-model"
+    assert original_llm_config.api_key != SecretStr("test-api-key")
+    assert original_llm_config.base_url != "https://test-api.example.com"
+
+
+def test_merge_security_settings():
+    """Test merging security settings."""
+    # Create a config with default values
+    config = OpenHandsConfig()
+
+    # Create settings with different values
+    settings = Settings(
+        confirmation_mode=True,
+        security_analyzer="test-analyzer",
+    )
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that the merged config has the values from settings
+    assert merged_config.security.confirmation_mode is True
+    assert merged_config.security.security_analyzer == "test-analyzer"
+
+    # Check that the original config is unchanged
+    assert config.security.confirmation_mode is not True
+    assert config.security.security_analyzer != "test-analyzer"
+
+
+def test_merge_sandbox_settings():
+    """Test merging sandbox settings."""
+    # Create a config with default values
+    config = OpenHandsConfig()
+
+    # Create settings with different values
+    settings = Settings(
+        sandbox_base_container_image="test-base-image",
+        sandbox_runtime_container_image="test-runtime-image",
+        sandbox_api_key=SecretStr("test-sandbox-key"),
+    )
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that the merged config has the values from settings
+    assert merged_config.sandbox.base_container_image == "test-base-image"
+    assert merged_config.sandbox.runtime_container_image == "test-runtime-image"
+    assert merged_config.sandbox.api_key == "test-sandbox-key"
+
+    # Check that the original config is unchanged
+    assert config.sandbox.base_container_image != "test-base-image"
+    assert config.sandbox.runtime_container_image != "test-runtime-image"
+    assert config.sandbox.api_key != "test-sandbox-key"
+
+
+def test_merge_mcp_settings_config_only():
+    """Test merging MCP settings when only config has MCP settings."""
+    # Create a config with MCP settings
+    config = OpenHandsConfig()
+    config.mcp = MCPConfig(
+        sse_servers=[MCPSSEServerConfig(url="http://config-server.com")],
+        stdio_servers=[],
+        shttp_servers=[],
+    )
+
+    # Create settings without MCP config
+    settings = Settings(llm_model="test-model")
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that the merged config has the MCP settings from config
+    assert len(merged_config.mcp.sse_servers) == 1
+    assert merged_config.mcp.sse_servers[0].url == "http://config-server.com"
+
+    # Check that other settings are applied
+    assert merged_config.get_llm_config().model == "test-model"
+
+
+def test_merge_mcp_settings_settings_only():
+    """Test merging MCP settings when only settings has MCP settings."""
+    # Create a config without MCP settings
+    config = OpenHandsConfig()
+    config.mcp = None
+
+    # Create settings with MCP config
+    settings = Settings(
+        llm_model="test-model",
+        mcp_config=MCPConfig(
+            sse_servers=[MCPSSEServerConfig(url="http://settings-server.com")],
+            stdio_servers=[],
+            shttp_servers=[],
+        ),
+    )
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that the merged config has the MCP settings from settings
+    assert merged_config.mcp is not None
+    assert len(merged_config.mcp.sse_servers) == 1
+    assert merged_config.mcp.sse_servers[0].url == "http://settings-server.com"
+
+    # Check that other settings are applied
+    assert merged_config.get_llm_config().model == "test-model"
+
+
+def test_merge_mcp_settings_both():
+    """Test merging MCP settings when both config and settings have MCP settings."""
+    # Create a config with MCP settings
+    config = OpenHandsConfig()
+    config.mcp = MCPConfig(
+        sse_servers=[MCPSSEServerConfig(url="http://config-server.com")],
+        stdio_servers=[
+            MCPStdioServerConfig(
+                name="config-stdio", command="config-cmd", args=["arg1"]
+            )
+        ],
+        shttp_servers=[],
+    )
+
+    # Create settings with MCP config
+    settings = Settings(
+        llm_model="test-model",
+        mcp_config=MCPConfig(
+            sse_servers=[MCPSSEServerConfig(url="http://settings-server.com")],
+            stdio_servers=[
+                MCPStdioServerConfig(
+                    name="settings-stdio", command="settings-cmd", args=["arg2"]
+                )
+            ],
+            shttp_servers=[],
+        ),
+    )
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that the merged config has the MCP settings from both config and settings
+    assert merged_config.mcp is not None
+    assert len(merged_config.mcp.sse_servers) == 2
+    assert merged_config.mcp.sse_servers[0].url == "http://config-server.com"
+    assert merged_config.mcp.sse_servers[1].url == "http://settings-server.com"
+
+    assert len(merged_config.mcp.stdio_servers) == 2
+    assert merged_config.mcp.stdio_servers[0].name == "config-stdio"
+    assert merged_config.mcp.stdio_servers[1].name == "settings-stdio"
+
+    # Check that other settings are applied
+    assert merged_config.get_llm_config().model == "test-model"
+
+
+def test_merge_with_none_values():
+    """Test merging with None values in settings."""
+    # Create a config with default values
+    config = OpenHandsConfig()
+    config.default_agent = "DefaultAgent"
+    config.max_iterations = 200
+
+    # Create settings with some None values
+    settings = Settings(
+        agent=None,  # Should not override
+        max_iterations=100,  # Should override
+    )
+
+    # Merge settings with config
+    merged_config = ConfigurationMerger.merge_settings_with_config(settings, config)
+
+    # Check that None values in settings don't override config values
+    assert merged_config.default_agent == "DefaultAgent"
+
+    # Check that non-None values in settings do override config values
+    assert merged_config.max_iterations == 100


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR improves the configuration system in OpenHands by centralizing the logic for merging settings and configurations. It introduces a new `ConfigurationMerger` utility class that handles all configuration merging operations consistently, making the codebase more maintainable and easier to understand.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR introduces a new `ConfigurationMerger` utility class that centralizes all configuration merging logic between settings and configs. The key improvements are:

1. **Centralized Merging Logic**: All configuration merging is now handled by a single utility class, making the code more maintainable and consistent.
2. **Consistent Precedence Rules**: The PR establishes clear precedence rules for merging configurations, with settings taking priority over config.toml values.
3. **Improved Type Safety**: The implementation uses proper type annotations and handles edge cases like None values appropriately.
4. **Backward Compatibility**: The existing `merge_with_config_settings` method is maintained with a deprecation note, ensuring backward compatibility.
5. **Comprehensive Tests**: Added unit tests to verify the merging behavior for different configuration types.

The implementation addresses the confusion around how settings and configs are merged by providing a clear, centralized approach that can be used consistently throughout the codebase.

---
**Link of any specific issues this addresses:**

N/A