### PR TITLE
DRAFT: Gemini latency investigation harness + LiteLLM raw request logging

### DIFF
--- a/Gemini-Latency-Investigation.md
+++ b/Gemini-Latency-Investigation.md
@@ -107,3 +107,11 @@ Potential differences to test for latency impact:
 - API credentials to run live tests
 - Whether to commit monkey patches vs behind a feature flag
 - Exact request payload produced by @google/genai for our tested scenarios (we can log via a small Node script)
+
+## Changes Implemented
+- OPENHANDS_GEMINI_CLI_COMPAT flag in OpenHands LLM to send thinking={type:'enabled'} and retain temperature/top_p for gemini-2.5-pro to mimic CLI.
+- experiments/gemini_latency_harness.py to benchmark OpenHands path.
+
+## TODO
+- Add minimal Node @google/genai script for parity tests and to log raw request payloads.
+- Monkey-patch LiteLLM to log final JSON request body for Gemini generateContent (temporary) to compare shapes.

--- a/Gemini-Latency-Investigation.md
+++ b/Gemini-Latency-Investigation.md
@@ -113,5 +113,7 @@ Potential differences to test for latency impact:
 - experiments/gemini_latency_harness.py to benchmark OpenHands path.
 
 ## TODO
+- Harness: add --log-dir flag to write OpenHands log_completions; llm.py now captures LiteLLM raw_request_typed_dict (curl/body/headers) when logging is enabled.
+
 - Add minimal Node @google/genai script for parity tests and to log raw request payloads.
 - Monkey-patch LiteLLM to log final JSON request body for Gemini generateContent (temporary) to compare shapes.

