### PR TITLE
refactor(frontend): update the styling for menu repository selector.

### DIFF
--- a/frontend/src/components/common/react-select-styles.ts
+++ b/frontend/src/components/common/react-select-styles.ts
@@ -114,7 +114,7 @@ export const providerDropdownStyles: StylesConfig<SelectOption, false> = {
       borderColor: "#727987",
     },
     "& .provider-dropdown__single-value": {
-      color: "#fff",
+      color: "#A3A3A3",
       fontSize: "0.75rem",
       fontWeight: "400",
       lineHeight: "1.25rem",
@@ -180,15 +180,14 @@ export const repoBranchDropdownStyles: StylesConfig<SelectOption, false> = {
   control: (provided) => ({
     ...provided,
     maxWidth: "auto",
-    height: "auto",
-    minHeight: "auto",
-    maxHeight: "auto",
-    padding: "0",
+    minHeight: "42px",
+    maxHeight: "42px",
     border: "1px solid #727987",
     backgroundColor: "#454545",
     borderRadius: "0.25rem",
     boxShadow: "none",
-    paddingLeft: "0.375rem",
+    padding: "0 0.75rem",
+    height: "42px",
     "> div:first-child": {
       transform: "translateY(-1px)",
     },
@@ -196,19 +195,19 @@ export const repoBranchDropdownStyles: StylesConfig<SelectOption, false> = {
       borderColor: "#727987",
     },
     "& .repo-branch-dropdown__single-value": {
-      color: "#fff",
+      color: "#A3A3A3",
       fontSize: "0.875rem",
       fontWeight: "400",
       lineHeight: "1.25rem",
     },
     "& .repo-branch-dropdown__value-container": {
-      height: "auto",
+      height: "42px",
       padding: "0 0.5rem",
       transform: "translateY(-1px)",
-      paddingLeft: "0.125rem",
+      paddingLeft: "0.25rem",
     },
     "& .repo-branch-dropdown__indicators-container": {
-      height: "auto",
+      height: "42px",
       padding: "0 0.5rem",
       "& > div": {
         padding: "0",
@@ -216,7 +215,7 @@ export const repoBranchDropdownStyles: StylesConfig<SelectOption, false> = {
     },
     "& .repo-branch-dropdown__indicators": {
       transform: "translateY(-1px)",
-      height: "auto",
+      height: "42px",
       padding: "0 0.5rem",
       "& > div": {
         padding: "0",

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -143,7 +143,7 @@ export function RepositorySelectionForm({
       testId="branch-dropdown"
       repositoryName={selectedRepository?.full_name}
       value={selectedBranch?.name || null}
-      placeholder="recent-branch"
+      placeholder=“your-branch"
       className="max-w-auto"
       disabled={!selectedRepository}
       onChange={handleBranchSelection}

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -127,7 +127,7 @@ export function RepositorySelectionForm({
       <GitRepositoryDropdown
         provider={selectedProvider || providers[0]}
         value={selectedRepository?.id || null}
-        placeholder="Search repositories..."
+        placeholder="user/recentrepo"
         disabled={!selectedProvider}
         onChange={handleRepoSelection}
         className="max-w-auto"
@@ -143,8 +143,8 @@ export function RepositorySelectionForm({
       testId="branch-dropdown"
       repositoryName={selectedRepository?.full_name}
       value={selectedBranch?.name || null}
-      placeholder="Select branch..."
-      className="max-w-[500px]"
+      placeholder="recent-branch"
+      className="max-w-auto"
       disabled={!selectedRepository}
       onChange={handleBranchSelection}
       styles={repoBranchDropdownStyles}
@@ -153,9 +153,9 @@ export function RepositorySelectionForm({
   );
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-[10px]">
+        <div className="flex items-center gap-[10px] pb-4">
           <RepoForkedIcon width={24} height={24} />
           <span className="leading-5 font-bold text-base text-white">
             {t(I18nKey.COMMON$OPEN_REPOSITORY)}
@@ -163,14 +163,16 @@ export function RepositorySelectionForm({
         </div>
       </div>
 
-      <div className="flex items-center justify-between">
-        <span className="text-sm text-white font-normal leading-5">
-          {t(I18nKey.HOME$SELECT_OR_INSERT_URL)}
-        </span>
-        {renderProviderSelector()}
+      <div className="flex flex-col gap-[10px] pb-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-white font-normal leading-[22px]">
+            {t(I18nKey.HOME$SELECT_OR_INSERT_URL)}
+          </span>
+          {renderProviderSelector()}
+        </div>
+        {renderRepositorySelector()}
+        {renderBranchSelector()}
       </div>
-      {renderRepositorySelector()}
-      {renderBranchSelector()}
 
       <BrandButton
         testId="repo-launch-button"

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -127,7 +127,7 @@ export function RepositorySelectionForm({
       <GitRepositoryDropdown
         provider={selectedProvider || providers[0]}
         value={selectedRepository?.id || null}
-        placeholder="user/recentrepo"
+        placeholder=“user/repo"
         disabled={!selectedProvider}
         onChange={handleRepoSelection}
         className="max-w-auto"

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -11632,10 +11632,10 @@
         "uk": "Натисніть тут"
     },
     "COMMON$OPEN_REPOSITORY": {
-        "en": "Open repository",
+        "en": "Open Repository",
         "ja": "リポジトリを開く",
         "zh-CN": "打开仓库",
-        "zh-TW": "開啟存儲庫",
+        "zh-TW": "打開存儲庫",
         "ko-KR": "저장소 열기",
         "no": "Åpne repository",
         "it": "Apri repository",
@@ -11643,7 +11643,7 @@
         "es": "Abrir repositorio",
         "ar": "افتح المستودع",
         "fr": "Ouvrir le dépôt",
-        "tr": "Depoyu aç",
+        "tr": "Depoyu Aç",
         "de": "Repository öffnen",
         "uk": "Відкрити репозиторій"
     },


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance criteria:**
- Vertical gap is too wide.
- Dropdown input styles are inconsistent.
- Padding adjustments needed.
- Gap between icon and placeholder/text is incorrect.
- Heading capitalization should be consistent.
- Verify expected font sizes and colors.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates the styling for menu repository selector.

We can refer to the image below for the output of the PR.

<img width="1440" height="743" alt="all-3112" src="https://github.com/user-attachments/assets/b535fe2a-8953-4b02-a35b-6104e71c400a" />

---
**Link of any specific issues this addresses:**
