### PR TITLE
feat(frontend): update the action suggestions (chat interface)

### DIFF
--- a/frontend/src/components/features/chat/action-suggestions.tsx
+++ b/frontend/src/components/features/chat/action-suggestions.tsx
@@ -45,7 +45,7 @@ export function ActionSuggestions({
   return (
     <div className="flex flex-col gap-2 mb-2">
       {providersAreSet && conversation?.selected_repository && (
-        <div className="flex flex-row gap-2 justify-center w-full">
+        <div className="flex flex-row gap-2 w-full">
           {!hasPullRequest ? (
             <>
               <SuggestionItem

--- a/frontend/src/components/features/suggestions/suggestion-item.tsx
+++ b/frontend/src/components/features/suggestions/suggestion-item.tsx
@@ -34,7 +34,7 @@ export function SuggestionItem({ suggestion, onClick }: SuggestionItemProps) {
   return (
     <button
       type="button"
-      className="list-none border border-[#525252] rounded-[15px] hover:bg-tertiary flex-1 flex items-center justify-center cursor-pointer gap-[10px] h-[55px] w-[224px] max-w-[224px]"
+      className="list-none border border-[#525252] rounded-[15px] hover:bg-tertiary flex-1 flex items-center justify-center cursor-pointer gap-[10px] h-[55px]"
       onClick={() => onClick(suggestion.value)}
     >
       {itemIcon}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When the chat interface is in full width, the suggestions are currently centered. We should update them to span the full width instead.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR make the suggestions take full-width. We can refer to the image below for more information.

<img width="1440" height="739" alt="image" src="https://github.com/user-attachments/assets/7080c61b-8860-45fa-b09a-b1e085e5553f" />

---
**Link of any specific issues this addresses:**
