### PR TITLE
Fix Windows prompt refinement: ensure 'bash' is replaced with 'powershell' in all prompts

### DIFF
--- a/openhands/agenthub/codeact_agent/tools/bash.py
+++ b/openhands/agenthub/codeact_agent/tools/bash.py
@@ -37,7 +37,18 @@ _SHORT_BASH_DESCRIPTION = """Execute a bash command in the terminal.
 
 def refine_prompt(prompt: str):
     if sys.platform == 'win32':
-        return prompt.replace('bash', 'powershell')
+        # Replace 'bash' with 'powershell' but preserve tool names like 'execute_bash'
+        import re
+
+        # First replace 'execute_bash' with 'execute_powershell' to handle tool names
+        result = re.sub(
+            r'\bexecute_bash\b', 'execute_powershell', prompt, flags=re.IGNORECASE
+        )
+        # Then replace standalone 'bash' with 'powershell'
+        result = re.sub(
+            r'(?<!execute_)(?<!_)\bbash\b', 'powershell', result, flags=re.IGNORECASE
+        )
+        return result
     return prompt
 
 

--- a/openhands/agenthub/codeact_agent/tools/bash.py
+++ b/openhands/agenthub/codeact_agent/tools/bash.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 from litellm import ChatCompletionToolParam, ChatCompletionToolParamFunctionChunk
@@ -38,8 +39,6 @@ _SHORT_BASH_DESCRIPTION = """Execute a bash command in the terminal.
 def refine_prompt(prompt: str):
     if sys.platform == 'win32':
         # Replace 'bash' with 'powershell' including tool names like 'execute_bash'
