### PR TITLE
feat: Add git user information to agent prompts

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/additional_info.j2
+++ b/openhands/agenthub/codeact_agent/prompts/additional_info.j2
@@ -44,6 +44,16 @@ You are have access to the following environment variables
 {% if runtime_info.date %}
 Today's date is {{ runtime_info.date }} (UTC).
 {% endif %}
+{% if runtime_info.git_user_name or runtime_info.git_user_email %}
+
+<GIT_USER_CONFIG>
+When making git commits, use the following user configuration:
+{% if runtime_info.git_user_name %}* Git user name: {{ runtime_info.git_user_name }}{% endif %}
+{% if runtime_info.git_user_email %}* Git user email: {{ runtime_info.git_user_email }}{% endif %}
+
+If there are existing git user credentials already configured, use them and add Co-authored-by: {{ runtime_info.git_user_name }} <{{ runtime_info.git_user_email }}> to any commit messages you make. If a git config doesn't exist, use the above credentials as the user.name and user.email by default.
+</GIT_USER_CONFIG>
+{% endif %}
 </RUNTIME_INFORMATION>
 {% if conversation_instructions and conversation_instructions.content -%}
 <CONVERSATION_INSTRUCTIONS>

--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -291,6 +291,8 @@ async def run_session(
         repo_directory=repo_directory,
         conversation_instructions=conversation_instructions,
         working_dir=os.getcwd(),
+        git_user_name=config.git_user_name,
+        git_user_email=config.git_user_email,
     )
 
     # Add MCP tools to the agent

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -136,6 +136,8 @@ async def run_controller(
             repo_directory=repo_directory,
             conversation_instructions=conversation_instructions,
             working_dir=config.workspace_mount_path_in_sandbox,
+            git_user_name=config.git_user_name,
+            git_user_email=config.git_user_email,
         )
 
     # Add MCP tools to the agent

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -169,6 +169,8 @@ def create_memory(
     status_callback: Callable | None = None,
     conversation_instructions: str | None = None,
     working_dir: str = DEFAULT_WORKSPACE_MOUNT_PATH_IN_SANDBOX,
+    git_user_name: str = '',
+    git_user_email: str = '',
 ) -> Memory:
     """Create a memory for the agent to use.
 
@@ -191,7 +193,7 @@ def create_memory(
 
     if runtime:
         # sets available hosts
-        memory.set_runtime_info(runtime, {}, working_dir)
+        memory.set_runtime_info(runtime, {}, working_dir, git_user_name, git_user_email)
 
         # loads microagents from repo/.openhands/microagents
         microagents: list[BaseMicroagent] = runtime.get_microagents_from_selected_repo(

--- a/openhands/events/observation/agent.py
+++ b/openhands/events/observation/agent.py
@@ -78,6 +78,8 @@ class RecallObservation(Observation):
     custom_secrets_descriptions: dict[str, str] = field(default_factory=dict)
     conversation_instructions: str = ''
     working_dir: str = ''
+    git_user_name: str = ''
+    git_user_email: str = ''
 
     # knowledge
     microagent_knowledge: list[MicroagentKnowledge] = field(default_factory=list)

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -526,12 +526,16 @@ class ConversationMemory:
                         date=date,
                         custom_secrets_descriptions=obs.custom_secrets_descriptions,
                         working_dir=obs.working_dir,
+                        git_user_name=obs.git_user_name,
+                        git_user_email=obs.git_user_email,
                     )
                 else:
                     runtime_info = RuntimeInfo(
                         date=date,
                         custom_secrets_descriptions=obs.custom_secrets_descriptions,
                         working_dir=obs.working_dir,
+                        git_user_name=obs.git_user_name,
+                        git_user_email=obs.git_user_email,
                     )
 
                 conversation_instructions = None

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -202,6 +202,12 @@ class Memory:
                 if self.conversation_instructions is not None
                 else '',
                 working_dir=self.runtime_info.working_dir if self.runtime_info else '',
+                git_user_name=self.runtime_info.git_user_name
+                if self.runtime_info
+                else '',
+                git_user_email=self.runtime_info.git_user_email
+                if self.runtime_info
+                else '',
             )
             return obs
         return None
@@ -341,25 +347,31 @@ class Memory:
         runtime: Runtime,
         custom_secrets_descriptions: dict[str, str],
         working_dir: str,
+        git_user_name: str = '',
+        git_user_email: str = '',
     ) -> None:
         """Store runtime info (web hosts, ports, etc.)."""
         # e.g. { '127.0.0.1': 8080 }
         utc_now = datetime.now(timezone.utc)
         date = str(utc_now.date())
 
-        if runtime.web_hosts or runtime.additional_agent_instructions:
+        if runtime and (runtime.web_hosts or runtime.additional_agent_instructions):
             self.runtime_info = RuntimeInfo(
                 available_hosts=runtime.web_hosts,
                 additional_agent_instructions=runtime.additional_agent_instructions,
                 date=date,
                 custom_secrets_descriptions=custom_secrets_descriptions,
                 working_dir=working_dir,
+                git_user_name=git_user_name,
+                git_user_email=git_user_email,
             )
         else:
             self.runtime_info = RuntimeInfo(
                 date=date,
                 custom_secrets_descriptions=custom_secrets_descriptions,
                 working_dir=working_dir,
+                git_user_name=git_user_name,
+                git_user_email=git_user_email,
             )
 
     def set_conversation_instructions(

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -156,6 +156,8 @@ class AgentSession:
                 conversation_instructions=conversation_instructions,
                 custom_secrets_descriptions=custom_secrets_handler.get_custom_secrets_descriptions(),
                 working_dir=config.workspace_mount_path_in_sandbox,
+                git_user_name=config.git_user_name,
+                git_user_email=config.git_user_email,
             )
 
             # NOTE: this needs to happen before controller is created
@@ -468,6 +470,8 @@ class AgentSession:
         conversation_instructions: str | None,
         custom_secrets_descriptions: dict[str, str],
         working_dir: str,
+        git_user_name: str,
+        git_user_email: str,
     ) -> Memory:
         memory = Memory(
             event_stream=self.event_stream,
@@ -478,7 +482,11 @@ class AgentSession:
         if self.runtime:
             # sets available hosts and other runtime info
             memory.set_runtime_info(
-                self.runtime, custom_secrets_descriptions, working_dir
+                self.runtime,
+                custom_secrets_descriptions,
+                working_dir,
+                git_user_name=git_user_name,
+                git_user_email=git_user_email,
             )
             memory.set_conversation_instructions(conversation_instructions)
 

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -16,6 +16,8 @@ class RuntimeInfo:
     additional_agent_instructions: str = ''
     custom_secrets_descriptions: dict[str, str] = field(default_factory=dict)
     working_dir: str = ''
+    git_user_name: str = ''
+    git_user_email: str = ''
 
 
 @dataclass


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This feature enables agents to use the correct git user credentials when making commits. Previously, agents would commit using default git credentials or fail to commit entirely. Now, when users configure their git username and email in OpenHands settings, this information is automatically provided to agents in their prompts, instructing them to use the proper credentials and add Co-authored-by lines for attribution.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR implements a complete flow for git user information from OpenHands configuration to agent prompts:

1. **RuntimeInfo Enhancement**: Added `git_user_name` and `git_user_email` fields to the `RuntimeInfo` dataclass to store git user configuration.

2. **Memory System Updates**: 
   - Updated `Memory.set_runtime_info()` to accept and store git user parameters
   - Added git user fields to `RecallObservation` for conversation memory persistence
   - Updated conversation memory to include git user information in runtime info

3. **Configuration Flow**: 
   - Modified `create_memory()` function to accept git user parameters
   - Updated all callers (CLI, core, agent session) to pass git configuration through the system
   - Ensured git user info flows from `OpenHandsConfig` → runtime → memory → prompts

4. **Prompt Template**: 
   - Enhanced `additional_info.j2` template to display git user configuration when available
   - Added clear instructions for agents to use proper git credentials
   - Included guidance for adding Co-authored-by lines for proper attribution

5. **Error Handling**: Fixed runtime None check in memory system to handle cases where runtime is not provided.

The design ensures that git user information configured in OpenHands settings automatically flows through the entire system and is presented to agents in a clear, actionable format.

---
**Link of any specific issues this addresses:**

This addresses the user request to check if `git_user_name` and `git_user_email` settings are used anywhere and modify the prompt template to include them for agent commits.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8a05cd65b7034515b0cd278ae5239678)