### PR TITLE
refactor(frontend): update the styling for recent conversations

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -51,7 +51,9 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
   } = usePaginatedConversations();
 
   // Flatten all pages into a single array of conversations
-  const conversations = data?.pages.flatMap((page) => page.results) ?? [];
+  let conversations = data?.pages.flatMap((page) => page.results) ?? [];
+
+  conversations = [...conversations, ...conversations, ...conversations];
 
   const { mutate: deleteConversation } = useDeleteConversation();
   const { mutate: stopConversation } = useStopConversation();

--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -51,9 +51,7 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
   } = usePaginatedConversations();
 
   // Flatten all pages into a single array of conversations
-  let conversations = data?.pages.flatMap((page) => page.results) ?? [];
-
-  conversations = [...conversations, ...conversations, ...conversations];
+  const conversations = data?.pages.flatMap((page) => page.results) ?? [];
 
   const { mutate: deleteConversation } = useDeleteConversation();
   const { mutate: stopConversation } = useStopConversation();

--- a/frontend/src/components/features/home/recent-conversations/recent-conversations-skeleton.tsx
+++ b/frontend/src/components/features/home/recent-conversations/recent-conversations-skeleton.tsx
@@ -1,6 +1,3 @@
-const getRandomNumber = (from = 3, to = 5) =>
-  Math.floor(Math.random() * (to - from + 1)) + from;
-
 function ConversationSkeleton() {
   return (
     <div className="flex flex-col gap-1 py-[14px]">
@@ -37,12 +34,11 @@ function RecentConversationSkeleton({
           <ConversationSkeleton key={index} />
         ))}
       </ul>
+      <div className="w-20 h-3 skeleton" />
     </div>
   );
 }
 
 export function RecentConversationsSkeleton() {
-  return Array.from({ length: getRandomNumber(2, 3) }).map((_, index) => (
-    <RecentConversationSkeleton key={index} items={getRandomNumber(3, 5)} />
-  ));
+  return <RecentConversationSkeleton />;
 }

--- a/frontend/src/components/features/home/tasks/task-suggestions.tsx
+++ b/frontend/src/components/features/home/tasks/task-suggestions.tsx
@@ -71,7 +71,7 @@ export function TaskSuggestions({ filterFor }: TaskSuggestionsProps) {
           displayedTaskGroups &&
           displayedTaskGroups.length > 0 && (
             <div className="flex flex-col">
-              <div className="transition-all duration-300 ease-in-out max-h-[420px] overflow-y-auto custom-scrollbar">
+              <div className="transition-all duration-300 ease-in-out overflow-y-auto custom-scrollbar">
                 <div className="flex flex-col">
                   {displayedTaskGroups.map((taskGroup, index) => (
                     <TaskGroup


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance criteria:**
- When in a loading state, there are more loading skeletons than needed. Since we show the top 3 before pressing “view more”, we should only show 3 skeletons.
- We now paginate conversations. If you open the conversation panel and scroll, the recent conversations section will also flicker between actual items and loading skeletons

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates the styling for recent conversations.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/0d0ac0d4-e58f-4930-a580-ccacf7bd3d3e

---
**Link of any specific issues this addresses:**
