### PR TITLE
feat(frontend): add the scroll buttons to scroll the git control bar

### DIFF
--- a/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
@@ -29,7 +29,7 @@ export function GitControlBarBranchButton({
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        "group flex items-center justify-between pl-2.5 pr-2.5 py-1 rounded-[100px]",
+        "group flex items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px]",
         hasBranch
           ? "bg-[#25272D] hover:bg-[#525662] cursor-pointer"
           : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed",

--- a/frontend/src/components/features/chat/git-control-bar-pr-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-pr-button.tsx
@@ -37,7 +37,7 @@ export function GitControlBarPrButton({
       onClick={handlePrClick}
       disabled={!isButtonEnabled}
       className={cn(
-        "flex flex-row gap-[11px] items-center justify-center px-2 py-1 rounded-[100px] w-[126px] h-7",
+        "flex flex-row gap-[11px] items-center justify-center px-2 py-1 rounded-[100px] w-[126px] min-w-[126px] h-7",
         isButtonEnabled
           ? "bg-[#25272D] hover:bg-[#525662] cursor-pointer"
           : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed",

--- a/frontend/src/components/features/chat/git-control-bar-pull-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-pull-button.tsx
@@ -35,7 +35,7 @@ export function GitControlBarPullButton({
       onClick={handlePullClick}
       disabled={!isButtonEnabled}
       className={cn(
-        "flex flex-row gap-1 items-center justify-center px-0.5 py-1 rounded-[100px] w-[76px]",
+        "flex flex-row gap-1 items-center justify-center px-0.5 py-1 rounded-[100px] w-[76px] min-w-[76px]",
         isButtonEnabled
           ? "bg-[#25272D] hover:bg-[#525662] cursor-pointer"
           : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed",

--- a/frontend/src/components/features/chat/git-control-bar-push-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-push-button.tsx
@@ -37,7 +37,7 @@ export function GitControlBarPushButton({
       onClick={handlePushClick}
       disabled={!isButtonEnabled}
       className={cn(
-        "flex flex-row gap-1 items-center justify-center px-0.5 py-1 rounded-[100px] w-[77px]",
+        "flex flex-row gap-1 items-center justify-center px-0.5 py-1 rounded-[100px] w-[77px] min-w-[77px]",
         isButtonEnabled
           ? "bg-[#25272D] hover:bg-[#525662] cursor-pointer"
           : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed",

--- a/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
@@ -29,7 +29,7 @@ export function GitControlBarRepoButton({
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        "group flex flex-row items-center justify-between pl-2.5 pr-2.5 py-1 rounded-[100px]",
+        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit min-w-fit max-w-none flex-shrink-0",
         hasRepository
           ? "bg-[#25272D] hover:bg-[#525662] cursor-pointer"
           : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed",

--- a/frontend/src/components/features/chat/git-control-bar.tsx
+++ b/frontend/src/components/features/chat/git-control-bar.tsx
@@ -5,10 +5,14 @@ import { GitControlBarBranchButton } from "./git-control-bar-branch-button";
 import { GitControlBarPullButton } from "./git-control-bar-pull-button";
 import { GitControlBarPushButton } from "./git-control-bar-push-button";
 import { GitControlBarPrButton } from "./git-control-bar-pr-button";
+import { GitScrollButton } from "./git-scroll-button";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
+import { useHorizontalScroll } from "#/hooks/use-horizontal-scroll";
 import { Provider } from "#/types/settings";
 import { I18nKey } from "#/i18n/declaration";
 import { GitControlBarTooltipWrapper } from "./git-control-bar-tooltip-wrapper";
+import ChevronLeftSmallIcon from "#/icons/chevron-left-small.svg?react";
+import ChevronRightSmallIcon from "#/icons/chevron-right-small.svg?react";
 
 interface GitControlBarProps {
   onSuggestionsClick: (value: string) => void;
@@ -24,6 +28,8 @@ export function GitControlBar({
   optimisticUserMessage,
 }: GitControlBarProps) {
   const { t } = useTranslation();
+  const { scrollContainerRef, canScrollLeft, canScrollRight, scroll } =
+    useHorizontalScroll();
 
   const { data: conversation } = useActiveConversation();
 
@@ -74,66 +80,94 @@ export function GitControlBar({
   const shouldShowTooltipForGitActions = !!tooltipMessage;
 
   return (
-    <div className="flex flex-row gap-2.5 items-center flex-wrap">
-      <GitControlBarTooltipWrapper
-        tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
-        testId="git-control-bar-repo-button-tooltip"
-        shouldShowTooltip={!hasRepository}
-      >
-        <GitControlBarRepoButton
-          selectedRepository={selectedRepository}
-          gitProvider={gitProvider}
-        />
-      </GitControlBarTooltipWrapper>
+    <div className="flex flex-row items-center">
+      {/* Left Arrow */}
+      {canScrollLeft && (
+        <GitScrollButton
+          direction="left"
+          onClick={() => scroll("left")}
+          ariaLabel="Scroll left"
+        >
+          <ChevronLeftSmallIcon width={24} height={24} color="#A3A3A3" />
+        </GitScrollButton>
+      )}
 
-      <GitControlBarTooltipWrapper
-        tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
-        testId="git-control-bar-branch-button-tooltip"
-        shouldShowTooltip={!hasRepository}
+      {/* Scrollable Container */}
+      <div
+        ref={scrollContainerRef}
+        className="flex flex-row gap-2.5 items-center overflow-x-auto flex-nowrap relative scrollbar-hide"
       >
-        <GitControlBarBranchButton
-          selectedBranch={selectedBranch}
-          selectedRepository={selectedRepository}
-          gitProvider={gitProvider}
-        />
-      </GitControlBarTooltipWrapper>
+        <GitControlBarTooltipWrapper
+          tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
+          testId="git-control-bar-repo-button-tooltip"
+          shouldShowTooltip={!hasRepository}
+        >
+          <GitControlBarRepoButton
+            selectedRepository={selectedRepository}
+            gitProvider={gitProvider}
+          />
+        </GitControlBarTooltipWrapper>
 
-      <GitControlBarTooltipWrapper
-        tooltipMessage={tooltipMessage}
-        testId="git-control-bar-pull-button-tooltip"
-        shouldShowTooltip={shouldShowTooltipForGitActions}
-      >
-        <GitControlBarPullButton
-          onSuggestionsClick={onSuggestionsClick}
-          isEnabled={isButtonEnabled}
-        />
-      </GitControlBarTooltipWrapper>
+        <GitControlBarTooltipWrapper
+          tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
+          testId="git-control-bar-branch-button-tooltip"
+          shouldShowTooltip={!hasRepository}
+        >
+          <GitControlBarBranchButton
+            selectedBranch={selectedBranch}
+            selectedRepository={selectedRepository}
+            gitProvider={gitProvider}
+          />
+        </GitControlBarTooltipWrapper>
 
-      <GitControlBarTooltipWrapper
-        tooltipMessage={tooltipMessage}
-        testId="git-control-bar-push-button-tooltip"
-        shouldShowTooltip={shouldShowTooltipForGitActions}
-      >
-        <GitControlBarPushButton
-          onSuggestionsClick={onSuggestionsClick}
-          isEnabled={isButtonEnabled}
-          hasRepository={hasRepository}
-          currentGitProvider={gitProvider}
-        />
-      </GitControlBarTooltipWrapper>
+        <GitControlBarTooltipWrapper
+          tooltipMessage={tooltipMessage}
+          testId="git-control-bar-pull-button-tooltip"
+          shouldShowTooltip={shouldShowTooltipForGitActions}
+        >
+          <GitControlBarPullButton
+            onSuggestionsClick={onSuggestionsClick}
+            isEnabled={isButtonEnabled}
+          />
+        </GitControlBarTooltipWrapper>
 
-      <GitControlBarTooltipWrapper
-        tooltipMessage={tooltipMessage}
-        testId="git-control-bar-pr-button-tooltip"
-        shouldShowTooltip={shouldShowTooltipForGitActions}
-      >
-        <GitControlBarPrButton
-          onSuggestionsClick={onSuggestionsClick}
-          isEnabled={isButtonEnabled}
-          hasRepository={hasRepository}
-          currentGitProvider={gitProvider}
-        />
-      </GitControlBarTooltipWrapper>
+        <GitControlBarTooltipWrapper
+          tooltipMessage={tooltipMessage}
+          testId="git-control-bar-push-button-tooltip"
+          shouldShowTooltip={shouldShowTooltipForGitActions}
+        >
+          <GitControlBarPushButton
+            onSuggestionsClick={onSuggestionsClick}
+            isEnabled={isButtonEnabled}
+            hasRepository={hasRepository}
+            currentGitProvider={gitProvider}
+          />
+        </GitControlBarTooltipWrapper>
+
+        <GitControlBarTooltipWrapper
+          tooltipMessage={tooltipMessage}
+          testId="git-control-bar-pr-button-tooltip"
+          shouldShowTooltip={shouldShowTooltipForGitActions}
+        >
+          <GitControlBarPrButton
+            onSuggestionsClick={onSuggestionsClick}
+            isEnabled={isButtonEnabled}
+            hasRepository={hasRepository}
+            currentGitProvider={gitProvider}
+          />
+        </GitControlBarTooltipWrapper>
+      </div>
+
+      {/* Right Arrow */}
+      {canScrollRight && (
+        <GitScrollButton
+          direction="right"
+          onClick={() => scroll("right")}
+          ariaLabel="Scroll right"
+        >
+          <ChevronRightSmallIcon width={24} height={24} color="#B1B9D3" />
+        </GitScrollButton>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/features/chat/git-scroll-button.tsx
+++ b/frontend/src/components/features/chat/git-scroll-button.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from "react";
+import { cn } from "#/utils/utils";
+
+interface GitScrollButtonProps {
+  direction: "left" | "right";
+  onClick: () => void;
+  ariaLabel: string;
+  children: ReactNode;
+}
+
+export function GitScrollButton({
+  direction,
+  onClick,
+  ariaLabel,
+  children,
+}: GitScrollButtonProps) {
+  const isLeft = direction === "left";
+
+  const baseClasses =
+    "flex items-center h-[28px] w-[30.6px] min-w-[30.6px] cursor-pointer relative z-10 bg-gradient-to-l from-transparent from-[7.76%] to-[#0D0F11] to-[80.02%]";
+
+  const pseudoCommonElementClasses =
+    "before:content-[''] before:absolute before:inset-y-0 before:w-[30px] before:pointer-events-none before:z-[5] before:backdrop-blur-[1px]";
+
+  const pseudoCommonGradientClasses =
+    "before:from-[rgba(13,15,17,0.98)] before:from-0% before:via-[rgba(13,15,17,0.85)] before:via-[25%] before:via-[rgba(13,15,17,0.6)] before:via-[50%] before:via-[rgba(13,15,17,0.2)] before:via-[80%] before:to-transparent before:to-[100%]";
+
+  const pseudoElementClasses = isLeft
+    ? "justify-start before:right-[-30px] before:bg-gradient-to-r"
+    : "justify-end before:left-[-30px] before:bg-gradient-to-l";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        baseClasses,
+        pseudoCommonElementClasses,
+        pseudoCommonGradientClasses,
+        pseudoElementClasses,
+      )}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/hooks/use-horizontal-scroll.ts
+++ b/frontend/src/hooks/use-horizontal-scroll.ts
@@ -1,0 +1,174 @@
+import { useRef, useState, useEffect } from "react";
+
+interface UseHorizontalScrollOptions {
+  scrollAmount?: number;
+  scrollBehavior?: ScrollBehavior;
+}
+
+interface UseHorizontalScrollReturn {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+  scroll: (direction: "left" | "right") => void;
+  updateScrollArrows: () => void;
+}
+
+export function useHorizontalScroll({
+  scrollAmount = 200,
+  scrollBehavior = "smooth",
+}: UseHorizontalScrollOptions = {}): UseHorizontalScrollReturn {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  // Check scroll position and update arrow states
+  const updateScrollArrows = () => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    // Check if content overflows the container
+    const hasOverflow = container.scrollWidth > container.clientWidth;
+
+    if (hasOverflow) {
+      // Has overflow - show arrows based on scroll position
+      const isAtStart = container.scrollLeft <= 0;
+      const isAtEnd =
+        container.scrollLeft >=
+        container.scrollWidth - container.clientWidth - 1; // -1 for floating point precision
+
+      setCanScrollLeft(!isAtStart);
+      setCanScrollRight(!isAtEnd);
+      return;
+    }
+
+    // No overflow - hide both arrows
+    setCanScrollLeft(false);
+    setCanScrollRight(false);
+  };
+
+  // Get the new scroll left position
+  const getNewScrollLeft = (
+    container: HTMLDivElement,
+    direction: "left" | "right",
+  ) => {
+    // Incremental scrolling behavior for left direction
+    if (direction === "left") {
+      return Math.max(0, container.scrollLeft - scrollAmount);
+    }
+
+    // For right direction, scroll to the very end of the container
+    // Add a small buffer to ensure we reach the true end position
+    const maxScrollLeft = container.scrollWidth - container.clientWidth;
+    return Math.min(maxScrollLeft, container.scrollLeft + scrollAmount);
+  };
+
+  // Calculate scroll amount based on wheel delta
+  const calculateWheelScrollAmount = (deltaY: number): number =>
+    // Use a smaller multiplier for more controlled scrolling
+    Math.min(Math.abs(deltaY) * 0.5, scrollAmount);
+
+  // Determine scroll direction from wheel delta
+  const getWheelScrollDirection = (deltaY: number): "left" | "right" =>
+    // Map wheel movement to horizontal scrolling:
+    // - Scroll down (positive deltaY) → move container right
+    // - Scroll up (negative deltaY) → move container left
+    deltaY > 0 ? "right" : "left";
+
+  // Calculate new scroll position for wheel scrolling
+  const getWheelScrollPosition = (
+    container: HTMLDivElement,
+    direction: "left" | "right",
+    wheelScrollAmount: number,
+  ): number => {
+    const currentScrollLeft = container.scrollLeft;
+
+    if (direction === "left") {
+      return Math.max(0, currentScrollLeft - wheelScrollAmount);
+    }
+
+    const maxScrollLeft = container.scrollWidth - container.clientWidth;
+    return Math.min(maxScrollLeft, currentScrollLeft + wheelScrollAmount);
+  };
+
+  // Scroll left or right
+  const scroll = (direction: "left" | "right") => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const newScrollLeft = getNewScrollLeft(container, direction);
+
+    container.scrollTo({
+      left: newScrollLeft,
+      behavior: scrollBehavior,
+    });
+
+    // Update arrow states after scrolling completes
+    updateScrollArrows();
+  };
+
+  // Handle mouse wheel scrolling
+  const handleWheel = (event: WheelEvent) => {
+    event.preventDefault(); // Prevent default vertical scrolling
+
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const { deltaY } = event;
+    const direction = getWheelScrollDirection(deltaY);
+    const wheelScrollAmount = calculateWheelScrollAmount(deltaY);
+    const newScrollLeft = getWheelScrollPosition(
+      container,
+      direction,
+      wheelScrollAmount,
+    );
+
+    container.scrollTo({
+      left: newScrollLeft,
+      behavior: scrollBehavior,
+    });
+
+    // Update arrow states after scrolling
+    updateScrollArrows();
+  };
+
+  // Update scroll arrows on mount and when content changes
+  useEffect(() => {
+    updateScrollArrows();
+
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    container.addEventListener("scroll", updateScrollArrows);
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    window.addEventListener("resize", updateScrollArrows);
+
+    // Use ResizeObserver to detect container size changes
+    const resizeObserver = new ResizeObserver(() => {
+      updateScrollArrows();
+    });
+    resizeObserver.observe(container);
+
+    return () => {
+      container.removeEventListener("scroll", updateScrollArrows);
+      container.removeEventListener("wheel", handleWheel);
+      window.removeEventListener("resize", updateScrollArrows);
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return {
+    scrollContainerRef,
+    canScrollLeft,
+    canScrollRight,
+    scroll,
+    updateScrollArrows,
+  };
+}

--- a/frontend/src/icons/chevron-left-small.svg
+++ b/frontend/src/icons/chevron-left-small.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.8227 16.6549L10.4043 12.6668L13.8227 8.67871L14.9615 9.6549L12.3799 12.6668L14.9615 15.6787L13.8227 16.6549Z" fill="currentColor"/>
+</svg>

--- a/frontend/src/icons/chevron-right-small.svg
+++ b/frontend/src/icons/chevron-right-small.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M10.8615 8.16992L14.2799 12.158L10.8615 16.1461L9.72266 15.1699L12.3043 12.158L9.72266 9.14611L10.8615 8.16992Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

We need to add the scroll buttons to scroll the git control bar.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR introduces scroll buttons for the Git control bar.

You can refer to the demo videos below for more details:

**Video 1:** Scrolling the Git control bar using the scroll buttons.

https://github.com/user-attachments/assets/7cfdb60e-0ac4-4029-9c5c-0eff7c0b26d0

**Video 2:** Scrolling the Git control bar using the mouse wheel.

https://github.com/user-attachments/assets/90f95519-ec47-4835-8666-b57608e2d546

**Video 3:** Hiding the scroll buttons when the width is sufficient to display all buttons.

https://github.com/user-attachments/assets/656a4c67-7ab8-4968-b535-303a7ded4dfb

---
**Link of any specific issues this addresses:**
