### PR TITLE
fix(cli): send authentication error resume message to user, not llm

### DIFF
--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -360,12 +360,12 @@ async def run_session(
             # Check if it's an authentication error
             if 'ERROR_LLM_AUTHENTICATION' in error_message:
                 # Start with base authentication error message
-                initial_message = 'Authentication error with the LLM provider. Please check your API key.'
+                welcome_message = 'Authentication error with the LLM provider. Please check your API key.'
 
                 # Add OpenHands-specific guidance if using an OpenHands model
                 llm_config = config.get_llm_config()
                 if llm_config.model.startswith('openhands/'):
-                    initial_message += " If you're using OpenHands models, get a new API key from https://app.all-hands.dev/settings/api-keys"
+                    welcome_message += "\nIf you're using OpenHands models, get a new API key from https://app.all-hands.dev/settings/api-keys"
             else:
                 # For other errors, use the standard message
                 initial_message = (


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

1. Shows the authentication error to the user, rather than sending it to the LLM (triggering another authentication error), when the CLI resumes a previous session.
2. Adds a newline before the Openhands provider-specific message, so that the `Type /help for help` instruction doesn't end up after a huge line.

---
**Link of any specific issues this addresses:**
