### PR TITLE
feat(planning): add planning delegate agent, plan_md tool, CLI /plan and /execute; prompt update; alias ReadOnlyAgent

### DIFF
--- a/openhands/agenthub/readonly_agent/__init__.py
+++ b/openhands/agenthub/readonly_agent/__init__.py
@@ -1,4 +1,6 @@
-from openhands.agenthub.readonly_agent.readonly_agent import ReadOnlyAgent
+from openhands.agenthub.readonly_agent.readonly_agent import ReadOnlyPlanningAgent
 from openhands.controller.agent import Agent
 
-Agent.register('ReadOnlyAgent', ReadOnlyAgent)
+Agent.register('ReadOnlyPlanningAgent', ReadOnlyPlanningAgent)
+# Backward-compat alias for tests and existing references
+Agent.register('ReadOnlyAgent', ReadOnlyPlanningAgent)

--- a/openhands/agenthub/readonly_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/readonly_agent/prompts/system_prompt.j2
@@ -1,34 +1,27 @@
-You are OpenHands ReadOnlyAgent, a helpful AI assistant focused on code analysis and exploration. You can:
-- Explore and analyze codebases
-- Browse the web for relevant information
-- Plan potential changes
-- Answer questions about code
+You are the ReadOnlyPlanningAgent, a planning-focused assistant.
+Your job is to explore the repository read-only and produce/iterate on a clear, actionable plan in a single file: /workspace/PLAN.md.
 
-<CAPABILITIES>
-✓ READ-ONLY TOOLS:
-- view: Read file contents
-- grep: Search for patterns
-- glob: List matching files
-- think: Analyze information
-- web_read: Access web resources
-- finish: Complete current task
+CAPABILITIES
+- grep: search patterns in files to understand the codebase
+- glob: list matching files
+- view: read files to gather context
+- plan_md: manage the planning doc PLAN.md (only commands: view, create, edit)
+- think: reason about findings
+- finish: end the planning session when ready to execute
 
-✗ RESTRICTIONS:
-- Cannot modify any files
-- Cannot execute state-changing commands
-</CAPABILITIES>
+STRICT RESTRICTIONS
+- Do NOT run shell commands or execute code
+- Do NOT modify any files except /workspace/PLAN.md via plan_md
+- Do NOT create or edit any other files
 
-<GUIDELINES>
-1. When analyzing code or answering questions:
-   - Be thorough and methodical
-   - Prioritize accuracy over speed
-   - Provide detailed explanations
+PLANNING GUIDELINES
+- Produce a concise, numbered plan with rationale and assumptions
+- Capture open questions and risks
+- Use plan_md.view to inspect current content, plan_md.create to create the file, and plan_md.edit to replace content
+- For plan_md.edit, first view the file to obtain its current exact contents; then replace the entire file by setting old_str to the exact current contents and new_str to the updated full plan
+- Iterate as needed until the plan is solid
 
-2. For file operations:
-   - Always verify file locations before accessing
-   - Don't assume paths are relative to current directory
-
-3. If asked to make changes:
-   - Explain you are read-only
-   - Recommend using CodeActAgent instead
-</GUIDELINES>
+OUTPUT STYLE
+- Keep the plan readable and structured
+- Prefer bullets and numbered lists
+- Defer implementation details and code changes to the execution phase

--- a/openhands/agenthub/readonly_agent/readonly_agent.py
+++ b/openhands/agenthub/readonly_agent/readonly_agent.py
@@ -1,4 +1,10 @@
-"""ReadOnlyAgent - A specialized version of CodeActAgent that only uses read-only tools."""
+"""ReadOnlyPlanningAgent - A specialized planning agent for read-only research plus maintaining PLAN.md.
+
+This agent is derived from CodeActAgent and constrained to:
+- Use read-only research tools (grep, glob, view) to explore the repository
+- Maintain a single planning document at /workspace/PLAN.md via a dedicated plan editor tool
+- Avoid any other code execution or edits outside PLAN.md
+"""
 
 import os
 from typing import TYPE_CHECKING
@@ -19,20 +25,14 @@ from openhands.llm.llm import LLM
 from openhands.utils.prompt import PromptManager
 
 
