### PR TITLE
fix: Initialise with LLM configuration from environment variables

### DIFF
--- a/openhands/server/user_auth/default_user_auth.py
+++ b/openhands/server/user_auth/default_user_auth.py
@@ -53,7 +53,12 @@ class DefaultUserAuth(UserAuth):
         settings_store = await self.get_user_settings_store()
         settings = await settings_store.load()
 
-        # Merge config.toml settings with stored settings
+        # If no stored settings exist, create default settings from config.toml
+        if not settings:
+            from openhands.storage.data_models.settings import Settings
+            settings = Settings.from_config()
+
+        # Merge config.toml settings with stored settings (if any exist)
         if settings:
             settings = settings.merge_with_config_settings()
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where users with no stored settings would receive `None` instead of default configuration values, and improves the settings merging logic to properly handle default values from config.toml.

## Problem

The user authentication system was returning `None` when no stored settings existed, instead of providing sensible defaults from the config.toml file. Additionally, the settings merging logic was overly aggressive, replacing stored user preferences with config.toml values even when the user had explicitly set different values.

## Changes Made

**Default Settings Creation**: Modified user authentication to create default settings from config.toml when no stored settings exist, ensuring users always receive a valid configuration object
**Settings Merging Logic**: Updated the merge logic to use config.toml settings as defaults only when stored settings are `None`, preserving user preferences while providing fallbacks
**Selective Field Merging**: Added explicit handling for core LLM fields (`llm_model`, `llm_api_key`, `llm_base_url`) to only use config defaults when stored values are `None`
**MCP Config Handling**: Maintained special merging behavior for MCP configuration while fixing the overall merging strategy

## Files Modified

**openhands/server/user_auth/default_user_auth.py**: Added logic to create default settings from config.toml when no stored settings exist, ensuring users always receive a valid configuration
**openhands/storage/data_models/settings.py**: Enhanced settings merging to use config.toml as defaults only when stored values are `None`, and added selective field merging for core LLM settings
**tests/unit/mcp/test_mcp_integration.py**: Updated test to reflect new behavior where default settings are created from config.toml instead of returning `None`

## Testing

- Verified that users with no stored settings receive default configuration from config.toml
- Confirmed that existing user preferences are preserved and not overwritten by config.toml values
- Ensured MCP configuration merging continues to work as expected
- Updated unit tests to reflect the new expected behavior

This resolves configuration issues for new users and improves the overall user experience by ensuring consistent default values while respecting user customizations.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
