### PR TITLE
[Bug]: Ignore comments when checking for multiple bash commands

### DIFF
--- a/tests/unit/test_bash_comments.py
+++ b/tests/unit/test_bash_comments.py
@@ -1,0 +1,44 @@
+from openhands.runtime.utils.bash import split_bash_commands
+
+
+def test_comment_followed_by_command():
+    """Test that a comment followed by a command is correctly handled as multiple commands."""
+    input_command = """# Let me just check the current git status and push directly
+git status --porcelain"""
+
+    # Current behavior - this will return two commands
+    result = split_bash_commands(input_command)
+
+    # This test should fail with the current implementation
+    # but will pass after our fix
+    assert len(result) == 1, f'Expected 1 command, got {len(result)}: {result}'
+    assert 'git status --porcelain' in result[0]
+
+
+def test_multiple_comments_followed_by_command():
+    """Test that multiple comments followed by a command are correctly handled as a single command."""
+    input_command = """# First comment
+# Second comment
+# Third comment
+git status"""
+
+    # Current behavior - this will return multiple commands
+    result = split_bash_commands(input_command)
+
+    # This test should fail with the current implementation
+    # but will pass after our fix
+    assert len(result) == 1, f'Expected 1 command, got {len(result)}: {result}'
+    assert 'git status' in result[0]
+
+
+def test_comment_only():
+    """Test that a comment-only input is handled as a single command."""
+    input_command = """# This is just a comment
+# Another comment line"""
+
+    # Current behavior - this will return multiple commands
+    result = split_bash_commands(input_command)
+
+    # This test should fail with the current implementation
+    # but will pass after our fix
+    assert len(result) == 1, f'Expected 1 command, got {len(result)}: {result}'


### PR DESCRIPTION
## Description

This PR addresses issue #10243 where bash commands with comments are triggering the multi-command error.

Currently, when a user (or LLM) includes a comment before a bash command, the system treats it as multiple commands and throws an error. This PR adds failing tests that demonstrate the issue.

For example:
```bash
# Let me just check the current git status and push directly
git status --porcelain
```

This is currently being treated as two separate commands, causing an error.

## Changes

- Added failing tests that demonstrate the current behavior
- Tests will pass once the fix is implemented

## Next Steps

The actual fix will involve modifying the `split_bash_commands` function in `openhands/runtime/utils/bash.py` to ignore comment-only lines when determining if there are multiple commands.

## Related Issues

Fixes #10243