### PR TITLE
Add support for updating MCP SHTTP servers with session_api_key

### DIFF
--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -1,8 +1,11 @@
 import os
 import re
 import shlex
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Dict, Any
 from urllib.parse import urlparse
+
+# Import the patch functions
+from openhands.core.config.mcp_config_patch import update_mcp_shttp_servers, get_mcp_shttp_servers
 
 from pydantic import (
     BaseModel,
@@ -342,7 +345,15 @@ class OpenHandsMCPConfig:
         if search_engine_stdio_server:
             stdio_servers.append(search_engine_stdio_server)
 
-        shttp_servers = MCPSHTTPServerConfig(url=f'http://{host}/mcp/mcp', api_key=None)
+        # Check if we have custom MCP SHTTP servers from the patch
+        custom_servers = get_mcp_shttp_servers()
+        if custom_servers:
+            # Use the first server from the custom servers
+            server = custom_servers[0]
+            shttp_servers = MCPSHTTPServerConfig(url=server['url'], api_key=server['api_key'])
+        else:
+            # Use the default server
+            shttp_servers = MCPSHTTPServerConfig(url=f'http://{host}/mcp/mcp', api_key=None)
 
         return shttp_servers, stdio_servers
 
@@ -353,3 +364,6 @@ openhands_mcp_config_cls = os.environ.get(
 )
 
 OpenHandsMCPConfigImpl = get_impl(OpenHandsMCPConfig, openhands_mcp_config_cls)
+
+# Export the patch functions
+__all__ = ['update_mcp_shttp_servers', 'get_mcp_shttp_servers']

--- a/openhands/core/config/mcp_config_patch.py
+++ b/openhands/core/config/mcp_config_patch.py
@@ -1,0 +1,31 @@
+"""
+Patch for the MCP config module to add the update_mcp_shttp_servers function.
+This patch will be applied to the OpenHands MCP config module.
+"""
+
+from typing import List, Dict, Any
+
+# Global variable to store the MCP SHTTP servers
+_mcp_shttp_servers = []
+
+
+def update_mcp_shttp_servers(servers: List[Dict[str, Any]]) -> None:
+    """
+    Update the MCP SHTTP servers configuration.
+    
+    Args:
+        servers: List of MCP SHTTP server configurations
+    """
+    global _mcp_shttp_servers
+    _mcp_shttp_servers = servers
+
+
+def get_mcp_shttp_servers() -> List[Dict[str, Any]]:
+    """
+    Get the current MCP SHTTP servers configuration.
+    
+    Returns:
+        List of MCP SHTTP server configurations
+    """
+    global _mcp_shttp_servers
+    return _mcp_shttp_servers


### PR DESCRIPTION
## Description
This PR adds support for updating MCP SHTTP servers with session_api_key. This is part of a larger change to remove the use of a separate `mcp_api_key` and instead use the `session_api_key` for MCP authentication.

## Changes
- Added `update_mcp_shttp_servers` and `get_mcp_shttp_servers` functions to the MCP config module
- Created a patch file with functions to update and get MCP SHTTP servers
- Modified the `create_default_mcp_server_config` method to use the custom MCP SHTTP servers if available

## Related PR
This PR is related to a PR in the deploy repository that removes the use of a separate `mcp_api_key` and instead uses the `session_api_key` for MCP authentication.

## Testing
- Verified that the changes work correctly with the corresponding changes in the deploy repository