### PR TITLE
Fix circular import in experiment_manager module

### DIFF
--- a/openhands/experiments/experiment_manager.py
+++ b/openhands/experiments/experiment_manager.py
@@ -55,8 +55,14 @@ class ExperimentManager:
         return config
 
 
-experiment_manager_cls = os.environ.get(
-    'OPENHANDS_EXPERIMENT_MANAGER_CLS',
-    'openhands.experiments.experiment_manager.ExperimentManager',
-)
-ExperimentManagerImpl = get_impl(ExperimentManager, experiment_manager_cls)
+def get_experiment_manager_impl():
+    """Get the experiment manager implementation, with lazy loading to avoid circular imports."""
+    experiment_manager_cls = os.environ.get(
+        'OPENHANDS_EXPERIMENT_MANAGER_CLS',
+        'openhands.experiments.experiment_manager.ExperimentManager',
+    )
+    return get_impl(ExperimentManager, experiment_manager_cls)
+
+
+# Lazy initialization to avoid circular import
+ExperimentManagerImpl = None

--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -19,7 +19,7 @@ from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import MessageAction
 from openhands.events.nested_event_store import NestedEventStore
 from openhands.events.stream import EventStream
-from openhands.experiments.experiment_manager import ExperimentManagerImpl
+from openhands.experiments.experiment_manager import get_experiment_manager_impl
 from openhands.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderHandler
 from openhands.llm.llm import LLM
 from openhands.runtime import get_runtime_cls
@@ -472,7 +472,8 @@ class DockerNestedConversationManager(ConversationManager):
         # is the easiest way to create the needed docker container
 
         # Run experiment manager variant test before creating session
-        config: OpenHandsConfig = ExperimentManagerImpl.run_config_variant_test(
+        experiment_manager_impl = get_experiment_manager_impl()
+        config: OpenHandsConfig = experiment_manager_impl.run_config_variant_test(
             user_id, sid, self.config
         )
 

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -5,7 +5,7 @@ from typing import Any
 from openhands.core.config.mcp_config import MCPConfig
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.message import MessageAction
-from openhands.experiments.experiment_manager import ExperimentManagerImpl
+from openhands.experiments.experiment_manager import get_experiment_manager_impl
 from openhands.integrations.provider import (
     CUSTOM_SECRETS_TYPE_WITH_JSON_SCHEMA,
     PROVIDER_TOKEN_TYPE,
@@ -103,7 +103,8 @@ async def create_new_conversation(
             extra={'user_id': user_id, 'session_id': conversation_id},
         )
 
-        conversation_init_data = ExperimentManagerImpl.run_conversation_variant_test(
+        experiment_manager_impl = get_experiment_manager_impl()
+        conversation_init_data = experiment_manager_impl.run_conversation_variant_test(
             user_id, conversation_id, conversation_init_data
         )
         conversation_title = get_default_conversation_title(conversation_id)
@@ -200,6 +201,7 @@ async def setup_init_convo_settings(
 
     convo_init_data = ConversationInitData(**session_init_args)
     # We should recreate the same experiment conditions when restarting a conversation
-    return ExperimentManagerImpl.run_conversation_variant_test(
+    experiment_manager_impl = get_experiment_manager_impl()
+    return experiment_manager_impl.run_conversation_variant_test(
         user_id, conversation_id, convo_init_data
     )

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -74,9 +74,10 @@ class Session:
         # Copying this means that when we update variables they are not applied to the shared global configuration!
         self.config = deepcopy(config)
         # Lazy import to avoid circular dependency
-        from openhands.experiments.experiment_manager import ExperimentManagerImpl
+        from openhands.experiments.experiment_manager import get_experiment_manager_impl
 
-        self.config = ExperimentManagerImpl.run_config_variant_test(
+        experiment_manager_impl = get_experiment_manager_impl()
+        self.config = experiment_manager_impl.run_config_variant_test(
             user_id, sid, self.config
         )
         self.loop = asyncio.get_event_loop()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This fix resolves a circular import error that was preventing the OpenHands experiment manager from loading properly. Users should no longer encounter `ImportError: cannot import name ExperimentConfig from partially initialized module` errors when using experiment management features.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes a circular import issue in the `experiment_manager.py` module by implementing lazy loading:

1. **Root Cause**: The module was trying to import from itself during initialization via `get_impl(ExperimentManager, experiment_manager_cls)`, creating a circular dependency.

2. **Solution**: 
   - Replaced module-level `ExperimentManagerImpl` initialization with a lazy loading function `get_experiment_manager_impl()`
   - Updated all consuming modules to use the new lazy loading approach instead of direct imports
   - This defers the import until the functionality is actually needed, breaking the circular dependency

3. **Files Changed**:
   - `openhands/experiments/experiment_manager.py`: Added lazy loading function
   - `openhands/server/services/conversation_service.py`: Updated to use lazy loading
   - `openhands/server/conversation_manager/docker_nested_conversation_manager.py`: Updated to use lazy loading  
   - `openhands/server/session/session.py`: Updated to use lazy loading

4. **Testing**: Verified that all imports work correctly and functionality is preserved.

---
**Link of any specific issues this addresses:**

Fixes the circular import error: `ImportError: cannot import name ExperimentConfig from partially initialized module openhands.experiments.experiment_manager`