### PR TITLE
feat(frontend): remove export conversation button from chat input area.

### DIFF
--- a/frontend/__tests__/components/feedback-actions.test.tsx
+++ b/frontend/__tests__/components/feedback-actions.test.tsx
@@ -8,7 +8,6 @@ describe("TrajectoryActions", () => {
   const user = userEvent.setup();
   const onPositiveFeedback = vi.fn();
   const onNegativeFeedback = vi.fn();
-  const onExportTrajectory = vi.fn();
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -19,14 +18,12 @@ describe("TrajectoryActions", () => {
       <TrajectoryActions
         onPositiveFeedback={onPositiveFeedback}
         onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
       />,
     );
 
     const actions = screen.getByTestId("feedback-actions");
     within(actions).getByTestId("positive-feedback");
     within(actions).getByTestId("negative-feedback");
-    within(actions).getByTestId("export-trajectory");
   });
 
   it("should call onPositiveFeedback when positive feedback is clicked", async () => {
@@ -34,7 +31,6 @@ describe("TrajectoryActions", () => {
       <TrajectoryActions
         onPositiveFeedback={onPositiveFeedback}
         onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
       />,
     );
 
@@ -49,7 +45,6 @@ describe("TrajectoryActions", () => {
       <TrajectoryActions
         onPositiveFeedback={onPositiveFeedback}
         onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
       />,
     );
 
@@ -59,48 +54,12 @@ describe("TrajectoryActions", () => {
     expect(onNegativeFeedback).toHaveBeenCalled();
   });
 
-  it("should call onExportTrajectory when export button is clicked", async () => {
-    renderWithProviders(
-      <TrajectoryActions
-        onPositiveFeedback={onPositiveFeedback}
-        onNegativeFeedback={onNegativeFeedback}
-        onExportTrajectory={onExportTrajectory}
-      />,
-    );
-
-    const exportButton = screen.getByTestId("export-trajectory");
-    await user.click(exportButton);
-
-    expect(onExportTrajectory).toHaveBeenCalled();
-  });
-
   describe("SaaS mode", () => {
-    it("should only render export button when isSaasMode is true", () => {
-      renderWithProviders(
-        <TrajectoryActions
-          onPositiveFeedback={onPositiveFeedback}
-          onNegativeFeedback={onNegativeFeedback}
-          onExportTrajectory={onExportTrajectory}
-          isSaasMode={true}
-        />,
-      );
-
-      const actions = screen.getByTestId("feedback-actions");
-
-      // Should not render feedback buttons in SaaS mode
-      expect(within(actions).queryByTestId("positive-feedback")).toBeNull();
-      expect(within(actions).queryByTestId("negative-feedback")).toBeNull();
-
-      // Should still render export button
-      within(actions).getByTestId("export-trajectory");
-    });
-
     it("should render all buttons when isSaasMode is false", () => {
       renderWithProviders(
         <TrajectoryActions
           onPositiveFeedback={onPositiveFeedback}
           onNegativeFeedback={onNegativeFeedback}
-          onExportTrajectory={onExportTrajectory}
           isSaasMode={false}
         />,
       );
@@ -108,7 +67,6 @@ describe("TrajectoryActions", () => {
       const actions = screen.getByTestId("feedback-actions");
       within(actions).getByTestId("positive-feedback");
       within(actions).getByTestId("negative-feedback");
-      within(actions).getByTestId("export-trajectory");
     });
 
     it("should render all buttons when isSaasMode is undefined (default behavior)", () => {
@@ -116,30 +74,12 @@ describe("TrajectoryActions", () => {
         <TrajectoryActions
           onPositiveFeedback={onPositiveFeedback}
           onNegativeFeedback={onNegativeFeedback}
-          onExportTrajectory={onExportTrajectory}
         />,
       );
 
       const actions = screen.getByTestId("feedback-actions");
       within(actions).getByTestId("positive-feedback");
       within(actions).getByTestId("negative-feedback");
-      within(actions).getByTestId("export-trajectory");
-    });
-
-    it("should call onExportTrajectory when export button is clicked in SaaS mode", async () => {
-      renderWithProviders(
-        <TrajectoryActions
-          onPositiveFeedback={onPositiveFeedback}
-          onNegativeFeedback={onNegativeFeedback}
-          onExportTrajectory={onExportTrajectory}
-          isSaasMode={true}
-        />,
-      );
-
-      const exportButton = screen.getByTestId("export-trajectory");
-      await user.click(exportButton);
-
-      expect(onExportTrajectory).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import posthog from "posthog-js";
 import { useParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import { I18nKey } from "#/i18n/declaration";
 import { convertImageToBase64 } from "#/utils/convert-image-to-base-64";
 import { TrajectoryActions } from "../trajectory/trajectory-actions";
 import { createChatMessage } from "#/services/chat-service";
@@ -23,8 +22,6 @@ import { ScrollProvider } from "#/context/scroll-context";
 
 import { ScrollToBottomButton } from "#/components/shared/buttons/scroll-to-bottom-button";
 import { LoadingSpinner } from "#/components/shared/loading-spinner";
-import { useGetTrajectory } from "#/hooks/mutation/use-get-trajectory";
-import { downloadTrajectory } from "#/utils/download-trajectory";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { useOptimisticUserMessage } from "#/hooks/use-optimistic-user-message";
 import { useWSErrorMessage } from "#/hooks/use-ws-error-message";
@@ -71,7 +68,6 @@ export function ChatInterface() {
     (state: RootState) => state.initialQuery,
   );
   const params = useParams();
-  const { mutate: getTrajectory } = useGetTrajectory();
   const { mutateAsync: uploadFiles } = useUploadFiles();
 
   const optimisticUserMessage = getOptimisticUserMessage();
@@ -157,25 +153,6 @@ export function ChatInterface() {
     setFeedbackPolarity(polarity);
   };
 
-  const onClickExportTrajectoryButton = () => {
-    if (!params.conversationId) {
-      displayErrorToast(t(I18nKey.CONVERSATION$DOWNLOAD_ERROR));
-      return;
-    }
-
-    getTrajectory(params.conversationId, {
-      onSuccess: async (data) => {
-        await downloadTrajectory(
-          params.conversationId ?? t(I18nKey.CONVERSATION$UNKNOWN),
-          data.trajectory,
-        );
-      },
-      onError: () => {
-        displayErrorToast(t(I18nKey.CONVERSATION$DOWNLOAD_ERROR));
-      },
-    });
-  };
-
   const isWaitingForUserInput =
     curAgentState === AgentState.AWAITING_USER_INPUT ||
     curAgentState === AgentState.FINISHED;
@@ -239,7 +216,6 @@ export function ChatInterface() {
               onNegativeFeedback={() =>
                 onClickShareFeedbackActionButton("negative")
               }
-              onExportTrajectory={() => onClickExportTrajectoryButton()}
               isSaasMode={config?.APP_MODE === "saas"}
             />
 

--- a/frontend/src/components/features/trajectory/trajectory-actions.tsx
+++ b/frontend/src/components/features/trajectory/trajectory-actions.tsx
@@ -2,20 +2,17 @@ import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import ThumbsUpIcon from "#/icons/thumbs-up.svg?react";
 import ThumbDownIcon from "#/icons/thumbs-down.svg?react";
-import ExportIcon from "#/icons/export.svg?react";
 import { TrajectoryActionButton } from "#/components/shared/buttons/trajectory-action-button";
 
 interface TrajectoryActionsProps {
   onPositiveFeedback: () => void;
   onNegativeFeedback: () => void;
-  onExportTrajectory: () => void;
   isSaasMode?: boolean;
 }
 
 export function TrajectoryActions({
   onPositiveFeedback,
   onNegativeFeedback,
-  onExportTrajectory,
   isSaasMode = false,
 }: TrajectoryActionsProps) {
   const { t } = useTranslation();
@@ -38,12 +35,6 @@ export function TrajectoryActions({
           />
         </>
       )}
-      <TrajectoryActionButton
-        testId="export-trajectory"
-        onClick={onExportTrajectory}
-        icon={<ExportIcon width={15} height={15} />}
-        tooltip={t(I18nKey.BUTTON$EXPORT_CONVERSATION)}
-      />
     </div>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

We should remove the “Export Conversation” button located above the chat input area, as the same functionality is already available in the context menu at the top-left corner of the screen. This change will simplify the UI and reduce redundancy.

**Acceptance Criteria:**
- The “Export Conversation” button above the chat input is completely removed.
- The export functionality remains accessible from the top-left context menu.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR removes export conversation button from chat input area.

---
**Link of any specific issues this addresses:**
