### PR TITLE
fix(frontend): issue when clicking on the same chat suggestion more than once

### DIFF
--- a/frontend/__tests__/components/interactive-chat-box.test.tsx
+++ b/frontend/__tests__/components/interactive-chat-box.test.tsx
@@ -320,7 +320,6 @@ describe("InteractiveChatBox", () => {
         <InteractiveChatBox
           onSubmit={onSubmit}
           onStop={onStop}
-          value=""
           isWaitingForUserInput={true}
           hasSubstantiveAgentActions={true}
           optimisticUserMessage={false}

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -60,9 +60,6 @@ export function ChatInterface() {
   const { data: config } = useConfig();
 
   const { curAgentState } = useSelector((state: RootState) => state.agent);
-  const { messageToSend } = useSelector(
-    (state: RootState) => state.conversation,
-  );
 
   const [feedbackPolarity, setFeedbackPolarity] = React.useState<
     "positive" | "negative"
@@ -243,7 +240,6 @@ export function ChatInterface() {
           <InteractiveChatBox
             onSubmit={handleSendMessage}
             onStop={handleStop}
-            value={messageToSend ?? undefined}
             isWaitingForUserInput={isWaitingForUserInput}
             hasSubstantiveAgentActions={hasSubstantiveAgentActions}
             optimisticUserMessage={!!optimisticUserMessage}

--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useCallback, useState } from "react";
+import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { ConversationStatus } from "#/types/conversation-status";
 import { ServerStatus } from "#/components/features/controls/server-status";
@@ -10,11 +11,11 @@ import { useAutoResize } from "#/hooks/use-auto-resize";
 import { DragOver } from "./drag-over";
 import { UploadedFiles } from "./uploaded-files";
 import { Tools } from "../controls/tools";
+import { RootState } from "#/store";
 
 export interface CustomChatInputProps {
   disabled?: boolean;
   showButton?: boolean;
-  value?: string;
   conversationStatus?: ConversationStatus | null;
   onSubmit: (message: string) => void;
   onStop?: () => void;
@@ -28,7 +29,6 @@ export interface CustomChatInputProps {
 export function CustomChatInput({
   disabled = false,
   showButton = true,
-  value = "",
   conversationStatus = null,
   onSubmit,
   onStop,
@@ -39,6 +39,10 @@ export function CustomChatInput({
   buttonClassName = "",
 }: CustomChatInputProps) {
   const [isDragOver, setIsDragOver] = useState(false);
+
+  const { messageToSend } = useSelector(
+    (state: RootState) => state.conversation,
+  );
 
   // Disable input when conversation is stopped
   const isConversationStopped = conversationStatus === "STOPPED";
@@ -70,7 +74,7 @@ export function CustomChatInput({
   const { autoResize } = useAutoResize(chatInputRef, {
     minHeight: 20,
     maxHeight: 450,
-    value,
+    value: messageToSend ?? undefined,
   });
 
   // Function to add files and notify parent

--- a/frontend/src/components/features/chat/interactive-chat-box.tsx
+++ b/frontend/src/components/features/chat/interactive-chat-box.tsx
@@ -21,7 +21,6 @@ import { processFiles, processImages } from "#/utils/file-processing";
 interface InteractiveChatBoxProps {
   onSubmit: (message: string, images: File[], files: File[]) => void;
   onStop: () => void;
-  value?: string;
   isWaitingForUserInput: boolean;
   hasSubstantiveAgentActions: boolean;
   optimisticUserMessage: boolean;
@@ -30,7 +29,6 @@ interface InteractiveChatBoxProps {
 export function InteractiveChatBox({
   onSubmit,
   onStop,
-  value,
   isWaitingForUserInput,
   hasSubstantiveAgentActions,
   optimisticUserMessage,
@@ -160,7 +158,6 @@ export function InteractiveChatBox({
         onSubmit={handleSubmit}
         onStop={onStop}
         onFilesPaste={handleUpload}
-        value={value}
         conversationStatus={conversation?.status || null}
       />
       <div className="mt-4">

--- a/frontend/src/hooks/use-auto-resize.ts
+++ b/frontend/src/hooks/use-auto-resize.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, RefObject } from "react";
+import { IMessageToSend } from "#/state/conversation-slice";
 
 interface UseAutoResizeOptions {
   minHeight?: number;
   maxHeight?: number;
-  value?: string;
+  value?: IMessageToSend;
 }
 
 interface UseAutoResizeReturn {
@@ -41,7 +42,7 @@ export const useAutoResize = (
   useEffect(() => {
     const element = elementRef.current;
     if (element && value !== undefined) {
-      element.textContent = value;
+      element.textContent = value.text;
       autoResize();
     }
   }, [value, autoResize]);

--- a/frontend/src/state/conversation-slice.tsx
+++ b/frontend/src/state/conversation-slice.tsx
@@ -1,12 +1,17 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+export interface IMessageToSend {
+  text: string;
+  timestamp: number;
+}
+
 interface ConversationState {
   isRightPanelShown: boolean;
   images: File[];
   files: File[];
   loadingFiles: string[]; // File names currently being processed
   loadingImages: string[]; // Image names currently being processed
-  messageToSend: string | null;
+  messageToSend: IMessageToSend | null;
   shouldShownAgentLoading: boolean;
 }
 
@@ -80,7 +85,10 @@ export const conversationSlice = createSlice({
       state.loadingImages = [];
     },
     setMessageToSend: (state, action) => {
-      state.messageToSend = action.payload;
+      state.messageToSend = {
+        text: action.payload,
+        timestamp: Date.now(),
+      };
     },
   },
 });


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When clicking the same chat suggestion or the Run button multiple times, the chat input does not behave as expected.

**Steps to Reproduce**

- Click on a chat suggestion or the Run button → the chat input is populated with a predefined prompt.

**Modify the chat input**

- Click on the same chat suggestion or the Run button again.

**Expected Behavior**

- The chat input should be re-populated with the predefined prompt each time.

**Actual Behavior**

- The chat input is not populated after the second click.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes issue when clicking on the same chat suggestion more than once.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/56c90597-5cf3-479a-b31b-7969c0ae5365

---
**Link of any specific issues this addresses:**
