### PR TITLE
CLI vi mode is activated when standard env variables EDITOR/VISUAL are set to vi

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -132,6 +132,29 @@ def load_from_env(
     # load default agent config from env
     default_agent_config = cfg.get_agent_config()
     set_attr_from_env(default_agent_config, 'AGENT_')
+    
+    # Auto-enable vi_mode for CLI config if EDITOR or VISUAL are set to vim-like editors
+    # Only do this if CLI_VI_MODE is not explicitly set
+    if 'CLI_VI_MODE' not in env_or_toml_dict and not cfg.cli.vi_mode:
+        editor = env_or_toml_dict.get('EDITOR', '').lower()
+        visual = env_or_toml_dict.get('VISUAL', '').lower()
+        
+        # Check if either EDITOR or VISUAL contains vim-like editor names
+        vim_editors = {'vi', 'vim', 'nvim'}
+        
+        # Extract just the command name (remove path and arguments)
+        def get_command_name(editor_path: str) -> str:
+            if not editor_path:
+                return ''
+            # Split by spaces to get the command part, then get the basename
+            command = editor_path.split()[0] if editor_path.split() else ''
+            return os.path.basename(command)
+        
+        editor_cmd = get_command_name(editor)
+        visual_cmd = get_command_name(visual)
+        
+        if editor_cmd in vim_editors or visual_cmd in vim_editors:
+            cfg.cli.vi_mode = True
 
 
 def load_from_toml(cfg: OpenHandsConfig, toml_file: str = 'config.toml') -> None:

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -132,16 +132,16 @@ def load_from_env(
     # load default agent config from env
     default_agent_config = cfg.get_agent_config()
     set_attr_from_env(default_agent_config, 'AGENT_')
-    
+
     # Auto-enable vi_mode for CLI config if EDITOR or VISUAL are set to vim-like editors
     # Only do this if CLI_VI_MODE is not explicitly set
     if 'CLI_VI_MODE' not in env_or_toml_dict and not cfg.cli.vi_mode:
         editor = env_or_toml_dict.get('EDITOR', '').lower()
         visual = env_or_toml_dict.get('VISUAL', '').lower()
-        
+
         # Check if either EDITOR or VISUAL contains vim-like editor names
         vim_editors = {'vi', 'vim', 'nvim'}
-        
+
         # Extract just the command name (remove path and arguments)
         def get_command_name(editor_path: str) -> str:
             if not editor_path:
@@ -149,10 +149,10 @@ def load_from_env(
             # Split by spaces to get the command part, then get the basename
             command = editor_path.split()[0] if editor_path.split() else ''
             return os.path.basename(command)
-        
+
         editor_cmd = get_command_name(editor)
         visual_cmd = get_command_name(visual)
-        
+
         if editor_cmd in vim_editors or visual_cmd in vim_editors:
             cfg.cli.vi_mode = True
 

--- a/tests/unit/test_cli_vi_mode.py
+++ b/tests/unit/test_cli_vi_mode.py
@@ -87,3 +87,113 @@ class TestCliViMode:
         assert config.cli.vi_mode is True, (
             'vi_mode should be True when CLI_VI_MODE is set'
         )
+
+    @patch.dict(os.environ, {'EDITOR': 'vim'})
+    def test_vi_mode_auto_enabled_from_editor_vim(self):
+        """Test that vi_mode is automatically enabled when EDITOR is set to vim."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is True, (
+            'vi_mode should be True when EDITOR is set to vim'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': 'nvim'})
+    def test_vi_mode_auto_enabled_from_editor_nvim(self):
+        """Test that vi_mode is automatically enabled when EDITOR is set to nvim."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is True, (
+            'vi_mode should be True when EDITOR is set to nvim'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': 'vi'})
+    def test_vi_mode_auto_enabled_from_editor_vi(self):
+        """Test that vi_mode is automatically enabled when EDITOR is set to vi."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is True, (
+            'vi_mode should be True when EDITOR is set to vi'
+        )
+
+    @patch.dict(os.environ, {'VISUAL': 'vim'})
+    def test_vi_mode_auto_enabled_from_visual_vim(self):
+        """Test that vi_mode is automatically enabled when VISUAL is set to vim."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is True, (
+            'vi_mode should be True when VISUAL is set to vim'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': '/usr/bin/vim'})
+    def test_vi_mode_auto_enabled_from_editor_with_path(self):
+        """Test that vi_mode is automatically enabled when EDITOR is set to vim with full path."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is True, (
+            'vi_mode should be True when EDITOR is set to /usr/bin/vim'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': 'vim -n'})
+    def test_vi_mode_auto_enabled_from_editor_with_args(self):
+        """Test that vi_mode is automatically enabled when EDITOR is set to vim with arguments."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is True, (
+            'vi_mode should be True when EDITOR is set to "vim -n"'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': 'nano', 'VISUAL': ''})
+    def test_vi_mode_not_auto_enabled_from_editor_nano(self):
+        """Test that vi_mode is not automatically enabled when EDITOR is set to nano."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is False, (
+            'vi_mode should be False when EDITOR is set to nano'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': 'emacs', 'VISUAL': ''})
+    def test_vi_mode_not_auto_enabled_from_editor_emacs(self):
+        """Test that vi_mode is not automatically enabled when EDITOR is set to emacs."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is False, (
+            'vi_mode should be False when EDITOR is set to emacs'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': 'vim', 'CLI_VI_MODE': 'False'})
+    def test_explicit_cli_vi_mode_overrides_editor(self):
+        """Test that explicit CLI_VI_MODE=False overrides EDITOR=vim."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is False, (
+            'CLI_VI_MODE=False should override EDITOR=vim'
+        )
+
+    @patch.dict(os.environ, {'EDITOR': 'nano', 'CLI_VI_MODE': 'True'})
+    def test_explicit_cli_vi_mode_overrides_non_vim_editor(self):
+        """Test that explicit CLI_VI_MODE=True overrides EDITOR=nano."""
+        from openhands.core.config.utils import load_from_env
+
+        config = OpenHandsConfig()
+        load_from_env(config, os.environ)
+        assert config.cli.vi_mode is True, (
+            'CLI_VI_MODE=True should override EDITOR=nano'
+        )


### PR DESCRIPTION
Similar to the already existing CLI_VI_MODE environment variable, but EDITOR and VISUAL are standard and commonly set by vi/vim/nvim users.

- Auto-enable vi_mode in CLI when standard EDITOR or VISUAL environment variables contain vi, vim, or nvim.
- Supports full paths (e.g., /usr/bin/vim) and command arguments (e.g., vim -n)
- Explicit CLI_VI_MODE setting still takes precedence over auto-detection
- Added comprehensive tests covering various scenarios including edge cases
- Maintains backward compatibility with existing CLI_VI_MODE environment variable

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
