### PR TITLE
refactor(frontend): move the drop arrow to the right (repo-selection form)

### DIFF
--- a/frontend/src/components/common/react-select-styles.ts
+++ b/frontend/src/components/common/react-select-styles.ts
@@ -186,7 +186,7 @@ export const repoBranchDropdownStyles: StylesConfig<SelectOption, false> = {
     backgroundColor: "#454545",
     borderRadius: "0.25rem",
     boxShadow: "none",
-    padding: "0 0.75rem",
+    padding: "0 0.5rem 0 0.75rem",
     height: "42px",
     "> div:first-child": {
       transform: "translateY(-1px)",
@@ -216,7 +216,7 @@ export const repoBranchDropdownStyles: StylesConfig<SelectOption, false> = {
     "& .repo-branch-dropdown__indicators": {
       transform: "translateY(-1px)",
       height: "42px",
-      padding: "0 0.5rem",
+      padding: "0",
       "& > div": {
         padding: "0",
       },


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="333" height="306" alt="all-3168-issue" src="https://github.com/user-attachments/assets/8585dcfb-c433-4f90-8674-21618c8e9d35" />

According to the image above, we need to move the drop arrow to the right (repo-selection form)

**Acceptance Criteria:**
- The drop arrow in the repo-selection form should be moved to the right.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR moves the drop arrow to the right (repo-selection form).

We can refer to the image below for the output of the PR.

<img width="1439" height="745" alt="all-3168" src="https://github.com/user-attachments/assets/6aa27c88-e889-431c-9778-a06b5dd8c36a" />

---
**Link of any specific issues this addresses:**
