### PR TITLE
Revert "fix(tests): increase hard timeout in test_bash_server to avoid timeout on Windows"

### DIFF
--- a/tests/runtime/test_bash.py
+++ b/tests/runtime/test_bash.py
@@ -94,7 +94,7 @@ def test_bash_server(temp_dir, runtime_cls, run_as_openhands):
         # Verify the server is actually stopped by trying to start another one
         # on the same port (regardless of OS)
         action = CmdRunAction(command='ls')
-        action.set_hard_timeout(3)
+        action.set_hard_timeout(1)
         obs = runtime.run_action(action)
         logger.info(obs, extra={'msg_type': 'OBSERVATION'})
         assert isinstance(obs, CmdOutputObservation)


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#9930

@llamantino From this PR forward, CI is failing on `main` branch. It doesn't make any sense to be because of this PR, but I make this revert PR just to see what CI jobs do.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6555bb9-nikolaik   --name openhands-app-6555bb9   docker.all-hands.dev/all-hands-ai/openhands:6555bb9
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@revert-9930-fix-test-bash-timeout openhands
```