### PR TITLE
Implement automatic git co-authorship in CLI runtime using PATH-based wrapper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^(docs/|modules/|python/|openhands-ui/|third_party/)
+      - id: end-of-file-fixer
+        exclude: ^(docs/|modules/|python/|openhands-ui/|third_party/)
+      - id: check-yaml
+        args: ["--allow-multiple-documents"]
+      - id: debug-statements
+
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.5.1
+    hooks:
+      - id: pyproject-fmt
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.24.1
+    hooks:
+      - id: validate-pyproject
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.11.8
+    hooks:
+      # Run the linter.
+      - id: ruff
+        entry: ruff check --config dev_config/python/ruff.toml
+        types_or: [python, pyi, jupyter]
+        args: [--fix, --unsafe-fixes]
+        exclude: third_party/
+      # Run the formatter.
+      - id: ruff-format
+        entry: ruff format --config dev_config/python/ruff.toml
+        types_or: [python, pyi, jupyter]
+        exclude: third_party/
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          [types-requests, types-setuptools, types-pyyaml, types-toml, types-docker, types-Markdown, pydantic, lxml]
+        # To see gaps add `--html-report mypy-report/`
+        entry: mypy --config-file dev_config/python/mypy.ini openhands/
+        always_run: true
+        pass_filenames: false

--- a/openhands/runtime/utils/git_hooks/README.md
+++ b/openhands/runtime/utils/git_hooks/README.md
@@ -1,0 +1,30 @@
+# OpenHands Git Hooks
+
+This directory contains git hooks that are automatically installed in the OpenHands runtime environment.
+
+## prepare-commit-msg
+
+This hook serves as a fallback mechanism to ensure that OpenHands contributions are properly attributed. It automatically adds `Co-authored-by: openhands <openhands@all-hands.dev>` to commit messages when the co-authorship line is not already present (case-insensitive check).
+
+### Behavior
+
+- **Primary workflow**: The OpenHands agent should manually add co-authorship lines to commit messages as instructed in the system prompt
+- **Fallback**: If the agent forgets to add the co-authorship line, this hook will automatically add it
+- **No-op**: If the co-authorship line is already present (in any case variation), the hook does nothing
+
+### Installation
+
+#### Docker Runtime
+
+The hook is automatically installed during Docker runtime build via the `Dockerfile.j2` template:
+
+1. Copied from `/openhands/code/openhands/runtime/utils/git_hooks/` to `/openhands/git-hooks/hooks/`
+2. Made executable with `chmod +x`
+3. Configured globally via `git config --global core.hooksPath /openhands/git-hooks/hooks`
+4. Set as template for new repositories via `git config --global init.templateDir /openhands/git-hooks`
+
+This ensures the hook works for both existing repositories and newly created ones.
+
+#### CLI Runtime
+
+For CLI runtime, git co-authorship is always enabled automatically. A git wrapper script is set up that intercepts git commit commands and automatically adds co-authorship. This approach is non-invasive as it doesn't modify the user's git configuration or install hooks in their repositories. Instead, it transparently wraps git commands to add the co-authorship line when needed.

--- a/openhands/runtime/utils/git_hooks/prepare-commit-msg
+++ b/openhands/runtime/utils/git_hooks/prepare-commit-msg
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# OpenHands Git Hook: prepare-commit-msg
+# This hook automatically adds "Co-authored-by: openhands <openhands@all-hands.dev>"
+# to commit messages if it's not already present. This serves as a fallback when
+# the agent doesn't manually add the co-authorship line.
+
+COMMIT_MSG_FILE=$1
+
+# Check if co-authorship line already exists (case-insensitive)
+if ! grep -qi "co-authored-by.*openhands.*<openhands@all-hands.dev>" "$COMMIT_MSG_FILE"; then
+    # Add two empty lines and co-authorship line
+    echo "" >> "$COMMIT_MSG_FILE"
+    echo "" >> "$COMMIT_MSG_FILE"
+    echo "Co-authored-by: openhands <openhands@all-hands.dev>" >> "$COMMIT_MSG_FILE"
+fi

--- a/openhands/runtime/utils/git_wrapper.sh
+++ b/openhands/runtime/utils/git_wrapper.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Git wrapper script that automatically adds co-authorship to commit messages
+# This script intercepts git commit commands and adds "Co-authored-by: openhands <openhands@all-hands.dev>"
+# if it's not already present in the commit message.
+
+# Function to add co-authorship to a commit message
+add_coauthorship() {
+    local commit_msg_file="$1"
+    local coauthor_line="Co-authored-by: openhands <openhands@all-hands.dev>"
+
+    # Check if co-authorship line already exists (case-insensitive)
+    if ! grep -qi "co-authored-by.*openhands" "$commit_msg_file" 2>/dev/null; then
+        # Add two empty lines and the co-authorship line
+        echo "" >> "$commit_msg_file"
+        echo "" >> "$commit_msg_file"
+        echo "$coauthor_line" >> "$commit_msg_file"
+    fi
+}
+
+# Function to handle git commit with message
+handle_commit_with_message() {
+    local temp_msg_file
+    temp_msg_file=$(mktemp)
+
+    # Extract the commit message from arguments
+    local commit_msg=""
+    local args=()
+    local skip_next=false
+
+    for arg in "$@"; do
+        if [ "$skip_next" = true ]; then
+            commit_msg="$arg"
+            args+=("$arg")
+            skip_next=false
+        elif [ "$arg" = "-m" ] || [ "$arg" = "--message" ]; then
+            args+=("$arg")
+            skip_next=true
+        else
+            args+=("$arg")
+        fi
+    done
+
+    # Write the commit message to temp file and add co-authorship
+    echo "$commit_msg" > "$temp_msg_file"
+    add_coauthorship "$temp_msg_file"
+
+    # Replace -m argument with -F (file) argument
+    local new_args=()
+    skip_next=false
+    for arg in "${args[@]}"; do
+        if [ "$skip_next" = true ]; then
+            new_args+=("-F" "$temp_msg_file")
+            skip_next=false
+        elif [ "$arg" = "-m" ] || [ "$arg" = "--message" ]; then
+            skip_next=true
+        else
+            new_args+=("$arg")
+        fi
+    done
+
+    # Execute git with modified arguments
+    command git "${new_args[@]}"
+    local exit_code=$?
+
+    # Clean up temp file
+    rm -f "$temp_msg_file"
+
+    return $exit_code
+}
+
+# Main logic
+if [ "$1" = "commit" ]; then
+    # Check if this is a commit with -m/--message flag
+    if [[ "$*" =~ -m[[:space:]] ]] || [[ "$*" =~ --message[[:space:]] ]] || [[ "$*" =~ -m= ]] || [[ "$*" =~ --message= ]]; then
+        handle_commit_with_message "$@"
+    else
+        # For other commit types (interactive, -F file, etc.), just pass through
+        # The prepare-commit-msg hook would handle these in Docker runtime
+        command git "$@"
+    fi
+else
+    # For non-commit commands, just pass through to real git
+    command git "$@"
+fi

