### PR TITLE
fix(frontend): UI breaks when user message contains codeblock that's too wide

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -53,7 +53,7 @@ export function ChatMessage({
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       className={cn(
-        "rounded-xl relative w-fit",
+        "rounded-xl relative w-fit max-w-[100%]",
         "flex flex-col gap-2",
         type === "user" && " p-4 bg-tertiary self-end",
         type === "agent" && "mt-6 max-w-full bg-transparent",

--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -53,7 +53,7 @@ export function ChatMessage({
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       className={cn(
-        "rounded-xl relative w-fit max-w-[100%]",
+        "rounded-xl relative w-fit max-w-full",
         "flex flex-col gap-2",
         type === "user" && " p-4 bg-tertiary self-end",
         type === "agent" && "mt-6 max-w-full bg-transparent",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

- UI breaks when user message contains codeblock that's too wide

<img width="1134" height="1908" alt="issue" src="https://github.com/user-attachments/assets/57bc35d6-04dd-465f-b195-1ac6995f3d5e" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR set the max width for the chat message.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/de98bbf7-702f-45e0-b408-0324c01b488f

---
**Link of any specific issues this addresses:**

Resolves #10272 
