### PR TITLE
feat(frontend): max input height should be 450px for the new chat input (conversation ux improvements).

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -60,7 +60,7 @@ export function CustomChatInput({
   // Use the auto-resize hook
   const { autoResize } = useAutoResize(chatInputRef, {
     minHeight: 20,
-    maxHeight: 80,
+    maxHeight: 450,
     value,
   });
 
@@ -308,7 +308,7 @@ export function CustomChatInput({
                 <div
                   ref={chatInputRef}
                   className={cn(
-                    "chat-input bg-transparent text-white text-[16px] font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[80px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap",
+                    "chat-input bg-transparent text-white text-[16px] font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[450px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap",
                     disabled && "cursor-not-allowed",
                   )}
                   contentEditable={!disabled}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Max input height should be 450px (chat input).

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates the max input height for the new chat input

---
**Link of any specific issues this addresses:**
