### PR TITLE
Fix: Pin MCP filesystem server and tolerate tool name drift to restore behavior

### DIFF
--- a/docs/usage/mcp.mdx
+++ b/docs/usage/mcp.mdx
@@ -46,7 +46,7 @@ For stdio-based MCP servers, we recommend using MCP proxy tools like [`supergate
 Start the proxy servers separately:
 ```bash
 # Terminal 1: Filesystem server proxy
-supergateway --stdio "npx @modelcontextprotocol/server-filesystem /" --port 8080
+supergateway --stdio "npx -y @modelcontextprotocol/server-filesystem@2025.8.18 /" --port 8080
 
 # Terminal 2: Fetch server proxy
 supergateway --stdio "uvx mcp-server-fetch" --port 8081
@@ -84,7 +84,7 @@ stdio_servers = [
     {
         name="filesystem",
         command="npx",
-        args=["@modelcontextprotocol/server-filesystem", "/"],
+        args=["@modelcontextprotocol/server-filesystem@2025.8.18", "/"],
         env={
             "DEBUG": "true"
         }

--- a/openhands/mcp/utils.py
+++ b/openhands/mcp/utils.py
@@ -234,11 +234,23 @@ async def call_tool_mcp(mcp_clients: list[MCPClient], action: MCPAction) -> Obse
 
     for client in mcp_clients:
         logger.debug(f'MCP client tools: {client.tools}')
-        if action.name in [tool.name for tool in client.tools]:
-            matching_client = client
+        tool_names = [tool.name for tool in client.tools]
+        for t in tool_names:
+            if (
+                t == action.name
+                or t.endswith('_' + action.name)
+                or action.name.endswith('_' + t)
+            ):
+                matching_client = client
+                break
+        if matching_client:
             break
 
     if matching_client is None:
+        available = [tool.name for c in mcp_clients for tool in c.tools]
+        logger.error(
+            f'No matching MCP agent found for tool name: {action.name}. Available tools: {available}'
+        )
         raise ValueError(f'No matching MCP agent found for tool name: {action.name}')
 
     logger.debug(f'Matching client: {matching_client}')

--- a/tests/runtime/test_mcp_action.py
+++ b/tests/runtime/test_mcp_action.py
@@ -44,7 +44,7 @@ def sse_mcp_docker_server():
 
     container_command_args = [
         '--stdio',
-        'npx -y @modelcontextprotocol/server-filesystem /',
+        'npx -y @modelcontextprotocol/server-filesystem@2025.8.18 /',
         '--port',
         str(container_internal_port),  # MCP server inside container listens on this
         '--baseUrl',
@@ -292,7 +292,7 @@ async def test_microagent_and_one_stdio_mcp_in_config(
             name='filesystem',
             command='npx',
             args=[
-                '@modelcontextprotocol/server-filesystem',
+                '@modelcontextprotocol/server-filesystem@2025.8.18',
                 '/',
             ],
         )


### PR DESCRIPTION
Summary
- CI started failing at commit 91d3d1d20 due to upstream changes in @modelcontextprotocol/server-filesystem (latest 2025.8.21) that altered tool naming/behavior. Not caused by our commits.
- This PR pins @modelcontextprotocol/server-filesystem to 2025.8.18 in tests and docs to stop dependency drift.
- Additionally, it improves runtime tool matching to tolerate minor prefix changes (e.g., filesystem_list_directory vs list_directory) so users who don’t pin still have working behavior.

Changes
- docs/usage/mcp.mdx: Pin server-filesystem to @2025.8.18 in SuperGateway and direct stdio examples
- tests/runtime/test_mcp_action.py: Use @2025.8.18 in SSE container command and stdio args to stabilize CI
- openhands/mcp/utils.py: Match MCP tools by exact name or with simple prefix tolerance; log available tools when not matched

Why
- Restore stability (CI and user experience) after upstream change
- Reduce risk from unpinned npm dependencies in examples/tests

Notes
- Last release 0.54.0 at commit 0166df6575 is not among failing commits; failures started later due to dependency drift.
- If CI still fails on SSE proxy, we may need to pin the supercorp/supergateway image tag used in tests.

Co-authored-by: OpenHands-GPT-5 openhands@all-hands.dev

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:37caebf-nikolaik   --name openhands-app-37caebf   docker.all-hands.dev/all-hands-ai/openhands:37caebf
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/mcp-pin-2025-08-21 openhands
```