### PR TITLE
feat(frontend): should not show the feedback buttons until there are messages visible.

### DIFF
--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -219,15 +219,17 @@ export function ChatInterface() {
 
         <div className="flex flex-col gap-[6px] px-4 pb-4">
           <div className="flex justify-between relative">
-            <TrajectoryActions
-              onPositiveFeedback={() =>
-                onClickShareFeedbackActionButton("positive")
-              }
-              onNegativeFeedback={() =>
-                onClickShareFeedbackActionButton("negative")
-              }
-              isSaasMode={config?.APP_MODE === "saas"}
-            />
+            {events.length > 0 && (
+              <TrajectoryActions
+                onPositiveFeedback={() =>
+                  onClickShareFeedbackActionButton("positive")
+                }
+                onNegativeFeedback={() =>
+                  onClickShareFeedbackActionButton("negative")
+                }
+                isSaasMode={config?.APP_MODE === "saas"}
+              />
+            )}
 
             <div className="absolute left-1/2 transform -translate-x-1/2 bottom-0">
               {curAgentState === AgentState.RUNNING && <TypingIndicator />}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

- We should not show the feedback buttons until there are messages visible.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR hides the feedback buttons until there are messages visible.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/ba28612f-5390-4b6c-8c77-da2afd78861b

---
**Link of any specific issues this addresses:**
