### PR TITLE
fix(frontend): terminal disappears after toggling expand icon

### DIFF
--- a/frontend/src/components/features/terminal/terminal.tsx
+++ b/frontend/src/components/features/terminal/terminal.tsx
@@ -67,26 +67,20 @@ function Terminal() {
         </div>
       </div>
 
-      {expanded && (
-        // eslint-disable-next-line react/jsx-no-useless-fragment
-        <>
-          {isRuntimeInactive ? (
-            <div className="w-full h-full flex items-center text-center justify-center text-2xl text-tertiary-light">
-              {t("DIFF_VIEWER$WAITING_FOR_RUNTIME")}
-            </div>
-          ) : (
-            <div
-              ref={ref}
-              className={cn(
-                "p-4",
-                isRuntimeInactive
-                  ? "w-0 h-0 opacity-0 overflow-hidden"
-                  : "h-full w-full",
-              )}
-            />
-          )}
-        </>
+      {isRuntimeInactive && (
+        <div className="w-full flex items-center text-center justify-center text-2xl text-tertiary-light pt-16">
+          {t("DIFF_VIEWER$WAITING_FOR_RUNTIME")}
+        </div>
       )}
+
+      <div
+        ref={ref}
+        className={cn(
+          isRuntimeInactive || !expanded
+            ? "p-0 w-0 h-0 opacity-0 overflow-hidden"
+            : "p-4 h-full w-full",
+        )}
+      />
     </div>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When toggling the expand icon, the terminal disappears.

**Acceptance Criteria:**

- Toggling the expand icon should correctly expand the terminal without removing it from view.

We can refer to the video below for more information.

https://github.com/user-attachments/assets/d4929280-ff9a-4720-b0ab-3dcae2bd15d2

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes terminal disappears after toggling expand icon.

We can refer to the video below for more information.

https://github.com/user-attachments/assets/dc51ab13-1414-401c-a841-f6697002b3d9

---
**Link of any specific issues this addresses:**
