### PR TITLE
Add uvx CLI command to PR descriptions

### DIFF
--- a/.github/scripts/update_pr_description.sh
+++ b/.github/scripts/update_pr_description.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script updates the PR description with commands to run the PR locally
+# It adds both Docker and uvx commands
+
+# Get the branch name for the PR
+BRANCH_NAME=$(gh pr view $PR_NUMBER --json headRefName --jq .headRefName)
+
+# Define the Docker command
+DOCKER_RUN_COMMAND="docker run -it --rm \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --add-host host.docker.internal:host-gateway \
+  -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:$SHORT_SHA-nikolaik \
+  --name openhands-app-$SHORT_SHA \
+  docker.all-hands.dev/all-hands-ai/openhands:$SHORT_SHA"
+
+# Define the uvx command
+UVX_RUN_COMMAND="uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@$BRANCH_NAME openhands"
+
+# Get the current PR body
+PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
+
+# Prepare the new PR body with both commands
+if echo "$PR_BODY" | grep -q "To run this PR locally, use the following command:"; then
+  # For existing PR descriptions, replace the command section
+  NEW_PR_BODY=$(echo "$PR_BODY" | sed "s|To run this PR locally, use the following command:.*\`\`\`|To run this PR locally, use the following command:\n\nGUI with Docker:\n\`\`\`\n$DOCKER_RUN_COMMAND\n\`\`\`\n\nCLI with uvx:\n\`\`\`\n$UVX_RUN_COMMAND\n\`\`\`|s")
+else
+  # For new PR descriptions
+  NEW_PR_BODY="${PR_BODY}
+
+---
+
+To run this PR locally, use the following command:
+
+GUI with Docker:
+\`\`\`
+$DOCKER_RUN_COMMAND
+\`\`\`
+
+CLI with uvx:
+\`\`\`
+$UVX_RUN_COMMAND
+\`\`\`"
+fi
+
+# Update the PR description
+echo "Updating PR description with Docker and uvx commands"
+gh pr edit $PR_NUMBER --body "$NEW_PR_BODY"

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -332,29 +332,3 @@ jobs:
           SHORT_SHA: ${{ steps.short_sha.outputs.SHORT_SHA }}
         shell: bash
         run: |
-          echo "updating PR description"
-          DOCKER_RUN_COMMAND="docker run -it --rm \
-            -p 3000:3000 \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            --add-host host.docker.internal:host-gateway \
-            -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:$SHORT_SHA-nikolaik \
-            --name openhands-app-$SHORT_SHA \
-            docker.all-hands.dev/all-hands-ai/openhands:$SHORT_SHA"
-
-          PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
-
-          if echo "$PR_BODY" | grep -q "To run this PR locally, use the following command:"; then
-            UPDATED_PR_BODY=$(echo "${PR_BODY}" | sed -E "s|docker run -it --rm.*|$DOCKER_RUN_COMMAND|")
-          else
-            UPDATED_PR_BODY="${PR_BODY}
-
-          ---
-
-          To run this PR locally, use the following command:
-          \`\`\`
-          $DOCKER_RUN_COMMAND
-          \`\`\`"
-          fi
-
-          echo "updated body: $UPDATED_PR_BODY"
-          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -332,3 +332,5 @@ jobs:
           SHORT_SHA: ${{ steps.short_sha.outputs.SHORT_SHA }}
         shell: bash
         run: |
+          echo "Updating PR description with Docker and uvx commands"
+          bash ${GITHUB_WORKSPACE}/.github/scripts/update_pr_description.sh


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR enhances the PR description by adding a command to run the CLI version of OpenHands using uvx. Now users can choose between running the GUI version with Docker or the CLI version with uvx directly from the PR description.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR modifies the GitHub workflow that updates PR descriptions to include both Docker and uvx commands for running the PR locally:

1. Created a dedicated script `.github/scripts/update_pr_description.sh` that:
   - Gets the branch name for the PR using GitHub CLI
   - Defines both Docker and uvx commands
   - Updates the PR description to include both commands in a structured format

2. Modified the GitHub workflow file `.github/workflows/ghcr-build.yml` to:
   - Call the script instead of directly updating the PR description
   - Pass the necessary environment variables to the script

The script approach makes the workflow file cleaner and easier to maintain, while also making it simpler to add more commands in the future if needed.

---
**Link of any specific issues this addresses:**

N/A

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c216019-nikolaik   --name openhands-app-c216019   docker.all-hands.dev/all-hands-ai/openhands:c216019
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@feature/add-uvx-command-to-pr-description openhands
```