### PR TITLE
fix: add padding to chat suggestions

### DIFF
--- a/frontend/src/components/features/suggestions/suggestion-item.tsx
+++ b/frontend/src/components/features/suggestions/suggestion-item.tsx
@@ -34,7 +34,7 @@ export function SuggestionItem({ suggestion, onClick }: SuggestionItemProps) {
   return (
     <button
       type="button"
-      className="list-none border border-[#525252] rounded-[15px] hover:bg-tertiary flex-1 flex items-center justify-center cursor-pointer gap-[10px] h-[55px]"
+      className="list-none border border-[#525252] rounded-[15px] hover:bg-tertiary flex-1 flex items-center justify-center cursor-pointer gap-[10px] h-[55px] px-4"
       onClick={() => onClick(suggestion.value)}
     >
       {itemIcon}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Currently, chat suggestions lack horizontal padding. We need to add left and right padding to improve spacing and alignment.

Refer to the image below for more details.

<img width="1440" height="743" alt="Screenshot 2025-08-14 at 16 01 20" src="https://github.com/user-attachments/assets/72c19e9b-1fcc-4381-87e6-1efdea062c0c" />

**Acceptance Criteria:**
- Add horizontal (left and right) padding to all chat suggestions.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR adds horizontal (left and right) padding to all chat suggestions.

We can refer to the image below for more information.

<img width="1440" height="743" alt="Screenshot 2025-08-14 at 16 01 06" src="https://github.com/user-attachments/assets/92619dfe-a5a5-403d-84ab-81ee231c3f73" />

---
**Link of any specific issues this addresses:**