--- a/Gemini-Latency-Investigation.md
+++ b/Gemini-Latency-Investigation.md
@@ -1,0 +1,109 @@
+# Gemini 2.5 Pro Latency Investigation
+
+Goal: Identify and fix extreme latency seen when using Gemini 2.5 Pro via OpenHands (through LiteLLM), which is not observed when using the official Gemini CLI.
+
+This doc tracks status, observations, experiments, and next steps.
+
+## Status
+- Cloned official Gemini CLI repository alongside OpenHands:
+  - Repo: https://github.com/google-gemini/gemini-cli
+  - Local path: /workspace/gemini-cli
+- Located OpenHands -> LiteLLM call path:
+  - openhands/llm/llm.py wraps litellm.completion and sets parameters
+  - Model-specific behavior (Gemini 2.5 Pro) is handled in this wrapper and by LiteLLM’s Gemini mapper
+- Found LiteLLM Gemini implementation on disk:
+  - litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+- Prepared a Python harness (experiments/gemini_latency_harness.py) to send comparable prompts via OpenHands wrapper for timing and logging. A small Node harness for @google/genai can be added if needed.
+
+## Initial Observations (CLI vs OpenHands)
+- Gemini CLI (TS, @google/genai):
+  - Uses GoogleGenAI and calls models.generateContent()
+  - Default generation config includes:
+    - temperature: 0
+    - topP: 1
+    - For models starting with gemini-2.5, adds thinkingConfig: { includeThoughts: true }
+  - System instructions are passed as systemInstruction (not as a chat message)
+  - Tools are set via functionDeclarations and sent as tools: [{ functionDeclarations: [...] }]
+  - Adds a custom User-Agent header (GeminiCLI/<version>)
+
+- OpenHands (Python, LiteLLM):
+  - Calls litellm.completion with kwargs assembled in openhands/llm/llm.py
+  - For gemini-2.5-pro specifically, current mapping does:
+    - If reasoning_effort in {None, "low", "none"}:
+      - Adds thinking = { budget_tokens: 128 }
+      - Sets allowed_openai_params = ["thinking"] (LiteLLM-internal allowance)
+      - Drops reasoning_effort
+    - Removes temperature and top_p when reasoning effort models are detected (to mirror OpenAI-like reasoning behavior)
+  - System message is included as a chat message; LiteLLM is expected to translate to systemInstruction. The exact mapping may differ from the CLI.
+  - Tools are passed as OpenAI-style tools/JSON schema; LiteLLM maps these to Gemini functionDeclarations.
+
+Potential differences to test for latency impact:
+- Thinking config
+  - CLI: includeThoughts: true with no explicit budget
+  - OpenHands: budget_tokens: 128 (no include flag)
+- Tool calling defaults
+  - tool_choice defaults to "auto" via LiteLLM mapping (FunctionCallingConfig mode AUTO), same as CLI behavior. But we should confirm.
+- System prompt handling
+  - CLI uses systemInstruction field; OpenHands uses a system chat message that LiteLLM should map. We should verify payloads.
+- LiteLLM global modify_params and other transformations
+  - OpenHands sets litellm.modify_params = True by default; confirm if this adds overhead or changes payload.
+- Parallel tool calls behavior and any added params by LiteLLM
+
+## Experiments Plan
+1) Baseline single-turn, no tools
+- Prompt: simple user message
+- Measure latency in OpenHands via experiments/gemini_latency_harness.py
+- Measure latency in Gemini CLI (or minimal @google/genai Node script) with the same API key and model
+
+2) Tool-calling turn
+- Provide one simple function (e.g., sum two numbers)
+- Ask the model to call the function
+- Compare latencies
+
+3) Parameter sweeps in OpenHands wrapper
+- thinking variants:
+  - no thinking (send nothing)
+  - includeThoughts only (no budget)
+  - budget_tokens = 128 (current)
+  - reasoning_effort = low|medium|high mapped via LiteLLM’s reasoning mapping (which sets thinkingConfig under the hood)
+- system prompt placement
+  - system chat message vs. explicitly setting systemInstruction (requires adjustment/patch)
+- LiteLLM flags
+  - modify_params True vs False
+  - drop_params True vs False (should be True anyway to avoid errors)
+- tool_choice
+  - explicit "auto" vs omit vs "none" (when testing tools)
+
+4) Capture exact outgoing request bodies
+- Enable OpenHands log_completions to write args/kwargs per call
+- Monkey-patch LiteLLM Gemini client to log final request JSON to a file for comparison against @google/genai requests
+
+## Hypotheses for Latency
+- Request shape differences cause the Gemini backend to take a slower path (e.g., tool config, system message mapping, or thinking config)
+- LiteLLM adds parameters (or retries/transformations) that increase effective latency
+- System prompt as a chat message vs systemInstruction affects planning/thinking durations
+- Parallel tool calling or internal AFC (automatic function calling) behavior differs
+
+## Next Steps (needs API access)
+- Provide GEMINI_API_KEY (or GOOGLE_API_KEY with vertex settings) as environment variables
+- Run the harness:
+  - OpenHands harness: poetry run python experiments/gemini_latency_harness.py --model gemini/gemini-2.5-pro
+  - Node harness using @google/genai (optional, we can add a script if needed)
+- Compare latencies across sweeps and record in this doc
+
+## Proposed Fix Directions (to validate by experiment)
+- Align OpenHands thinking config with CLI:
+  - Option A: send thinkingConfig includeThoughts: true, no explicit budget (let server default)
+  - Option B: allow users to toggle thinking behavior via config; ensure reasoning_effort = "none" truly disables thinking (currently it still sets budget 128)
+- Ensure tool configuration mirrors CLI’s shape closely (functionDeclarations array within tools, auto mode)
+- Consider passing systemInstruction explicitly for Gemini models instead of a system chat message (pending LiteLLM support and tests)
+- If a specific LiteLLM transform adds latency, monkey-patch around it in OpenHands
+
+## Artifacts
+- Python harness: experiments/gemini_latency_harness.py (measures OpenHands path latency; logs args/kwargs and response)
+- This doc: Gemini-Latency-Investigation.md
+
+## Open Questions / Needs
+- API credentials to run live tests
+- Whether to commit monkey patches vs behind a feature flag
+- Exact request payload produced by @google/genai for our tested scenarios (we can log via a small Node script)

--- a/experiments/gemini_latency_harness.py
+++ b/experiments/gemini_latency_harness.py
@@ -78,6 +78,12 @@ def main() -> None:
     parser.add_argument(
         '--log-dir', default=None, help='Enable log_completions to this directory'
     )
+    parser.add_argument(
+        '--modify-params',
+        default=os.getenv('OPENHANDS_MODIFY_PARAMS', 'true'),
+        choices=['true', 'false', '1', '0', 'yes', 'no'],
+        help='Set litellm.modify_params behavior for this run (default: true)',
+    )
     args = parser.parse_args()
 
     if not args.api_key:
@@ -96,6 +102,7 @@ def main() -> None:
         top_p=args.top_p,
         max_output_tokens=args.max_output_tokens,
         reasoning_effort=args.reasoning,
+        modify_params=(str(args.modify_params).lower() in ('1', 'true', 'yes')),
         log_completions=bool(args.log_dir),
         log_completions_folder=args.log_dir,
     )

