### PR TITLE
feat(thought): structure Action.thought as dataclass with optional reasoning_content (wire-compat), capture provider reasoning, and add tests

### DIFF
--- a/openhands/agenthub/browsing_agent/response_parser.py
+++ b/openhands/agenthub/browsing_agent/response_parser.py
@@ -62,9 +62,11 @@ class BrowsingActionParserMessage(ActionParser):
 
     def parse(self, action_str: str) -> Action:
         msg = f'send_msg_to_user("""{action_str}""")'
+        from openhands.events.action.action import Thought
+
         return BrowseInteractiveAction(
             browser_actions=msg,
-            thought=action_str,
+            thought=Thought(text=action_str),
             browsergym_send_msg_to_user=action_str,
         )
 
@@ -119,8 +121,10 @@ class BrowsingActionParserBrowseInteractive(ActionParser):
                     else:
                         msg_content = ''
 
+        from openhands.events.action.action import Thought
+
         return BrowseInteractiveAction(
             browser_actions=browser_actions,
-            thought=thought,
+            thought=Thought(text=thought),
             browsergym_send_msg_to_user=msg_content,
         )

--- a/openhands/agenthub/dummy_agent/agent.py
+++ b/openhands/agenthub/dummy_agent/agent.py
@@ -13,6 +13,7 @@ from openhands.events.action import (
     FileWriteAction,
     MessageAction,
 )
+from openhands.events.action.action import Thought
 from openhands.events.observation import (
     AgentStateChangedObservation,
     CmdOutputMetadata,
@@ -87,7 +88,7 @@ class DummyAgent(Agent):
             },
             {
                 'action': AgentFinishAction(
-                    outputs={}, thought='Task completed', action='finish'
+                    outputs={}, thought=Thought(text='Task completed'), action='finish'
                 ),
                 'observations': [AgentStateChangedObservation('', AgentState.FINISHED)],
             },

