### PR TITLE
feat: add scripts/openhands_api.py and weekly automation workflows

### DIFF
--- a/.github/workflows/weekly-architecture-refresh.yml
+++ b/.github/workflows/weekly-architecture-refresh.yml
@@ -1,0 +1,78 @@
+name: Weekly Architecture Docs Refresh
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  arch-refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests jinja2
+
+      - name: Run OpenHands conversation to refresh architecture docs
+        env:
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python - << 'PY'
+          import os
+          from pathlib import Path
+          from jinja2 import Environment, FileSystemLoader
+          from scripts.openhands_api import OpenHandsAPI
+
+          repo = os.environ.get('GITHUB_REPOSITORY')
+          prompts_dir = Path('scripts/prompts')
+          env = Environment(loader=FileSystemLoader(str(prompts_dir)))
+
+          # Render the architecture prompt with common tail
+          common_tail = Path(prompts_dir / 'common_tail.j2').read_text()
+          template = env.get_template('architecture_refresh.j2')
+          prompt = template.render(common_tail=common_tail)
+
+          client = OpenHandsAPI()
+          resp = client.create_conversation(
+              initial_user_msg=prompt,
+              repository=repo,
+          )
+          convo_id = resp['conversation_id']
+          print(f"Started conversation: {convo_id}")
+          PY
+
+      - name: Run pre-commit for docs
+        run: pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --all-files || true
+
+      - name: Create Pull Request for docs refresh
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            docs: weekly architecture docs refresh
+
+            Co-authored-by: OpenHands-GPT-5 openhands@all-hands.dev
+          committer: Engel Nyst <engel.nyst@gmail.com>
+          author: Engel Nyst <engel.nyst@gmail.com>
+          branch: docs/arch-refresh-${{ github.run_id }}
+          title: 'docs: weekly architecture docs refresh'
+          body: |
+            This automated PR refreshes the architecture documentation per the weekly workflow.
+            The agent was instructed to open a PR itself if it has changes; this PR consolidates local changes as well.
+          labels: documentation
+          add-paths: |
+            docs/usage/architecture/**

--- a/.github/workflows/weekly-openapi-sync.yml
+++ b/.github/workflows/weekly-openapi-sync.yml
@@ -1,0 +1,62 @@
+name: Weekly OpenAPI Sync
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  openapi-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install project deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install --no-interaction --no-root
+          poetry install --only-root --no-interaction
+
+      - name: Generate openapi.json from FastAPI app
+        run: |
+          python - << 'PY'
+          import json
+          from openhands.server.app import app
+          spec = app.openapi()
+          with open('docs/openapi.json', 'w') as f:
+              json.dump(spec, f, indent=2)
+          PY
+
+      - name: Run pre-commit (python only)
+        run: pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --all-files || true
+
+      - name: Create Pull Request
+        if: ${{ github.ref_name == 'main' || github.ref == 'refs/heads/main' }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            chore: weekly OpenAPI sync
+
+            Co-authored-by: OpenHands-GPT-5 openhands@all-hands.dev
+          committer: Engel Nyst <engel.nyst@gmail.com>
+          author: Engel Nyst <engel.nyst@gmail.com>
+          branch: ci/openapi-update-${{ github.run_id }}
+          title: 'chore: weekly OpenAPI sync'
+          body: |
+            This PR updates docs/openapi.json from the FastAPI app definition.
+
+            - Generated on: ${{ github.run_id }}
+            - Source: openhands.server.app.openapi()
+
+            Please review spec changes. CI should pass.
+          labels: documentation
+          add-paths: |
+            docs/openapi.json

--- a/scripts/openhands_api.py
+++ b/scripts/openhands_api.py
@@ -1,0 +1,137 @@
+"""OpenHands API Python helper for automation tasks.
+
+Default base_url is local server at http://localhost:3000.
+Use https://app.all-hands.dev as secondary non-default option.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+class OpenHandsAPI:
+    """Minimal client for interacting with the OpenHands API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str = 'http://localhost:3000',
+    ):
+        """Initialize the API client.
+
+        Args:
+            api_key: OpenHands API key. If not provided, will use OPENHANDS_API_KEY env var.
+            base_url: Base URL for the OpenHands API. Defaults to localhost:3000.
+        """
+        self.api_key = api_key or os.getenv('OPENHANDS_API_KEY')
+        if not self.api_key:
+            raise ValueError(
+                'API key is required. Set OPENHANDS_API_KEY environment variable or pass api_key parameter.'
+            )
+
+        self.base_url = base_url.rstrip('/')
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                'Authorization': f'Bearer {self.api_key}',
+                'Content-Type': 'application/json',
+            }
+        )
+
+    def create_conversation(
+        self,
+        initial_user_msg: str,
+        repository: str | None = None,
+        selected_branch: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new conversation.
+
+        Args:
+            initial_user_msg: The initial message to start the conversation
+            repository: Git repository name in format "owner/repo" (optional)
+            selected_branch: Git branch to use (optional)
+
+        Returns:
+            Response containing conversation_id and status
+        """
+        conversation_data: dict[str, Any] = {'initial_user_msg': initial_user_msg}
+        if repository:
+            conversation_data['repository'] = repository
+        if selected_branch:
+            conversation_data['selected_branch'] = selected_branch
+
+        response = self.session.post(
+            f'{self.base_url}/api/conversations', json=conversation_data
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def create_conversation_from_files(
+        self,
+        main_prompt_path: str,
+        repository: str | None = None,
+        append_common_tail: bool = True,
+        common_tail_path: str = 'scripts/prompts/common_tail.j2',
+    ) -> dict[str, Any]:
+        """Create a conversation by reading a prompt file and optional common tail."""
+        main_text = Path(main_prompt_path).read_text()
+        if append_common_tail and Path(common_tail_path).exists():
+            tail = Path(common_tail_path).read_text()
+            initial_user_msg = f'{main_text}\n\n{tail}'
+        else:
+            initial_user_msg = main_text
+        return self.create_conversation(
+            initial_user_msg=initial_user_msg,
+            repository=repository,
+        )
+
+    def get_conversation(self, conversation_id: str) -> dict[str, Any]:
+        """Get conversation status and details."""
+        response = self.session.get(
+            f'{self.base_url}/api/conversations/{conversation_id}'
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_trajectory(self, conversation_id: str) -> dict[str, Any]:
+        """Get the trajectory (event history) for a conversation."""
+        response = self.session.get(
+            f'{self.base_url}/api/conversations/{conversation_id}/trajectory'
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def poll_until_stopped(
+        self, conversation_id: str, timeout: int = 1200, poll_interval: int = 30
+    ) -> dict[str, Any]:
+        """Poll conversation until it stops or times out."""
+        start = time.time()
+        while time.time() - start < timeout:
+            convo = self.get_conversation(conversation_id)
+            status = str(convo.get('status', '')).upper()
+            if status == 'STOPPED':
+                return convo
+            if status in ['FAILED', 'ERROR', 'CANCELLED']:
+                return convo
+            time.sleep(poll_interval)
+        raise TimeoutError(
+            f'Conversation {conversation_id} did not stop within {timeout} seconds'
+        )
+
+    def post_github_comment(
+        self, repo: str, issue_number: int, comment: str, token: str
+    ) -> None:
+        """Post a comment to a GitHub issue/PR."""
+        url = f'https://api.github.com/repos/{repo}/issues/{issue_number}/comments'
+        headers = {
+            'Authorization': f'token {token}',
+            'Accept': 'application/vnd.github.v3+json',
+        }
+        data = {'body': comment}
+        response = requests.post(url, headers=headers, json=data)
+        response.raise_for_status()

--- a/scripts/prompts/architecture_refresh.j2
+++ b/scripts/prompts/architecture_refresh.j2
@@ -1,0 +1,69 @@
+You are OpenHands, improving the repository's architecture documentation. Your task this week is to review the current repo state and regenerate or update the architecture documentation with high factual accuracy and comprehensive coverage.
+
+Important naming:
+- Use the term "OpenHands API" (never "Cloud API").
+- The default OpenHands API server is http://localhost:3000. The second, non-default option is https://app.all-hands.dev.
+
+Scope:
+- Cover the entire application: backend server, agent & controller, event stream, storage, runtime (client and action execution server), plugins (Jupyter, VSCode, Browser, Agent Skills), microagents & prompt manager, LLM integration, frontend, security, integrations (VSCode extension), and OpenHands API.
+
+Output location:
+- Write or update MDX pages under docs/usage/architecture/ as follows:
+  - overview.mdx (high-level index linking all component pages)
+  - components/agent.mdx
+  - components/event-stream.mdx
+  - components/server.mdx (renamed from backend-server)
+  - components/storage.mdx
+  - components/runtime.mdx
+  - components/plugins.mdx
+  - components/microagents.mdx
+  - components/llm-integration.mdx
+  - components/frontend.mdx
+  - components/security.mdx
+  - components/integrations.mdx
+  - components/openhands-api.mdx (renamed from cloud-api)
+
+Per-page structure:
+- Frontmatter: title, optional sidebar position
+- Purpose and responsibilities
+- Key modules, classes, entry points (with code references to file paths)
+- Interactions with other components (Mermaid flowchart)
+- Critical paths / sequences (Mermaid sequence diagram)
+- Important configuration and environment variables
+- Error handling and observability
+- Security considerations
+- Extension points
+- Known limitations / TODOs (link issues if applicable)
+- References: list code paths and docs pages used as sources
+- Footer: Last updated (ISO timestamp) and Source commit (git rev-parse HEAD)
+
+Diagrams:
+- Use Mermaid blocks: flowchart, classDiagram, and sequenceDiagram where appropriate.
+- Keep diagrams focused and scoped to the page.
+
+Factuality and citations:
+- Do not invent functionality. Base all assertions on code or existing docs in this repository.
+- For each non-obvious claim, include a parenthetical citation (e.g., source: openhands/server/app.py).
+
+Process:
+- Analyze the repository to determine current architecture and any changes since last week.
+- Update existing docs/usage/architecture/backend.mdx and runtime.mdx by migrating or linking content into components/server.mdx and components/runtime.mdx. Preserve useful diagrams and improve them as needed.
+- Create any missing component pages listed above with initial content and diagrams.
+- Ensure all references to the API use the term "OpenHands API" and respect the default server and secondary server addresses.
+
+Pull Request:
+- If you have changes compared to the prior week, open a PR yourself.
+- Read and follow .github/pull_request_template.md.
+- Title: "docs: weekly architecture docs refresh".
+- Body:
+  - Summary of changes
+  - List of updated/added pages
+  - Notable diagrams and their sources
+  - Citations of key code references
+- Run pre-commit hooks and ensure CI passes before finalizing.
+
+At the end of your updates, ensure all pages render on GitHub (MDX + Mermaid) and link together cleanly from overview.mdx.
+
+Include the following common guidance at the end of each generated/updated file:
+
+{{ common_tail }}

--- a/scripts/prompts/common_tail.j2
+++ b/scripts/prompts/common_tail.j2
@@ -1,0 +1,13 @@
+Style and factuality requirements:
+- Do not invent behavior; verify every statement against repository code or existing docs.
+- Cite sources inline with file paths and short context, e.g., (source: openhands/runtime/action_execution_server.py).
+- Keep tone clear, concise, and neutral.
+- Prefer Mermaid diagrams for flows, classes, and sequences.
+- Include a Last updated timestamp and Source commit (git rev-parse HEAD) at the bottom of each page.
+
+Pull Request requirements:
+- If you propose changes compared to the previous week, open a PR yourself.
+- Read and follow .github/pull_request_template.md.
+- Title: "docs: weekly architecture docs refresh".
+- Body: summarize updated/added pages and major changes; list sources cited.
+- Run pre-commit hooks and ensure CI passes.


### PR DESCRIPTION
This PR introduces a minimal OpenHands API helper and two weekly automation workflows.

Highlights
- scripts/openhands_api.py: Minimal Python helper for the OpenHands API
  - Default base_url: http://localhost:3000
  - Secondary non-default: https://app.all-hands.dev (user can override via parameter)
  - Methods: create_conversation, create_conversation_from_files, get_conversation, get_trajectory, poll_until_stopped
  - Includes a helper to post GitHub comments
  - Intentionally omits LLM settings configuration (can be considered separately)

- .github/workflows/weekly-openapi-sync.yml: Weekly OpenAPI sync
  - Runs weekly (Mon 06:00 UTC) and on manual dispatch
  - Generates docs/openapi.json from the FastAPI app (app.openapi())
  - Opens a PR with the updated spec when changes are detected

- .github/workflows/weekly-architecture-refresh.yml: Weekly architecture docs refresh
  - Runs weekly (Mon 07:00 UTC) and on manual dispatch
  - Starts an OpenHands conversation using a deep prompt
  - Instructs the agent to update per-component pages and diagrams, with citations and last-updated metadata
  - Opens a PR with docs changes under docs/usage/architecture/**

- scripts/prompts/
  - architecture_refresh.j2: Deep prompt specifying scope, naming, per-component page structure, diagrams, citations, and PR guidance (agent explicitly instructed to open a PR if it proposes changes)
  - common_tail.j2: Shared style/citation/PR requirements appended to docs

Notes
- Terminology: Consistently use "OpenHands API" (never "Cloud API").
- Defaults: The helper’s default server is localhost:3000; all-hands.dev is the non-default option.
- Docs naming guidance embedded in the prompt: server.mdx (instead of backend-server.mdx), openhands-api.mdx (instead of cloud-api.mdx).

Validation
- Local pre-commit hooks were executed for basic checks.
- Workflows are scoped to add-paths.

Co-authored-by: OpenHands-GPT-5 openhands@all-hands.dev