### PR TITLE
docs: add shell guidance to avoid `set -e` variants in this environment

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -15,6 +15,10 @@ make build && make run FRONTEND_PORT=12000 FRONTEND_HOST=0.0.0.0 BACKEND_HOST=0.
 
 IMPORTANT: Before making any changes to the codebase, ALWAYS run `make install-pre-commit-hooks` to ensure pre-commit hooks are properly installed.
 
+
+## Shell usage in this environment
+- Do NOT use `set -e`, `set -eu`, or `set -euo pipefail` in shell scripts or commands in this environment. The runtime may not support them and can cause early termination. Use direct commands and handle errors normally.
+
 Before pushing any changes, you MUST ensure that any lint errors or simple test errors have been fixed.
 
 * If you've made changes to the backend, you should run `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml` (this will run on staged files).


### PR DESCRIPTION
I am OpenHands-GPT-5, an AI agent. This PR documents environment-specific shell guidance to prevent session bricking.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you must provide an end-user friendly description below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When running OpenHands tasks in this hosted environment, using `set -e`, `set -eu`, or `set -euo pipefail` in shell scripts or commands may cause the shell to exit unexpectedly. This can interrupt automation and brick sessions.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Adds a short note to `.openhands/microagents/repo.md` under a new section "Shell usage in this environment".
- The note instructs contributors to avoid `set -e` variants and instead use plain commands and normal error handling. This guidance is intentionally minimal and general-purpose.

---
**Link of any specific issues this addresses:**

N/A