### PR TITLE
refactor(frontend): run server button should send message immediately

### DIFF
--- a/frontend/src/components/features/chat/chat-actions.tsx
+++ b/frontend/src/components/features/chat/chat-actions.tsx
@@ -5,7 +5,7 @@ import BlockDrawerLeftIcon from "#/icons/block-drawer-left.svg?react";
 import PlayIcon from "#/icons/play-solid.svg?react";
 import {
   setIsRightPanelShown,
-  setMessageToSend,
+  setSubmittedMessage,
 } from "#/state/conversation-slice";
 import { RootState } from "#/store";
 import { cn } from "#/utils/utils";
@@ -34,7 +34,7 @@ export function ChatActions() {
     if (activeHost) {
       onTabChange("served");
     } else {
-      dispatch(setMessageToSend(RUN_SERVER_SUGGESTION));
+      dispatch(setSubmittedMessage(RUN_SERVER_SUGGESTION));
     }
   }, [activeHost]);
 

--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useCallback, useState } from "react";
-import { useSelector } from "react-redux";
+import React, { useRef, useCallback, useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { ConversationStatus } from "#/types/conversation-status";
 import { ServerStatus } from "#/components/features/controls/server-status";
@@ -12,6 +12,7 @@ import { DragOver } from "./drag-over";
 import { UploadedFiles } from "./uploaded-files";
 import { Tools } from "../controls/tools";
 import { RootState } from "#/store";
+import { setSubmittedMessage } from "#/state/conversation-slice";
 
 export interface CustomChatInputProps {
   disabled?: boolean;
@@ -40,13 +41,24 @@ export function CustomChatInput({
 }: CustomChatInputProps) {
   const [isDragOver, setIsDragOver] = useState(false);
 
-  const { messageToSend } = useSelector(
+  const { messageToSend, submittedMessage } = useSelector(
     (state: RootState) => state.conversation,
   );
+
+  const dispatch = useDispatch();
 
   // Disable input when conversation is stopped
   const isConversationStopped = conversationStatus === "STOPPED";
   const isDisabled = disabled || isConversationStopped;
+
+  // Listen to submittedMessage state changes
+  useEffect(() => {
+    if (!submittedMessage || disabled) {
+      return;
+    }
+    onSubmit(submittedMessage);
+    dispatch(setSubmittedMessage(null));
+  }, [submittedMessage, disabled, onSubmit, dispatch]);
 
   const { t } = useTranslation();
 

--- a/frontend/src/state/conversation-slice.tsx
+++ b/frontend/src/state/conversation-slice.tsx
@@ -13,6 +13,7 @@ interface ConversationState {
   loadingImages: string[]; // Image names currently being processed
   messageToSend: IMessageToSend | null;
   shouldShownAgentLoading: boolean;
+  submittedMessage: string | null;
 }
 
 export const conversationSlice = createSlice({
@@ -27,6 +28,7 @@ export const conversationSlice = createSlice({
     loadingImages: [],
     messageToSend: null,
     shouldShownAgentLoading: false,
+    submittedMessage: null,
   } as ConversationState,
   reducers: {
     setIsRightPanelShown: (state, action) => {
@@ -90,6 +92,9 @@ export const conversationSlice = createSlice({
         timestamp: Date.now(),
       };
     },
+    setSubmittedMessage: (state, action) => {
+      state.submittedMessage = action.payload;
+    },
   },
 });
 
@@ -109,6 +114,7 @@ export const {
   removeImageLoading,
   clearAllLoading,
   setMessageToSend,
+  setSubmittedMessage,
 } = conversationSlice.actions;
 
 export default conversationSlice.reducer;


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

On the conversation page, clicking the Run Server button should send the message right away. Currently, it loads the message into the prompt instead of sending it directly.

**Acceptance Criteria:**
- Clicking the Run Server button sends the message immediately.
- The message should not be preloaded into the prompt field.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR makes the run server button should send message immediately.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/41259582-dba4-4823-a7cd-f9014339b728

---
**Link of any specific issues this addresses:**
