### PR TITLE
fix(runtime): Fix issue 10572, fix metrics import and update agent session

### DIFF
--- a/openhands/llm/metrics.py
+++ b/openhands/llm/metrics.py
@@ -195,6 +195,30 @@ class Metrics:
             self.accumulated_token_usage + other.accumulated_token_usage
         )
 
+    def get_performance_metrics(self) -> str:
+        """Formats the metrics into a string to be displayed."""
+        total_in = self.accumulated_token_usage.prompt_tokens
+        total_out = self.accumulated_token_usage.completion_tokens
+        cache_read = self.accumulated_token_usage.cache_read_tokens
+        cache_write = self.accumulated_token_usage.cache_write_tokens
+        total_tokens = total_in + total_out
+
+        if total_tokens == 0 and self.accumulated_cost == 0:
+            return ''
+
+        parts = ['\n\n**Usage Metrics**']
+        if total_tokens > 0:
+            part = f'- **Tokens:** {total_in} input | {total_out} output'
+            parts.append(part)
+
+        if cache_read > 0 or cache_write > 0:
+            cache_ratio = (cache_read / total_in * 100) if total_in > 0 else 0
+            cache_part = f'- **Cache:** {cache_read} hit ({cache_ratio:.1f}%) | {cache_write} write'
+            parts.append(cache_part)
+
+        parts.append(f'- **Cost:** ${self.accumulated_cost:.6f} (total)')
+        return '\n'.join(parts)
+
     def get(self) -> dict:
         """Return the metrics in a dictionary."""
         return {


### PR DESCRIPTION
…t session

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Created a new method in openhands/llm/metrics.py, utilized the metrics collected from litellm. In the openhands/runtime/base.py, use this method, and add the metrics to convesation content, and retrieve the metrics in agent session.

Note that I am using Gemini 2.0 flash in the pictures, with which cached_read_tokens and other information is not available, so you can't see cache ratio here. But it will work for APIs with cached_read_tokens and other informations

Basically, if we run the project with this feature, we can view the metrics after every action
<img width="1355" height="732" alt="image" src="https://github.com/user-attachments/assets/3fcfc2ee-70b1-4eab-bc7c-7d6334dbf88e" />

and we can view it from the log if we set LOG_LEVEL to ALL as well
<img width="1937" height="1085" alt="Screenshot from 2025-08-27 00-19-58" src="https://github.com/user-attachments/assets/daba0513-092e-4a79-bf40-a42f9a4b750d" />


---
**Link of any specific issues this addresses:**
https://github.com/All-Hands-AI/OpenHands/issues/10572
