### PR TITLE
feat(agent): stop using short tool description for gpt-5

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -106,7 +106,7 @@ class CodeActAgent(Agent):
     def _get_tools(self) -> list['ChatCompletionToolParam']:
         # For these models, we use short tool descriptions ( < 1024 tokens)
         # to avoid hitting the OpenAI token limit for tool descriptions.
-        SHORT_TOOL_DESCRIPTION_LLM_SUBSTRS = ['gpt-', 'o3', 'o1', 'o4']
+        SHORT_TOOL_DESCRIPTION_LLM_SUBSTRS = ['gpt-4', 'o3', 'o1', 'o4']
 
         use_short_tool_desc = False
         if self.llm is not None:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Previously OpenAI enforces max function description length of 1k characters (https://community.openai.com/t/function-call-description-max-length/529902). Because of that we maintain a short version for each function description.

But according to a more recent post, it seems have gone away: https://community.openai.com/t/was-the-character-limit-for-schema-descriptions-upgraded/1225975

I tested locally, and gpt-5 doesn't seem to throw error at long function descriptions, so maybe safe to remove them now.


---
**Link of any specific issues this addresses:**
