### PR TITLE
cli: fix Ubuntu white-on-white model autocomplete by merging default prompt_toolkit UI style

### DIFF
--- a/openhands/cli/pt_style.py
+++ b/openhands/cli/pt_style.py
@@ -1,0 +1,27 @@
+from prompt_toolkit.styles import Style, merge_styles
+from prompt_toolkit.styles.defaults import default_ui_style
+
+# Centralized helper for CLI styles so we can safely merge our custom colors
+# with prompt_toolkit's default UI style. This preserves completion menu and
+# fuzzy-match visibility across different terminal themes (e.g., Ubuntu).
+
+COLOR_GOLD = '#FFD700'
+COLOR_GREY = '#808080'
+COLOR_AGENT_BLUE = '#4682B4'  # Steel blue - readable on light/dark backgrounds
+
+
+def get_cli_style() -> Style:
+    base = default_ui_style()
+    custom = Style.from_dict(
+        {
+            'gold': COLOR_GOLD,
+            'grey': COLOR_GREY,
+            'prompt': f'{COLOR_GOLD} bold',
+            # The following entries are mostly redundant because default_ui_style
+            # already sets sane values. We keep them minimal on purpose to avoid
+            # clutter and ensure high contrast on various themes.
+            # 'completion-menu': 'bg:#bbbbbb #000000',
+            # 'completion-menu.completion.current': 'reverse',
+        }
+    )
+    return merge_styles([base, custom])

--- a/openhands/cli/settings.py
+++ b/openhands/cli/settings.py
@@ -8,6 +8,7 @@ from prompt_toolkit.shortcuts import print_container
 from prompt_toolkit.widgets import Frame, TextArea
 from pydantic import SecretStr
 
+from openhands.cli.pt_style import get_cli_style
 from openhands.cli.tui import (
     COLOR_GREY,
     UserCancelledError,
@@ -242,7 +243,7 @@ async def modify_llm_settings_basic(
     provider_list = verified_providers + provider_list
 
     provider_completer = FuzzyWordCompleter(provider_list, WORD=True)
-    session = PromptSession(key_bindings=kb_cancel())
+    session = PromptSession(key_bindings=kb_cancel(), style=get_cli_style())
 
     current_provider, current_model, current_api_key = (
         _get_current_values_for_modification_basic(config)
@@ -490,7 +491,7 @@ async def modify_llm_settings_basic(
 async def modify_llm_settings_advanced(
     config: OpenHandsConfig, settings_store: FileSettingsStore
 ) -> None:
-    session = PromptSession(key_bindings=kb_cancel())
+    session = PromptSession(key_bindings=kb_cancel(), style=get_cli_style())
     llm_config = config.get_llm_config()
 
     custom_model = None
@@ -621,7 +622,7 @@ async def modify_search_api_settings(
     config: OpenHandsConfig, settings_store: FileSettingsStore
 ) -> None:
     """Modify search API settings."""
-    session = PromptSession(key_bindings=kb_cancel())
+    session = PromptSession(key_bindings=kb_cancel(), style=get_cli_style())
 
     search_api_key = None
 

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -31,6 +31,12 @@ from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import Frame, TextArea
 
 from openhands import __version__
+from openhands.cli.pt_style import (
+    COLOR_AGENT_BLUE,
+    COLOR_GOLD,
+    COLOR_GREY,
+    get_cli_style,
+)
 from openhands.core.config import OpenHandsConfig
 from openhands.core.schema import AgentState
 from openhands.events import EventSource, EventStream
@@ -64,16 +70,8 @@ recent_thoughts: list[str] = []
 MAX_RECENT_THOUGHTS = 5
 
 # Color and styling constants
-COLOR_GOLD = '#FFD700'
-COLOR_GREY = '#808080'
-COLOR_AGENT_BLUE = '#4682B4'  # Steel blue - less saturated, works well on both light and dark backgrounds
-DEFAULT_STYLE = Style.from_dict(
-    {
-        'gold': COLOR_GOLD,
-        'grey': COLOR_GREY,
-        'prompt': f'{COLOR_GOLD} bold',
-    }
-)
+# Now sourced from pt_style to ensure we merge with prompt_toolkit defaults
+DEFAULT_STYLE = get_cli_style()
 
 COMMANDS = {
     '/exit': 'Exit the application',


### PR DESCRIPTION
Hi! I'm OpenHands-GPT-5, an automated developer assisting with improvements.

Context
- This addresses issue #10330: on some Ubuntu terminals, the CLI model autocomplete (prompt_toolkit) rendered white text on white background.

Root cause
- We passed a custom Style to PromptSession that replaced prompt_toolkit's default UI style. As a result, completion menu/fuzzy-match classes were missing, falling back to theme defaults; on some Ubuntu themes that meant white-on-white.

What this PR does
- Introduces a small helper: openhands/cli/pt_style.py with get_cli_style().
- get_cli_style() merges prompt_toolkit.styles.defaults.default_ui_style() with our minimal custom colors using merge_styles().
- Updates tui.py and settings.py to use get_cli_style() (and to import shared color constants).

Why this approach
- Centralized, minimal, and avoids OS-specific conditionals.
- Leverages prompt_toolkit defaults (per the references in the issue) to ensure proper contrast for completion menu and fuzzymatch classes across terminal themes.

Files changed
- add: openhands/cli/pt_style.py
- mod: openhands/cli/tui.py
- mod: openhands/cli/settings.py

Validation
- Backend pre-commit checks pass locally (ruff, mypy, etc.).

Co-authored-by: OpenHands-GPT-5 openhands@all-hands.dev