### PR TITLE
Fix for issues where callbacks are not batched

### DIFF
--- a/openhands/server/shared.py
+++ b/openhands/server/shared.py
@@ -27,11 +27,11 @@ assert isinstance(server_config_interface, ServerConfig), (
 )
 server_config: ServerConfig = server_config_interface
 file_store: FileStore = get_file_store(
-    config.file_store,
-    config.file_store_path,
-    config.file_store_web_hook_url,
-    config.file_store_web_hook_headers,
-    batch=config.file_store_web_hook_batch,
+    file_store_type=config.file_store,
+    file_store_path=config.file_store_path,
+    file_store_web_hook_url=config.file_store_web_hook_url,
+    file_store_web_hook_headers=config.file_store_web_hook_headers,
+    file_store_web_hook_batch=config.file_store_web_hook_batch,
 )
 
 client_manager = None

--- a/openhands/storage/__init__.py
+++ b/openhands/storage/__init__.py
@@ -16,7 +16,7 @@ def get_file_store(
     file_store_path: str | None = None,
     file_store_web_hook_url: str | None = None,
     file_store_web_hook_headers: dict | None = None,
-    batch: bool = False,
+    file_store_web_hook_batch: bool = False,
 ) -> FileStore:
     store: FileStore
     if file_store_type == 'local':
@@ -40,7 +40,7 @@ def get_file_store(
 
         client = httpx.Client(headers=file_store_web_hook_headers or {})
 
-        if batch:
+        if file_store_web_hook_batch:
             # Use batched webhook file store
             store = BatchedWebHookFileStore(
                 store,

--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -106,10 +106,11 @@ class FileConversationStore(ConversationStore):
         cls, config: OpenHandsConfig, user_id: str | None
     ) -> FileConversationStore:
         file_store = get_file_store(
-            config.file_store,
-            config.file_store_path,
-            config.file_store_web_hook_url,
-            config.file_store_web_hook_headers,
+            file_store_type=config.file_store,
+            file_store_path=config.file_store_path,
+            file_store_web_hook_url=config.file_store_web_hook_url,
+            file_store_web_hook_headers=config.file_store_web_hook_headers,
+            file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
         return FileConversationStore(file_store)
 

--- a/openhands/storage/secrets/file_secrets_store.py
+++ b/openhands/storage/secrets/file_secrets_store.py
@@ -40,9 +40,10 @@ class FileSecretsStore(SecretsStore):
         cls, config: OpenHandsConfig, user_id: str | None
     ) -> FileSecretsStore:
         file_store = get_file_store(
-            config.file_store,
-            config.file_store_path,
-            config.file_store_web_hook_url,
-            config.file_store_web_hook_headers,
+            file_store_type=config.file_store,
+            file_store_path=config.file_store_path,
+            file_store_web_hook_url=config.file_store_web_hook_url,
+            file_store_web_hook_headers=config.file_store_web_hook_headers,
+            file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
         return FileSecretsStore(file_store)

--- a/openhands/storage/settings/file_settings_store.py
+++ b/openhands/storage/settings/file_settings_store.py
@@ -34,9 +34,10 @@ class FileSettingsStore(SettingsStore):
         cls, config: OpenHandsConfig, user_id: str | None
     ) -> FileSettingsStore:
         file_store = get_file_store(
-            config.file_store,
-            config.file_store_path,
-            config.file_store_web_hook_url,
-            config.file_store_web_hook_headers,
+            file_store_type=config.file_store,
+            file_store_path=config.file_store_path,
+            file_store_web_hook_url=config.file_store_web_hook_url,
+            file_store_web_hook_headers=config.file_store_web_hook_headers,
+            file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
         return FileSettingsStore(file_store)

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -260,10 +260,11 @@ def _load_runtime(
         config.mcp = override_mcp_config
 
     file_store = file_store = get_file_store(
-        config.file_store,
-        config.file_store_path,
-        config.file_store_web_hook_url,
-        config.file_store_web_hook_headers,
+        file_store_type=config.file_store,
+        file_store_path=config.file_store_path,
+        file_store_web_hook_url=config.file_store_web_hook_url,
+        file_store_web_hook_headers=config.file_store_web_hook_headers,
+        file_store_web_hook_batch=config.file_store_web_hook_batch,
     )
     event_stream = EventStream(sid, file_store)
 

--- a/tests/unit/test_file_settings_store.py
+++ b/tests/unit/test_file_settings_store.py
@@ -86,4 +86,10 @@ async def test_get_instance():
 
         assert isinstance(store, FileSettingsStore)
         assert store.file_store == mock_store
-        mock_get_store.assert_called_once_with('local', '/test/path', None, None)
+        mock_get_store.assert_called_once_with(
+            file_store_type='local',
+            file_store_path='/test/path',
+            file_store_web_hook_url=None,
+            file_store_web_hook_headers=None,
+            file_store_web_hook_batch=False,
+        )


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes a configuration issue where webhook batching was not being properly enabled even when configured. This improves performance by reducing the number of webhook calls when file store operations are batched.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes a bug where the `file_store_web_hook_batch` configuration parameter was not being properly passed through to the `get_file_store()` function in several locations. The issue was that some calls were using positional arguments while others were using named arguments, and the batching parameter was being lost.

**Changes made:**
- Standardized all `get_file_store()` calls to use named parameters consistently
- Updated calls in `openhands/server/shared.py`, `openhands/storage/__init__.py`, and various store classes
- Fixed parameter name mismatch (`batch` vs `file_store_web_hook_batch`) in the `get_file_store()` function signature
- Updated test configuration in `tests/runtime/conftest.py`

This ensures that when `file_store_web_hook_batch=True` is configured, the `BatchedWebHookFileStore` wrapper is properly applied, enabling webhook batching functionality that was introduced in PR #10119.

---
**Link of any specific issues this addresses:**

This addresses issues where webhook batching was not working as expected despite being configured, leading to unnecessary individual webhook calls instead of batched operations.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:41b3525-nikolaik   --name openhands-app-41b3525   docker.all-hands.dev/all-hands-ai/openhands:41b3525
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix-callbacks openhands
```