### PR TITLE
Refactor conversation status

### DIFF
--- a/openhands/storage/data_models/conversation_status.py
+++ b/openhands/storage/data_models/conversation_status.py
@@ -1,6 +1,6 @@
 """
 This class is similar to the RuntimeStatus defined in the runtime api. (When this class was defined
-a `RuntimeStatus` class already existed in OpenHands which serves a completely different purpose) Some of
+a RuntimeStatus class already existed in OpenHands which serves a completely different purpose) Some of
 the status definitions do not match up:
 
 STOPPED/paused - the runtime is not running but may be restarted
@@ -11,7 +11,7 @@ from enum import Enum
 
 
 class ConversationStatus(Enum):
-    # The runtime is starting
+    # The conversation is starting
     STARTING = 'STARTING'
     # The conversation is running - the agent may be working or idle
     RUNNING = 'RUNNING'
@@ -19,5 +19,5 @@ class ConversationStatus(Enum):
     STOPPED = 'STOPPED'
     # The conversation has been archived and cannot be restarted.
     ARCHIVED = 'ARCHIVED'
-    # Something has gone wrong with the conversation
+    # Something has gone wrong with the conversation (The runtime rather than the agent)
     ERROR = 'ERROR'

--- a/openhands/storage/data_models/conversation_status.py
+++ b/openhands/storage/data_models/conversation_status.py
@@ -1,15 +1,13 @@
-from enum import Enum
+"""
+This class is similar to the RuntimeStatus defined in the runtime api. (When this class was defined
+a `RuntimeStatus` class already existed in OpenHands which serves a completely different purpose) Some of
+the status definitions do not match up:
 
-# TODO: I think this class should be deprecated and replaced with `RuntimeStatus` - the values for which are
-# defined in the runtime api:
-# * running: currently RUNNING
-# * stopped currently ARCHIVED
-# * paused: currently STOPPED
-# * error: currently ERROR
-# * starting: currently STARTING
-#
-# Unifying these two would simplify the codebase - particularly related to what `STOPPED` actually means.
-# Calling this `RuntimeStatus` is more descriptive of what this actually means too.
+STOPPED/paused - the runtime is not running but may be restarted
+ARCHIVED/stopped - the runtime is not running and will not restart due to deleted files.
+"""
+
+from enum import Enum
 
 
 class ConversationStatus(Enum):

--- a/openhands/storage/data_models/conversation_status.py
+++ b/openhands/storage/data_models/conversation_status.py
@@ -1,8 +1,25 @@
 from enum import Enum
 
+# TODO: I think this class should be deprecated and replaced with `RuntimeStatus` - the values for which are
+# defined in the runtime api:
+# * running: currently RUNNING
+# * stopped currently ARCHIVED
+# * paused: currently STOPPED
+# * error: currently ERROR
+# * starting: currently STARTING
+#
+# Unifying these two would simplify the codebase - particularly related to what `STOPPED` actually means.
+# Calling this `RuntimeStatus` is more descriptive of what this actually means too.
+
 
 class ConversationStatus(Enum):
+    # The runtime is starting
     STARTING = 'STARTING'
+    # The conversation is running - the agent may be working or idle
     RUNNING = 'RUNNING'
+    # The conversation has stopped (This is synonymous with `paused` in the runtime API.)
     STOPPED = 'STOPPED'
+    # The conversation has been archived and cannot be restarted.
     ARCHIVED = 'ARCHIVED'
+    # Something has gone wrong with the conversation
+    ERROR = 'ERROR'

--- a/openhands/storage/data_models/conversation_status.py
+++ b/openhands/storage/data_models/conversation_status.py
@@ -5,3 +5,4 @@ class ConversationStatus(Enum):
     STARTING = 'STARTING'
     RUNNING = 'RUNNING'
     STOPPED = 'STOPPED'
+    ARCHIVED = 'ARCHIVED'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Added 2 new conversation states to give parity with runtime API:
* `ARCHIVED`: Conversation has stopped and cannot be restarted.
* `ERROR`: Huston we have a problem!

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
The runtime API can get into a state where a conversation did exist but data related to it was deleted, so the conversation cannot be restarted. The OpenHands API needs to reflect this. (So old conversations do not yield such confusion)

---
**Link of any specific issues this addresses:**
