### PR TITLE
fix(backend): show name of created branch in conversation list.

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -1036,6 +1036,27 @@ fi
         self.git_handler.set_cwd(cwd)
         return self.git_handler.get_git_diff(file_path)
 
+    def get_workspace_branch(self, primary_repo_path: str | None = None) -> str | None:
+        """
+        Get the current branch of the workspace.
+
+        Args:
+            primary_repo_path: Path to the primary repository within the workspace.
+                              If None, uses the workspace root.
+
+        Returns:
+            str | None: The current branch name, or None if not a git repository or error occurs.
+        """
+        if primary_repo_path:
+            # Use the primary repository path
+            git_cwd = str(self.workspace_root / primary_repo_path)
+        else:
+            # Use the workspace root
+            git_cwd = str(self.workspace_root)
+
+        self.git_handler.set_cwd(git_cwd)
+        return self.git_handler.get_current_branch()
+
     @property
     def additional_agent_instructions(self) -> str:
         return ''

--- a/openhands/runtime/utils/git_handler.py
+++ b/openhands/runtime/utils/git_handler.py
@@ -10,6 +10,7 @@ GIT_CHANGES_CMD = 'python3 /openhands/code/openhands/runtime/utils/git_changes.p
 GIT_DIFF_CMD = (
     'python3 /openhands/code/openhands/runtime/utils/git_diff.py "{file_path}"'
 )
+GIT_BRANCH_CMD = 'git branch --show-current'
 
 
 @dataclass
@@ -41,6 +42,7 @@ class GitHandler:
         self.cwd: str | None = None
         self.git_changes_cmd = GIT_CHANGES_CMD
         self.git_diff_cmd = GIT_DIFF_CMD
+        self.git_branch_cmd = GIT_BRANCH_CMD
 
     def set_cwd(self, cwd: str) -> None:
         """
@@ -58,6 +60,28 @@ class GitHandler:
             self.create_file_fn(str(script_file), f.read())
             result = self.execute(f'chmod +x "{script_file}"', self.cwd)
         return script_file
+
+    def get_current_branch(self) -> str | None:
+        """
+        Retrieves the current branch name of the git repository.
+
+        Returns:
+            str | None: The current branch name, or None if not a git repository or error occurs.
+        """
+        # If cwd is not set, return None
+        if not self.cwd:
+            return None
+
+        result = self.execute(self.git_branch_cmd, self.cwd)
+        if result.exit_code == 0:
+            branch = result.content.strip()
+            # git branch --show-current returns empty string if not on any branch (detached HEAD)
+            if branch:
+                return branch
+            return None
+
+        # If not a git repository or other error, return None
+        return None
 
     def get_git_changes(self) -> list[dict[str, str]] | None:
         """

--- a/openhands/server/conversation_manager/standalone_conversation_manager.py
+++ b/openhands/server/conversation_manager/standalone_conversation_manager.py
@@ -491,9 +491,6 @@ class StandaloneConversationManager(ConversationManager):
                     token_usage.prompt_tokens + token_usage.completion_tokens
                 )
 
-        print(f'event: {event}')
-        print(f'is_git_related_event: {self._is_git_related_event(event)}')
-
         # Check for branch changes if this is a git-related event
         if event and self._is_git_related_event(event):
             await self._update_conversation_branch(conversation)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

If a conversation begins from main but branches off into a new thread (e.g., DAISY-1287) during the discussion, OpenHands should update the conversation metadata so that it references DAISY-1287 instead of main.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR modifies the code to listen for Git-related events and update the current branch when necessary.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/00e9e1bb-55d8-4e06-9581-1e3f83f249de

---
**Link of any specific issues this addresses:**
