### PR TITLE
fix(llm): include gpt-5 to fn call model; set top p default value to None

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -67,7 +67,7 @@ class LLMConfig(BaseModel):
         default=30_000
     )  # maximum number of characters in an observation's content when sent to the llm
     temperature: float = Field(default=0.0)
-    top_p: float | None = Field(default=None)
+    top_p: float = Field(default=1.0)
     top_k: float | None = Field(default=None)
     custom_llm_provider: str | None = Field(default=None)
     max_input_tokens: int | None = Field(default=None)

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -67,7 +67,7 @@ class LLMConfig(BaseModel):
         default=30_000
     )  # maximum number of characters in an observation's content when sent to the llm
     temperature: float = Field(default=0.0)
-    top_p: float = Field(default=1.0)
+    top_p: float | None = Field(default=None)
     top_k: float | None = Field(default=None)
     custom_llm_provider: str | None = Field(default=None)
     max_input_tokens: int | None = Field(default=None)

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -94,6 +94,7 @@ FUNCTION_CALLING_SUPPORTED_MODELS = [
     'kimi-k2-instruct',
     'Qwen3-Coder-480B-A35B-Instruct',
     'qwen3-coder',  # this will match both qwen3-coder-480b (openhands provider) and qwen3-coder (for openrouter)
+    'gpt-5',
     'gpt-5-2025-08-07',
 ]
 
@@ -108,6 +109,7 @@ REASONING_EFFORT_SUPPORTED_MODELS = [
     'o4-mini-2025-04-16',
     'gemini-2.5-flash',
     'gemini-2.5-pro',
+    'gpt-5',
     'gpt-5-2025-08-07',
 ]
 

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -111,6 +111,7 @@ REASONING_EFFORT_SUPPORTED_MODELS = [
     'gemini-2.5-pro',
     'gpt-5',
     'gpt-5-2025-08-07',
+    'claude-opus-4-1-20250805',  # we need to remove top_p for opus 4.1
 ]
 
 MODELS_WITHOUT_STOP_WORDS = [


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fix the issue in LLM arguments when using `gpt-5` and `opus-4-1`

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- make `top_p` None by default so it uses provider default and solves the opus-4-1 issue mentioned in https://github.com/All-Hands-AI/OpenHands/issues/10346
- add gpt-5 to fncall support model

---
**Link of any specific issues this addresses:**

Fix https://github.com/All-Hands-AI/OpenHands/issues/10346

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a8d21ef-nikolaik   --name openhands-app-a8d21ef   docker.all-hands.dev/all-hands-ai/openhands:a8d21ef
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@xw/fix-10346 openhands
```