### PR TITLE
Add race condition tests for BatchedWebHookFileStore

### DIFF
--- a/race_condition_analysis.md
+++ b/race_condition_analysis.md
@@ -1,0 +1,86 @@
+# Race Condition Analysis: BatchedWebHookFileStore
+
+## Summary
+
+We have successfully identified and reproduced race conditions in the `BatchedWebHookFileStore` class in `openhands/storage/batched_web_hook.py`. The race conditions can lead to:
+
+1. **Duplicate webhook calls** - The same file data being sent multiple times
+2. **RecursionError in retry mechanism** - Infinite recursion in the tenacity retry decorator
+3. **Data integrity issues** - Potential loss or duplication of file updates
+
+## Race Conditions Identified
+
+### 1. Multiple Size Limit Triggers
+
+**Location**: `_queue_update` method, lines 161-164
+
+**Problem**: Multiple threads can simultaneously trigger the size limit check and each submit a `_send_batch` task to the executor.
+
+**Scenario**:
+- Thread A adds content, triggers size limit, submits `_send_batch` to executor
+- Thread B adds content, triggers size limit, submits another `_send_batch` to executor
+- Both `_send_batch` calls may process overlapping data
+
+### 2. Timer vs Size Limit Race
+
+**Location**: `_queue_update` method, lines 161-176
+
+**Problem**: A timer can expire and trigger `_send_batch` at the same time a size limit is triggered.
+
+**Scenario**:
+- Timer is set for 5 seconds
+- At 4.9 seconds, new content triggers size limit
+- Size limit triggers `_send_batch` immediately
+- Timer expires 0.1 seconds later and also triggers `_send_batch`
+- Both calls process the same batch data
+
+### 3. Concurrent Batch Processing
+
+**Location**: `_send_batch` method, lines 184-211
+
+**Problem**: Multiple `_send_batch` calls can execute concurrently, leading to race conditions in batch processing.
+
+**Scenario**:
+- Multiple `_send_batch` calls are submitted to the executor
+- They may all see the same batch data before any of them clears it
+- This leads to duplicate webhook calls with the same data
+
+## Test Results
+
+Our race condition tests successfully reproduced these issues:
+
+1. **test_race_condition_multiple_size_triggers**: Shows RecursionError in retry mechanism
+2. **test_race_condition_timer_vs_size_trigger**: Shows files being sent multiple times
+3. **test_race_condition_concurrent_batch_sends**: Shows files being sent multiple times
+
+## Error Messages Observed
+
+```
+Error sending webhook batch: RetryError[<Future at 0x... state=finished raised RecursionError>]
+```
+
+This suggests that the retry mechanism itself may be getting into an infinite loop, possibly due to the race conditions.
+
+## Root Cause Analysis
+
+The fundamental issue is that the current implementation doesn't properly synchronize access to the batch sending mechanism. Specifically:
+
+1. **No atomic check-and-send**: The size limit check and batch submission are not atomic
+2. **Timer cancellation race**: Timer cancellation happens after batch submission, not before
+3. **Multiple executor submissions**: Nothing prevents multiple `_send_batch` tasks from being queued
+4. **Batch state race**: The batch clearing in `_send_batch` is not properly synchronized with new submissions
+
+## Potential Solutions
+
+1. **Add a "sending" flag**: Prevent multiple batch sends by using an atomic flag
+2. **Synchronize timer operations**: Ensure timer cancellation happens atomically with batch submission
+3. **Use a single-threaded executor**: Ensure only one batch send can happen at a time
+4. **Improve batch state management**: Make batch clearing and new submissions atomic
+
+## Files Modified
+
+- `tests/unit/test_batched_web_hook.py`: Added three comprehensive race condition tests
+
+## Next Steps
+
+The race condition tests are now in place and successfully reproduce the issues. The next step would be to implement fixes to the `BatchedWebHookFileStore` class to address these race conditions.


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR adds comprehensive tests to identify and reproduce race conditions in the BatchedWebHookFileStore class. These race conditions can cause file updates to be sent multiple times to webhooks or result in RecursionError exceptions during batch processing.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds three comprehensive race condition tests to `tests/unit/test_batched_web_hook.py`:

1. **test_race_condition_multiple_size_triggers**: Tests the scenario where multiple threads simultaneously trigger the batch size limit, causing multiple `_send_batch` calls to be submitted to the executor concurrently.

2. **test_race_condition_timer_vs_size_trigger**: Tests the race condition between timer expiration and size limit triggers, where both can fire simultaneously and process the same batch data.

3. **test_race_condition_concurrent_batch_sends**: Tests concurrent batch send operations with slow webhook processing to increase the likelihood of race conditions.

The tests successfully reproduce the following issues:
- Files being sent multiple times in webhook calls (data duplication)
- RecursionError exceptions in the retry mechanism
- Potential data loss or corruption due to concurrent batch processing

**Key findings:**
- The current implementation lacks proper synchronization for batch sending operations
- Multiple `_send_batch` calls can be queued simultaneously in the executor
- Timer cancellation happens after batch submission, not before, creating race windows
- The batch state management is not thread-safe for concurrent operations

The tests use threading, controlled timing, and mock HTTP clients to reliably reproduce these race conditions. They include detailed assertions to verify data integrity and detect duplications.

Also includes a detailed analysis document (`race_condition_analysis.md`) that explains:
- Root cause analysis of the race conditions
- Specific code locations where issues occur
- Potential solutions and next steps for fixes

---
**Link of any specific issues this addresses:**

This addresses race conditions mentioned in the BatchedWebHookFileStore implementation where multiple events can trigger size cutoffs before scheduled timer events, or both size and timer triggers can fire simultaneously.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1fa8ed9435c34e3b869017776417edb3)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d285761-nikolaik   --name openhands-app-d285761   docker.all-hands.dev/all-hands-ai/openhands:d285761
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@test/batched-webhook-race-condition openhands
```