--- a/experiments/gemini_latency_harness.py
+++ b/experiments/gemini_latency_harness.py
@@ -75,6 +75,9 @@ def main() -> None:
         action='store_true',
         help='Set OPENHANDS_GEMINI_CLI_COMPAT=1 for this run',
     )
+    parser.add_argument(
+        '--log-dir', default=None, help='Enable log_completions to this directory'
+    )
     args = parser.parse_args()
 
     if not args.api_key:
@@ -93,7 +96,8 @@ def main() -> None:
         top_p=args.top_p,
         max_output_tokens=args.max_output_tokens,
         reasoning_effort=args.reasoning,
-        log_completions=True,
+        log_completions=bool(args.log_dir),
+        log_completions_folder=args.log_dir,
     )
 
     llm = LLM(cfg)

--- a/experiments/gemini_latency_harness.py
+++ b/experiments/gemini_latency_harness.py
@@ -1,0 +1,134 @@
+import argparse
+import json
+import os
+import time
+from typing import Any
+
+from openhands.core.config.llm_config import LLMConfig
+from openhands.llm.llm import LLM
+
+
+def make_messages(prompt: str, system: str | None = None) -> list[dict[str, Any]]:
+    msgs: list[dict[str, Any]] = []
+    if system:
+        msgs.append({'role': 'system', 'content': system})
+    msgs.append({'role': 'user', 'content': prompt})
+    return msgs
+
+
+def make_tools(include: bool) -> list[dict[str, Any]] | None:
+    if not include:
+        return None
+    # Simple echo tool for function-calling path
+    return [
+        {
+            'type': 'function',
+            'function': {
+                'name': 'echo',
+                'description': 'Echo the provided text',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {
+                        'text': {'type': 'string'},
+                    },
+                    'required': ['text'],
+                },
+            },
+        }
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Measure Gemini latency via OpenHands -> LiteLLM'
+    )
+    parser.add_argument(
+        '--model', default=os.getenv('OPENHANDS_MODEL', 'gemini/gemini-2.5-pro')
+    )
+    parser.add_argument(
+        '--api-key', default=os.getenv('GEMINI_API_KEY') or os.getenv('GOOGLE_API_KEY')
+    )
+    parser.add_argument('--base-url', default=os.getenv('OPENHANDS_BASE_URL'))
+    parser.add_argument('--reasoning', default=os.getenv('OPENHANDS_REASONING'))
+    parser.add_argument(
+        '--temperature',
+        type=float,
+        default=float(os.getenv('OPENHANDS_TEMPERATURE', '0')),
+    )
+    parser.add_argument(
+        '--top-p', type=float, default=float(os.getenv('OPENHANDS_TOP_P', '1'))
+    )
+    parser.add_argument(
+        '--max-output-tokens',
+        type=int,
+        default=int(os.getenv('OPENHANDS_MAX_OUTPUT_TOKENS', '1024')),
+    )
+    parser.add_argument('--with-tools', action='store_true')
+    parser.add_argument(
+        '--prompt',
+        default="Say hello and then call the echo function with text='hello' if tools exist.",
+    )
+    parser.add_argument('--system', default='You are a helpful assistant.')
+    parser.add_argument('--runs', type=int, default=3)
+    parser.add_argument(
+        '--cli-compat',
+        action='store_true',
+        help='Set OPENHANDS_GEMINI_CLI_COMPAT=1 for this run',
+    )
+    args = parser.parse_args()
+
+    if not args.api_key:
+        raise SystemExit(
+            'Please set --api-key or GEMINI_API_KEY/GOOGLE_API_KEY env var'
+        )
+
+    if args.cli_compat:
+        os.environ['OPENHANDS_GEMINI_CLI_COMPAT'] = '1'
+
+    cfg = LLMConfig(
+        model=args.model,
+        api_key=args.api_key,  # type: ignore[arg-type]
+        base_url=args.base_url,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        max_output_tokens=args.max_output_tokens,
+        reasoning_effort=args.reasoning,
+        log_completions=True,
+    )
+
+    llm = LLM(cfg)
+
+    tools = make_tools(args.with_tools)
+    messages = make_messages(args.prompt, args.system)
+
+    latencies: list[float] = []
+    for i in range(args.runs):
+        t0 = time.time()
+        resp = llm.completion(messages=messages, **({'tools': tools} if tools else {}))
+        dt = time.time() - t0
+        latencies.append(dt)
+        choice = resp.get('choices', [{}])[0]
+        text = choice.get('message', {}).get('content') or choice.get(
+            'message', {}
+        ).get('text')
+        print(f'Run {i + 1}: latency={dt:.3f}s text={str(text)[:120]!r}')
+
+    if latencies:
+        print(
+            json.dumps(
+                {
+                    'model': args.model,
+                    'runs': len(latencies),
+                    'avg_latency_sec': sum(latencies) / len(latencies),
+                    'min_latency_sec': min(latencies),
+                    'max_latency_sec': max(latencies),
+                    'cli_compat': bool(args.cli_compat),
+                    'with_tools': bool(args.with_tools),
+                },
+                indent=2,
+            )
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/genai_minimal.js
+++ b/experiments/genai_minimal.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/*
+Minimal @google/genai script to mirror Gemini CLI baseline and log raw request payloads.
+
+Usage:
+  node experiments/genai_minimal.js \
+    --model gemini-2.5-pro \
+    --api-key $GEMINI_API_KEY \
+    --prompt "Hello" \
+    --system "You are a helpful assistant." \
+    --with-tools \
+    --temperature 0 \
+    --top-p 1 \
+    --max-output-tokens 1024 \
+    --log-dir /tmp/gemini-node-logs
+
+Notes:
+- If model starts with "gemini-2.5", we set thinkingConfig: { includeThoughts: true }.
+- Tools are passed using functionDeclarations under tools: [{ functionDeclarations: [...] }].
+- Logs HTTP request: method, url, headers (Authorization masked), and JSON body into log-dir.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+
+async function main() {
+  // Simple arg parsing
+  const args = process.argv.slice(2);
+  const arg = (name, def = undefined) => {
+    const i = args.findIndex((a) => a === `--${name}`);
+    if (i !== -1 && i + 1 < args.length) return args[i + 1];
+    return def;
+  };
+  const hasFlag = (name) => args.includes(`--${name}`);
+
+  const model = arg('model', process.env.MODEL || 'gemini-2.5-pro');
+  const apiKey = arg('api-key', process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY);
+  const prompt = arg('prompt', 'Say hello.');
+  const system = arg('system', 'You are a helpful assistant.');
+  const withTools = hasFlag('with-tools');
+  const temperature = parseFloat(arg('temperature', '0'));
+  const topP = parseFloat(arg('top-p', '1'));
+  const maxOutputTokens = parseInt(arg('max-output-tokens', '1024'), 10);
+  const logDir = arg('log-dir', null);
+
+  if (!apiKey) {
+    console.error('Missing --api-key or GEMINI_API_KEY/GOOGLE_API_KEY');
+    process.exit(2);
+  }
+
+  if (logDir) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+
+  // Ensure global fetch exists (Node 18+). If not, polyfill via undici.
+  try {
+    if (typeof globalThis.fetch !== 'function') {
+      const undici = require('undici');
+      globalThis.fetch = undici.fetch;
+    }
+  } catch (_) {
+    // ignore
+  }
+
+  // Intercept fetch to log request payload
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init = {}) => {
+    const url = typeof input === 'string' ? input : (input && input.url ? input.url : String(input));
+    const method = (init.method || 'GET').toUpperCase();
+    const headers = Object.fromEntries(Object.entries(init.headers || {}).map(([k, v]) => [k.toLowerCase(), String(v)]));
+    if (headers['authorization']) headers['authorization'] = 'Bearer ***';
+
+    let bodyText = undefined;
+    if (init.body && typeof init.body === 'string') {
+      bodyText = init.body;
+    } else if (init.body && Buffer.isBuffer(init.body)) {
+      bodyText = init.body.toString('utf8');
+    }
+
+    const shouldLog = logDir && method === 'POST' && url.includes('generateContent');
+    const reqId = randomUUID();
+
+    if (shouldLog) {
+      const out = {
+        ts: Date.now(),
+        reqId,
+        method,
+        url,
+        headers,
+        body: (() => { try { return bodyText ? JSON.parse(bodyText) : null; } catch { return bodyText; } })(),
+      };
+      fs.writeFileSync(path.join(logDir, `genai_request_${reqId}.json`), JSON.stringify(out, null, 2));
+    }
+
+    const t0 = Date.now();
+    const res = await originalFetch(input, init);
+    const dt = Date.now() - t0;
+
+    if (shouldLog) {
+      let text = null;
+      try { text = await res.clone().text(); } catch { /* ignore */ }
+      const out = {
+        ts: Date.now(),
+        reqId,
+        status: res.status,
+        duration_ms: dt,
+        headers: Object.fromEntries(res.headers.entries()),
+        body: (() => { try { return text ? JSON.parse(text) : null; } catch { return text; } })(),
+      };
+      fs.writeFileSync(path.join(logDir, `genai_response_${reqId}.json`), JSON.stringify(out, null, 2));
+    }
+
+    return res;
+  };
+
+  // Dynamically import ESM @google/genai
+  const { GoogleGenAI } = await import('@google/genai');
+
+  const genAI = new GoogleGenAI({
+    apiKey,
+    httpOptions: { headers: { 'User-Agent': 'OpenHandsGenAI-Minimal/1.0' } },
+  });
+
+  // Build request
+  const contents = [
+    system ? { role: 'user', parts: [{ text: `SYSTEM: ${system}` }] } : null,
+    { role: 'user', parts: [{ text: prompt }] },
+  ].filter(Boolean);
+
+  const config = {
+    temperature,
+    topP,
+    maxOutputTokens,
+  };
+
+  if (/^gemini-2\.5/.test(model) || /gemini-2\.5/.test(model)) {
+    config.thinkingConfig = { includeThoughts: true };
+  }
+
+  if (system) {
+    // Prefer explicit systemInstruction like CLI
+    config.systemInstruction = system;
+  }
+
+  let tools = undefined;
+  if (withTools) {
+    tools = [
+      {
+        functionDeclarations: [
+          {
+            name: 'echo',
+            description: 'Echo the provided text',
+            parameters: {
+              type: 'OBJECT',
+              properties: {
+                text: { type: 'STRING' },
+              },
+              required: ['text'],
+            },
+          },
+        ],
+      },
+    ];
+  }
+
+  const req = { model, contents, config };
+  if (tools) {
+    req.tools = tools;
+  }
+
+  const t0 = Date.now();
+  const resp = await genAI.models.generateContent(req);
+  const dt = (Date.now() - t0) / 1000;
+  const text = resp?.candidates?.[0]?.content?.parts?.map((p) => p.text).filter(Boolean).join('\n');
+  console.log(JSON.stringify({ model, latency_sec: dt, text: String(text || '').slice(0, 200) }));
+}
+
+main().catch((err) => {
+  console.error('Error:', err?.stack || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
Context
- Investigate extreme latency with Gemini 2.5 Pro when used via OpenHands (LiteLLM) versus Gemini CLI.
- Goal: Align request parameters and compare outgoing payloads and latencies, then patch/monkey-patch if needed.

Changes
- openhands/llm/llm.py
  - When log_completions is enabled, set litellm.log_raw_request_response and pass a per-call logger_fn to capture LiteLLM model_call_details (including raw request body/headers/base URL). Add the captured details into the saved log for diffing against @google/genai payloads.
- experiments/gemini_latency_harness.py
  - Add --modify-params flag to toggle litellm.modify_params per run.
  - Supports --cli-compat, --with-tools, --log-dir to run sweeps.
- experiments/genai_minimal.js
  - Minimal @google/genai script that mirrors CLI behavior and logs fetch requests/responses to disk (masked Authorization) for payload diffing.
- Gemini-Latency-Investigation.md
  - Notes on capturing LiteLLM raw request context and planned testing steps.

How to run
1) Provide GEMINI_API_KEY or GOOGLE_API_KEY.
2) OpenHands harness (LiteLLM):
   poetry run python experiments/gemini_latency_harness.py \
     --model gemini/gemini-2.5-pro --api-key $GEMINI_API_KEY \
     --prompt "Ping" --runs 3 --with-tools --cli-compat \
     --log-dir /workspace/OpenHands/.openhands_logs \
     --modify-params true
   Repeat with --modify-params false.
3) Node harness (@google/genai):
   npm i @google/genai
   node experiments/genai_minimal.js \
     --model gemini-2.5-pro --api-key $GEMINI_API_KEY \
     --prompt "Ping" --with-tools \
     --log-dir /workspace/OpenHands/.genai_logs

Next steps
- Compare payloads from OpenHands vs Node and measure latencies.
- Identify deltas (thinkingConfig, systemInstruction handling, tools structure, sampling params) that correlate with latency.
- Adjust OpenHands/LiteLLM usage (or monkey patch LiteLLM mappings) to reduce latency.

Note
- This PR is draft and intended for investigation/logging, not final fixes.
