### PR TITLE
[Fix]: token refresh for nested runtimes

### DIFF
--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -181,6 +181,9 @@ class ProviderHandler:
                     },
                     params={'provider': provider, 'sid': self.sid},
                 )
+
+                print('token response', resp)
+
             data = TokenResponse.model_validate_json(resp.text)
             return SecretStr(data.token)
 

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
 from types import MappingProxyType
 from typing import Annotated, Any, Coroutine, Literal, cast, overload
 
+import httpx
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -28,6 +30,7 @@ from openhands.integrations.service_types import (
     Repository,
     ResourceNotFoundError,
     SuggestedTask,
+    TokenResponse,
     User,
 )
 from openhands.microagent.types import MicroagentContentResponse, MicroagentResponse
@@ -112,6 +115,8 @@ class ProviderHandler:
         external_auth_id: str | None = None,
         external_auth_token: SecretStr | None = None,
         external_token_manager: bool = False,
+        session_api_key: str | None = None,
+        sid: str | None = None,
     ):
         if not isinstance(provider_tokens, MappingProxyType):
             raise TypeError(
@@ -127,7 +132,13 @@ class ProviderHandler:
         self.external_auth_id = external_auth_id
         self.external_auth_token = external_auth_token
         self.external_token_manager = external_token_manager
+        self.session_api_key = session_api_key
+        self.sid = sid
         self._provider_tokens = provider_tokens
+        WEB_HOST = os.getenv('WEB_HOST', '').strip()
+        self.REFRESH_TOKEN_URL = (
+            f'https://{WEB_HOST}/api/refresh-tokens' if WEB_HOST else None
+        )
 
     @property
     def provider_tokens(self) -> PROVIDER_TOKEN_TYPE:
@@ -161,8 +172,22 @@ class ProviderHandler:
         self, provider: ProviderType
     ) -> SecretStr | None:
         """Get latest token from service"""
-        service = self._get_service(provider)
-        return await service.get_latest_token()
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    self.REFRESH_TOKEN_URL,
+                    headers={
+                        'X-Session-API-Key': self.session_api_key,
+                    },
+                    params={'provider': provider, 'sid': self.sid},
+                )
+            data = TokenResponse.model_validate_json(resp.text)
+            return SecretStr(data.token)
+
+        except Exception as e:
+            logger.warning(f'Failed to fetch latest token for provider {provider}: {e}')
+
+        return None
 
     async def get_github_installations(self) -> list[str]:
         service = cast(InstallationsService, self._get_service(ProviderType.GITHUB))
@@ -356,7 +381,7 @@ class ProviderHandler:
                     else SecretStr('')
                 )
 
-                if get_latest:
+                if get_latest and self.REFRESH_TOKEN_URL and self.sid:
                     token = await self._get_latest_provider_token(provider)
 
                 if token:

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -179,14 +179,14 @@ class ProviderHandler:
                     headers={
                         'X-Session-API-Key': self.session_api_key,
                     },
-                    params={'provider': provider, 'sid': self.sid},
+                    params={'provider': provider.value, 'sid': self.sid},
                 )
 
                 print('token response', resp)
                 print('token resp', resp.text)
 
             data = TokenResponse.model_validate_json(resp.text)
-            return SecretStr(data.token)
+            return data.token
 
         except Exception as e:
             logger.warning(f'Failed to fetch latest token for provider {provider}: {e}')

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -182,9 +182,7 @@ class ProviderHandler:
                     params={'provider': provider.value, 'sid': self.sid},
                 )
 
-                print('token response', resp)
-                print('token resp', resp.text)
-
+            resp.raise_for_status()
             data = TokenResponse.model_validate_json(resp.text)
             return SecretStr(data.token)
 

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -186,7 +186,7 @@ class ProviderHandler:
                 print('token resp', resp.text)
 
             data = TokenResponse.model_validate_json(resp.text)
-            return data.token
+            return SecretStr(data.token)
 
         except Exception as e:
             logger.warning(f'Failed to fetch latest token for provider {provider}: {e}')

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -183,6 +183,7 @@ class ProviderHandler:
                 )
 
                 print('token response', resp)