--- a/openhands/agenthub/readonly_agent/function_calling.py
+++ b/openhands/agenthub/readonly_agent/function_calling.py
@@ -117,12 +117,23 @@ def response_to_actions(
     if hasattr(assistant_msg, 'tool_calls') and assistant_msg.tool_calls:
         # Check if there's assistant_msg.content. If so, add it to the thought
         thought = ''
+        reasoning_content: str | None = None
         if isinstance(assistant_msg.content, str):
             thought = assistant_msg.content
         elif isinstance(assistant_msg.content, list):
             for msg in assistant_msg.content:
                 if msg['type'] == 'text':
                     thought += msg['text']
+                if msg.get('type') in {'reasoning', 'thinking'} and 'text' in msg:
+                    reasoning_content = (
+                        reasoning_content + '\n' if reasoning_content else ''
+                    ) + msg['text']
+        for attr in ('reasoning_content', 'reasoning', 'thinking'):
+            rc = getattr(assistant_msg, attr, None)
+            if isinstance(rc, str) and rc.strip():
+                reasoning_content = (
+                    rc if reasoning_content is None else reasoning_content + '\n' + rc
+                )
 
         # Process each tool call to OpenHands action
         for i, tool_call in enumerate(assistant_msg.tool_calls):
@@ -161,7 +172,11 @@ def response_to_actions(
             # AgentThinkAction
             # ================================================
             elif tool_call.function.name == ThinkTool['function']['name']:
-                action = AgentThinkAction(thought=arguments.get('thought', ''))
+                from openhands.events.action.action import Thought
+
+                action = AgentThinkAction(
+                    thought=Thought(text=arguments.get('thought', ''))
+                )
 
             # ================================================
             # GrepTool (file content search)
@@ -210,7 +225,7 @@ def response_to_actions(
 
             # We only add thought to the first action
             if i == 0:
-                action = combine_thought(action, thought)
+                action = combine_thought(action, thought, reasoning_content)
             # Add metadata for tool calling
             action.tool_call_metadata = ToolCallMetadata(
                 tool_call_id=tool_call.id,

--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -264,7 +264,7 @@ def display_event(event: Event, config: OpenHandsConfig) -> None:
         if isinstance(event, CmdRunAction):
             # For CmdRunAction, display thought first, then command
             if hasattr(event, 'thought') and event.thought:
-                display_thought_if_new(event.thought)
+                display_thought_if_new(str(event.thought))
 
             # Only display the command if it's not already confirmed
             # Commands are always shown when AWAITING_CONFIRMATION, so we don't need to show them again when CONFIRMED
@@ -280,7 +280,7 @@ def display_event(event: Event, config: OpenHandsConfig) -> None:
         elif isinstance(event, Action):
             # For other actions, display thoughts normally
             if hasattr(event, 'thought') and event.thought:
-                display_thought_if_new(event.thought)
+                display_thought_if_new(str(event.thought))
             if hasattr(event, 'final_thought') and event.final_thought:
                 # Display final thoughts with agent styling
                 display_message(event.final_thought, is_agent_message=True)
@@ -531,7 +531,7 @@ def display_task_tracking_action(event: TaskTrackingAction) -> None:
     """Display a TaskTracking action in the CLI."""
     # Display thought first if present
     if hasattr(event, 'thought') and event.thought:
-        display_message(event.thought)
+        display_message(str(event.thought))
 
     # Format the command and task list for display
     display_text = f'Command: {event.command}'

--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -608,7 +608,14 @@ class AgentController:
             new_state in (AgentState.USER_CONFIRMED, AgentState.USER_REJECTED)
         ):
             if hasattr(self._pending_action, 'thought'):
-                self._pending_action.thought = ''  # type: ignore[union-attr]
+                # Support both Thought dataclass and legacy string
+                try:
+                    if hasattr(self._pending_action.thought, 'text'):
+                        self._pending_action.thought.text = ''  # type: ignore[attr-defined]
+                    else:
+                        self._pending_action.thought = ''  # type: ignore[union-attr]
+                except Exception:
+                    self._pending_action.thought = ''  # type: ignore[union-attr]
             if new_state == AgentState.USER_CONFIRMED:
                 confirmation_state = ActionConfirmationStatus.CONFIRMED
             else:

--- a/openhands/events/action/action.py
+++ b/openhands/events/action/action.py
@@ -21,3 +21,22 @@ class ActionSecurityRisk(int, Enum):
 @dataclass
 class Action(Event):
     runnable: ClassVar[bool] = False
+
+
+@dataclass
+class Thought:
+    """Container for agent reasoning.
+
+    Attributes:
+        text: The visible plain thought string used throughout the UI/logs.
+        reasoning_content: Optional provider-native reasoning content (e.g., LiteLLM reasoning).
+    """
+
+    text: str = ''
+    reasoning_content: str | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self.text or self.reasoning_content)
+
+    def __str__(self) -> str:
+        return self.text

--- a/openhands/events/action/agent.py
+++ b/openhands/events/action/agent.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from openhands.core.schema import ActionType
-from openhands.events.action.action import Action
+from openhands.events.action.action import Action, Thought
 from openhands.events.event import RecallType
 
 
@@ -11,7 +11,7 @@ class ChangeAgentStateAction(Action):
     """Fake action, just to notify the client that a task state has changed."""
 
     agent_state: str
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.CHANGE_AGENT_STATE
 
     @property
@@ -32,13 +32,13 @@ class AgentFinishAction(Action):
 
     final_thought: str = ''
     outputs: dict[str, Any] = field(default_factory=dict)
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.FINISH
 
     @property
     def message(self) -> str:
-        if self.thought != '':
-            return self.thought
+        if self.thought and str(self.thought) != '':
+            return str(self.thought)
         return "All done! What's next on the agenda?"
 
 
@@ -51,7 +51,7 @@ class AgentThinkAction(Action):
         action (str): The action type, namely ActionType.THINK.
     """
 
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.THINK
 
     @property
@@ -62,7 +62,7 @@ class AgentThinkAction(Action):
 @dataclass
 class AgentRejectAction(Action):
     outputs: dict = field(default_factory=dict)
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.REJECT
 
     @property
@@ -77,7 +77,7 @@ class AgentRejectAction(Action):
 class AgentDelegateAction(Action):
     agent: str
     inputs: dict
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.DELEGATE
 
     @property
@@ -91,7 +91,7 @@ class RecallAction(Action):
 
     recall_type: RecallType
     query: str = ''
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.RECALL
 
     @property
@@ -214,7 +214,7 @@ class TaskTrackingAction(Action):
 
     command: str = 'view'
     task_list: list[dict[str, Any]] = field(default_factory=list)
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.TASK_TRACKING
 
     @property

--- a/openhands/events/action/browse.py
+++ b/openhands/events/action/browse.py
@@ -1,14 +1,14 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from openhands.core.schema import ActionType
-from openhands.events.action.action import Action, ActionSecurityRisk
+from openhands.events.action.action import Action, ActionSecurityRisk, Thought
 
 
 @dataclass
 class BrowseURLAction(Action):
     url: str
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.BROWSE
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
@@ -29,7 +29,7 @@ class BrowseURLAction(Action):
 @dataclass
 class BrowseInteractiveAction(Action):
     browser_actions: str
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     browsergym_send_msg_to_user: str = ''
     action: str = ActionType.BROWSE_INTERACTIVE
     runnable: ClassVar[bool] = True

--- a/openhands/events/action/commands.py
+++ b/openhands/events/action/commands.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from openhands.core.schema import ActionType
@@ -6,6 +6,7 @@ from openhands.events.action.action import (
     Action,
     ActionConfirmationStatus,
     ActionSecurityRisk,
+    Thought,
 )
 
 
@@ -15,7 +16,7 @@ class CmdRunAction(Action):
         str  # When `command` is empty, it will be used to print the current tmux window
     )
     is_input: bool = False  # if True, the command is an input to the running process
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     blocking: bool = False  # if True, the command will be run in a blocking manner, but a timeout must be set through _set_hard_timeout
     is_static: bool = False  # if True, runs the command in a separate process
     cwd: str | None = None  # current working directory, only used if is_static is True
@@ -42,7 +43,7 @@ class CmdRunAction(Action):
 @dataclass
 class IPythonRunCellAction(Action):
     code: str
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     include_extra: bool = (
         True  # whether to include CWD & Python interpreter in the output
     )

--- a/openhands/events/action/files.py
+++ b/openhands/events/action/files.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from openhands.core.schema import ActionType
-from openhands.events.action.action import Action, ActionSecurityRisk
+from openhands.events.action.action import Action, ActionSecurityRisk, Thought
 from openhands.events.event import FileEditSource, FileReadSource
 
 
@@ -16,7 +16,7 @@ class FileReadAction(Action):
     path: str
     start: int = 0
     end: int = -1
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.READ
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
@@ -39,7 +39,7 @@ class FileWriteAction(Action):
     content: str
     start: int = 0
     end: int = -1
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.WRITE
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None
@@ -108,7 +108,7 @@ class FileEditAction(Action):
     end: int = -1
 
     # Shared arguments
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.EDIT
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None

--- a/openhands/events/action/mcp.py
+++ b/openhands/events/action/mcp.py
@@ -2,14 +2,14 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
 from openhands.core.schema import ActionType
-from openhands.events.action.action import Action, ActionSecurityRisk
+from openhands.events.action.action import Action, ActionSecurityRisk, Thought
 
 
 @dataclass
 class MCPAction(Action):
     name: str
     arguments: dict[str, Any] = field(default_factory=dict)
-    thought: str = ''
+    thought: Thought = field(default_factory=Thought)
     action: str = ActionType.MCP
     runnable: ClassVar[bool] = True
     security_risk: ActionSecurityRisk | None = None

--- a/openhands/events/serialization/event.py
+++ b/openhands/events/serialization/event.py
@@ -126,6 +126,16 @@ def event_to_dict(event: 'Event') -> dict:
         props.pop('task_completed')
     if 'action' in d:
         d['args'] = props
+        # Normalize Thought dataclass to wire format: thought (str) + optional reasoning_content (str)
+        if isinstance(d.get('args'), dict) and 'thought' in d['args']:
+            t = d['args'].get('thought')
+            if isinstance(t, dict):
+                # Extract reasoning_content to top-level args and collapse thought to string
+                rc = t.get('reasoning_content')
+                text = t.get('text', '')
+                d['args']['thought'] = text
+                if rc is not None:
+                    d['args']['reasoning_content'] = rc
         if event.timeout is not None:
             d['timeout'] = event.timeout
     elif 'observation' in d:

--- a/tests/unit/test_thought_serialization.py
+++ b/tests/unit/test_thought_serialization.py
@@ -1,0 +1,66 @@
+from openhands.events.action.action import Thought
+from openhands.events.action.commands import CmdRunAction
+from openhands.events.serialization.event import event_from_dict, event_to_dict
+
+
+def test_thought_serialization_flatten_with_reasoning():
+    a = CmdRunAction(command='echo 1', thought=Thought(text='t', reasoning_content='r'))
+    d = event_to_dict(a)
+    assert d['action'] == a.action
+    assert 'args' in d
+    assert d['args']['thought'] == 't'
+    assert d['args']['reasoning_content'] == 'r'
+
+    # Round-trip back
+    a2 = event_from_dict(d)
+    assert isinstance(a2.thought, Thought)
+    assert a2.thought.text == 't'
+    assert a2.thought.reasoning_content == 'r'
+
+
+def test_thought_deserialization_from_string_plus_rc():
+    d = {
+        'action': 'run',
+        'args': {'command': 'echo 1', 'thought': 'hello', 'reasoning_content': 'why'},
+    }
+    a = event_from_dict(d)
+    assert isinstance(a.thought, Thought)
+    assert a.thought.text == 'hello'
+    assert a.thought.reasoning_content == 'why'
+
+
+def test_thought_deserialization_from_dict_text_key():
+    d = {
+        'action': 'run',
+        'args': {
+            'command': 'echo 1',
+            'thought': {'text': 'hi', 'reasoning_content': 'rc'},
+        },
+    }
+    a = event_from_dict(d)
+    assert isinstance(a.thought, Thought)
+    assert a.thought.text == 'hi'
+    assert a.thought.reasoning_content == 'rc'
+
+
+def test_thought_deserialization_from_dict_legacy_thought_key():
+    d = {
+        'action': 'run',
+        'args': {'command': 'echo 1', 'thought': {'thought': 'legacy'}},
+    }
+    a = event_from_dict(d)
+    assert isinstance(a.thought, Thought)
+    assert a.thought.text == 'legacy'
+    assert a.thought.reasoning_content is None
+
+
+def test_thought_backwards_compat_direct_init_with_str():
+    # Direct construction with a string should still work via __str__ accessors elsewhere
+    a = CmdRunAction(command='echo 1', thought='plain')  # type: ignore[arg-type]
+    d = event_to_dict(a)  # serializer should keep thought as string on wire
+    assert d['args']['thought'] == 'plain'
+
+    # When it comes back from wire, it becomes Thought
+    a2 = event_from_dict(d)
+    assert isinstance(a2.thought, Thought)
+    assert a2.thought.text == 'plain'


### PR DESCRIPTION
Summary
- Introduces Thought dataclass: Thought(text: str = '', reasoning_content: str | None = None), with __str__/__bool__ semantics for seamless use in existing code
- Keeps wire compatibility: args.thought remains a string; optionally sends args.reasoning_content if present
- event_to_dict flattens Thought; action_from_dict reconstructs Thought from legacy shapes (string/dict) and attaches optional reasoning_content
- Captures provider-native reasoning content from LiteLLM in function-calling paths and stores on Action.thought.reasoning_content

Key Changes
1) Core data model
- openhands/events/action/action.py: Add Thought; update Action subclasses to use Thought as thought field

2) Serialization/Deserialization
- openhands/events/serialization/event.py: flatten Thought to thought string and optional reasoning_content
- openhands/events/serialization/action.py: coerce thought string/legacy dict to Thought; merge rc from args.reasoning_content

3) Agents and consumers updated
- codeact_agent/readonly_agent/loc_agent/function_calling.py: capture reasoning_content from message blocks/attributes and attach; combine_thought updated to be Thought-aware
- browsing_agent/response_parser.py and dummy_agent: wrap thoughts in Thought
- conversation_memory.py: treat thought as Thought; append assistant content to .text on finish and capture reasoning_content from provider
- cli/tui and security invariant parser: rely on event_to_dict; behavior and trace preserved

4) Tests
- tests/unit/test_thought_serialization.py: round-trip and legacy compatibility tests

Backward Compatibility
- External callers that construct Action with thought as a string continue to serialize as string and deserialize to Thought(text=...)
- Wire format preserved (thought string + optional reasoning_content)

Motivation
- Provide a structured place to persist provider-native reasoning (LiteLLM, etc.) without breaking existing integrations or the UI/trace

Follow-ups
- Frontend: display reasoning_content in the agent chat box near thought (before/after). I can implement a minimal UI update to show this in the same place we display thought content.
- Optional: expose reasoning_content in debug mode or behind a toggle to avoid clutter where not desired

Checklist
- [x] mypy/ruff/pre-commit pass with dev config: pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml
- [x] unit tests covering serialization and legacy compatibility
- [x] verified function-calling capture across agents

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/22876cdf249a445880bfd656a9c58a2f)