### PR TITLE
fix(frontend): update input text color in repo-selection-form

### DIFF
--- a/frontend/__tests__/components/features/home/repo-selection-form.test.tsx
+++ b/frontend/__tests__/components/features/home/repo-selection-form.test.tsx
@@ -268,7 +268,7 @@ describe("RepositorySelectionForm", () => {
 
     // Verify that the onRepoSelection callback prop was provided
     expect(mockOnRepoSelection).toBeDefined();
-    
+
     // Since testing complex dropdown interactions is challenging with the current mocking setup,
     // we'll verify that the basic structure is in place and the callback is available
     expect(typeof mockOnRepoSelection).toBe("function");

--- a/frontend/src/components/common/react-select-styles.ts
+++ b/frontend/src/components/common/react-select-styles.ts
@@ -205,6 +205,11 @@ export const repoBranchDropdownStyles: StylesConfig<SelectOption, false> = {
       padding: "0 0.5rem",
       transform: "translateY(-1px)",
       paddingLeft: "0.25rem",
+      "& .repo-branch-dropdown__input": {
+        color: "#A3A3A3 !important",
+        fontSize: "0.875rem !important",
+        fontWeight: "400 !important",
+      },
     },
     "& .repo-branch-dropdown__indicators-container": {
       height: "42px",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Currently, the input text color in the repository and branch search fields is black. Update it to `#A3A3A3` so it aligns with the existing style.

We can refer to the image below for visual guidance.

<img width="1440" height="742" alt="all-3232-issue" src="https://github.com/user-attachments/assets/28853d5d-f116-4245-918a-e06795fa137e" />

**Acceptance Criteria:**

The input text color should be changed from black to `#A3A3A3`.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates input text color in repo-selection-form.

We can refer to the image below for the output of the PR.

<img width="1440" height="742" alt="all-3232-output" src="https://github.com/user-attachments/assets/4dd1df9c-11ca-410f-8c61-df194fc0c19c" />

---
**Link of any specific issues this addresses:**
