### PR TITLE
Fix for issue where exceptions are swallowed

### DIFF
--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -198,18 +198,12 @@ class ProviderHandler:
 
         if selected_provider:
             if not page or not per_page:
-                logger.error('Failed to provider params for paginating repos')
-                return []
+                raise ValueError('Failed to provider params for paginating repos')
 
             service = self._get_service(selected_provider)
-            try:
-                return await service.get_paginated_repos(
-                    page, per_page, sort, installation_id
-                )
-            except Exception as e:
-                logger.warning(f'Error fetching repos from {selected_provider}: {e}')
-
-            return []
+            return await service.get_paginated_repos(
+                page, per_page, sort, installation_id
+            )
 
         all_repos: list[Repository] = []
         for provider in self.provider_tokens:
@@ -246,17 +240,10 @@ class ProviderHandler:
         if selected_provider:
             service = self._get_service(selected_provider)
             public = self._is_repository_url(query, selected_provider)
-            try:
-                user_repos = await service.search_repositories(
-                    query, per_page, sort, order, public
-                )
-                return self._deduplicate_repositories(user_repos)
-            except Exception as e:
-                logger.warning(
-                    f'Error searching repos from select provider {selected_provider}: {e}'
-                )
-
-            return []
+            user_repos = await service.search_repositories(
+                query, per_page, sort, order, public
+            )
+            return self._deduplicate_repositories(user_repos)
 
         all_repos: list[Repository] = []
         for provider in self.provider_tokens:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
If a particular provider is selected and the operation fails, we want an exception to be raised and passed to the exception handler. (Rather than an empty list returned)

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
To test this, I need an invalid github token. Open your `.openhands/secrets.json` and set your github token like so:
```
{"provider_tokens":{"github":{"token":"ghp_not_a_real_token","host":"","user_id":null}}...`

After the change, in the ui, you should see this (Rather than no error as it is now):
<img width="657" height="447" alt="image" src="https://github.com/user-attachments/assets/655b1729-959b-4c4d-9bc2-de249a0fd058" />

---
**Link of any specific issues this addresses:**
