### PR TITLE
fix: validate `task_list` schema for task tracker

### DIFF
--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -280,21 +280,13 @@ def response_to_actions(
                             'status': task.get('status', 'todo'),
                             'notes': task.get('notes', ''),
                         }
-                    elif isinstance(task, str):
-                        # Task is a string, convert to proper dictionary format
-                        normalized_task = {
-                            'id': f'task-{i + 1}',
-                            'title': task,
-                            'status': 'todo',
-                            'notes': '',
-                        }
                     else:
                         # Unexpected format, raise validation error
                         logger.warning(
                             f'Unexpected task format in task_list: {type(task)} - {task}'
                         )
                         raise FunctionCallValidationError(
-                            f'Unexpected task format in task_list: {type(task)}. Each task should be either a string or a dictionary.'
+                            f'Unexpected task format in task_list: {type(task)}. Each task shoud be a dictionary.'
                         )
                     normalized_task_list.append(normalized_task)
 

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -263,9 +263,44 @@ def response_to_actions(
                         f'Missing required argument "task_list" for "plan" command in tool call {tool_call.function.name}'
                     )
 
+                raw_task_list = arguments.get('task_list', [])
+                if not isinstance(raw_task_list, list):
+                    raise FunctionCallValidationError(
+                        f'Invalid format for "task_list". Expected a list but got {type(raw_task_list)}.'
+                    )
+
+                # Normalize task_list to ensure it's always a list of dictionaries
+                normalized_task_list = []
+                for i, task in enumerate(raw_task_list):
+                    if isinstance(task, dict):
+                        # Task is already in correct format, ensure required fields exist
+                        normalized_task = {
+                            'id': task.get('id', f'task-{i + 1}'),
+                            'title': task.get('title', 'Untitled task'),
+                            'status': task.get('status', 'todo'),
+                            'notes': task.get('notes', ''),
+                        }
+                    elif isinstance(task, str):
+                        # Task is a string, convert to proper dictionary format
+                        normalized_task = {
+                            'id': f'task-{i + 1}',
+                            'title': task,
+                            'status': 'todo',
+                            'notes': '',
+                        }
+                    else:
+                        # Unexpected format, raise validation error
+                        logger.warning(
+                            f'Unexpected task format in task_list: {type(task)} - {task}'
+                        )
+                        raise FunctionCallValidationError(
+                            f'Unexpected task format in task_list: {type(task)}. Each task should be either a string or a dictionary.'
+                        )
+                    normalized_task_list.append(normalized_task)
+
                 action = TaskTrackingAction(
                     command=arguments['command'],
-                    task_list=arguments.get('task_list', []),
+                    task_list=normalized_task_list,
                 )
 
             # ================================================


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The crash occurred because some LLMs were not following the JSON schema correctly and were passing `task_list` as a list of strings instead of a list of dictionaries. This PR fixes it by adding normalization for task items that are strings and raising validation errors otherwise.

---
**Link of any specific issues this addresses:**

Fix #10584
