### PR TITLE
fix(frontend): status message missing

### DIFF
--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -122,5 +122,5 @@ export function getStatusCode(
     return runtimeStatus;
   }
 
-  return "STATUS$ERROR"; // illegal state
+  return I18nKey.CHAT_INTERFACE$AGENT_ERROR_MESSAGE; // illegal state
 }

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -122,5 +122,5 @@ export function getStatusCode(
     return runtimeStatus;
   }
 
-  return I18nKey.CHAT_INTERFACE$AGENT_ERROR_MESSAGE; // illegal state
+  return I18nKey.CHAT_INTERFACE$AGENT_ERROR_MESSAGE;
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

## 📝 Description
The agent’s status message displays as `STATUS$ERROR` instead of showing a meaningful, user-friendly error message.

---

## ✅ Expected Behavior
- Show a clear and descriptive error message instead of `STATUS$ERROR`.

---

## ❌ Current Behavior
- Status message is missing and appears as `STATUS$ERROR`.

---

## 🔁 Steps to Reproduce
1. Navigate to the **Conversation** page.
2. Trigger an error scenario for the agent.
3. Observe the status message displayed.

---

## 📷 Additional Context
Refer to the image below for details:

<img width="1088" height="722" alt="Image" src="https://github.com/user-attachments/assets/ce0e01f0-a475-4cdb-9d35-65b28297de41" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR adds the missing status message.

---
**Link of any specific issues this addresses:**

Resolves #10348 