+                print('token resp', resp.text)
 
             data = TokenResponse.model_validate_json(resp.text)
             return SecretStr(data.token)

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -14,6 +14,10 @@ from openhands.microagent.types import MicroagentContentResponse, MicroagentResp
 from openhands.server.types import AppMode
 
 
+class TokenResponse(BaseModel):
+    token: str
+
+
 class ProviderType(Enum):
     GITHUB = 'github'
     GITLAB = 'gitlab'

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -15,7 +15,7 @@ from openhands.server.types import AppMode
 
 
 class TokenResponse(BaseModel):
-    token: SecretStr
+    token: str
 
 
 class ProviderType(Enum):

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -15,7 +15,7 @@ from openhands.server.types import AppMode
 
 
 class TokenResponse(BaseModel):
-    token: str
+    token: SecretStr
 
 
 class ProviderType(Enum):

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -171,8 +171,6 @@ class Runtime(FileEditRuntimeMixin):
             or cast(PROVIDER_TOKEN_TYPE, MappingProxyType({})),
             external_auth_id=user_id,
             external_token_manager=True,
-            session_api_key=self.session_api_key,
-            sid=sid,
         )
         raw_env_vars: dict[str, str] = call_async_from_sync(
             self.provider_handler.get_env_vars, GENERAL_TIMEOUT, True, None, False
@@ -332,8 +330,17 @@ class Runtime(FileEditRuntimeMixin):
         if not providers_called:
             return
 
+        provider_handler = ProviderHandler(
+            provider_tokens=self.git_provider_tokens
+            or cast(PROVIDER_TOKEN_TYPE, MappingProxyType({})),
+            external_auth_id=self.user_id,
+            external_token_manager=True,
+            session_api_key=self.session_api_key,
+            sid=self.sid,
+        )
+
         logger.info(f'Fetching latest provider tokens for runtime: {self.sid}')
-        env_vars = await self.provider_handler.get_env_vars(
+        env_vars = await provider_handler.get_env_vars(
             providers=providers_called, expose_secrets=False, get_latest=True
         )
 
@@ -342,10 +349,10 @@ class Runtime(FileEditRuntimeMixin):
 
         try:
             if self.event_stream:
-                await self.provider_handler.set_event_stream_secrets(
+                await provider_handler.set_event_stream_secrets(
                     self.event_stream, env_vars=env_vars
                 )
-            self.add_env_vars(self.provider_handler.expose_env_vars(env_vars))
+            self.add_env_vars(provider_handler.expose_env_vars(env_vars))
         except Exception as e:
             logger.warning(
                 f'Failed export latest github token to runtime: {self.sid}, {e}'

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -171,6 +171,8 @@ class Runtime(FileEditRuntimeMixin):
             or cast(PROVIDER_TOKEN_TYPE, MappingProxyType({})),
             external_auth_id=user_id,
             external_token_manager=True,
+            session_api_key=self.session_api_key,
+            sid=sid,
         )
         raw_env_vars: dict[str, str] = call_async_from_sync(
             self.provider_handler.get_env_vars, GENERAL_TIMEOUT, True, None, False
@@ -323,9 +325,6 @@ class Runtime(FileEditRuntimeMixin):
 
     async def _export_latest_git_provider_tokens(self, event: Action) -> None:
         """Refresh runtime provider tokens when agent attemps to run action with provider token"""
-        if not self.user_id:
-            return
-
         providers_called = ProviderHandler.check_cmd_action_for_provider_token_ref(
             event
         )


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Fix tokens expiring in the middle of a running conversation

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

We need to contact the main server from the runtime pod for the refreshed tokens; the nested runtime pod also doesn't contain a user_id, the main server will figure it out from the session api key

---
**Link of any specific issues this addresses:**
Fixes ALL-2989
https://github.com/All-Hands-AI/OpenHands-Cloud/issues/131

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:157f876-nikolaik   --name openhands-app-157f876   docker.all-hands.dev/all-hands-ai/openhands:157f876
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@refresh-token openhands
```