### PR TITLE
Remove SecretStr conversion in GAIA eval

### DIFF
--- a/evaluation/benchmarks/gaia/run_infer.py
+++ b/evaluation/benchmarks/gaia/run_infer.py
@@ -80,8 +80,7 @@ def get_config(
 
     config_copy = copy.deepcopy(config)
     load_from_toml(config_copy)
-    if config_copy.search_api_key:
-        config.search_api_key = SecretStr(config_copy.search_api_key)
+    config.search_api_key = config_copy.search_api_key
     return config
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Previously we needed a custom `SecretStr` conversion in GAIA for `search_api_key` loaded from `config.toml` file. In the MCP support for CLI PR, we handled it in a more generic way, so this PR removes the old code to avoid duplicate conversion.

https://github.com/All-Hands-AI/OpenHands/blob/3302c31c60c3c2681804e34455c2ce8747914730/openhands/core/config/utils.py#L175-L183 

---
**Link of any specific issues this addresses:**
