### PR TITLE
Added changes to resolve bug 10237

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -184,3 +184,13 @@ class LLMConfig(BaseModel):
         # Azure issue: https://github.com/All-Hands-AI/OpenHands/issues/7755
         if self.model.startswith('azure') and self.api_version is None:
             self.api_version = '2024-12-01-preview'
+
+        # Set AWS credentials as environment variables for LiteLLM Bedrock
+        if self.aws_access_key_id:
+            os.environ['AWS_ACCESS_KEY_ID'] = self.aws_access_key_id.get_secret_value()
+        if self.aws_secret_access_key:
+            os.environ['AWS_SECRET_ACCESS_KEY'] = (
+                self.aws_secret_access_key.get_secret_value()
+            )
+        if self.aws_region_name:
+            os.environ['AWS_REGION_NAME'] = self.aws_region_name


### PR DESCRIPTION

**Summarize what the PR does, explaining any non-trivial design decisions.**
This PR simply ensures aws credentials are set as environment variables when loading LLM configs.


---
**Link of any specific issues this addresses:** #10237 
