### PR TITLE
fix: copy microagents file into runtime image

### DIFF
--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -280,6 +280,12 @@ def prep_build_folder(
         ),
     )
 
+    # Copy the 'microagents' directory (Microagents)
+    shutil.copytree(
+        Path(project_root, 'microagents'),
+        Path(build_folder, 'code', 'microagents')
+    )
+
     # Copy pyproject.toml and poetry.lock files
     for file in ['pyproject.toml', 'poetry.lock']:
         src = Path(openhands_source_dir, file)

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -239,7 +239,8 @@ COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 # ================================================================
 RUN if [ -d /openhands/code/openhands ]; then rm -rf /openhands/code/openhands; fi
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
-
+RUN if [ -d /openhands/code/microagents ]; then rm -rf /openhands/code/microagents; fi
+COPY ./code/microagents /openhands/code/microagents
 COPY ./code/openhands /openhands/code/openhands
 RUN chmod a+rwx /openhands/code/openhands/__init__.py
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

In the nested runtime (SaaS), the agent was launched within the runtime, so we will need microagents folder there too

---
**Link of any specific issues this addresses:**
