### PR TITLE
Add instruction to use existing repository labels in PR/MR microagents

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -87,6 +87,8 @@ VSCode Extension:
 
 If you are starting a pull request (PR), please follow the template in `.github/pull_request_template.md`.
 
+When opening a PR, you should check the existing labels defined on that repository and select from existing ones. Do not invent your own labels.
+
 ## Implementation Details
 
 These details may or may not be useful for your current task.

--- a/microagents/github.md
+++ b/microagents/github.md
@@ -26,6 +26,7 @@ Here are some instructions for pushing, but ONLY do this if the user asks you to
 * Use the `create_pr` tool to create a pull request, if you haven't already
 * Once you've created your own branch or a pull request, continue to update it. Do NOT create a new one unless you are explicitly asked to. Update the PR title and description as necessary, but don't change the branch name.
 * Use the main branch as the base branch, unless the user requests otherwise
+* When opening a PR, check the existing labels defined on that repository and select from existing ones. Do not invent your own labels.
 * After opening or updating a pull request, send the user a short message with a link to the pull request.
 * Do NOT mark a pull request as ready to review unless the user explicitly says so
 * Do all of the above in as few steps as possible. E.g. you could push changes with one step by running the following bash commands:

--- a/microagents/gitlab.md
+++ b/microagents/gitlab.md
@@ -26,6 +26,7 @@ Here are some instructions for pushing, but ONLY do this if the user asks you to
 * Use the `create_mr` tool to create a merge request, if you haven't already
 * Once you've created your own branch or a merge request, continue to update it. Do NOT create a new one unless you are explicitly asked to. Update the PR title and description as necessary, but don't change the branch name.
 * Use the main branch as the base branch, unless the user requests otherwise
+* When opening a MR, check the existing labels defined on that repository and select from existing ones. Do not invent your own labels.
 * After opening or updating a merge request, send the user a short message with a link to the merge request.
 * Do all of the above in as few steps as possible. E.g. you could push changes with one step by running the following bash commands:
 ```bash


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This change improves OpenHands agents' behavior when creating pull requests and merge requests by instructing them to use existing repository labels rather than inventing new ones. This ensures better consistency with repository conventions and reduces label proliferation.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds instructions to microagents that guide OpenHands agents to check and use existing repository labels when opening pull requests or merge requests, rather than creating new labels.

**Changes made:**
- **GitHub microagent** (`microagents/github.md`): Added instruction to check existing labels when opening PRs
- **GitLab microagent** (`microagents/gitlab.md`): Added instruction to check existing labels when opening MRs  
- **OpenHands repo microagent** (`.openhands/microagents/repo.md`): Added instruction in the PR template section
- **Bitbucket microagent**: Intentionally not modified as Bitbucket Cloud lacks native label support

**Design decisions:**
- Added the instruction to all relevant platform microagents for consistency
- Placed the instruction in the appropriate context within each microagent's PR/MR creation guidelines
- Researched platform capabilities to ensure accuracy (GitLab and GitHub support labels natively, Bitbucket does not)

---
**Link of any specific issues this addresses:**

This addresses the general issue of agents creating unnecessary or inconsistent labels when opening PRs/MRs across different repositories.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/40f0ab8d5fdb4244a39bb4b646580de0)