-        import re
-
         # First replace 'execute_bash' with 'execute_powershell' to handle tool names
         result = re.sub(
             r'\bexecute_bash\b', 'execute_powershell', prompt, flags=re.IGNORECASE

--- a/openhands/agenthub/codeact_agent/tools/bash.py
+++ b/openhands/agenthub/codeact_agent/tools/bash.py
@@ -37,7 +37,7 @@ _SHORT_BASH_DESCRIPTION = """Execute a bash command in the terminal.
 
 def refine_prompt(prompt: str):
     if sys.platform == 'win32':
-        # Replace 'bash' with 'powershell' but preserve tool names like 'execute_bash'
+        # Replace 'bash' with 'powershell' including tool names like 'execute_bash'
         import re
 
         # First replace 'execute_bash' with 'execute_powershell' to handle tool names

--- a/openhands/llm/fn_call_converter.py
+++ b/openhands/llm/fn_call_converter.py
@@ -383,7 +383,7 @@ Do NOT assume the environment is the same as in the example above.
 """
     example = example.lstrip()
 
-    return example
+    return refine_prompt(example)
 
 
 IN_CONTEXT_LEARNING_EXAMPLE_PREFIX = get_example_for_tools

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -4,6 +4,7 @@ from itertools import islice
 
 from jinja2 import Template
 
+from openhands.agenthub.codeact_agent.tools.bash import refine_prompt
 from openhands.controller.state.state import State
 from openhands.core.message import Message, TextContent
 from openhands.events.observation.agent import MicroagentKnowledge
@@ -91,7 +92,8 @@ class PromptManager:
             return Template(file.read())
 
     def get_system_message(self) -> str:
-        return self.system_template.render().strip()
+        system_message = self.system_template.render().strip()
+        return refine_prompt(system_message)
 
     def get_example_user_message(self) -> str:
         """This is an initial user message that can be provided to the agent

--- a/tests/unit/test_windows_prompt_refinement.py
+++ b/tests/unit/test_windows_prompt_refinement.py
@@ -1,0 +1,179 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from openhands.agenthub.codeact_agent.codeact_agent import CodeActAgent
+from openhands.core.config import AgentConfig
+from openhands.llm.llm import LLM
+
+# Skip all tests in this module if not running on Windows
+pytestmark = pytest.mark.skipif(
+    sys.platform != 'win32', reason='Windows prompt refinement tests require Windows'
+)
+
+
+@pytest.fixture
+def mock_llm():
+    """Create a mock LLM for testing."""
+    llm = LLM(config={'model': 'gpt-4', 'api_key': 'test'})
+    return llm
+
+
+@pytest.fixture
+def agent_config():
+    """Create a basic agent config for testing."""
+    return AgentConfig()
+
+
+def test_codeact_agent_system_prompt_no_bash_on_windows(mock_llm, agent_config):
+    """Test that CodeActAgent's system prompt doesn't contain 'bash' on Windows."""
+    # Create a CodeActAgent instance
+    agent = CodeActAgent(llm=mock_llm, config=agent_config)
+
+    # Get the system prompt
+    system_prompt = agent.prompt_manager.get_system_message()
+
+    # Assert that 'bash' doesn't exist in the system prompt (case-insensitive)
+    assert 'bash' not in system_prompt.lower(), (
+        f"System prompt contains 'bash' on Windows platform. "
+        f"It should be replaced with 'powershell'. "
+        f'System prompt: {system_prompt}'
+    )
+
+    # Verify that 'powershell' exists instead (case-insensitive)
+    assert 'powershell' in system_prompt.lower(), (
+        f"System prompt should contain 'powershell' on Windows platform. "
+        f'System prompt: {system_prompt}'
+    )
+
+
+def test_codeact_agent_tool_descriptions_no_bash_on_windows(mock_llm, agent_config):
+    """Test that CodeActAgent's tool descriptions don't contain 'bash' on Windows."""
+    # Create a CodeActAgent instance
+    agent = CodeActAgent(llm=mock_llm, config=agent_config)
+
+    # Get the tools
+    tools = agent.tools
+
+    # Check each tool's description and parameters
+    for tool in tools:
+        if tool['type'] == 'function':
+            function_info = tool['function']
+
+            # Check function description
+            description = function_info.get('description', '')
+            assert 'bash' not in description.lower(), (
+                f"Tool '{function_info['name']}' description contains 'bash' on Windows. "
+                f'Description: {description}'
+            )
+
+            # Check parameter descriptions
+            parameters = function_info.get('parameters', {})
+            properties = parameters.get('properties', {})
+
+            for param_name, param_info in properties.items():
+                param_description = param_info.get('description', '')
+                assert 'bash' not in param_description.lower(), (
+                    f"Tool '{function_info['name']}' parameter '{param_name}' "
+                    f"description contains 'bash' on Windows. "
+                    f'Parameter description: {param_description}'
+                )
+
+
+def test_in_context_learning_example_no_bash_on_windows():
+    """Test that in-context learning examples don't contain 'bash' on Windows."""
+    from openhands.agenthub.codeact_agent.tools.bash import create_cmd_run_tool
+    from openhands.agenthub.codeact_agent.tools.finish import FinishTool
+    from openhands.agenthub.codeact_agent.tools.str_replace_editor import (
+        create_str_replace_editor_tool,
+    )
+    from openhands.llm.fn_call_converter import get_example_for_tools
+
+    # Create a sample set of tools
+    tools = [
+        create_cmd_run_tool(),
+        create_str_replace_editor_tool(),
+        FinishTool,
+    ]
+
+    # Get the in-context learning example
+    example = get_example_for_tools(tools)
+
+    # Assert that 'bash' doesn't exist in the example (case-insensitive)
+    assert 'bash' not in example.lower(), (
+        f"In-context learning example contains 'bash' on Windows platform. "
+        f"It should be replaced with 'powershell'. "
+        f'Example: {example}'
+    )
+
+    # Verify that 'powershell' exists instead (case-insensitive)
+    if example:  # Only check if example is not empty
+        assert 'powershell' in example.lower(), (
+            f"In-context learning example should contain 'powershell' on Windows platform. "
+            f'Example: {example}'
+        )
+
+
+def test_refine_prompt_function_works():
+    """Test that the refine_prompt function correctly replaces 'bash' with 'powershell'."""
+    from openhands.agenthub.codeact_agent.tools.bash import refine_prompt
+
+    # Test basic replacement
+    test_prompt = 'Execute a bash command to list files'
+    refined_prompt = refine_prompt(test_prompt)
+
+    assert 'bash' not in refined_prompt.lower()
+    assert 'powershell' in refined_prompt.lower()
+    assert refined_prompt == 'Execute a powershell command to list files'
+
+    # Test multiple occurrences
+    test_prompt = 'Use bash to run bash commands in the bash shell'
+    refined_prompt = refine_prompt(test_prompt)
+
+    assert 'bash' not in refined_prompt.lower()
+    assert (
+        refined_prompt
+        == 'Use powershell to run powershell commands in the powershell shell'
+    )
+
+    # Test case sensitivity
+    test_prompt = 'BASH and Bash and bash should all be replaced'
+    refined_prompt = refine_prompt(test_prompt)
+
+    assert 'bash' not in refined_prompt.lower()
+    assert (
+        refined_prompt
+        == 'powershell and powershell and powershell should all be replaced'
+    )
+
+    # Test execute_bash tool name replacement
+    test_prompt = 'Use the execute_bash tool to run commands'
+    refined_prompt = refine_prompt(test_prompt)
+
+    assert 'execute_bash' not in refined_prompt.lower()
+    assert 'execute_powershell' in refined_prompt.lower()
+    assert refined_prompt == 'Use the execute_powershell tool to run commands'
+
+    # Test that words containing 'bash' but not equal to 'bash' are preserved
+    test_prompt = 'The bashful person likes bash-like syntax'
+    refined_prompt = refine_prompt(test_prompt)
+
+    # 'bashful' should be preserved, 'bash-like' should become 'powershell-like'
+    assert 'bashful' in refined_prompt
+    assert 'powershell-like' in refined_prompt
+    assert refined_prompt == 'The bashful person likes powershell-like syntax'
+
+
+def test_refine_prompt_function_on_non_windows():
+    """Test that the refine_prompt function doesn't change anything on non-Windows platforms."""
+    from openhands.agenthub.codeact_agent.tools.bash import refine_prompt
+
+    # Mock sys.platform to simulate non-Windows
+    with patch('openhands.agenthub.codeact_agent.tools.bash.sys.platform', 'linux'):
+        test_prompt = 'Execute a bash command to list files'
+        refined_prompt = refine_prompt(test_prompt)
+
+        # On non-Windows, the prompt should remain unchanged
+        assert refined_prompt == test_prompt
+        assert 'bash' in refined_prompt.lower()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where CodeActAgent system prompts and in-context learning examples contained references to "bash" on Windows platforms, which should be replaced with "powershell" for consistency with the Windows runtime environment. This ensures that Windows users see appropriate shell references in all agent communications.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR addresses missing applications of the `refine_prompt` function in the Windows runtime. The `refine_prompt` function was designed to replace "bash" references with "powershell" on Windows, but it was only being applied to tool descriptions, not to system prompts or in-context learning examples.

**Changes made:**

1. **Enhanced `refine_prompt` function** (`openhands/agenthub/codeact_agent/tools/bash.py`):
   - Improved to handle case-insensitive replacement with proper word boundaries
   - Properly handles "execute_bash" → "execute_powershell" transformation
   - Preserves words like "bashful" that contain "bash" but aren't the word "bash"
   - Fixed misleading comment

2. **Applied `refine_prompt` to system messages** (`openhands/utils/prompt.py`):
   - Modified `PromptManager.get_system_message()` to apply `refine_prompt` to rendered system messages

3. **Applied `refine_prompt` to in-context learning examples** (`openhands/llm/fn_call_converter.py`):
   - Modified `get_example_for_tools()` to apply `refine_prompt` to generated examples

4. **Added comprehensive unit tests** (`tests/unit/test_windows_prompt_refinement.py`):
   - Tests that run only on Windows (skipped on other platforms)
   - Verifies system prompts, tool descriptions, and in-context learning examples don't contain "bash" on Windows
   - Tests the `refine_prompt` function directly with various edge cases

**Design decisions:**
- Used regex with word boundaries and negative lookbehind to ensure precise replacement
- Applied refinement at the final rendering stage to catch all prompt content
- Made tests Windows-specific using `pytest.mark.skipif` to avoid false failures on other platforms

---
**Link of any specific issues this addresses:**

This addresses an internal consistency issue where Windows users would see mixed "bash" and "powershell" references in agent prompts, which could be confusing.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ba5c635-nikolaik   --name openhands-app-ba5c635   docker.all-hands.dev/all-hands-ai/openhands:ba5c635
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/windows-prompt-refinement-bash-replacement openhands
```