### PR TITLE
feat: add mcp_config to conversation initialization

### DIFF
--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import re
 import shlex
@@ -301,6 +302,13 @@ class MCPConfig(BaseModel):
         except ValidationError as e:
             raise ValueError(f'Invalid MCP configuration: {e}')
         return mcp_mapping
+
+    def merge(self, other: MCPConfig):
+        return MCPConfig(
+            sse_servers=self.sse_servers + other.sse_servers,
+            stdio_servers=self.stdio_servers + other.stdio_servers,
+            shttp_servers=self.shttp_servers + other.shttp_servers,
+        )
 
 
 class OpenHandsMCPConfig:

--- a/openhands/core/config/mcp_config.py
+++ b/openhands/core/config/mcp_config.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import re
 import shlex

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -10,7 +10,7 @@ from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel, ConfigDict, Field
 
 from openhands.core.config.llm_config import LLMConfig
-from openhands.core.config.mcp_config import MCPSHTTPServerConfig
+from openhands.core.config.mcp_config import MCPConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import (
     ChangeAgentStateAction,
@@ -88,7 +88,7 @@ class InitSessionRequest(BaseModel):
     suggested_task: SuggestedTask | None = None
     create_microagent: CreateMicroagent | None = None
     conversation_instructions: str | None = None
-    mcp_shttp_servers: list[MCPSHTTPServerConfig] | None = None
+    mcp_config: MCPConfig | None = None
     # Only nested runtimes require the ability to specify a conversation id, and it could be a security risk
     if os.getenv('ALLOW_SET_CONVERSATION_ID', '0') == '1':
         conversation_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
@@ -180,7 +180,7 @@ async def new_conversation(
             conversation_instructions=conversation_instructions,
             git_provider=git_provider,
             conversation_id=conversation_id,
-            mcp_shttp_servers=data.mcp_shttp_servers,
+            mcp_config=data.mcp_config,
         )
 
         return ConversationResponse(

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -10,6 +10,7 @@ from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel, ConfigDict, Field
 
 from openhands.core.config.llm_config import LLMConfig
+from openhands.core.config.mcp_config import MCPSHTTPServerConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import (
     ChangeAgentStateAction,
@@ -87,6 +88,7 @@ class InitSessionRequest(BaseModel):
     suggested_task: SuggestedTask | None = None
     create_microagent: CreateMicroagent | None = None
     conversation_instructions: str | None = None
+    mcp_shttp_servers: list[MCPSHTTPServerConfig] | None = None
     # Only nested runtimes require the ability to specify a conversation id, and it could be a security risk
     if os.getenv('ALLOW_SET_CONVERSATION_ID', '0') == '1':
         conversation_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
@@ -178,6 +180,7 @@ async def new_conversation(
             conversation_instructions=conversation_instructions,
             git_provider=git_provider,
             conversation_id=conversation_id,
+            mcp_shttp_servers=data.mcp_shttp_servers,
         )
 
         return ConversationResponse(

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -85,9 +85,7 @@ async def create_new_conversation(
     session_init_args['git_provider'] = git_provider
     session_init_args['conversation_instructions'] = conversation_instructions
     if mcp_shttp_servers:
-        session_init_args['mcp_config'] = MCPConfig(
-            shttp_servers=mcp_shttp_servers
-        )
+        session_init_args['mcp_config'] = MCPConfig(shttp_servers=mcp_shttp_servers)
 
     session_init_args['mcp_shttp_servers'] = mcp_shttp_servers
     conversation_init_data = ConversationInitData(**session_init_args)

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -2,7 +2,7 @@ import uuid
 from types import MappingProxyType
 from typing import Any
 
-from openhands.core.config.mcp_config import MCPConfig, MCPSHTTPServerConfig
+from openhands.core.config.mcp_config import MCPConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.message import MessageAction
 from openhands.experiments.experiment_manager import ExperimentManagerImpl

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -2,6 +2,7 @@ import uuid
 from types import MappingProxyType
 from typing import Any
 
+from openhands.core.config.mcp_config import MCPSHTTPServerConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.message import MessageAction
 from openhands.experiments.experiment_manager import ExperimentManagerImpl
@@ -44,6 +45,7 @@ async def create_new_conversation(
     attach_convo_id: bool = False,
     git_provider: ProviderType | None = None,
     conversation_id: str | None = None,
+    mcp_shttp_servers: list[MCPSHTTPServerConfig] | None = None,
 ) -> AgentLoopInfo:
     logger.info(
         'Creating conversation',
@@ -82,6 +84,7 @@ async def create_new_conversation(
     session_init_args['selected_branch'] = selected_branch
     session_init_args['git_provider'] = git_provider
     session_init_args['conversation_instructions'] = conversation_instructions
+    session_init_args['mcp_shttp_servers'] = mcp_shttp_servers
     conversation_init_data = ConversationInitData(**session_init_args)
 
     logger.info('Loading conversation store')

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -2,7 +2,7 @@ import uuid
 from types import MappingProxyType
 from typing import Any
 
-from openhands.core.config.mcp_config import MCPSHTTPServerConfig
+from openhands.core.config.mcp_config import MCPConfig, MCPSHTTPServerConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.message import MessageAction
 from openhands.experiments.experiment_manager import ExperimentManagerImpl
@@ -84,6 +84,11 @@ async def create_new_conversation(
     session_init_args['selected_branch'] = selected_branch
     session_init_args['git_provider'] = git_provider
     session_init_args['conversation_instructions'] = conversation_instructions
+    if mcp_shttp_servers:
+        session_init_args['mcp_config'] = MCPConfig(
+            shttp_servers=mcp_shttp_servers
+        )
+
     session_init_args['mcp_shttp_servers'] = mcp_shttp_servers
     conversation_init_data = ConversationInitData(**session_init_args)
 

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -45,7 +45,7 @@ async def create_new_conversation(
     attach_convo_id: bool = False,
     git_provider: ProviderType | None = None,
     conversation_id: str | None = None,
-    mcp_shttp_servers: list[MCPSHTTPServerConfig] | None = None,
+    mcp_config: MCPConfig | None = None,
 ) -> AgentLoopInfo:
     logger.info(
         'Creating conversation',
@@ -84,10 +84,9 @@ async def create_new_conversation(
     session_init_args['selected_branch'] = selected_branch
     session_init_args['git_provider'] = git_provider
     session_init_args['conversation_instructions'] = conversation_instructions
-    if mcp_shttp_servers:
-        session_init_args['mcp_config'] = MCPConfig(shttp_servers=mcp_shttp_servers)
+    if mcp_config:
+        session_init_args['mcp_config'] = mcp_config
 
-    session_init_args['mcp_shttp_servers'] = mcp_shttp_servers
     conversation_init_data = ConversationInitData(**session_init_args)
 
     logger.info('Loading conversation store')

--- a/openhands/server/session/conversation_init_data.py
+++ b/openhands/server/session/conversation_init_data.py
@@ -1,5 +1,6 @@
 from pydantic import ConfigDict, Field
 
+from openhands.core.config.mcp_config import MCPSHTTPServerConfig
 from openhands.integrations.provider import CUSTOM_SECRETS_TYPE, PROVIDER_TOKEN_TYPE
 from openhands.integrations.service_types import ProviderType
 from openhands.storage.data_models.settings import Settings
@@ -17,6 +18,7 @@ class ConversationInitData(Settings):
     selected_branch: str | None = Field(default=None)
     conversation_instructions: str | None = Field(default=None)
     git_provider: ProviderType | None = Field(default=None)
+    mcp_shttp_servers: list[MCPSHTTPServerConfig] | None = Field(default=None)
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/openhands/server/session/conversation_init_data.py
+++ b/openhands/server/session/conversation_init_data.py
@@ -1,6 +1,5 @@
 from pydantic import ConfigDict, Field
 
-from openhands.core.config.mcp_config import MCPSHTTPServerConfig
 from openhands.integrations.provider import CUSTOM_SECRETS_TYPE, PROVIDER_TOKEN_TYPE
 from openhands.integrations.service_types import ProviderType
 from openhands.storage.data_models.settings import Settings

--- a/openhands/server/session/conversation_init_data.py
+++ b/openhands/server/session/conversation_init_data.py
@@ -18,7 +18,6 @@ class ConversationInitData(Settings):
     selected_branch: str | None = Field(default=None)
     conversation_instructions: str | None = Field(default=None)
     git_provider: ProviderType | None = Field(default=None)
-    mcp_shttp_servers: list[MCPSHTTPServerConfig] | None = Field(default=None)
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -161,17 +161,17 @@ class Session:
             # Use the provided MCP SHTTP servers instead of default setup
             self.config.mcp = mcp_config
             self.logger.debug(f'Using custom MCP Config: {mcp_config}')
-        else:
-            # Add OpenHands' MCP server by default
-            openhands_mcp_server, openhands_mcp_stdio_servers = (
-                OpenHandsMCPConfigImpl.create_default_mcp_server_config(
-                    self.config.mcp_host, self.config, self.user_id
-                )
-            )
 
-            if openhands_mcp_server:
-                self.config.mcp.shttp_servers.append(openhands_mcp_server)
-                self.logger.debug('Added default MCP HTTP server to config')
+        # Add OpenHands' MCP server by default
+        openhands_mcp_server, openhands_mcp_stdio_servers = (
+            OpenHandsMCPConfigImpl.create_default_mcp_server_config(
+                self.config.mcp_host, self.config, self.user_id
+            )
+        )
+
+        if openhands_mcp_server:
+            self.config.mcp.shttp_servers.append(openhands_mcp_server)
+            self.logger.debug('Added default MCP HTTP server to config')
 
             self.config.mcp.stdio_servers.extend(openhands_mcp_stdio_servers)
 

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -155,7 +155,7 @@ class Session:
             f'MCP configuration before setup - self.config.mcp_config: {self.config.mcp}'
         )
 
-        # Check if settings has custom mcp_shttp_servers
+        # Check if settings has custom mcp_config
         mcp_config = getattr(settings, 'mcp_config', None)
         if mcp_config is not None:
             # Use the provided MCP SHTTP servers instead of default setup

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -159,7 +159,7 @@ class Session:
         mcp_shttp_servers = getattr(settings, 'mcp_shttp_servers', None)
         if mcp_shttp_servers is not None:
             # Use the provided MCP SHTTP servers instead of default setup
-            self.config.mcp.shttp_servers.extend(mcp_shttp_servers)
+            self.config.mcp.shttp_servers = mcp_shttp_servers
             self.logger.debug(
                 f'Using custom MCP SHTTP servers: {mcp_shttp_servers}'
             )

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -160,9 +160,7 @@ class Session:
         if mcp_shttp_servers is not None:
             # Use the provided MCP SHTTP servers instead of default setup
             self.config.mcp.shttp_servers = mcp_shttp_servers
-            self.logger.debug(
-                f'Using custom MCP SHTTP servers: {mcp_shttp_servers}'
-            )
+            self.logger.debug(f'Using custom MCP SHTTP servers: {mcp_shttp_servers}')
         else:
             # Add OpenHands' MCP server by default
             openhands_mcp_server, openhands_mcp_stdio_servers = (

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -156,11 +156,11 @@ class Session:
         )
 
         # Check if settings has custom mcp_shttp_servers
-        mcp_shttp_servers = getattr(settings, 'mcp_shttp_servers', None)
-        if mcp_shttp_servers is not None:
+        mcp_config = getattr(settings, 'mcp_config', None)
+        if mcp_config is not None:
             # Use the provided MCP SHTTP servers instead of default setup
-            self.config.mcp.shttp_servers = mcp_shttp_servers
-            self.logger.debug(f'Using custom MCP SHTTP servers: {mcp_shttp_servers}')
+            self.config.mcp = mcp_config
+            self.logger.debug(f'Using custom MCP Config: {mcp_config}')
         else:
             # Add OpenHands' MCP server by default
             openhands_mcp_server, openhands_mcp_stdio_servers = (

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -152,18 +152,30 @@ class Session:
         self.logger.debug(
             f'MCP configuration before setup - self.config.mcp_config: {self.config.mcp}'
         )
-        # Add OpenHands' MCP server by default
-        openhands_mcp_server, openhands_mcp_stdio_servers = (
-            OpenHandsMCPConfigImpl.create_default_mcp_server_config(
-                self.config.mcp_host, self.config, self.user_id
+
+        # Check if settings has custom mcp_shttp_servers
+        if (
+            isinstance(settings, ConversationInitData)
+            and settings.mcp_shttp_servers is not None
+        ):
+            # Use the provided MCP SHTTP servers instead of default setup
+            self.config.mcp.shttp_servers.extend(settings.mcp_shttp_servers)
+            self.logger.debug(
+                f'Using custom MCP SHTTP servers: {settings.mcp_shttp_servers}'
             )
-        )
+        else:
+            # Add OpenHands' MCP server by default
+            openhands_mcp_server, openhands_mcp_stdio_servers = (
+                OpenHandsMCPConfigImpl.create_default_mcp_server_config(
+                    self.config.mcp_host, self.config, self.user_id
+                )
+            )
 
-        if openhands_mcp_server:
-            self.config.mcp.shttp_servers.append(openhands_mcp_server)
-            self.logger.debug('Added default MCP HTTP server to config')
+            if openhands_mcp_server:
+                self.config.mcp.shttp_servers.append(openhands_mcp_server)
+                self.logger.debug('Added default MCP HTTP server to config')
 
-        self.config.mcp.stdio_servers.extend(openhands_mcp_stdio_servers)
+            self.config.mcp.stdio_servers.extend(openhands_mcp_stdio_servers)
 
         self.logger.debug(
             f'MCP configuration after setup - self.config.mcp: {self.config.mcp}'

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -124,10 +124,12 @@ class Session:
         )
 
         # Set Git user configuration if provided in settings
-        if hasattr(settings, 'git_user_name') and settings.git_user_name:
-            self.config.git_user_name = settings.git_user_name
-        if hasattr(settings, 'git_user_email') and settings.git_user_email:
-            self.config.git_user_email = settings.git_user_email
+        git_user_name = getattr(settings, 'git_user_name', None)
+        if git_user_name is not None:
+            self.config.git_user_name = git_user_name
+        git_user_email = getattr(settings, 'git_user_email', None)
+        if git_user_email is not None:
+            self.config.git_user_email = git_user_email
         max_iterations = settings.max_iterations or self.config.max_iterations
 
         # Prioritize settings over config for max_budget_per_task
@@ -154,14 +156,12 @@ class Session:
         )
 
         # Check if settings has custom mcp_shttp_servers
-        if (
-            isinstance(settings, ConversationInitData)
-            and settings.mcp_shttp_servers is not None
-        ):
+        mcp_shttp_servers = getattr(settings, 'mcp_shttp_servers', None)
+        if mcp_shttp_servers is not None:
             # Use the provided MCP SHTTP servers instead of default setup
-            self.config.mcp.shttp_servers.extend(settings.mcp_shttp_servers)
+            self.config.mcp.shttp_servers.extend(mcp_shttp_servers)
             self.logger.debug(
-                f'Using custom MCP SHTTP servers: {settings.mcp_shttp_servers}'
+                f'Using custom MCP SHTTP servers: {mcp_shttp_servers}'
             )
         else:
             # Add OpenHands' MCP server by default

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -159,8 +159,8 @@ class Session:
         mcp_config = getattr(settings, 'mcp_config', None)
         if mcp_config is not None:
             # Use the provided MCP SHTTP servers instead of default setup
-            self.config.mcp = mcp_config
-            self.logger.debug(f'Using custom MCP Config: {mcp_config}')
+            self.config.mcp = self.config.mcp.merge(mcp_config)
+            self.logger.debug(f'Merged custom MCP Config: {mcp_config}')
 
         # Add OpenHands' MCP server by default
         openhands_mcp_server, openhands_mcp_stdio_servers = (


### PR DESCRIPTION


---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:11aabf2-nikolaik   --name openhands-app-11aabf2   docker.all-hands.dev/all-hands-ai/openhands:11aabf2
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@feat/mcp-shttp-servers-override openhands
```