### PR TITLE
Refactor thought field to dictionary structure with backward compatibility

### DIFF
--- a/frontend/src/components/features/chat/event-content-helpers/get-action-content.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/get-action-content.ts
@@ -9,6 +9,7 @@ import {
   ThinkAction,
   OpenHandsAction,
   FinishAction,
+  getDefaultThought,
 } from "#/types/core/actions";
 import { getDefaultEventContent, MAX_CONTENT_LENGTH } from "./shared";
 import i18n from "#/i18n";
@@ -75,7 +76,7 @@ const getMcpActionContent = (event: MCPAction): string => {
 };
 
 const getThinkActionContent = (event: ThinkAction): string =>
-  event.args.thought;
+  getDefaultThought(event.args.thought);
 
 const getFinishActionContent = (event: FinishAction): string =>
   event.args.final_thought.trim();

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -11,18 +11,18 @@ export type Thoughts = string | ThoughtsDict;
 
 // Utility function to extract the default thought from the Thoughts type
 export function getDefaultThought(thoughts: Thoughts): string {
-  if (typeof thoughts === 'string') {
+  if (typeof thoughts === "string") {
     return thoughts;
   }
-  return thoughts.default || '';
+  return thoughts.default || "";
 }
 
 // Utility function to extract the reasoning content from the Thoughts type
 export function getReasoningContent(thoughts: Thoughts): string {
-  if (typeof thoughts === 'string') {
-    return '';
+  if (typeof thoughts === "string") {
+    return "";
   }
-  return thoughts.reasoning_content || '';
+  return thoughts.reasoning_content || "";
 }
 
 export interface UserMessageAction extends OpenHandsActionEvent<"message"> {

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -1,6 +1,30 @@
 import { OpenHandsActionEvent } from "./base";
 import { ActionSecurityRisk } from "#/state/security-analyzer-slice";
 
+// Thoughts can be either a string (backward compatibility) or a dictionary
+export type ThoughtsDict = {
+  default: string;
+  reasoning_content?: string;
+};
+
+export type Thoughts = string | ThoughtsDict;
+
+// Utility function to extract the default thought from the Thoughts type
+export function getDefaultThought(thoughts: Thoughts): string {
+  if (typeof thoughts === 'string') {
+    return thoughts;
+  }
+  return thoughts.default || '';
+}
+
+// Utility function to extract the reasoning content from the Thoughts type
+export function getReasoningContent(thoughts: Thoughts): string {
+  if (typeof thoughts === 'string') {
+    return '';
+  }
+  return thoughts.reasoning_content || '';
+}
+
 export interface UserMessageAction extends OpenHandsActionEvent<"message"> {
   source: "user";
   args: {
@@ -26,7 +50,7 @@ export interface CommandAction extends OpenHandsActionEvent<"run"> {
     command: string;
     security_risk: ActionSecurityRisk;
     confirmation_state: "confirmed" | "rejected" | "awaiting_confirmation";
-    thought: string;
+    thought: Thoughts;
     hidden?: boolean;
   };
 }
@@ -35,7 +59,7 @@ export interface AssistantMessageAction
   extends OpenHandsActionEvent<"message"> {
   source: "agent";
   args: {
-    thought: string;
+    thought: Thoughts;
     image_urls: string[] | null;
     file_urls: string[];
     wait_for_response: boolean;
@@ -49,14 +73,14 @@ export interface IPythonAction extends OpenHandsActionEvent<"run_ipython"> {
     security_risk: ActionSecurityRisk;
     confirmation_state: "confirmed" | "rejected" | "awaiting_confirmation";
     kernel_init_code: string;
-    thought: string;
+    thought: Thoughts;
   };
 }
 
 export interface ThinkAction extends OpenHandsActionEvent<"think"> {
   source: "agent";
   args: {
-    thought: string;
+    thought: Thoughts;
   };
 }
 
@@ -65,7 +89,7 @@ export interface FinishAction extends OpenHandsActionEvent<"finish"> {
   args: {
     final_thought: string;
     outputs: Record<string, unknown>;
-    thought: string;
+    thought: Thoughts;
   };
 }
 
@@ -75,7 +99,7 @@ export interface DelegateAction extends OpenHandsActionEvent<"delegate"> {
   args: {
     agent: "BrowsingAgent";
     inputs: Record<string, string>;
-    thought: string;
+    thought: Thoughts;
   };
 }
 
@@ -83,7 +107,7 @@ export interface BrowseAction extends OpenHandsActionEvent<"browse"> {
   source: "agent";
   args: {
     url: string;
-    thought: string;
+    thought: Thoughts;
   };
 }
 
@@ -93,7 +117,7 @@ export interface BrowseInteractiveAction
   timeout: number;
   args: {
     browser_actions: string;
-    thought: string | null;
+    thought: Thoughts | null;
     browsergym_send_msg_to_user: string;
   };
 }
@@ -102,7 +126,7 @@ export interface FileReadAction extends OpenHandsActionEvent<"read"> {
   source: "agent";
   args: {
     path: string;
-    thought: string;
+    thought: Thoughts;
     security_risk: ActionSecurityRisk | null;
     impl_source?: string;
     view_range?: number[] | null;
@@ -114,7 +138,7 @@ export interface FileWriteAction extends OpenHandsActionEvent<"write"> {
   args: {
     path: string;
     content: string;
-    thought: string;
+    thought: Thoughts;
   };
 }
 
@@ -131,7 +155,7 @@ export interface FileEditAction extends OpenHandsActionEvent<"edit"> {
     content?: string;
     start?: number;
     end?: number;
-    thought: string;
+    thought: Thoughts;
     security_risk: ActionSecurityRisk | null;
     impl_source?: string;
   };
@@ -140,7 +164,7 @@ export interface FileEditAction extends OpenHandsActionEvent<"edit"> {
 export interface RejectAction extends OpenHandsActionEvent<"reject"> {
   source: "agent";
   args: {
-    thought: string;
+    thought: Thoughts;
   };
 }
 
@@ -149,7 +173,7 @@ export interface RecallAction extends OpenHandsActionEvent<"recall"> {
   args: {
     recall_type: "workspace_context" | "knowledge";
     query: string;
-    thought: string;
+    thought: Thoughts;
   };
 }
 
@@ -158,7 +182,7 @@ export interface MCPAction extends OpenHandsActionEvent<"call_tool_mcp"> {
   args: {
     name: string;
     arguments: Record<string, unknown>;
-    thought?: string;
+    thought?: Thoughts;
   };
 }
 

--- a/openhands/agenthub/browsing_agent/response_parser.py
+++ b/openhands/agenthub/browsing_agent/response_parser.py
@@ -7,6 +7,7 @@ from openhands.events.action import (
     Action,
     BrowseInteractiveAction,
 )
+from openhands.events.action.thoughts import ThoughtsDict
 
 
 class BrowsingResponseParser(ResponseParser):
@@ -64,7 +65,7 @@ class BrowsingActionParserMessage(ActionParser):
         msg = f'send_msg_to_user("""{action_str}""")'
         return BrowseInteractiveAction(
             browser_actions=msg,
-            thought=action_str,
+            thought=ThoughtsDict(action_str),
             browsergym_send_msg_to_user=action_str,
         )
 
@@ -121,6 +122,6 @@ class BrowsingActionParserBrowseInteractive(ActionParser):
 
         return BrowseInteractiveAction(
             browser_actions=browser_actions,
-            thought=thought,
+            thought=ThoughtsDict(thought),
             browsergym_send_msg_to_user=msg_content,
         )

--- a/openhands/agenthub/dummy_agent/agent.py
+++ b/openhands/agenthub/dummy_agent/agent.py
@@ -13,6 +13,7 @@ from openhands.events.action import (
     FileWriteAction,
     MessageAction,
 )
+from openhands.events.action.thoughts import ThoughtsDict
 from openhands.events.observation import (
     AgentStateChangedObservation,
     CmdOutputMetadata,
@@ -87,7 +88,7 @@ class DummyAgent(Agent):
             },
             {
                 'action': AgentFinishAction(
-                    outputs={}, thought='Task completed', action='finish'
+                    outputs={}, thought=ThoughtsDict('Task completed'), action='finish'
                 ),
                 'observations': [AgentStateChangedObservation('', AgentState.FINISHED)],
             },

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -262,7 +262,7 @@ def display_event(event: Event, config: OpenHandsConfig) -> None:
         if isinstance(event, CmdRunAction):
             # For CmdRunAction, display thought first, then command
             if hasattr(event, 'thought') and event.thought:
-                display_thought_if_new(event.thought)
+                display_thought_if_new(str(event.thought))
 
             # Only display the command if it's not already confirmed
             # Commands are always shown when AWAITING_CONFIRMATION, so we don't need to show them again when CONFIRMED
@@ -276,7 +276,7 @@ def display_event(event: Event, config: OpenHandsConfig) -> None:
         elif isinstance(event, Action):
             # For other actions, display thoughts normally
             if hasattr(event, 'thought') and event.thought:
-                display_thought_if_new(event.thought)
+                display_thought_if_new(str(event.thought))
             if hasattr(event, 'final_thought') and event.final_thought:
                 # Display final thoughts with agent styling
                 display_message(event.final_thought, is_agent_message=True)

--- a/openhands/events/action/action.py
+++ b/openhands/events/action/action.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from openhands.events.event import Event
 
@@ -18,6 +18,25 @@ class ActionSecurityRisk(int, Enum):
     HIGH = 2
 
 
+class ThoughtsMixin:
+    """Mixin to handle backward compatibility for thought field assignment."""
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == 'thought' and isinstance(value, str):
+            # Import here to avoid circular imports
+            from openhands.events.action.thoughts import ThoughtsDict
+
+            # Convert string assignment to ThoughtsDict
+            if hasattr(self, 'thought') and isinstance(
+                getattr(self, 'thought'), ThoughtsDict
+            ):
+                getattr(self, 'thought').set_default(value)
+                return
+            else:
+                value = ThoughtsDict(value)
+        super().__setattr__(name, value)
+
+
 @dataclass
-class Action(Event):
+class Action(ThoughtsMixin, Event):
     runnable: ClassVar[bool] = False

--- a/openhands/events/action/agent.py
+++ b/openhands/events/action/agent.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from openhands.core.schema import ActionType
 from openhands.events.action.action import Action
+from openhands.events.action.thoughts import ThoughtsDict
 from openhands.events.event import RecallType
 
 
@@ -11,7 +12,7 @@ class ChangeAgentStateAction(Action):
     """Fake action, just to notify the client that a task state has changed."""
 
     agent_state: str
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.CHANGE_AGENT_STATE
 
     @property
@@ -32,13 +33,13 @@ class AgentFinishAction(Action):
 
     final_thought: str = ''
     outputs: dict[str, Any] = field(default_factory=dict)
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.FINISH
 
     @property
     def message(self) -> str:
         if self.thought != '':
-            return self.thought
+            return str(self.thought)
         return "All done! What's next on the agenda?"
 
 
@@ -51,7 +52,7 @@ class AgentThinkAction(Action):
         action (str): The action type, namely ActionType.THINK.
     """
 
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.THINK
 
     @property
@@ -62,7 +63,7 @@ class AgentThinkAction(Action):
 @dataclass
 class AgentRejectAction(Action):
     outputs: dict = field(default_factory=dict)
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.REJECT
 
     @property
@@ -77,7 +78,7 @@ class AgentRejectAction(Action):
 class AgentDelegateAction(Action):
     agent: str
     inputs: dict
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.DELEGATE
 
     @property
@@ -91,7 +92,7 @@ class RecallAction(Action):
 
     recall_type: RecallType
     query: str = ''
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.RECALL
 
     @property

--- a/openhands/events/action/browse.py
+++ b/openhands/events/action/browse.py
@@ -1,14 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from openhands.core.schema import ActionType
 from openhands.events.action.action import Action, ActionSecurityRisk
+from openhands.events.action.thoughts import ThoughtsDict
 
 
 @dataclass
 class BrowseURLAction(Action):
     url: str
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.BROWSE
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
@@ -29,7 +30,7 @@ class BrowseURLAction(Action):
 @dataclass
 class BrowseInteractiveAction(Action):
     browser_actions: str
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     browsergym_send_msg_to_user: str = ''
     action: str = ActionType.BROWSE_INTERACTIVE
     runnable: ClassVar[bool] = True

--- a/openhands/events/action/commands.py
+++ b/openhands/events/action/commands.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from openhands.core.schema import ActionType
@@ -7,6 +7,7 @@ from openhands.events.action.action import (
     ActionConfirmationStatus,
     ActionSecurityRisk,
 )
+from openhands.events.action.thoughts import ThoughtsDict
 
 
 @dataclass
@@ -15,7 +16,7 @@ class CmdRunAction(Action):
         str  # When `command` is empty, it will be used to print the current tmux window
     )
     is_input: bool = False  # if True, the command is an input to the running process
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     blocking: bool = False  # if True, the command will be run in a blocking manner, but a timeout must be set through _set_hard_timeout
     is_static: bool = False  # if True, runs the command in a separate process
     cwd: str | None = None  # current working directory, only used if is_static is True
@@ -42,7 +43,7 @@ class CmdRunAction(Action):
 @dataclass
 class IPythonRunCellAction(Action):
     code: str
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     include_extra: bool = (
         True  # whether to include CWD & Python interpreter in the output
     )

--- a/openhands/events/action/files.py
+++ b/openhands/events/action/files.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from openhands.core.schema import ActionType
 from openhands.events.action.action import Action, ActionSecurityRisk
+from openhands.events.action.thoughts import ThoughtsDict
 from openhands.events.event import FileEditSource, FileReadSource
 
 
@@ -16,7 +17,7 @@ class FileReadAction(Action):
     path: str
     start: int = 0
     end: int = -1
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.READ
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
@@ -39,7 +40,7 @@ class FileWriteAction(Action):
     content: str
     start: int = 0
     end: int = -1
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.WRITE
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
@@ -108,7 +109,7 @@ class FileEditAction(Action):
     end: int = -1
 
     # Shared arguments
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.EDIT
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None

--- a/openhands/events/action/mcp.py
+++ b/openhands/events/action/mcp.py
@@ -3,13 +3,14 @@ from typing import Any, ClassVar
 
 from openhands.core.schema import ActionType
 from openhands.events.action.action import Action, ActionSecurityRisk
+from openhands.events.action.thoughts import ThoughtsDict
 
 
 @dataclass
 class MCPAction(Action):
     name: str
     arguments: dict[str, Any] = field(default_factory=dict)
-    thought: str = ''
+    thought: ThoughtsDict = field(default_factory=ThoughtsDict)
     action: str = ActionType.MCP
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None

--- a/openhands/events/action/thoughts.py
+++ b/openhands/events/action/thoughts.py
@@ -1,0 +1,97 @@
+"""
+Custom thoughts dictionary that provides backward compatibility.
+"""
+
+from typing import Any
+
+
+class ThoughtsDict(dict[str, str]):
+    """
+    A dictionary that stores thoughts with backward compatibility.
+
+    This class allows the thoughts field to work as both a dictionary
+    and maintain backward compatibility with string access patterns.
+
+    Keys:
+    - 'default': The main thought content (backward compatible)
+    - 'reasoning_content': LiteLLM reasoning content
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Handle initialization from string (backward compatibility)
+        if len(args) == 1 and isinstance(args[0], str):
+            super().__init__({'default': args[0]})
+        elif len(args) == 1 and isinstance(args[0], dict):
+            # Ensure 'default' key exists
+            data = args[0].copy()
+            if 'default' not in data:
+                data['default'] = ''
+            super().__init__(data)
+        else:
+            super().__init__(*args, **kwargs)
+            # Ensure 'default' key exists
+            if 'default' not in self:
+                self['default'] = ''
+
+    def __str__(self) -> str:
+        """Return the default thought for backward compatibility."""
+        return self.get('default', '')
+
+    def __bool__(self) -> bool:
+        """Return True if any thought content exists."""
+        return any(value.strip() for value in self.values())
+
+    def __eq__(self, other: Any) -> bool:
+        """Support comparison with strings for backward compatibility."""
+        if isinstance(other, str):
+            return str(self) == other
+        return super().__eq__(other)
+
+    def __ne__(self, other: Any) -> bool:
+        """Support not-equal comparison with strings for backward compatibility."""
+        return not self.__eq__(other)
+
+    @classmethod
+    def from_string(cls, thought: str) -> 'ThoughtsDict':
+        """Create a ThoughtsDict from a string."""
+        return cls({'default': thought})
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> 'ThoughtsDict':
+        """Create a ThoughtsDict from a dictionary."""
+        return cls(data)
+
+    def set_default(self, thought: str) -> None:
+        """Set the default thought."""
+        self['default'] = thought
+
+    def set_reasoning_content(self, reasoning: str) -> None:
+        """Set the reasoning content from LiteLLM."""
+        self['reasoning_content'] = reasoning
+
+    def get_default(self) -> str:
+        """Get the default thought."""
+        return self.get('default', '')
+
+    def get_reasoning_content(self) -> str:
+        """Get the reasoning content."""
+        return self.get('reasoning_content', '')
+
+    def __reduce__(self):
+        """Custom serialization for pickle/dataclass serialization."""
+        # For backward compatibility, serialize as the default string
+        return (str, (self.get_default(),))
+
+    def __iadd__(self, other: str) -> 'ThoughtsDict':
+        """Support += operator for string concatenation."""
+        current_default = self.get_default()
+        self.set_default(current_default + other)
+        return self
+
+    def __add__(self, other: str) -> str:
+        """Support + operator for string concatenation."""
+        return self.get_default() + other
+
+    def __radd__(self, other: str) -> str:
+        """Support reverse + operator for string concatenation."""
+        return other + self.get_default()

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -269,7 +269,7 @@ class ConversationMemory:
                     if action.thought != content:
                         action.thought += '\n' + content
                 else:
-                    action.thought = content
+                    action.thought.set_default(content)
 
                 # remove the tool call metadata
                 action.tool_call_metadata = None
@@ -278,7 +278,7 @@ class ConversationMemory:
             return [
                 Message(
                     role=role,  # type: ignore[arg-type]
-                    content=[TextContent(text=action.thought)],
+                    content=[TextContent(text=str(action.thought))],
                 )
             ]
         elif isinstance(action, MessageAction):


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This change enhances OpenHands' Action system to support structured thoughts with both default content and reasoning information from LiteLLM, while maintaining full backward compatibility with existing code. This enables the display of reasoning content from models like DeepSeek-R1 that provide step-by-step reasoning.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR refactors the `thought` field in OpenHands Action subclasses from a simple string to a dictionary structure while maintaining complete backward compatibility:

## Key Changes:

1. **New ThoughtsDict Class**: Created a custom dictionary class that behaves like a string for backward compatibility but supports structured data with 'default' and 'reasoning_content' keys.

2. **Updated All Action Subclasses**: Replaced `thought: str = ''` with `thought: ThoughtsDict = field(default_factory=ThoughtsDict)` in:
   - CmdRunAction, IPythonRunCellAction (commands.py)
   - FileReadAction, FileWriteAction, FileEditAction (files.py)
   - BrowseURLAction, BrowseInteractiveAction (browse.py)
   - AgentThinkAction, AgentFinishAction, ChangeAgentStateAction, etc. (agent.py)
   - MCPAction (mcp.py)

3. **Backward Compatibility**: ThoughtsDict implements `__str__`, `__bool__`, `__eq__`, `__iadd__`, `__add__`, and `__radd__` methods to ensure existing code continues to work unchanged.

4. **Frontend Updates**: Updated TypeScript types to support the new Thoughts union type with utility functions `getDefaultThought()` and `getReasoningContent()`.

5. **Fixed All Usage Locations**: Updated all places where thought fields are used (CLI, memory, browsing agent, etc.) to handle the new structure properly.

## Design Decisions:

- **Custom Dictionary Class**: Instead of using plain dict, created ThoughtsDict to provide seamless string-like behavior for existing code
- **Mixin Pattern**: Added ThoughtsMixin to base Action class to handle string assignments transparently
- **Serialization Compatibility**: Ensured dataclasses.asdict() works correctly for JSON serialization
- **String Concatenation Support**: Added operators to support existing patterns like `action.thought += "more text"`

## Testing:

- All existing tests pass without modification
- Serialization/deserialization works correctly
- Comprehensive functionality testing confirms backward compatibility
- MyPy type checking passes
- All linting checks pass (frontend and backend)

This change enables future LiteLLM integration to store reasoning content alongside default thoughts while ensuring zero breaking changes to existing code.

---
**Link of any specific issues this addresses:**

Closes #9370 - Support reasoning_content to display to the user