--- a/openhands/runtime/utils/git_wrapper_README.md
+++ b/openhands/runtime/utils/git_wrapper_README.md
@@ -1,0 +1,39 @@
+# Git Wrapper for Co-authorship
+
+This git wrapper script (`git_wrapper.sh`) provides a non-invasive way to automatically add co-authorship to git commits without modifying the user's git configuration or installing hooks in their repositories.
+
+## How it works
+
+The wrapper script intercepts git commit commands and:
+
+1. **For `git commit -m "message"` commands**: Extracts the commit message, adds co-authorship, and uses a temporary file to commit with the enhanced message.
+
+2. **For other commit types**: Passes through to the regular git command (interactive commits, file-based commits, etc. would be handled by git hooks in Docker runtime).
+
+## Usage
+
+The wrapper is automatically set up in CLI runtime.
+
+When active:
+- The wrapper script is copied to the workspace as `.openhands_git_wrapper.sh`
+- Git commands are transparently intercepted and processed
+- Co-authorship is automatically added: `Co-authored-by: openhands <openhands@all-hands.dev>`
+
+## Benefits
+
+- **Non-invasive**: Doesn't modify user's git configuration or repository hooks
+- **Transparent**: Agent thinks it's running regular git commands
+- **Automatic**: No manual intervention required
+- **Safe**: Only affects the current workspace session
+
+## Example
+
+```bash
+# Without wrapper
+git commit -m "Fix bug"
+# Results in: "Fix bug"
+
+# With wrapper enabled
+git commit -m "Fix bug"
+# Results in: "Fix bug\n\nCo-authored-by: openhands <openhands@all-hands.dev>"
+```

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -221,7 +221,15 @@ RUN \
     touch /openhands/code/openhands/__init__.py && \
     # Set global git configuration to ensure proper author/committer information
     git config --global user.name "openhands" && \
-    git config --global user.email "openhands@all-hands.dev"
+    git config --global user.email "openhands@all-hands.dev" && \
+    # Set up global git hook template directory for automatic co-authorship fallback
+    mkdir -p /openhands/git-hooks/hooks && \
+    git config --global init.templateDir /openhands/git-hooks && \
+    # Copy git hooks from source code
+    cp /openhands/code/openhands/runtime/utils/git_hooks/prepare-commit-msg /openhands/git-hooks/hooks/ && \
+    chmod +x /openhands/git-hooks/hooks/prepare-commit-msg && \
+    # Set up global git hooks path for existing repositories
+    git config --global core.hooksPath /openhands/git-hooks/hooks
 
 COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 


### PR DESCRIPTION
## Summary

This PR implements automatic git co-authorship in CLI runtime by replacing the conditional environment variable check with an always-enabled PATH-based git wrapper approach.

## Changes

- **Removed conditional logic**: Git co-authorship is now always enabled in CLI runtime instead of requiring `OPENHANDS_ENABLE_GIT_COAUTHOR` environment variable
- **PATH-based wrapper**: Uses PATH manipulation instead of command wrapping to handle chained commands like `cd dir && git commit`
- **Recursion prevention**: Creates modified git wrapper that uses full path to real git executable to avoid infinite recursion
- **Updated tests**: Modified test to reflect always-enabled behavior and check for wrapper in correct location
- **Comprehensive documentation**: Added documentation for both git hooks and wrapper functionality

## Technical Details

The new approach:
1. Finds the real git executable path using `which git`
2. Creates a `.openhands_bin` directory in the workspace
3. Copies the git wrapper script as `git` executable in that directory
4. Modifies the wrapper to call the real git with full path (prevents recursion)
5. Prepends the bin directory to PATH so our wrapper is found first

This works for all git commands including chained ones like `cd some/dir && git commit -m "message"` because the shell will find our `git` executable in PATH regardless of how it's invoked.

## Testing

- Updated existing test to check for wrapper in new location
- Test verifies that co-authorship is automatically added to commit messages
- All existing git functionality remains unchanged

## Fixes

Fixes https://github.com/All-Hands-AI/OpenHands/issues/9957

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c634879118f448f4a09dbdeb87074664)