### PR TITLE
Modify experiment manager defaults for nested runtimes

### DIFF
--- a/openhands/experiments/experiment_manager.py
+++ b/openhands/experiments/experiment_manager.py
@@ -1,3 +1,5 @@
+import copy
+import json
 import os
 
 from openhands.core.config.openhands_config import OpenHandsConfig
@@ -20,6 +22,22 @@ class ExperimentManager:
         logger.debug(
             f'Running agent config variant test for user_id={user_id}, conversation_id={conversation_id}'
         )
+
+        config_copy = copy.deepcopy(config)
+        exp_config_str = os.getenv('EXPERIMENT_MANAGER_DEFAULT_CONFIG')
+        if exp_config_str:
+            try:
+                exp_config: dict[str, str] = json.loads(exp_config_str)
+                agent_cfg = config_copy.get_agent_config(config_copy.default_agent)
+
+                # Apply updates dynamically
+                for attr, value in exp_config.items():
+                    if hasattr(agent_cfg, attr):
+                        setattr(agent_cfg, attr, value)
+
+            except json.JSONDecodeError:
+                logger.warning('Invalid JSON in EXPERIMENT_MANAGER_DEFAULT_CONFIG')
+
         return config
 
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The nested runtime doesn't pick up on the changes made by the experiment manager, so modify the no-ops in the experiment manager via envs for nested runtimes


---
**Link of any specific issues this addresses:**
