### PR TITLE
refactor(frontend): remove scrollbar background on all canvas screens

### DIFF
--- a/frontend/src/components/features/jupyter/jupyter.tsx
+++ b/frontend/src/components/features/jupyter/jupyter.tsx
@@ -35,7 +35,7 @@ export function JupyterEditor({ maxWidth }: JupyterEditorProps) {
         <div className="flex-1 h-full flex flex-col" style={{ maxWidth }}>
           <div
             data-testid="jupyter-container"
-            className="flex-1 overflow-y-auto fast-smooth-scroll"
+            className="flex-1 overflow-y-auto fast-smooth-scroll custom-scrollbar-always"
             ref={jupyterRef}
             onScroll={(e) => onChatBodyScroll(e.currentTarget)}
           >

--- a/frontend/src/routes/changes-tab.tsx
+++ b/frontend/src/routes/changes-tab.tsx
@@ -67,7 +67,7 @@ function GitChanges() {
   ]);
 
   return (
-    <main className="h-full overflow-y-scroll px-4 py-3 gap-3 flex flex-col items-center">
+    <main className="h-full overflow-y-scroll px-4 py-3 gap-3 flex flex-col items-center custom-scrollbar-always">
       {!isSuccess || !gitChanges.length ? (
         <div className="relative flex h-full w-full items-center">
           <div className="absolute inset-x-0 top-1/2 -translate-y-1/2">

--- a/frontend/src/routes/served-tab.tsx
+++ b/frontend/src/routes/served-tab.tsx
@@ -89,7 +89,7 @@ function ServedApp() {
         key={refreshKey}
         title={t(I18nKey.SERVED_APP$TITLE)}
         src={fullUrl}
-        className="w-full h-full"
+        className="w-full h-full custom-scrollbar-always"
       />
     </div>
   );


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="395" height="1600" alt="all-3172-issue" src="https://github.com/user-attachments/assets/e36e048c-adb6-4268-8c4a-53868e2441d5" />

According to the image above, we need to remove scrollbar background on all canvas screens.

**Acceptance criteria:**
- The scrollbar background should be removed on all Canvas screens.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR removes scrollbar background on all canvas screens.

> - VSCode uses its default scrollbar, which does not have a background.  
>- The scrollbars in the **App** and **Browser** tabs belong to the rendered application.  
>  Therefore, we do not need to make any changes for those tabs.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/1284fd3d-e6ce-4315-a1e3-706b9f53ad8e

---
**Link of any specific issues this addresses:**
