### PR TITLE
fix(frontend): styling for the repo and branch buttons

### DIFF
--- a/frontend/__tests__/components/features/home/repo-selection-form.test.tsx
+++ b/frontend/__tests__/components/features/home/repo-selection-form.test.tsx
@@ -268,7 +268,7 @@ describe("RepositorySelectionForm", () => {
 
     // Verify that the onRepoSelection callback prop was provided
     expect(mockOnRepoSelection).toBeDefined();
-    
+
     // Since testing complex dropdown interactions is challenging with the current mocking setup,
     // we'll verify that the basic structure is in place and the callback is available
     expect(typeof mockOnRepoSelection).toBe("function");

--- a/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
@@ -29,10 +29,10 @@ export function GitControlBarBranchButton({
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        "group flex items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px]",
+        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit min-w-fit max-w-none flex-shrink-0",
         hasBranch
           ? "bg-[#25272D] hover:bg-[#525662] cursor-pointer"
-          : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed",
+          : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed min-w-[108px]",
       )}
     >
       <div className="flex flex-row gap-2 items-center justify-start">

--- a/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
@@ -32,7 +32,7 @@ export function GitControlBarRepoButton({
         "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit min-w-fit max-w-none flex-shrink-0",
         hasRepository
           ? "bg-[#25272D] hover:bg-[#525662] cursor-pointer"
-          : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed",
+          : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed min-w-[170px]",
       )}
     >
       <div className="flex flex-row gap-2 items-center justify-start">


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When no repository or branch is selected, the repo and branch buttons appear misaligned/inconsistent with the current style.

We can refer to the image below for more information.

<img width="1440" height="742" alt="Screenshot 2025-08-21 at 19 50 21" src="https://github.com/user-attachments/assets/53c55ee1-045b-46db-b1ad-66d36e01ffc8" />

**Acceptance Criteria:**

- Update the styling of the repo and branch buttons so they look consistent even when no repository or branch is selected.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes the styling for the repo and branch buttons.

We can refer to the image below for more information.

<img width="1440" height="740" alt="Screenshot 2025-08-21 at 20 45 07" src="https://github.com/user-attachments/assets/981e4e57-8f30-4017-8497-b6d9e8f3d97a" />

---
**Link of any specific issues this addresses:**
