### PR TITLE
Fix #10304: Support user sending FileReadAction without tool_call_metadata

### DIFF
--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -316,7 +316,7 @@ class ConversationMemory:
             content = [TextContent(text=f'User requested to read file: {action.path}')]
             return [
                 Message(
-                    role='user',  # Always user for FileReadAction from user
+                    role='user',
                     content=content,
                 )
             ]

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -217,19 +217,22 @@ class ConversationMemory:
             tool call results are available.
         """
         # create a regular message from an event
-        if isinstance(
-            action,
-            (
-                AgentDelegateAction,
-                AgentThinkAction,
-                IPythonRunCellAction,
-                FileEditAction,
-                FileReadAction,
-                BrowseInteractiveAction,
-                BrowseURLAction,
-                MCPAction,
-            ),
-        ) or (isinstance(action, CmdRunAction) and action.source == 'agent'):
+        if (
+            isinstance(
+                action,
+                (
+                    AgentDelegateAction,
+                    AgentThinkAction,
+                    IPythonRunCellAction,
+                    FileEditAction,
+                    BrowseInteractiveAction,
+                    BrowseURLAction,
+                    MCPAction,
+                ),
+            )
+            or (isinstance(action, CmdRunAction) and action.source == 'agent')
+            or (isinstance(action, FileReadAction) and action.source == 'agent')
+        ):
             tool_metadata = action.tool_call_metadata
             assert tool_metadata is not None, (
                 'Tool call metadata should NOT be None when function calling is enabled. Action: '
@@ -306,6 +309,14 @@ class ConversationMemory:
             return [
                 Message(
                     role='user',  # Always user for CmdRunAction
+                    content=content,
+                )
+            ]
+        elif isinstance(action, FileReadAction) and action.source == 'user':
+            content = [TextContent(text=f'User requested to read file: {action.path}')]
+            return [
+                Message(
+                    role='user',  # Always user for FileReadAction from user
                     content=content,
                 )
             ]


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where users could not send "read" actions from websocket connections without providing tool_call_metadata. Now users can request file reads directly through websocket without requiring the metadata that was previously mandatory for all FileReadAction instances.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR implements source-aware handling for `FileReadAction` in the conversation memory system:

1. **Removed `FileReadAction` from the main tuple** that requires `tool_call_metadata` for all sources
2. **Added specific condition for agent-sourced `FileReadAction`** to still require metadata: `(isinstance(action, FileReadAction) and action.source == 'agent')`
3. **Added handling for user-sourced `FileReadAction`** that doesn't require metadata, following the same pattern as `CmdRunAction`
4. **Added comprehensive tests** to verify both user (no metadata required) and agent (metadata required) scenarios

The design decision follows the existing pattern used for `CmdRunAction`, where user-sourced actions don't require `tool_call_metadata` but agent-sourced actions do. This maintains backward compatibility while fixing the websocket issue.

**Key changes:**
- Modified `openhands/memory/conversation_memory.py` to implement source-aware FileReadAction handling
- Added tests in `tests/unit/test_conversation_memory.py` for both user and agent scenarios
- All 46 existing tests continue to pass, ensuring no regression

---
**Link of any specific issues this addresses:**

Fixes #10304

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/94e1db61982d4e9981e6e36f6a1d0a59)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:44e052e-nikolaik   --name openhands-app-44e052e   docker.all-hands.dev/all-hands-ai/openhands:44e052e
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix-filereadaction-user-websocket openhands
```