### PR TITLE
chore: remove timeout >600s warning log in Event.set_hard_timeout

### DIFF
--- a/openhands/events/event.py
+++ b/openhands/events/event.py
@@ -90,14 +90,6 @@ class Event:
         until the timeout is reached.
         """
         self._timeout = value
-        if value is not None and value > 600:
-            from openhands.core.logger import openhands_logger as logger
-
-            logger.warning(
-                'Timeout greater than 600 seconds may not be supported by '
-                'the runtime. Consider setting a lower timeout.'
-            )
-
         # Check if .blocking is an attribute of the event
         if hasattr(self, 'blocking'):
             # .blocking needs to be set to True if .timeout is set


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you must provide an end-user friendly description for your change below

End-user friendly description of the problem this fixes or functionality this introduces.

Removes an unnecessary warning message that appeared when setting timeouts greater than 600 seconds. This cleans up logs and avoids confusion since timeouts above 600s may still be valid depending on the runtime configuration.

---
Summarize what the PR does, explaining any non-trivial design decisions.

With nested runtime in SaaS, this is no long relavant

- Removes the logger.warning block in openhands/events/event.py within Event.set_hard_timeout that printed "Timeout greater than 600 seconds may not be supported by the runtime. Consider setting a lower timeout."
- No functional behavior change beyond log output; timeout handling remains unchanged.
- No test updates required as this only affects logging.

---
Link of any specific issues this addresses:

N/A

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d20a141-nikolaik   --name openhands-app-d20a141   docker.all-hands.dev/all-hands-ai/openhands:d20a141
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@remove-timeout-600s-warning openhands
```