### PR TITLE
Add get_issue_discussions method to GitLabService

### DIFF
--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -653,6 +653,22 @@ class GitLabService(BaseGitService, GitService):
 
         return project_id
 
+    async def get_issue_discussions(
+        self, project_id: str, issue_iid: int
+    ) -> list[dict]:
+        """Get all discussion notes associated with an issue.
+
+        Args:
+            project_id: The ID or URL-encoded path of the project
+            issue_iid: The IID of the issue
+
+        Returns:
+            list[dict]: A list of discussion items, each containing notes
+        """
+        url = f'{self.BASE_URL}/projects/{project_id}/issues/{issue_iid}/discussions'
+        discussions, _ = await self._make_request(url)
+        return discussions
+
     async def get_microagent_content(
         self, repository: str, file_path: str
     ) -> MicroagentContentResponse:


### PR DESCRIPTION
This PR adds a new method to the GitLabService class for getting all discussion notes associated with an issue, given a project_id and issue_iid.

## Changes
- Added `get_issue_discussions` method to `GitLabService` class
- Added unit test for the new method

## Testing
- Added a unit test that verifies the method correctly calls the GitLab API with the right URL and returns the expected response
- Ran the test successfully
- Ensured all pre-commit hooks pass

This implementation follows the GitLab API documentation for [listing project issue discussion items](https://docs.gitlab.com/ee/api/discussions.html#list-project-issue-discussion-items).