### PR TITLE
Support gpt-5-2025-08-07 and add it to OpenHands provider

### DIFF
--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -23,6 +23,7 @@ export const VERIFIED_MODELS = [
   "devstral-medium-2507",
   "kimi-k2-0711-preview",
   "qwen3-coder-480b",
+  "gpt-5-2025-08-07",
 ];
 
 // LiteLLM does not return OpenAI models with the provider, so we list them here to set them ourselves for consistency
@@ -73,6 +74,7 @@ export const VERIFIED_OPENHANDS_MODELS = [
   "devstral-small-2505",
   "kimi-k2-0711-preview",
   "qwen3-coder-480b",
+  "gpt-5-2025-08-07",
 ];
 
 // Default model for OpenHands provider

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -65,6 +65,7 @@ export const VERIFIED_MISTRAL_MODELS = [
 // (e.g., they return `claude-sonnet-4-20250514` instead of `openhands/claude-sonnet-4-20250514`)
 export const VERIFIED_OPENHANDS_MODELS = [
   "claude-sonnet-4-20250514",
+  "gpt-5-2025-08-07",
   "claude-opus-4-20250514",
   "claude-opus-4-1-20250805",
   "gemini-2.5-pro",
@@ -75,7 +76,6 @@ export const VERIFIED_OPENHANDS_MODELS = [
   "devstral-small-2505",
   "kimi-k2-0711-preview",
   "qwen3-coder-480b",
-  "gpt-5-2025-08-07",
 ];
 
 // Default model for OpenHands provider

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -33,6 +33,7 @@ export const VERIFIED_OPENAI_MODELS = [
   "gpt-4o-mini",
   "gpt-4.1",
   "gpt-4.1-2025-04-14",
+  "gpt-5-2025-08-07",
   "o3",
   "o3-2025-04-16",
   "o4-mini",

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -29,11 +29,11 @@ export const VERIFIED_MODELS = [
 // LiteLLM does not return OpenAI models with the provider, so we list them here to set them ourselves for consistency
 // (e.g., they return `gpt-4o` instead of `openai/gpt-4o`)
 export const VERIFIED_OPENAI_MODELS = [
+  "gpt-5-2025-08-07",
   "gpt-4o",
   "gpt-4o-mini",
   "gpt-4.1",
   "gpt-4.1-2025-04-14",
-  "gpt-5-2025-08-07",
   "o3",
   "o3-2025-04-16",
   "o4-mini",

--- a/openhands/cli/utils.py
+++ b/openhands/cli/utils.py
@@ -156,6 +156,7 @@ VERIFIED_OPENAI_MODELS = [
     'gpt-4-32k',
     'gpt-4.1',
     'gpt-4.1-2025-04-14',
+    'gpt-5-2025-08-07',
     'o1-mini',
     'o3',
     'codex-mini-latest',

--- a/openhands/cli/utils.py
+++ b/openhands/cli/utils.py
@@ -193,6 +193,7 @@ VERIFIED_OPENHANDS_MODELS = [
     'gemini-2.5-pro',
     'kimi-k2-0711-preview',
     'qwen3-coder-480b',
+    'gpt-5-2025-08-07',
 ]
 
 

--- a/openhands/cli/utils.py
+++ b/openhands/cli/utils.py
@@ -150,13 +150,13 @@ def organize_models_and_providers(
 VERIFIED_PROVIDERS = ['openhands', 'anthropic', 'openai', 'mistral']
 
 VERIFIED_OPENAI_MODELS = [
+    'gpt-5-2025-08-07',
     'o4-mini',
     'gpt-4o',
     'gpt-4o-mini',
     'gpt-4-32k',
     'gpt-4.1',
     'gpt-4.1-2025-04-14',
-    'gpt-5-2025-08-07',
     'o1-mini',
     'o3',
     'codex-mini-latest',

--- a/openhands/cli/utils.py
+++ b/openhands/cli/utils.py
@@ -185,6 +185,7 @@ VERIFIED_MISTRAL_MODELS = [
 
 VERIFIED_OPENHANDS_MODELS = [
     'claude-sonnet-4-20250514',
+    'gpt-5-2025-08-07',
     'claude-opus-4-20250514',
     'claude-opus-4-1-20250805',
     'devstral-small-2507',
@@ -194,7 +195,6 @@ VERIFIED_OPENHANDS_MODELS = [
     'gemini-2.5-pro',
     'kimi-k2-0711-preview',
     'qwen3-coder-480b',
-    'gpt-5-2025-08-07',
 ]
 
 

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -94,6 +94,7 @@ FUNCTION_CALLING_SUPPORTED_MODELS = [
     'kimi-k2-instruct',
     'Qwen3-Coder-480B-A35B-Instruct',
     'qwen3-coder',  # this will match both qwen3-coder-480b (openhands provider) and qwen3-coder (for openrouter)
+    'gpt-5-2025-08-07',
 ]
 
 REASONING_EFFORT_SUPPORTED_MODELS = [
@@ -107,6 +108,7 @@ REASONING_EFFORT_SUPPORTED_MODELS = [
     'o4-mini-2025-04-16',
     'gemini-2.5-flash',
     'gemini-2.5-pro',
+    'gpt-5-2025-08-07',
 ]
 
 MODELS_WITHOUT_STOP_WORDS = [

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -56,6 +56,7 @@ def get_supported_llm_models(config: OpenHandsConfig) -> list[str]:
     # Add OpenHands provider models
     openhands_models = [
         'openhands/claude-sonnet-4-20250514',
+        'openhands/gpt-5-2025-08-07',
         'openhands/claude-opus-4-20250514',
         'openhands/gemini-2.5-pro',
         'openhands/o3',
@@ -65,7 +66,6 @@ def get_supported_llm_models(config: OpenHandsConfig) -> list[str]:
         'openhands/devstral-medium-2507',
         'openhands/kimi-k2-0711-preview',
         'openhands/qwen3-coder-480b',
-        'openhands/gpt-5-2025-08-07',
     ]
     model_list = openhands_models + model_list
 

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -65,6 +65,7 @@ def get_supported_llm_models(config: OpenHandsConfig) -> list[str]:
         'openhands/devstral-medium-2507',
         'openhands/kimi-k2-0711-preview',
         'openhands/qwen3-coder-480b',
+        'openhands/gpt-5-2025-08-07',
     ]
     model_list = openhands_models + model_list
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Adds support for the new `gpt-5-2025-08-07` model to the OpenHands provider, enabling users to select and use this model for AI-powered development tasks. The model includes function calling and reasoning effort capabilities.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds the `gpt-5-2025-08-07` model to the OpenHands provider by:

1. **Frontend Integration**: Added the model to verified model arrays in `frontend/src/utils/verified-models.ts`
2. **Backend Integration**: Added the model to verified model arrays in `openhands/cli/utils.py` and `openhands/utils/llm.py`
3. **Feature Support**: Enabled function calling and reasoning effort support by adding the model to `FUNCTION_CALLING_SUPPORTED_MODELS` and `REASONING_EFFORT_SUPPORTED_MODELS` arrays in `openhands/llm/llm.py`

The implementation follows the same pattern as existing models like `qwen3-coder-480b`, ensuring consistency across the codebase. All changes have been validated with linting checks and the frontend builds successfully.

---
**Link of any specific issues this addresses:**

N/A - This is a new model addition requested by the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:570d83d-nikolaik   --name openhands-app-570d83d   docker.all-hands.dev/all-hands-ai/openhands:570d83d
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@add-gpt-5-2025-08-07-model openhands
```