### PR TITLE
Supprot for named volumes in docker_runtime

### DIFF
--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -255,7 +255,18 @@ class DockerRuntime(ActionExecutionClient):
             for mount in mounts:
                 parts = mount.split(':')
                 if len(parts) >= 2:
-                    host_path = os.path.abspath(parts[0])
+                    # Support both bind mounts (absolute paths) and Docker named volumes.
+                    # Named volume syntax:
+                    #   volume:<name>   (explicit)
+                    #   <name>          (implicit when not starting with '/')
+                    raw_host_part = parts[0]
+
+                    if raw_host_part.startswith('volume:'):
+                        host_path = raw_host_part.split('volume:', 1)[1]
+                    elif not os.path.isabs(raw_host_part):
+                        host_path = raw_host_part  # treat as named volume
+                    else:
+                        host_path = os.path.abspath(raw_host_part)
                     container_path = parts[1]
                     # Default mode is 'rw' if not specified
                     mount_mode = parts[2] if len(parts) > 2 else 'rw'
@@ -321,7 +332,8 @@ class DockerRuntime(ActionExecutionClient):
             container_path = parts[1]
             mount_mode = parts[2] if len(parts) > 2 else 'rw'
 
-            if 'overlay' not in mount_mode:
+            # Only consider overlay mounts for host-bind paths (absolute)
+            if (not os.path.isabs(parts[0])) or ('overlay' not in mount_mode):
                 continue
 
             # Prepare upper and work directories unique to this container and mount


### PR DESCRIPTION
- [ X] This change is worth documenting at https://docs.all-hands.dev/
- [ X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

Adds support for binding named docker volumes into docker_runtime - both implicit and volume: notations are supperted