### PR TITLE
feat: hide conversations after PR closure or merge (microagent management)

### DIFF
--- a/openhands/integrations/bitbucket/bitbucket_service.py
+++ b/openhands/integrations/bitbucket/bitbucket_service.py
@@ -593,6 +593,21 @@ class BitBucketService(BaseGitService, GitService, InstallationsService):
         # Return the URL to the pull request
         return data.get('links', {}).get('html', {}).get('href', '')
 
+    async def get_pr_details(self, repository: str, pr_number: int) -> dict:
+        """Get detailed information about a specific pull request
+
+        Args:
+            repository: Repository name in format 'owner/repo'
+            pr_number: The pull request number
+
+        Returns:
+            Raw Bitbucket API response for the pull request
+        """
+        url = f'{self.BASE_URL}/repositories/{repository}/pullrequests/{pr_number}'
+        pr_data, _ = await self._make_request(url)
+
+        return pr_data
+
     async def get_microagent_content(
         self, repository: str, file_path: str
     ) -> MicroagentContentResponse:

--- a/openhands/integrations/github/github_service.py
+++ b/openhands/integrations/github/github_service.py
@@ -672,6 +672,21 @@ class GitHubService(BaseGitService, GitService, InstallationsService):
         # Return the HTML URL of the created PR
         return response['html_url']
 
+    async def get_pr_details(self, repository: str, pr_number: int) -> dict:
+        """Get detailed information about a specific pull request
+
+        Args:
+            repository: Repository name in format 'owner/repo'
+            pr_number: The pull request number
+
+        Returns:
+            Raw GitHub API response for the pull request
+        """
+        url = f'{self.BASE_URL}/repos/{repository}/pulls/{pr_number}'
+        pr_data, _ = await self._make_request(url)
+
+        return pr_data
+
     async def get_microagent_content(
         self, repository: str, file_path: str
     ) -> MicroagentContentResponse:

--- a/openhands/integrations/gitlab/gitlab_service.py
+++ b/openhands/integrations/gitlab/gitlab_service.py
@@ -626,6 +626,22 @@ class GitLabService(BaseGitService, GitService):
 
         return response['web_url']
 