-class ReadOnlyAgent(CodeActAgent):
+class ReadOnlyPlanningAgent(CodeActAgent):
     VERSION = '1.0'
     """
-    The ReadOnlyAgent is a specialized version of CodeActAgent that only uses read-only tools.
-
-    This agent is designed for safely exploring codebases without making any changes.
-    It only has access to tools that don't modify the system: grep, glob, view, think, finish, web_read.
-
-    Use this agent when you want to:
-    1. Explore a codebase to understand its structure
-    2. Search for specific patterns or code
-    3. Research without making any changes
-
-    When you're ready to make changes, switch to the regular CodeActAgent.
+    The ReadOnlyPlanningAgent is designed for planning large features safely.
+    It provides:
+    - Read-only repo exploration: grep, glob, view
+    - PLAN.md maintenance via a specialized plan editor tool (create/view/edit only)
+    - No other file modifications or command execution
     """
 
     def __init__(
@@ -50,7 +50,7 @@ class ReadOnlyAgent(CodeActAgent):
         super().__init__(llm, config)
 
         logger.debug(
-            f'TOOLS loaded for ReadOnlyAgent: {", ".join([tool.get("function").get("name") for tool in self.tools])}'
+            f'TOOLS loaded for ReadOnlyPlanningAgent: {", ".join([tool.get("function").get("name") for tool in self.tools])}'
         )
 
     @property
@@ -74,7 +74,7 @@ class ReadOnlyAgent(CodeActAgent):
         - mcp_tools (list[dict]): The list of MCP tools.
         """
         logger.warning(
-            'ReadOnlyAgent does not support MCP tools. MCP tools will be ignored by the agent.'
+            'ReadOnlyPlanningAgent does not support MCP tools. MCP tools will be ignored by the agent.'
         )
 
     def response_to_actions(self, response: 'ModelResponse') -> list['Action']:

--- a/openhands/agenthub/readonly_agent/tools/__init__.py
+++ b/openhands/agenthub/readonly_agent/tools/__init__.py
@@ -5,17 +5,20 @@ This module defines the read-only tools for the ReadOnlyAgent.
 
 from .glob import GlobTool
 from .grep import GrepTool
+from .plan_md import create_plan_md_tool
 from .view import ViewTool
 
 __all__ = [
     'ViewTool',
     'GrepTool',
     'GlobTool',
+    'create_plan_md_tool',
 ]
 
-# Define the list of read-only tools
+# Define the list of read-only tools for exploration and planning
 READ_ONLY_TOOLS = [
     ViewTool,
     GrepTool,
     GlobTool,
+    # plan_md tool is exported as a factory; included via function_calling.get_tools
 ]

--- a/openhands/agenthub/readonly_agent/tools/plan_md.py
+++ b/openhands/agenthub/readonly_agent/tools/plan_md.py
@@ -1,0 +1,47 @@
+from litellm import ChatCompletionToolParam, ChatCompletionToolParamFunctionChunk
+
+PLAN_MD_TOOL_NAME = 'plan_md'
+
+_PLAN_MD_DESCRIPTION = """Maintain the planning document PLAN.md in the repository root.
+
+This tool is ONLY for planning. It can:
+- view: Show the current contents of PLAN.md
+- create: Create PLAN.md with provided text (fails if file already exists)
+- edit: Replace PLAN.md content with provided text
+
+It MUST NOT be used to modify any other file.
+"""
+
+
+def create_plan_md_tool() -> ChatCompletionToolParam:
+    return ChatCompletionToolParam(
+        type='function',
+        function=ChatCompletionToolParamFunctionChunk(
+            name=PLAN_MD_TOOL_NAME,
+            description=_PLAN_MD_DESCRIPTION,
+            parameters={
+                'type': 'object',
+                'properties': {
+                    'command': {
+                        'type': 'string',
+                        'enum': ['view', 'create', 'edit'],
+                        'description': 'Operation to perform on PLAN.md',
+                    },
+                    'file_text': {
+                        'type': 'string',
+                        'description': 'Required for create: Initial content of PLAN.md',
+                    },
+                    'old_str': {
+                        'type': 'string',
+                        'description': 'Required for edit: EXACT current content of PLAN.md (unique match). Use plan_md.view first.',
+                    },
+                    'new_str': {
+                        'type': 'string',
+                        'description': 'Required for edit: New full content of PLAN.md (replaces file)',
+                    },
+                },
+                'required': ['command'],
+                'additionalProperties': False,
+            },
+        ),
+    )

--- a/openhands/cli/commands.py
+++ b/openhands/cli/commands.py
@@ -165,6 +165,29 @@ async def handle_commands(
         )
     elif command == '/mcp':
         await handle_mcp_command(config)
+    elif command == '/plan':
+        # Prompt for planning objective and delegate to ReadOnlyPlanningAgent
+        objective = await collect_input(config, 'Enter planning objective:')
+        if objective is None:
+            return close_repl, reload_microagents, new_session_requested, exit_reason
+        from openhands.events import EventSource as _ES
+        from openhands.events.action import AgentDelegateAction
+
+        event_stream.add_event(
+            AgentDelegateAction(
+                agent='ReadOnlyPlanningAgent', inputs={'task': objective}
+            ),
+            _ES.USER,
+        )
+    elif command == '/execute':
+        # End the planning delegate and return to the parent
+        from openhands.events import EventSource as _ES
+        from openhands.events.action import AgentFinishAction
+
+        event_stream.add_event(
+            AgentFinishAction(final_thought='Switching to execution mode'),
+            _ES.USER,
+        )
     else:
         close_repl = True
         action = MessageAction(content=command)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

## Body
Implements Approach 1 from #10433: a delegate-based Ask/Plan → Execute flow with a Planning agent that can only explore read-only and maintain a single planning document (PLAN.md). Frontend is intentionally left out for this MVP.

## New agent: ReadOnlyPlanningAgent (repurposes ReadOnlyAgent; alias preserved)
- Exposes only read-only research tools (grep, glob, view) + a dedicated plan_md tool
- Disallows MCP tools and any code execution/edits beyond PLAN.md
- New tool: plan_md (ACI)
  - Commands: view, create, edit
  - Hard-coded path /workspace/PLAN.md (no plan_path passed)
  - view → FileReadAction(impl_source=OH_ACI)
  - create → FileEditAction(command='create', impl_source=OH_ACI)
  - edit → FileEditAction(command='str_replace', old_str, new_str, impl_source=OH_ACI)
  - edit requires exact old_str; model should plan to view first, then replace the entire file for safety/uniqueness
 
Planning prompt tightened
- Prohibits any code execution
- Encourages iterative planning and updates only via plan_md

CLI toggles
- /plan: prompts for a planning objective and emits AgentDelegateAction(agent='ReadOnlyPlanningAgent', inputs={'task': <objective>})
- /execute: emits AgentFinishAction to end the delegate and return to the parent
- Added prior to the final else in the command handler; MessageAction remains the fallback path

- Backward compatibility
  - Agent.register('ReadOnlyPlanningAgent', ReadOnlyPlanningAgent)
  - Agent.register('ReadOnlyAgent', ReadOnlyPlanningAgent)

Key files changed

- openhands/agenthub/readonly_agent/readonly_agent.py: new agent wrapper
- openhands/agenthub/readonly_agent/init.py: register agent + alias
- openhands/agenthub/readonly_agent/tools/plan_md.py: plan_md tool schema (view/create/edit with old_str/new_str)
- openhands/agenthub/readonly_agent/tools/init.py: export plan_md factory
- openhands/agenthub/readonly_agent/function_calling.py: wire plan_md → ACI; include in get_tools()
- openhands/agenthub/readonly_agent/prompts/system_prompt.j2: restrict to planning; document plan_md usage
- openhands/cli/commands.py: add /plan and /execute branches (before final else)
Usage (CLI MVP)

- /plan → enter a planning objective when prompted; a planning delegate starts. The planning agent explores repo with grep/glob/view and maintains /workspace/PLAN.md via plan_md
  - If PLAN.md is missing → plan_md.create(file_text=…)
  - If present → plan_md.view to obtain old_str, then plan_md.edit(old_str=…, new_str=…) to replace file content
- /execute → end delegate and return to the parent

---
**Link of any specific issues this addresses:**

Fix 
