### PR TITLE
Handle image content in `FileReadObservation`

### DIFF
--- a/openhands/agenthub/codeact_agent/tools/str_replace_editor.py
+++ b/openhands/agenthub/codeact_agent/tools/str_replace_editor.py
@@ -5,7 +5,7 @@ from openhands.llm.tool_names import STR_REPLACE_EDITOR_TOOL_NAME
 _DETAILED_STR_REPLACE_EDITOR_DESCRIPTION = """Custom editing tool for viewing, creating and editing files in plain-text format
 * State is persistent across command calls and discussions with the user
 * If `path` is a text file, `view` displays the result of applying `cat -n`. If `path` is a directory, `view` lists non-hidden files and directories up to 2 levels deep
-* The following binary file extensions can be viewed in Markdown format: [".xlsx", ".pptx", ".wav", ".mp3", ".m4a", ".flac", ".pdf", ".docx"]. IT DOES NOT HANDLE IMAGES.
+* The following binary file extensions can be viewed in Markdown format: [".xlsx", ".pptx", ".wav", ".mp3", ".m4a", ".flac", ".pdf", ".docx"]. IT ALSO HANDLES IMAGES.
 * The `create` command cannot be used if the specified `path` already exists as a file
 * If a `command` generates a long output, it will be truncated and marked with `<response clipped>`
 * The `undo_edit` command will revert the last edit made to the file at `path`

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -426,9 +426,12 @@ class ConversationMemory:
             text = truncate_content(str(obs), max_message_chars)
             message = Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, FileReadObservation):
-            message = Message(
-                role='user', content=[TextContent(text=obs.content)]
-            )  # Content is already truncated by openhands-aci
+            content = []
+            if obs.content.strip().startswith("data:image/png;"):
+                content.append(ImageContent(image_urls=[obs.content.strip()]))
+            else:
+                content.append(TextContent(text=obs.content))
+            message = Message(role='user', content=content)
         elif isinstance(obs, BrowserOutputObservation):
             text = obs.content
             if (


### PR DESCRIPTION

Updates ConversationMemory to detect and process image data URLs in FileReadObservation, wrapping them in ImageContent instead of TextContent. This ensures proper handling of image content in user messages.

---

After #10200

<img width="1026" height="1309" alt="image" src="https://github.com/user-attachments/assets/9faf4ecc-d02c-4255-9e67-c3a56677b579" />


