### PR TITLE
refactor(frontend): remove period from “no page loaded.” text

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -8176,20 +8176,20 @@
     "uk": "Підключено"
   },
   "BROWSER$NO_PAGE_LOADED": {
-    "en": "No page loaded.",
+    "en": "No page loaded",
     "ja": "ブラウザは空です",
     "zh-CN": "页面未加载",
-    "zh-TW": "未載入任何頁面。",
-    "de": "Keine Seite geladen.",
-    "ko-KR": "페이지가 로드되지 않았습니다.",
-    "no": "Ingen side lastet.",
-    "it": "Nessuna pagina caricata.",
-    "pt": "Nenhuma página carregada.",
-    "es": "Ninguna página cargada.",
-    "ar": "لم يتم تحميل أي صفحة.",
-    "fr": "Aucune page chargée.",
-    "tr": "Sayfa yüklenmedi.",
-    "uk": "Сторінка не завантажена."
+    "zh-TW": "未載入任何頁面",
+    "de": "Keine Seite geladen",
+    "ko-KR": "페이지가 로드되지 않았습니다",
+    "no": "Ingen side lastet",
+    "it": "Nessuna pagina caricata",
+    "pt": "Nenhuma página carregada",
+    "es": "Ninguna página cargada",
+    "ar": "لم يتم تحميل أي صفحة",
+    "fr": "Aucune page chargée",
+    "tr": "Sayfa yüklenmedi",
+    "uk": "Сторінка не завантажена"
   },
   "USER$AVATAR_PLACEHOLDER": {
     "en": "user avatar placeholder",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The text “No page loaded.” currently includes a period, which should be removed.

**Acceptance Criteria:**
- The period at the end of “No page loaded.” is removed, so it reads “No page loaded”.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR removes period from “no page loaded.” text

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f46d7c3-nikolaik   --name openhands-app-f46d7c3   docker.all-hands.dev/all-hands-ai/openhands:f46d7c3
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3288 openhands
```