+    async def get_pr_details(self, repository: str, pr_number: int) -> dict:
+        """Get detailed information about a specific merge request
+
+        Args:
+            repository: Repository name in format 'owner/repo'
+            pr_number: The merge request number (iid)
+
+        Returns:
+            Raw GitLab API response for the merge request
+        """
+        project_id = self._extract_project_id(repository)
+        url = f'{self.BASE_URL}/projects/{project_id}/merge_requests/{pr_number}'
+        mr_data, _ = await self._make_request(url)
+
+        return mr_data
+
     def _extract_project_id(self, repository: str) -> str:
         """Extract project_id from repository name for GitLab API calls.
 

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -626,3 +626,218 @@ class ProviderHandler:
             remote_url = f'https://{domain}/{repo_name}.git'
 
         return remote_url
+
+    async def get_pr_details(
+        self,
+        repository: str,
+        pr_number: int,
+        specified_provider: ProviderType | None = None,
+    ) -> dict:
+        """Get detailed information about a specific pull request/merge request
+
+        Args:
+            repository: Repository name in format 'owner/repo'
+            pr_number: The pull request/merge request number
+            specified_provider: Optional provider type to use
+
+        Returns:
+            Raw API response from the git provider
+
+        Raises:
+            AuthenticationError: If authentication fails
+        """
+        if specified_provider:
+            return await self._get_pr_details_from_specified_provider(
+                repository, pr_number, specified_provider
+            )
+
+        return await self._get_pr_details_from_all_providers(repository, pr_number)
+
+    async def _get_pr_details_from_specified_provider(
+        self, repository: str, pr_number: int, specified_provider: ProviderType
+    ) -> dict:
+        """Get PR details from a specified provider.
+
+        Args:
+            repository: Repository name in format 'owner/repo'
+            pr_number: The pull request/merge request number
+            specified_provider: The specific provider type to use
+
+        Returns:
+            Raw API response from the specified git provider
+
+        Raises:
+            AuthenticationError: If authentication fails
+        """
+        try:
+            service = self._get_service(specified_provider)
+            return await service.get_pr_details(repository, pr_number)
+        except Exception as e:
+            logger.warning(f'Error fetching PR details from {specified_provider}: {e}')
+            raise
+
+    async def _get_pr_details_from_all_providers(
+        self, repository: str, pr_number: int
+    ) -> dict:
+        """Get PR details by trying all available providers in order.
+
+        Args:
+            repository: Repository name in format 'owner/repo'
+            pr_number: The pull request/merge request number
+
+        Returns:
+            Raw API response from the first successful git provider
+
+        Raises:
+            AuthenticationError: If all providers fail
+        """
+        # Try all available providers in order
+        errors = []
+        for provider in self.provider_tokens:
+            try:
+                service = self._get_service(provider)
+                result = await service.get_pr_details(repository, pr_number)
+                if result:
+                    return result
+            except Exception as e:
+                errors.append(f'{provider.value}: {str(e)}')
+                logger.warning(
+                    f'Error fetching PR details from {provider} for {repository}#{pr_number}: {e}'
+                )
+
+        # If all providers failed, raise an error
+        if errors:
+            logger.error(
+                f'Failed to fetch PR details for {repository}#{pr_number} with all available providers. Errors: {"; ".join(errors)}'
+            )
+            raise AuthenticationError(
+                f'Unable to fetch PR details for {repository}#{pr_number}'
+            )
+
+        raise AuthenticationError(f'PR #{pr_number} not found in {repository}')
+
+    async def _is_pr_active(
+        self, repository: str, pr_number: int, git_provider: ProviderType
+    ) -> bool:
+        """Check if a PR is still active (not closed/merged).
+
+        This method checks the PR status using provider-specific logic based on
+        the actual API response structures from GitHub, GitLab, and Bitbucket.
+
+        Args:
+            repository: Repository name in format 'owner/repo'
+            pr_number: The PR number to check
+            git_provider: The Git provider type for this repository
+
+        Returns:
+            True if PR is active (open), False if closed/merged, True if can't determine
+        """
+        try:
+            pr_details = await self.get_pr_details(repository, pr_number, git_provider)
+
+            # Provider-specific logic based on actual API response structures
+            if git_provider == ProviderType.GITHUB:
+                return self._check_github_pr_status(pr_details, repository, pr_number)
+            elif git_provider == ProviderType.GITLAB:
+                return self._check_gitlab_pr_status(pr_details, repository, pr_number)
+            elif git_provider == ProviderType.BITBUCKET:
+                return self._check_bitbucket_pr_status(
+                    pr_details, repository, pr_number
+                )
+
+            # If we can't determine the state, assume it's active (safer default)
+            logger.warning(
+                f'Could not determine PR status for {repository}#{pr_number} on {git_provider}. '
+                f'Response keys: {list(pr_details.keys())}. Assuming PR is active.'
+            )
+            return True
+
+        except Exception as e:
+            logger.warning(
+                f'Could not determine PR status for {repository}#{pr_number}: {e}. '
+                f'Including conversation to be safe.'
+            )
+            # If we can't determine the PR status, include the conversation to be safe
+            return True
+
+    def _check_github_pr_status(
+        self, pr_details: dict, repository: str, pr_number: int
+    ) -> bool:
+        """Check GitHub PR status based on API response structure.
+
+        Args:
+            pr_details: Raw GitHub API response for the PR
+            repository: Repository name for logging
+            pr_number: PR number for logging
+
+        Returns:
+            True if PR is active (open), False if closed/merged
+        """
+        # GitHub API response structure
+        # https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+        if 'state' in pr_details:
+            return pr_details['state'] == 'open'
+        elif 'merged' in pr_details and 'closed_at' in pr_details:
+            # Check if PR is merged or closed
+            return not (pr_details['merged'] or pr_details['closed_at'])
+
+        # If we can't determine the state, assume it's active (safer default)
+        logger.warning(
+            f'Could not determine GitHub PR status for {repository}#{pr_number}. '
+            f'Response keys: {list(pr_details.keys())}. Assuming PR is active.'
+        )
+        return True
+
+    def _check_gitlab_pr_status(
+        self, pr_details: dict, repository: str, pr_number: int
+    ) -> bool:
+        """Check GitLab merge request status based on API response structure.
+
+        Args:
+            pr_details: Raw GitLab API response for the MR
+            repository: Repository name for logging
+            pr_number: MR number for logging
+
+        Returns:
+            True if MR is active (opened), False if closed/merged
+        """
+        # GitLab API response structure
+        # https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr
+        if 'state' in pr_details:
+            return pr_details['state'] == 'opened'
+        elif 'merged_at' in pr_details and 'closed_at' in pr_details:
+            # Check if MR is merged or closed
+            return not (pr_details['merged_at'] or pr_details['closed_at'])
+
+        # If we can't determine the state, assume it's active (safer default)
+        logger.warning(
+            f'Could not determine GitLab MR status for {repository}#{pr_number}. '
+            f'Response keys: {list(pr_details.keys())}. Assuming MR is active.'
+        )
+        return True
+
+    def _check_bitbucket_pr_status(
+        self, pr_details: dict, repository: str, pr_number: int
+    ) -> bool:
+        """Check Bitbucket pull request status based on API response structure.
+
+        Args:
+            pr_details: Raw Bitbucket API response for the PR
+            repository: Repository name for logging
+            pr_number: PR number for logging
+
+        Returns:
+            True if PR is active (OPEN), False if closed/merged
+        """
+        # Bitbucket API response structure
+        # https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-get
+        if 'state' in pr_details:
+            # Bitbucket state values: OPEN, MERGED, DECLINED, SUPERSEDED
+            return pr_details['state'] == 'OPEN'
+
+        # If we can't determine the state, assume it's active (safer default)
+        logger.warning(
+            f'Could not determine Bitbucket PR status for {repository}#{pr_number}. '
+            f'Response keys: {list(pr_details.keys())}. Assuming PR is active.'
+        )
+        return True

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -520,3 +520,15 @@ class GitService(Protocol):
             MicroagentContentResponse with parsed content and triggers
         """
         ...
+
+    async def get_pr_details(self, repository: str, pr_number: int) -> dict:
+        """Get detailed information about a specific pull request/merge request
+
+        Args:
+            repository: Repository name in format specific to the provider
+            pr_number: The pull request/merge request number
+
+        Returns:
+            Raw API response from the git provider
+        """
+        ...


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Conversations should only be displayed if they are associated with OPEN or DRAFT PRs for new microagents.

If a conversation has resulted in a CLOSED or MERGED PR, it should no longer be shown.

**Acceptance Criteria:**
- Only conversations linked to OPEN or DRAFT PRs are visible.
- Conversations with CLOSED or MERGED PRs are hidden.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates the search conversations API to hide conversations after PR closure or merge (microagent management)

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/6df73471-f5fb-4289-ae88-2a2b88b65b07

---
**Link of any specific issues this addresses:**
