### PR TITLE
feat(frontend): make the action panel take 50% width.

### DIFF
--- a/frontend/src/components/features/conversation/conversation-main.tsx
+++ b/frontend/src/components/features/conversation/conversation-main.tsx
@@ -80,7 +80,7 @@ export function ConversationMain() {
       <ResizablePanel
         orientation={Orientation.HORIZONTAL}
         className="grow h-full min-h-0 min-w-0"
-        initialSize={500}
+        initialSize={(width - 101) * 0.5}
         firstClassName="overflow-hidden bg-base"
         secondClassName="flex flex-col overflow-hidden"
         firstChild={


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

- We need to make the action panel take 50% width.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR makes the action panel take 50% width.

We can refer to the video below for more information.

<img width="1440" height="743" alt="all-3116" src="https://github.com/user-attachments/assets/bb9b0207-6cf3-4b14-b57e-01bc0b09c85f" />

---
**Link of any specific issues this addresses:**
