### PR TITLE
fix(cli): remove unused mouse support and fix settings autocomplete

### DIFF
--- a/openhands/cli/settings.py
+++ b/openhands/cli/settings.py
@@ -241,7 +241,7 @@ async def modify_llm_settings_basic(
     provider_list = [p for p in provider_list if p not in verified_providers]
     provider_list = verified_providers + provider_list
 
-    provider_completer = FuzzyWordCompleter(provider_list)
+    provider_completer = FuzzyWordCompleter(provider_list, WORD=True)
     session = PromptSession(key_bindings=kb_cancel())
 
     current_provider, current_model, current_api_key = (
@@ -392,7 +392,7 @@ async def modify_llm_settings_basic(
             )
 
             if change_model:
-                model_completer = FuzzyWordCompleter(provider_models)
+                model_completer = FuzzyWordCompleter(provider_models, WORD=True)
 
                 # Define a validator function that allows custom models but shows a warning
                 def model_validator(x):
@@ -528,7 +528,7 @@ async def modify_llm_settings_advanced(
         )
 
         agent_list = Agent.list_agents()
-        agent_completer = FuzzyWordCompleter(agent_list)
+        agent_completer = FuzzyWordCompleter(agent_list, WORD=True)
         agent = await get_validated_input(
             session,
             '(Step 4/6) Agent (TAB for options, CTRL-c to cancel): ',

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -906,7 +906,6 @@ def cli_confirm(
         layout=layout,
         key_bindings=kb,
         style=style,
-        mouse_support=True,
         full_screen=False,
     )
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

1. Removes unused mouse support from the CLI to allow scrolling
2. Fixes settings autocomplete so it no longer stops at hyphens

Screenshot of the now-working autocomplete:
<img width="583" height="170" alt="image" src="https://github.com/user-attachments/assets/53cb9aba-dfcf-436f-90f0-988c0b4ee3e1" />

---
**Link of any specific issues this addresses:**
