### PR TITLE
docs(server): clarify session concepts and consistency across modes (#10336)

### DIFF
--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -39,7 +39,11 @@ WAIT_TIME_BEFORE_CLOSE_INTERVAL = 5
 
 
 class AgentSession:
-    """Represents a session with an Agent
+    """Conversation-scoped agent lifecycle manager.
+
+    This class is transport-agnostic and manages the runtime, memory and
+    agent controller for a single conversation. It is used by the web server
+    via the Web Session wrapper and could be used in a similar way by the CLI.
 
     Attributes:
         controller: The AgentController instance for controlling the agent.

--- a/openhands/server/session/conversation.py
+++ b/openhands/server/session/conversation.py
@@ -10,6 +10,14 @@ from openhands.utils.async_utils import call_sync_from_async
 
 
 class ServerConversation:
+    """Attachable conversation facade used by the web server.
+
+    This object can either attach to an existing runtime for a given conversation
+    (identified by `sid`, a.k.a. conversation_id) or create a lightweight
+    connection to stream events. It does not own the agent lifecycle like
+    AgentSession; it simply provides a way to subscribe/relay events.
+    """
+
     sid: str
     file_store: FileStore
     event_stream: EventStream

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -38,6 +38,14 @@ from openhands.storage.files import FileStore
 
 
 class Session:
+    """Web server-bound session wrapper.
+
+    Manages a single web client connection and orchestrates the AgentSession lifecycle
+    for that conversation. Conceptually this is a WebSession. The attribute `sid` is
+    the conversation_id which uniquely identifies a conversation and is shared across
+    all modes (Web, CLI, Headless).
+    """
+
     sid: str
     sio: socketio.AsyncServer | None
     last_active_ts: int = 0
@@ -81,6 +89,11 @@ class Session:
         )
         self.loop = asyncio.get_event_loop()
         self.user_id = user_id
+
+    @property
+    def conversation_id(self) -> str:
+        """Alias for sid to emphasize conversation identity across modes."""
+        return self.sid
 
     async def close(self) -> None:
         if self.sio:


### PR DESCRIPTION
(vibe-testing GPT-5 on arch; extracting small stuff from a conversation)

This PR proposes a few missing docstrings, while the agent was figuring out sessions and conversations, and which is web-specific and which isn't.

Sort of part of
- https://github.com/All-Hands-AI/OpenHands/issues/10336

---

(OpenHands-GPT-5 write-up)
Introduce clearer session semantics across the server components and add a small convenience alias.

- Add explanatory docstrings to:
  - openhands/server/session/session.py (web-bound session wrapper)
  - openhands/server/session/agent_session.py (transport-agnostic conversation manager)
  - openhands/server/session/conversation.py (attachable conversation facade)
- Explicitly note that `sid` is the conversation identifier shared across Web, CLI, and Headless modes
- Add `conversation_id` property alias on Session for readability (non-breaking)

Why
- Addresses Issue #10336 by documenting and aligning on the conceptual model of "sessions" vs "conversations" across the app. This reduces ambiguity between web server Session/AgentSession and sid/conversation_id used in CLI and headless mode.
- Provides a foundation for potential future renames (e.g., Session -> WebSession; possible CLISession) without breaking API today.

Notes
- No behavior changes; purely documentation/clarity + a read-only alias.
- All pre-commit hooks pass locally.

References
- Closes #10336

Co-authored-by: OpenHands-GPT-5 <openhands@all-hands.dev>

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ce66bc6-nikolaik   --name openhands-app-ce66bc6   docker.all-hands.dev/all-hands-ai/openhands:ce66bc6
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@chore/session-architecture-10336 openhands
```