### PR TITLE
refactor(frontend): hide the chat suggestions if the chat input height is too large (conversation ux improvements)

### DIFF
--- a/frontend/src/components/features/chat/chat-suggestions.tsx
+++ b/frontend/src/components/features/chat/chat-suggestions.tsx
@@ -1,8 +1,10 @@
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 import { Suggestions } from "#/components/features/suggestions/suggestions";
 import { I18nKey } from "#/i18n/declaration";
 import BuildIt from "#/icons/build-it.svg?react";
 import { SUGGESTIONS } from "#/utils/suggestions";
+import { RootState } from "#/store";
 
 interface ChatSuggestionsProps {
   onSuggestionsClick: (value: string) => void;
@@ -10,6 +12,14 @@ interface ChatSuggestionsProps {
 
 export function ChatSuggestions({ onSuggestionsClick }: ChatSuggestionsProps) {
   const { t } = useTranslation();
+  const shouldHideSuggestions = useSelector(
+    (state: RootState) => state.conversation.shouldHideSuggestions,
+  );
+
+  // Don't render if suggestions should be hidden
+  if (shouldHideSuggestions) {
+    return null;
+  }
 
   return (
     <div

--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -1,5 +1,6 @@
-import React, { useRef, useCallback, useState } from "react";
+import React, { useRef, useCallback, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
 import { ConversationStatus } from "#/types/conversation-status";
 import { ServerStatus } from "#/components/features/controls/server-status";
 import { AgentStatus } from "#/components/features/controls/agent-status";
@@ -10,6 +11,8 @@ import { useAutoResize } from "#/hooks/use-auto-resize";
 import { DragOver } from "./drag-over";
 import { UploadedFiles } from "./uploaded-files";
 import { Tools } from "../controls/tools";
+import { setShouldHideSuggestions } from "#/state/conversation-slice";
+import { CHAT_INPUT } from "#/utils/constants";
 
 export interface CustomChatInputProps {
   disabled?: boolean;
@@ -39,6 +42,7 @@ export function CustomChatInput({
   buttonClassName = "",
 }: CustomChatInputProps) {
   const [isDragOver, setIsDragOver] = useState(false);
+  const dispatch = useDispatch();
 
   // Disable input when conversation is stopped
   const isConversationStopped = conversationStatus === "STOPPED";
@@ -66,12 +70,31 @@ export function CustomChatInput({
     }
   }, [isContentEmpty]);
 
-  // Use the auto-resize hook
+  // Callback to handle height changes and manage suggestions visibility
+  const handleHeightChange = useCallback(
+    (height: number) => {
+      // Hide suggestions when input height exceeds the threshold
+      const shouldHideChatSuggestions = height > CHAT_INPUT.HEIGHT_THRESHOLD;
+      dispatch(setShouldHideSuggestions(shouldHideChatSuggestions));
+    },
+    [dispatch],
+  );
+
+  // Use the auto-resize hook with height change callback
   const { autoResize } = useAutoResize(chatInputRef, {
     minHeight: 20,
     maxHeight: 450,
     value,
+    onHeightChange: handleHeightChange,
   });
+
+  // Cleanup: reset suggestions visibility when component unmounts
+  useEffect(
+    () => () => {
+      dispatch(setShouldHideSuggestions(false));
+    },
+    [dispatch],
+  );
 
   // Function to add files and notify parent
   const addFiles = useCallback(
@@ -137,8 +160,9 @@ export function CustomChatInput({
         fileInputRef.current.value = "";
       }
 
-      // Reset height
+      // Reset height and show suggestions again
       autoResize();
+      dispatch(setShouldHideSuggestions(false));
     }
   };
 
@@ -156,8 +180,9 @@ export function CustomChatInput({
       fileInputRef.current.value = "";
     }
 
-    // Reset height
+    // Reset height and show suggestions again
     autoResize();
+    dispatch(setShouldHideSuggestions(false));
   };
 
   // Handle stop button click
@@ -174,6 +199,11 @@ export function CustomChatInput({
     // Clear empty content to ensure placeholder shows
     if (chatInputRef.current) {
       clearEmptyContent();
+    }
+
+    // Check if content is empty and show suggestions if it is
+    if (isContentEmpty()) {
+      dispatch(setShouldHideSuggestions(false));
     }
 
     // Ensure cursor stays visible when content is scrollable

--- a/frontend/src/hooks/use-auto-resize.ts
+++ b/frontend/src/hooks/use-auto-resize.ts
@@ -4,6 +4,7 @@ interface UseAutoResizeOptions {
   minHeight?: number;
   maxHeight?: number;
   value?: string;
+  onHeightChange?: (height: number) => void; // New callback for height changes
 }
 
 interface UseAutoResizeReturn {
@@ -14,7 +15,27 @@ export const useAutoResize = (
   elementRef: RefObject<HTMLElement | null>,
   options: UseAutoResizeOptions = {},
 ): UseAutoResizeReturn => {
-  const { minHeight = 20, maxHeight = 120, value } = options;
+  const { minHeight = 20, maxHeight = 120, value, onHeightChange } = options;
+
+  // Helper function to calculate final height and apply styles
+  const calculateAndApplyHeight = useCallback(
+    (element: HTMLElement, scrollHeight: number) => {
+      let finalHeight: number;
+
+      if (scrollHeight <= maxHeight) {
+        finalHeight = Math.max(scrollHeight, minHeight);
+        element.style.setProperty("height", `${finalHeight}px`);
+        element.style.setProperty("overflow-y", "hidden");
+      } else {
+        finalHeight = maxHeight;
+        element.style.setProperty("height", `${maxHeight}px`);
+        element.style.setProperty("overflow-y", "auto");
+      }
+
+      return finalHeight;
+    },
+    [minHeight, maxHeight],
+  );
 
   // Auto-resize functionality for contenteditable div
   const autoResize = useCallback(() => {
@@ -22,20 +43,18 @@ export const useAutoResize = (
     if (!element) return;
 
     // Reset height to auto to get the actual content height
-    element.style.height = "auto";
-    element.style.overflowY = "hidden";
+    element.style.setProperty("height", "auto");
+    element.style.setProperty("overflow-y", "hidden");
 
     // Set the height based on scroll height, with min and max constraints
     const { scrollHeight } = element;
+    const finalHeight = calculateAndApplyHeight(element, scrollHeight);
 
-    if (scrollHeight <= maxHeight) {
-      element.style.height = `${Math.max(scrollHeight, minHeight)}px`;
-      element.style.overflowY = "hidden";
-    } else {
-      element.style.height = `${maxHeight}px`;
-      element.style.overflowY = "auto";
+    // Call the height change callback if provided
+    if (onHeightChange) {
+      onHeightChange(finalHeight);
     }
-  }, [elementRef, minHeight, maxHeight]);
+  }, [elementRef, calculateAndApplyHeight, onHeightChange]);
 
   // Update content and resize when value prop changes
   useEffect(() => {

--- a/frontend/src/state/conversation-slice.tsx
+++ b/frontend/src/state/conversation-slice.tsx
@@ -8,6 +8,7 @@ interface ConversationState {
   loadingImages: string[]; // Image names currently being processed
   messageToSend: string | null;
   shouldShownAgentLoading: boolean;
+  shouldHideSuggestions: boolean; // New state to hide suggestions when input expands
 }
 
 export const conversationSlice = createSlice({
@@ -22,6 +23,7 @@ export const conversationSlice = createSlice({
     loadingImages: [],
     messageToSend: null,
     shouldShownAgentLoading: false,
+    shouldHideSuggestions: false, // Initialize to false
   } as ConversationState,
   reducers: {
     setIsRightPanelShown: (state, action) => {
@@ -29,6 +31,9 @@ export const conversationSlice = createSlice({
     },
     setShouldShownAgentLoading: (state, action) => {
       state.shouldShownAgentLoading = action.payload;
+    },
+    setShouldHideSuggestions: (state, action) => {
+      state.shouldHideSuggestions = action.payload;
     },
     addImages: (state, action) => {
       state.images = [...state.images, ...action.payload];
@@ -88,6 +93,7 @@ export const conversationSlice = createSlice({
 export const {
   setIsRightPanelShown,
   setShouldShownAgentLoading,
+  setShouldHideSuggestions,
   addImages,
   addFiles,
   removeImage,

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -54,3 +54,8 @@ export const GIT_PROVIDER_OPTIONS = [
 ];
 
 export const CONTEXT_MENU_ICON_TEXT_CLASSNAME = "h-[30px]";
+
+// Chat input constants
+export const CHAT_INPUT = {
+  HEIGHT_THRESHOLD: 100, // Height in pixels when suggestions should be hidden
+};


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When starting a new conversation with no messages, if the chat input height becomes too large, the chat suggestions section is pushed upward along with the input area. This causes a broken UI layout.

We can refer to the video below for more information.

https://github.com/user-attachments/assets/e0c2760b-8421-4473-a65c-84392a5e1b9d

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR hides the chat suggestions if the chat input height is too large (conversation ux improvements)

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/8ab7da09-81ed-4826-84df-fe6f7688f12d

---
**Link of any specific issues this addresses:**
