### PR TITLE
fix(frontend): fix icon active state (conversation tabs)

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-nav.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-nav.tsx
@@ -25,7 +25,7 @@ export function ConversationTabNav({
       className={cn(
         "p-1 rounded-md",
         "text-[#9299AA] bg-[#0D0F11]",
-        isActive && "bg-[#25272D]",
+        isActive && "bg-[#25272D] text-white",
         isActive
           ? "hover:text-white hover:bg-tertiary"
           : "hover:text-white hover:bg-[#0D0F11]",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When a conversation tab is selected, its icon color should appear white to indicate the active state.

Refer to the video below for more details.

**Acceptance Criteria:**

- Selected conversation tab icons must display in white.

https://github.com/user-attachments/assets/10392562-98ed-4ee3-8cc6-2d21002d2141

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes the icon active state (conversation tabs).

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/6317e7dd-65d5-4559-8549-e2aa6ae41960

---
**Link of any specific issues this addresses:**
