### PR TITLE
fix: allow logout access when stuck in 401 state in SAAS mode

### DIFF
--- a/frontend/__tests__/hooks/mutation/use-logout.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-logout.test.tsx
@@ -1,0 +1,127 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useLogout } from "#/hooks/mutation/use-logout";
+import { useConfig } from "#/hooks/query/use-config";
+import OpenHands from "#/api/open-hands";
+import { clearLoginData } from "#/utils/local-storage";
+
+// Mock the dependencies
+vi.mock("#/hooks/query/use-config");
+vi.mock("#/api/open-hands");
+vi.mock("#/utils/local-storage");
+vi.mock("posthog-js", () => ({
+  default: {
+    reset: vi.fn(),
+  },
+}));
+
+// Mock window.location.reload
+Object.defineProperty(window, "location", {
+  value: {
+    reload: vi.fn(),
+  },
+  writable: true,
+});
+
+const mockUseConfig = vi.mocked(useConfig);
+const mockOpenHands = vi.mocked(OpenHands);
+const mockClearLoginData = vi.mocked(clearLoginData);
+
+// Create a wrapper component for React Query
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useLogout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseConfig.mockReturnValue({ data: { APP_MODE: "saas" } } as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should perform client-side cleanup on successful logout", async () => {
+    mockOpenHands.logout = vi.fn().mockResolvedValue(undefined);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useLogout(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockOpenHands.logout).toHaveBeenCalledWith("saas");
+    expect(mockClearLoginData).toHaveBeenCalled();
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it("should perform client-side cleanup even when logout API fails with 401", async () => {
+    const error = new Error("Unauthorized");
+    (error as any).response = { status: 401 };
+    mockOpenHands.logout = vi.fn().mockRejectedValue(error);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useLogout(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockOpenHands.logout).toHaveBeenCalledWith("saas");
+    expect(mockClearLoginData).toHaveBeenCalled();
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it("should perform client-side cleanup even when logout API fails with other errors", async () => {
+    const error = new Error("Network error");
+    mockOpenHands.logout = vi.fn().mockRejectedValue(error);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useLogout(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockOpenHands.logout).toHaveBeenCalledWith("saas");
+    expect(mockClearLoginData).toHaveBeenCalled();
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it("should not clear login data in OSS mode", async () => {
+    mockUseConfig.mockReturnValue({ data: { APP_MODE: "oss" } } as any);
+    mockOpenHands.logout = vi.fn().mockResolvedValue(undefined);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useLogout(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockOpenHands.logout).toHaveBeenCalledWith("oss");
+    expect(mockClearLoginData).not.toHaveBeenCalled();
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/hooks/use-should-show-user-features.test.tsx
+++ b/frontend/__tests__/hooks/use-should-show-user-features.test.tsx
@@ -1,0 +1,134 @@
+import { renderHook } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { useShouldShowUserFeatures } from "#/hooks/use-should-show-user-features";
+import { useConfig } from "#/hooks/query/use-config";
+import { useIsAuthed } from "#/hooks/query/use-is-authed";
+import { useUserProviders } from "#/hooks/use-user-providers";
+import { getLoginMethod, LoginMethod } from "#/utils/local-storage";
+
+// Mock the dependencies
+vi.mock("#/hooks/query/use-config");
+vi.mock("#/hooks/query/use-is-authed");
+vi.mock("#/hooks/use-user-providers");
+vi.mock("#/utils/local-storage");
+
+const mockUseConfig = vi.mocked(useConfig);
+const mockUseIsAuthed = vi.mocked(useIsAuthed);
+const mockUseUserProviders = vi.mocked(useUserProviders);
+const mockGetLoginMethod = vi.mocked(getLoginMethod);
+
+describe("useShouldShowUserFeatures", () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return false when config is not loaded", () => {
+    mockUseConfig.mockReturnValue({ data: null } as any);
+    mockUseIsAuthed.mockReturnValue({ data: false } as any);
+    mockUseUserProviders.mockReturnValue({ providers: [] } as any);
+    mockGetLoginMethod.mockReturnValue(null);
+
+    const { result } = renderHook(() => useShouldShowUserFeatures());
+
+    expect(result.current).toBe(false);
+  });
+
+  describe("SAAS mode", () => {
+    it("should return true when authenticated", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "saas" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: true } as any);
+      mockUseUserProviders.mockReturnValue({ providers: [] } as any);
+      mockGetLoginMethod.mockReturnValue(null);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should return true when not authenticated but has login method stored", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "saas" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: false } as any);
+      mockUseUserProviders.mockReturnValue({ providers: [] } as any);
+      mockGetLoginMethod.mockReturnValue(LoginMethod.GITHUB);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should return false when not authenticated and no login method stored", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "saas" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: false } as any);
+      mockUseUserProviders.mockReturnValue({ providers: [] } as any);
+      mockGetLoginMethod.mockReturnValue(null);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("OSS mode", () => {
+    it("should return true when authenticated and has providers", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "oss" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: true } as any);
+      mockUseUserProviders.mockReturnValue({ providers: ["github"] } as any);
+      mockGetLoginMethod.mockReturnValue(null);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should return false when authenticated but no providers", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "oss" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: true } as any);
+      mockUseUserProviders.mockReturnValue({ providers: [] } as any);
+      mockGetLoginMethod.mockReturnValue(null);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(false);
+    });
+
+    it("should return false when not authenticated even with login method stored", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "oss" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: false } as any);
+      mockUseUserProviders.mockReturnValue({ providers: ["github"] } as any);
+      mockGetLoginMethod.mockReturnValue(LoginMethod.GITHUB);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("Other modes", () => {
+    it("should return true when authenticated", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "other" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: true } as any);
+      mockUseUserProviders.mockReturnValue({ providers: [] } as any);
+      mockGetLoginMethod.mockReturnValue(null);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should return false when not authenticated", () => {
+      mockUseConfig.mockReturnValue({ data: { APP_MODE: "other" } } as any);
+      mockUseIsAuthed.mockReturnValue({ data: false } as any);
+      mockUseUserProviders.mockReturnValue({ providers: [] } as any);
+      mockGetLoginMethod.mockReturnValue(LoginMethod.GITHUB);
+
+      const { result } = renderHook(() => useShouldShowUserFeatures());
+
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -8,23 +8,31 @@ export const useLogout = () => {
   const queryClient = useQueryClient();
   const { data: config } = useConfig();
 
+  const performClientSideLogout = () => {
+    queryClient.removeQueries({ queryKey: ["tasks"] });
+    queryClient.removeQueries({ queryKey: ["settings"] });
+    queryClient.removeQueries({ queryKey: ["user"] });
+    queryClient.removeQueries({ queryKey: ["secrets"] });
+
+    // Clear login method and last page from local storage
+    if (config?.APP_MODE === "saas") {
+      clearLoginData();
+    }
+
+    posthog.reset();
+
+    // Refresh the page after all logout logic is completed
+    window.location.reload();
+  };
+
   return useMutation({
     mutationFn: () => OpenHands.logout(config?.APP_MODE ?? "oss"),
-    onSuccess: async () => {
-      queryClient.removeQueries({ queryKey: ["tasks"] });
-      queryClient.removeQueries({ queryKey: ["settings"] });
-      queryClient.removeQueries({ queryKey: ["user"] });
-      queryClient.removeQueries({ queryKey: ["secrets"] });
-
-      // Clear login method and last page from local storage
-      if (config?.APP_MODE === "saas") {
-        clearLoginData();
-      }
-
-      posthog.reset();
-
-      // Refresh the page after all logout logic is completed
-      window.location.reload();
+    onSuccess: performClientSideLogout,
+    onError: (error) => {
+      // If logout API call fails (e.g., due to 401), still perform client-side cleanup
+      // This is especially important when users are stuck in a 401 state
+      console.warn("Logout API call failed, performing client-side cleanup:", error);
+      performClientSideLogout();
     },
   });
 };

--- a/frontend/src/hooks/use-should-show-user-features.ts
+++ b/frontend/src/hooks/use-should-show-user-features.ts
@@ -2,6 +2,7 @@ import React from "react";
 import { useConfig } from "./query/use-config";
 import { useIsAuthed } from "./query/use-is-authed";
 import { useUserProviders } from "./use-user-providers";
+import { getLoginMethod } from "#/utils/local-storage";
 
 /**
  * Hook to determine if user-related features should be shown or enabled
@@ -15,14 +16,20 @@ export const useShouldShowUserFeatures = (): boolean => {
   const { providers } = useUserProviders();
 
   return React.useMemo(() => {
-    if (!config?.APP_MODE || !isAuthed) return false;
+    if (!config?.APP_MODE) return false;
 
-    // In OSS mode, only show user features if Git providers are configured
-    if (config.APP_MODE === "oss") {
-      return providers.length > 0;
+    // In SAAS mode, show user features if authenticated OR if there's a stored login method
+    // This allows users to logout even when stuck in a 401 state
+    if (config.APP_MODE === "saas") {
+      return isAuthed || !!getLoginMethod();
     }
 
-    // In non-OSS modes (saas), always show user features when authenticated
-    return true;
+    // In OSS mode, only show user features if authenticated and Git providers are configured
+    if (config.APP_MODE === "oss") {
+      return isAuthed && providers.length > 0;
+    }
+
+    // For other modes, show when authenticated
+    return !!isAuthed;
   }, [config?.APP_MODE, isAuthed, providers.length]);
 };


### PR DESCRIPTION
## Problem

Users in SAAS environments were getting stuck in a 401 authentication state where:
- All API calls return 401 errors
- Users cannot see the user avatar (which contains the logout menu)
- Users cannot manually logout to clear their authentication state
- Auto-login keeps trying to redirect but fails
- Users have to manually click on an invisible user avatar area to access logout

## Root Cause

The issue was in the `useShouldShowUserFeatures` hook logic:
- The user avatar was only shown when `isAuthed = true`
- When stuck in a 401 state, `isAuthed = false`, so the avatar disappeared
- Without the avatar, users couldn't access the logout functionality
- This created a catch-22 where users needed to logout but couldn't access the logout button

## Solution

### 1. Modified `useShouldShowUserFeatures` Hook
- In SAAS mode, now shows user features if authenticated OR if there's a stored login method
- This allows users to access the logout functionality even when stuck in a 401 state
- OSS mode behavior remains unchanged (requires authentication AND providers)

### 2. Improved Logout Error Handling
- Added graceful error handling for logout API failures
- Ensures client-side cleanup happens even if the logout API call fails with 401
- Helpful console warning when logout API fails
- Ensures localStorage is cleared and page is refreshed regardless of API response

## Testing

- ✅ Added comprehensive unit tests for `useShouldShowUserFeatures` (9 tests)
- ✅ Added comprehensive unit tests for `useLogout` error handling (4 tests)
- ✅ All existing tests continue to pass
- ✅ Frontend build completes successfully
- ✅ No TypeScript errors

## User Experience Impact

### Before Fix:
1. User gets stuck in 401 state
2. User avatar disappears
3. No way to access logout functionality
4. User must know to click on invisible avatar area
5. Frustrating user experience

### After Fix:
1. User gets stuck in 401 state
2. User avatar remains visible (because login method is stored)
3. User can click avatar and select logout
4. Logout works even if API call fails
5. User returns to clean authentication state

## Backward Compatibility

- ✅ No breaking changes to existing functionality
- ✅ OSS mode behavior unchanged
- ✅ Only affects SAAS mode when users have stored login methods
- ✅ Existing authenticated users see no difference

## Files Modified

- `frontend/src/hooks/use-should-show-user-features.ts` - Core logic fix
- `frontend/src/hooks/mutation/use-logout.ts` - Error handling improvement
- `frontend/__tests__/hooks/use-should-show-user-features.test.tsx` - New tests
- `frontend/__tests__/hooks/mutation/use-logout.test.tsx` - New tests

@amanape can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a280a298b370494ca38a6179b6d2da29)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2d51d14-nikolaik   --name openhands-app-2d51d14   docker.all-hands.dev/all-hands-ai/openhands:2d51d14
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/frontend-401-stuck-state openhands
```