### PR TITLE
refactor(frontend): improve context menu provider.

### DIFF
--- a/frontend/src/components/features/controls/git-tools-submenu.tsx
+++ b/frontend/src/components/features/controls/git-tools-submenu.tsx
@@ -18,10 +18,10 @@ import ArrowDownIcon from "#/icons/u-arrow-down.svg?react";
 import PrIcon from "#/icons/u-pr.svg?react";
 import CodeBranchIcon from "#/icons/u-code-branch.svg?react";
 import { I18nKey } from "#/i18n/declaration";
+import { CONTEXT_MENU_ICON_TEXT_CLASSNAME } from "#/utils/constants";
 
 const contextMenuListItemClassName =
   "cursor-pointer p-0 h-auto hover:bg-transparent px-[6px] !w-auto whitespace-nowrap";
-
 interface GitToolsSubmenuProps {
   onClose: () => void;
 }
@@ -66,6 +66,7 @@ export function GitToolsSubmenu({ onClose }: GitToolsSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<ArrowDownIcon width={16} height={16} />}
           text={t(I18nKey.COMMON$GIT_PULL)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
 
@@ -77,6 +78,7 @@ export function GitToolsSubmenu({ onClose }: GitToolsSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<ArrowUpIcon width={16} height={16} />}
           text={t(I18nKey.COMMON$GIT_PUSH)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
 
@@ -88,6 +90,7 @@ export function GitToolsSubmenu({ onClose }: GitToolsSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<PrIcon width={16} height={16} />}
           text={t(I18nKey.COMMON$CREATE_PR)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
 
@@ -99,6 +102,7 @@ export function GitToolsSubmenu({ onClose }: GitToolsSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<CodeBranchIcon width={16} height={16} />}
           text={t(I18nKey.COMMON$CREATE_NEW_BRANCH)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
     </ContextMenu>

--- a/frontend/src/components/features/controls/git-tools-submenu.tsx
+++ b/frontend/src/components/features/controls/git-tools-submenu.tsx
@@ -56,7 +56,7 @@ export function GitToolsSubmenu({ onClose }: GitToolsSubmenuProps) {
   return (
     <ContextMenu
       testId="git-tools-submenu"
-      className="text-white bg-tertiary rounded-[6px] py-[6px] flex flex-col gap-2 w-max"
+      className="text-white bg-tertiary rounded-[6px] py-[6px] px-1 flex flex-col gap-2 w-max"
     >
       <ContextMenuListItem
         testId="git-pull-button"

--- a/frontend/src/components/features/controls/macros-submenu.tsx
+++ b/frontend/src/components/features/controls/macros-submenu.tsx
@@ -11,6 +11,7 @@ import WaterIcon from "#/icons/u-water.svg?react";
 import { I18nKey } from "#/i18n/declaration";
 import { setMessageToSend } from "#/state/conversation-slice";
 import { REPO_SUGGESTIONS } from "#/utils/suggestions/repo-suggestions";
+import { CONTEXT_MENU_ICON_TEXT_CLASSNAME } from "#/utils/constants";
 
 const contextMenuListItemClassName =
   "cursor-pointer p-0 h-auto hover:bg-transparent px-[6px] !w-auto whitespace-nowrap";
@@ -53,6 +54,7 @@ export function MacrosSubmenu({ onClose }: MacrosSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<TachometerFastIcon width={16} height={16} />}
           text={t(I18nKey.INCREASE_TEST_COVERAGE)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
 
@@ -64,6 +66,7 @@ export function MacrosSubmenu({ onClose }: MacrosSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<DocumentIcon width={16} height={16} />}
           text={t(I18nKey.FIX_README)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
 
@@ -75,6 +78,7 @@ export function MacrosSubmenu({ onClose }: MacrosSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<PrStatusIcon width={16} height={16} />}
           text={t(I18nKey.AUTO_MERGE_PRS)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
 
@@ -86,6 +90,7 @@ export function MacrosSubmenu({ onClose }: MacrosSubmenuProps) {
         <ToolsContextMenuIconText
           icon={<WaterIcon width={16} height={16} />}
           text={t(I18nKey.CLEAN_DEPENDENCIES)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
     </ContextMenu>

--- a/frontend/src/components/features/controls/macros-submenu.tsx
+++ b/frontend/src/components/features/controls/macros-submenu.tsx
@@ -43,7 +43,7 @@ export function MacrosSubmenu({ onClose }: MacrosSubmenuProps) {
   return (
     <ContextMenu
       testId="macros-submenu"
-      className="text-white bg-tertiary rounded-[6px] py-[6px] flex flex-col gap-2 overflow-visible"
+      className="text-white bg-tertiary rounded-[6px] py-[6px] px-1 flex flex-col gap-2 overflow-visible"
     >
       <ContextMenuListItem
         testId="increase-test-coverage-button"

--- a/frontend/src/components/features/controls/tools-context-menu-icon-text.tsx
+++ b/frontend/src/components/features/controls/tools-context-menu-icon-text.tsx
@@ -1,16 +1,25 @@
+import { cn } from "#/utils/utils";
+
 interface ToolsContextMenuIconTextProps {
   icon: React.ReactNode;
   text: string;
   rightIcon?: React.ReactNode;
+  className?: string;
 }
 
 export function ToolsContextMenuIconText({
   icon,
   text,
   rightIcon,
+  className,
 }: ToolsContextMenuIconTextProps) {
   return (
-    <div className="flex items-center justify-between p-2 hover:bg-[#5C5D62] rounded">
+    <div
+      className={cn(
+        "flex items-center justify-between p-2 hover:bg-[#5C5D62] rounded",
+        className,
+      )}
+    >
       <div className="flex items-center gap-2">
         {icon}
         {text}

--- a/frontend/src/components/features/controls/tools-context-menu.tsx
+++ b/frontend/src/components/features/controls/tools-context-menu.tsx
@@ -46,7 +46,7 @@ export function ToolsContextMenu({
       ref={ref}
       testId="tools-context-menu"
       className={cn(
-        "flex flex-col gap-2 left-[-16px] absolute mb-2 z-50 text-white bg-tertiary rounded-[6px] py-[6px]",
+        "flex flex-col gap-2 left-[-16px] absolute mb-2 z-50 text-white bg-tertiary rounded-[6px] py-[6px] px-1",
         "bottom-full overflow-visible",
       )}
     >
@@ -88,7 +88,7 @@ export function ToolsContextMenu({
         </div>
       </div>
 
-      <ContextMenuSeparator className="bg-[#959CB2]" />
+      <ContextMenuSeparator className="bg-[#5C5D62]" />
 
       {/* Show Available Microagents */}
       <ContextMenuListItem

--- a/frontend/src/components/features/controls/tools-context-menu.tsx
+++ b/frontend/src/components/features/controls/tools-context-menu.tsx
@@ -17,9 +17,12 @@ import CarretRightFillIcon from "#/icons/carret-right-fill.svg?react";
 import { ToolsContextMenuIconText } from "./tools-context-menu-icon-text";
 import { GitToolsSubmenu } from "./git-tools-submenu";
 import { MacrosSubmenu } from "./macros-submenu";
+import { CONTEXT_MENU_ICON_TEXT_CLASSNAME } from "#/utils/constants";
 
-const contextMenuListItemClassName =
-  "cursor-pointer p-0 h-auto hover:bg-transparent px-[6px]";
+const contextMenuListItemClassName = cn(
+  "cursor-pointer p-0 h-auto hover:bg-transparent",
+  CONTEXT_MENU_ICON_TEXT_CLASSNAME,
+);
 
 interface ToolsContextMenuProps {
   onClose: () => void;
@@ -45,10 +48,7 @@ export function ToolsContextMenu({
     <ContextMenu
       ref={ref}
       testId="tools-context-menu"
-      className={cn(
-        "flex flex-col gap-2 left-[-16px] absolute mb-2 z-50 text-white bg-tertiary rounded-[6px] py-[6px] px-1",
-        "bottom-full overflow-visible",
-      )}
+      className="flex flex-col gap-2 left-[-16px] absolute mb-2 z-50 text-white bg-tertiary rounded-[6px] py-[6px] px-1 bottom-full overflow-visible"
     >
       {/* Git Tools */}
       {showGitTools && (
@@ -62,6 +62,7 @@ export function ToolsContextMenu({
               icon={<CodeBranchIcon width={16} height={16} />}
               text={t(I18nKey.COMMON$GIT_TOOLS)}
               rightIcon={<CarretRightFillIcon width={10} height={10} />}
+              className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
             />
           </ContextMenuListItem>
           <div className="absolute left-full top-[-6px] z-60 opacity-0 invisible pointer-events-none group-hover/git:opacity-100 group-hover/git:visible group-hover/git:pointer-events-auto hover:opacity-100 hover:visible hover:pointer-events-auto transition-all duration-200 ml-[1px]">
@@ -81,6 +82,7 @@ export function ToolsContextMenu({
             icon={<SettingsIcon width={16} height={16} />}
             text={t(I18nKey.COMMON$MACROS)}
             rightIcon={<CarretRightFillIcon width={10} height={10} />}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
         <div className="absolute left-full top-[-4px] z-60 opacity-0 invisible pointer-events-none group-hover/macros:opacity-100 group-hover/macros:visible group-hover/macros:pointer-events-auto hover:opacity-100 hover:visible hover:pointer-events-auto transition-all duration-200 ml-[1px]">
@@ -99,6 +101,7 @@ export function ToolsContextMenu({
         <ToolsContextMenuIconText
           icon={<RobotIcon width={16} height={16} />}
           text={t(I18nKey.CONVERSATION$SHOW_MICROAGENTS)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
 
@@ -111,6 +114,7 @@ export function ToolsContextMenu({
         <ToolsContextMenuIconText
           icon={<ToolsIcon width={16} height={16} />}
           text={t(I18nKey.BUTTON$SHOW_AGENT_TOOLS_AND_METADATA)}
+          className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
         />
       </ContextMenuListItem>
     </ContextMenu>

--- a/frontend/src/components/features/conversation/conversation-name-context-menu-icon-text.tsx
+++ b/frontend/src/components/features/conversation/conversation-name-context-menu-icon-text.tsx
@@ -1,14 +1,23 @@
+import { cn } from "#/utils/utils";
+
 interface ConversationNameContextMenuIconTextProps {
   icon: React.ReactNode;
   text: string;
+  className?: string;
 }
 
 export function ConversationNameContextMenuIconText({
   icon,
   text,
+  className,
 }: ConversationNameContextMenuIconTextProps) {
   return (
-    <div className="flex items-center gap-2 p-2 hover:bg-[#5C5D62] rounded">
+    <div
+      className={cn(
+        "flex items-center gap-2 p-2 hover:bg-[#5C5D62] rounded",
+        className,
+      )}
+    >
       {icon}
       {text}
     </div>

--- a/frontend/src/components/features/conversation/conversation-name-context-menu.tsx
+++ b/frontend/src/components/features/conversation/conversation-name-context-menu.tsx
@@ -58,7 +58,7 @@ export function ConversationNameContextMenu({
       ref={ref}
       testId="conversation-name-context-menu"
       className={cn(
-        "flex flex-col gap-2 left-0 absolute mt-2 z-50 text-white bg-tertiary rounded-[6px] py-[6px]",
+        "flex flex-col gap-2 left-0 absolute mt-2 z-50 text-white bg-tertiary rounded-[6px] py-[6px] px-1",
         position === "top" && "bottom-full",
         position === "bottom" && "top-full",
       )}
@@ -76,7 +76,7 @@ export function ConversationNameContextMenu({
         </ContextMenuListItem>
       )}
 
-      {hasTools && <ContextMenuSeparator className="bg-[#959CB2]" />}
+      {hasTools && <ContextMenuSeparator className="bg-[#5C5D62]" />}
 
       {onShowMicroagents && (
         <ContextMenuListItem
@@ -105,7 +105,7 @@ export function ConversationNameContextMenu({
       )}
 
       {(hasExport || hasDownload) && (
-        <ContextMenuSeparator className="bg-[#959CB2]" />
+        <ContextMenuSeparator className="bg-[#5C5D62]" />
       )}
 
       {onExportConversation && (
@@ -135,7 +135,7 @@ export function ConversationNameContextMenu({
       )}
 
       {(hasInfo || hasControl) && (
-        <ContextMenuSeparator className="bg-[#959CB2]" />
+        <ContextMenuSeparator className="bg-[#5C5D62]" />
       )}
 
       {onDisplayCost && (

--- a/frontend/src/components/features/conversation/conversation-name-context-menu.tsx
+++ b/frontend/src/components/features/conversation/conversation-name-context-menu.tsx
@@ -15,9 +15,12 @@ import CreditCardIcon from "#/icons/u-credit-card.svg?react";
 import CloseIcon from "#/icons/u-close.svg?react";
 import DeleteIcon from "#/icons/u-delete.svg?react";
 import { ConversationNameContextMenuIconText } from "./conversation-name-context-menu-icon-text";
+import { CONTEXT_MENU_ICON_TEXT_CLASSNAME } from "#/utils/constants";
 
-const contextMenuListItemClassName =
-  "cursor-pointer p-0 h-auto hover:bg-transparent px-[6px]";
+const contextMenuListItemClassName = cn(
+  "cursor-pointer p-0 h-auto hover:bg-transparent",
+  CONTEXT_MENU_ICON_TEXT_CLASSNAME,
+);
 
 interface ConversationNameContextMenuProps {
   onClose: () => void;
@@ -72,6 +75,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<EditIcon width={16} height={16} />}
             text={t(I18nKey.BUTTON$RENAME)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}
@@ -87,6 +91,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<RobotIcon width={16} height={16} />}
             text={t(I18nKey.CONVERSATION$SHOW_MICROAGENTS)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}
@@ -100,6 +105,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<ToolsIcon width={16} height={16} />}
             text={t(I18nKey.BUTTON$SHOW_AGENT_TOOLS_AND_METADATA)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}
@@ -117,6 +123,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<FileExportIcon width={16} height={16} />}
             text={t(I18nKey.BUTTON$EXPORT_CONVERSATION)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}
@@ -130,6 +137,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<DownloadIcon width={16} height={16} />}
             text={t(I18nKey.BUTTON$DOWNLOAD_VIA_VSCODE)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}
@@ -147,6 +155,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<CreditCardIcon width={16} height={16} />}
             text={t(I18nKey.BUTTON$DISPLAY_COST)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}
@@ -160,6 +169,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<CloseIcon width={16} height={16} />}
             text={t(I18nKey.COMMON$CLOSE_CONVERSATION_STOP_RUNTIME)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}
@@ -173,6 +183,7 @@ export function ConversationNameContextMenu({
           <ConversationNameContextMenuIconText
             icon={<DeleteIcon width={16} height={16} />}
             text={t(I18nKey.COMMON$DELETE_CONVERSATION)}
+            className={CONTEXT_MENU_ICON_TEXT_CLASSNAME}
           />
         </ContextMenuListItem>
       )}

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -52,3 +52,5 @@ export const GIT_PROVIDER_OPTIONS = [
     value: "bitbucket",
   },
 ];
+
+export const CONTEXT_MENU_ICON_TEXT_CLASSNAME = "h-[30px]";


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

- Context menu divider takes full width when it should be partial width just like the other context menus.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR improves the context menu provider.

We can refer to the video below for more information.

https://github.com/user-attachments/assets/2a16b6e6-3440-4957-b5a9-c5b56da819d0

---
**Link of any specific issues this addresses:**
