### PR TITLE
Fix auto title generation broken by pagination race condition

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavLink, useParams, useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 import { I18nKey } from "#/i18n/declaration";
 import { ConversationCard } from "./conversation-card";
 import { usePaginatedConversations } from "#/hooks/query/use-paginated-conversations";
@@ -15,6 +16,7 @@ import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { Provider } from "#/types/settings";
 import { useUpdateConversation } from "#/hooks/mutation/use-update-conversation";
 import { displaySuccessToast } from "#/utils/custom-toast-handlers";
+import { useWsClient } from "#/context/ws-client-provider";
 
 interface ConversationPanelProps {
   onClose: () => void;
@@ -56,6 +58,30 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
   const { mutate: deleteConversation } = useDeleteConversation();
   const { mutate: stopConversation } = useStopConversation();
   const { mutate: updateConversation } = useUpdateConversation();
+
+  // WebSocket client and query client for real-time updates
+  const { events } = useWsClient();
+  const queryClient = useQueryClient();
+
+  // Listen for title updates via WebSocket
+  React.useEffect(() => {
+    if (!events.length) return;
+
+    const latestEvent = events[events.length - 1];
+
+    // Check if this is a status update with a conversation title
+    if (
+      typeof latestEvent === "object" &&
+      latestEvent !== null &&
+      "status_update" in latestEvent &&
+      latestEvent.status_update === true &&
+      "conversation_title" in latestEvent &&
+      typeof latestEvent.conversation_title === "string"
+    ) {
+      // Invalidate the conversations query to refetch with updated titles
+      queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    }
+  }, [events, queryClient]);
 
   // Set up infinite scroll
   const scrollContainerRef = useInfiniteScroll({


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes an issue where conversation titles were showing generic names like "Conversation 13300" instead of meaningful auto-generated titles. This was caused by a race condition introduced when the conversation list was changed to use pagination - conversations were being displayed before their titles could be generated. Now conversations will show proper descriptive titles that are automatically generated based on their content.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes the auto title generation that was broken by the pagination changes in PR #10129. The issue was a timing problem where conversations were loaded and displayed before title generation could complete.

**Root Cause:**
- Auto-pagination changed conversation loading from simple array to paginated infinite scroll
- Title generation only triggers during conversation events, not when loading conversation lists
- This created a race condition where conversations display before auto title generation completes

**Solution:**
1. **Frontend WebSocket Listeners** (`conversation-panel.tsx`):
   - Added WebSocket event listeners for title update events
   - When title updates are received, query cache is invalidated to trigger UI refresh
   - Provides real-time title updates without page refresh

2. **Backend Title Generation Trigger** (`manage_conversations.py`):
   - Added `_trigger_title_generation_if_needed()` function that checks for default titles
   - Triggers existing `_update_conversation_for_event()` mechanism for conversations with default titles
   - Integrated into both `search_conversations` and `get_conversation` APIs
   - Uses fire-and-forget async tasks to avoid blocking API responses

**Design Decisions:**
- Leverages existing title generation infrastructure instead of duplicating logic
- Uses WebSocket events for real-time updates (consistent with existing architecture)
- Non-blocking approach ensures API performance isn't impacted
- Maintains backward compatibility with existing functionality

**How it works:**
1. User loads conversation list → API returns conversations (some with default titles)
2. Backend triggers title generation for conversations with default titles (async)
3. Title generation completes → WebSocket event is emitted
4. Frontend receives WebSocket event → Query cache is invalidated → UI refreshes with new titles

---
**Link of any specific issues this addresses:**

This addresses the issue reported where conversations were showing generic titles like "Conversation 13300" instead of meaningful auto-generated titles, which was introduced by the auto-pagination changes in commit 56f752557.