### PR TITLE
fix(runtime): correctly set session_api_key for local runtime

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -201,8 +201,14 @@ class LocalRuntime(ActionExecutionClient):
 
         # If there is an API key in the environment we use this in requests to the runtime
         session_api_key = os.getenv('SESSION_API_KEY')
+        self._session_api_key: str | None = None
         if session_api_key:
             self.session.headers['X-Session-API-Key'] = session_api_key
+            self._session_api_key = session_api_key
+
+    @property
+    def session_api_key(self) -> str | None:
+        return self._session_api_key
 
     @property
     def action_execution_server_url(self) -> str:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:14196df-nikolaik   --name openhands-app-14196df   docker.all-hands.dev/all-hands-ai/openhands:14196df
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@xw/mcp-fix openhands
```