### PR TITLE
DO NOT MERGE: investigate load times for bitbucket repo listing

### DIFF
--- a/openhands/integrations/bitbucket/bitbucket_service.py
+++ b/openhands/integrations/bitbucket/bitbucket_service.py
@@ -356,6 +356,9 @@ class BitBucketService(BaseGitService, GitService, InstallationsService):
         Returns:
             A list of Repository objects
         """
+
+        print('reached with params', page, per_page, sort, installation_id, query)
+
         if not installation_id:
             return []
 
@@ -387,7 +390,7 @@ class BitBucketService(BaseGitService, GitService, InstallationsService):
         if query:
             params['q'] = f'name~"{query}"'
 
-        response, headers = await self._make_request(workspace_repos_url, params)
+        response, _ = await self._make_request(workspace_repos_url, params)
 
         # Extract repositories from the response
         repos = response.get('values', [])
@@ -416,7 +419,7 @@ class BitBucketService(BaseGitService, GitService, InstallationsService):
             self._parse_repository(repo, link_header=formatted_link_header)
             for repo in repos
         ]
-
+        print('repositories', repositories)
         return repositories
 
     async def get_all_repositories(

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -200,6 +200,7 @@ class ProviderHandler:
             if not page or not per_page:
                 raise ValueError('Failed to provider params for paginating repos')
 
+            print('fetching paginated repos', selected_provider, page, per_page)
             service = self._get_service(selected_provider)
             return await service.get_paginated_repos(
                 page, per_page, sort, installation_id

--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -80,6 +80,7 @@ async def get_user_repositories(
         )
 
         try:
+            print('fetching repos', sort, selected_provider, page, per_page, installation_id)
             return await client.get_repositories(
                 sort,
                 server_config.app_mode,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1b4c61a-nikolaik   --name openhands-app-1b4c61a   docker.all-hands.dev/all-hands-ai/openhands:1b4c61a
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@debug-repo-list openhands
```