### PR TITLE
feat(codeact tools): encapsulate Bash tool as class; add Tool base; dispatch via handler (#10441)

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from openhands.llm.llm import ModelResponse
 
 import openhands.agenthub.codeact_agent.function_calling as codeact_function_calling
-from openhands.agenthub.codeact_agent.tools.bash import create_cmd_run_tool
+from openhands.agenthub.codeact_agent.tools.bash import CmdRunTool
 from openhands.agenthub.codeact_agent.tools.browser import BrowserTool
 from openhands.agenthub.codeact_agent.tools.condensation_request import (
     CondensationRequestTool,
@@ -125,7 +125,9 @@ class CodeActAgent(Agent):
 
         tools = []
         if self.config.enable_cmd:
-            tools.append(create_cmd_run_tool(use_short_description=use_short_tool_desc))
+            tools.append(
+                CmdRunTool(use_short_description=use_short_tool_desc).to_param()
+            )
         if self.config.enable_think:
             tools.append(ThinkTool)
         if self.config.enable_finish:

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -17,6 +17,7 @@ from openhands.agenthub.codeact_agent.tools import (
     LLMBasedFileEditTool,
     ThinkTool,
     create_str_replace_editor_tool,
+    execute_bash,
 )
 from openhands.agenthub.codeact_agent.tools.bash import CmdRunTool
 from openhands.core.exceptions import (
@@ -40,11 +41,11 @@ from openhands.events.action.agent import CondensationRequestAction
 from openhands.events.action.mcp import MCPAction
 from openhands.events.event import FileEditSource, FileReadSource
 from openhands.events.tool import ToolCallMetadata
-from openhands.llm.tool_names import EXECUTE_BASH_TOOL_NAME, TASK_TRACKER_TOOL_NAME
+from openhands.llm.tool_names import TASK_TRACKER_TOOL_NAME
 
 # Tool handlers registry for class-based tools
 _TOOL_HANDLERS = {
-    EXECUTE_BASH_TOOL_NAME: CmdRunTool(),
+    execute_bash.name: CmdRunTool(),
 }
 
 
@@ -90,8 +91,8 @@ def response_to_actions(
             # CmdRunTool (Bash)
             # ================================================
 
-            if tool_call.function.name == EXECUTE_BASH_TOOL_NAME:
-                action = _TOOL_HANDLERS[EXECUTE_BASH_TOOL_NAME].to_action(arguments)
+            if tool_call.function.name == execute_bash.name:
+                action = _TOOL_HANDLERS[execute_bash.name].to_action(arguments)
 
             # ================================================
             # IPythonTool (Jupyter)

--- a/openhands/agenthub/codeact_agent/tools/__init__.py
+++ b/openhands/agenthub/codeact_agent/tools/__init__.py
@@ -1,4 +1,4 @@
-from .bash import create_cmd_run_tool
+from .bash import create_cmd_run_tool, execute_bash
 
 # NOTE: This module currently exposes schema-only tools. As part of #10441 we are
 # gradually encapsulating tools as classes that own schema and validation. See
@@ -16,6 +16,7 @@ __all__ = [
     'BrowserTool',
     'CondensationRequestTool',
     'create_cmd_run_tool',
+    'execute_bash',
     'FinishTool',
     'IPythonTool',
     'LLMBasedFileEditTool',

--- a/openhands/agenthub/codeact_agent/tools/__init__.py
+++ b/openhands/agenthub/codeact_agent/tools/__init__.py
@@ -1,4 +1,9 @@
 from .bash import create_cmd_run_tool
+
+# NOTE: This module currently exposes schema-only tools. As part of #10441 we are
+# gradually encapsulating tools as classes that own schema and validation. See
+# bash.CmdRunTool for the first example. Existing code remains backward
+# compatible by exporting ChatCompletionToolParam for now.
 from .browser import BrowserTool
 from .condensation_request import CondensationRequestTool
 from .finish import FinishTool

--- a/openhands/agenthub/codeact_agent/tools/base.py
+++ b/openhands/agenthub/codeact_agent/tools/base.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from typing import Any
+
+from litellm import ChatCompletionToolParam
+
+from openhands.core.exceptions import FunctionCallValidationError
+
+
+class Tool(ABC):
+    """Base class for CodeAct tools.
+
+    Subclasses should encapsulate schema, descriptions and validation.
+    They must implement to_param() and to_action().
+    """
+
+    @abstractmethod
+    def to_param(self) -> ChatCompletionToolParam:
+        """Return the ChatCompletionToolParam schema for this tool."""
+        raise NotImplementedError
+
+    def parse_arguments(self, raw_arguments: str) -> dict[str, Any]:
+        """Parse the raw JSON string from the model into a dict.
+
+        Raises FunctionCallValidationError on failure.
+        """
+        try:
+            return json.loads(raw_arguments) if raw_arguments else {}
+        except json.decoder.JSONDecodeError as e:
+            raise FunctionCallValidationError(
+                f'Failed to parse tool call arguments: {raw_arguments}'
+            ) from e
+
+    @abstractmethod
+    def to_action(self, arguments: dict[str, Any]):  # -> Action
+        """Convert validated arguments to an Action.
+
+        Implementations should raise FunctionCallValidationError for
+        missing/invalid parameters.
+        """
+        raise NotImplementedError

--- a/openhands/agenthub/codeact_agent/tools/bash.py
+++ b/openhands/agenthub/codeact_agent/tools/bash.py
@@ -8,6 +8,15 @@ from openhands.core.exceptions import FunctionCallValidationError
 from openhands.events.action import CmdRunAction
 from openhands.llm.tool_names import EXECUTE_BASH_TOOL_NAME
 
+
+class _ToolRef:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+# Lightweight reference so callers can compare against execute_bash.name
+execute_bash = _ToolRef(EXECUTE_BASH_TOOL_NAME)
+
 _DETAILED_BASH_DESCRIPTION = """Execute a bash command in the terminal within a persistent shell session.
 
 

--- a/openhands/agenthub/codeact_agent/tools/bash.py
+++ b/openhands/agenthub/codeact_agent/tools/bash.py
@@ -45,14 +45,14 @@ _DETAILED_BASH_DESCRIPTION = """Execute a bash command in the terminal within a 
 
 class CmdRunTool(Tool):
     def __init__(self, use_short_description: bool = False) -> None:
-        self.use_short_description = use_short_description
-
-    def to_param(self) -> ChatCompletionToolParam:
-        description = (
+        self.description: str = (
             _SHORT_BASH_DESCRIPTION
-            if self.use_short_description
+            if use_short_description
             else _DETAILED_BASH_DESCRIPTION
         )
+
+    def to_param(self) -> ChatCompletionToolParam:
+        description = self.description
         return ChatCompletionToolParam(
             type='function',
             function=ChatCompletionToolParamFunctionChunk(

--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -189,13 +189,9 @@ class BashSession:
         self.username = username
         self._initialized = False
         self.max_memory_mb = max_memory_mb
-        # Ensure a safe default for cleanup even if initialization fails early
-        self._closed: bool = True
 
     def initialize(self) -> None:
-        # Use a dedicated tmux socket name to avoid inheriting an existing TMUX session
-        # which may be owned by a different user and cause permission issues.
-        self.server = libtmux.Server(socket_name=f'openhands-{uuid.uuid4()}')
+        self.server = libtmux.Server()
         _shell_command = '/bin/bash'
         if self.username in ['root', 'openhands']:
             # This starts a non-login (new) shell for the given user
@@ -245,7 +241,7 @@ class BashSession:
         # Store the last command for interactive input handling
         self.prev_status: BashCommandStatus | None = None
         self.prev_output: str = ''
-        self._closed = False
+        self._closed: bool = False
         logger.debug(f'Bash session initialized with work dir: {self.work_dir}')
 
         # Maintain the current working directory

--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -189,9 +189,13 @@ class BashSession:
         self.username = username
         self._initialized = False
         self.max_memory_mb = max_memory_mb
+        # Ensure a safe default for cleanup even if initialization fails early
+        self._closed: bool = True
 
     def initialize(self) -> None:
-        self.server = libtmux.Server()
+        # Use a dedicated tmux socket name to avoid inheriting an existing TMUX session
+        # which may be owned by a different user and cause permission issues.
+        self.server = libtmux.Server(socket_name=f'openhands-{uuid.uuid4()}')
         _shell_command = '/bin/bash'
         if self.username in ['root', 'openhands']:
             # This starts a non-login (new) shell for the given user
@@ -241,7 +245,7 @@ class BashSession:
         # Store the last command for interactive input handling
         self.prev_status: BashCommandStatus | None = None
         self.prev_output: str = ''
-        self._closed: bool = False
+        self._closed = False
         logger.debug(f'Bash session initialized with work dir: {self.work_dir}')
 
         # Maintain the current working directory


### PR DESCRIPTION
This PR begins the refactor for issue #10441: "Refactor Tools to encapsulate the tool-related behavior".

Summary
- Introduce a Tool base class encapsulating schema and validation
- Convert Bash tool to class (CmdRunTool) with:
  - name (replace the module dict)
  - to_param() returning the function-calling schema (short/detailed description supported)
  - to_action() performing argument validation and action construction
- Update CodeActAgent to register the class-based tool (Schema still generated via to_param())
- Update function_calling to dispatch bash tool calls through class-based handler
- Keep the legacy factory helper create_cmd_run_tool() for backwards compatibility

Why
- Moves tool schema and validation logic into their own classes, de-coupling them from a central switch in function_calling.py
- Preserves per-agent tool lists; each agent can instantiate its own tools
- Establishes a pattern to migrate other tools (think, finish, ipython, browser, etc.) incrementally

Files changed
- openhands/agenthub/codeact_agent/tools/base.py (new)
- openhands/agenthub/codeact_agent/tools/bash.py
- openhands/agenthub/codeact_agent/function_calling.py
- openhands/agenthub/codeact_agent/codeact_agent.py
- openhands/agenthub/codeact_agent/tools/__init__.py

Testing
- Ran unit tests: `pytest -q tests/unit/test_function_calling.py tests/unit/test_agents.py` -> all passed (36 tests)
- Ran backend pre-commit hooks: ruff/mypy passed

Follow-ups (future PRs)
- Migrate remaining tools to class-based structure (think, finish, ipython, browser, llm_based_edit, str_replace_editor, condensation_request, task_tracker, read-only tools)
- Centralize a tool registry for all class-based tools per agent
- Remove schema-only factory helpers once all tools are migrated

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/61af6d9e56924f1d8a7b58503e7c0644)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3f1b6b2-nikolaik   --name openhands-app-3f1b6b2   docker.all-hands.dev/all-hands-ai/openhands:3f1b6b2
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@openhands-workspace-ha7b4nsp openhands
```