### PR TITLE
refactor(frontend): replace design library toast

### DIFF
--- a/frontend/src/components/features/chat/microagent/microagent-status-toast.tsx
+++ b/frontend/src/components/features/chat/microagent/microagent-status-toast.tsx
@@ -1,10 +1,9 @@
 import toast from "react-hot-toast";
-import { toasterMessages, Typography } from "@openhands/ui";
 import { Spinner } from "@heroui/react";
 import { useTranslation } from "react-i18next";
+import { TOAST_OPTIONS } from "#/utils/custom-toast-handlers";
 import CloseIcon from "#/icons/close.svg?react";
 import { SuccessIndicator } from "../success-indicator";
-import { TOAST_OPTIONS } from "#/utils/custom-toast-handlers";
 
 interface ConversationCreatedToastProps {
   conversationId: string;
@@ -22,20 +21,19 @@ function ConversationCreatedToast({
 }: ConversationCreatedToastProps) {
   const { t } = useTranslation();
   return (
-    <div className="flex items-start gap-2 pl-4">
+    <div className="flex items-start gap-2">
       <Spinner size="sm" />
       <div>
-        <Typography.H6> {t("MICROAGENT$ADDING_CONTEXT")}</Typography.H6>
-        <Typography.Text>
-          <a
-            href={`/conversations/${conversationId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            {t("MICROAGENT$VIEW_CONVERSATION")}
-          </a>
-        </Typography.Text>
+        {t("MICROAGENT$ADDING_CONTEXT")}
+        <br />
+        <a
+          href={`/conversations/${conversationId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          {t("MICROAGENT$VIEW_CONVERSATION")}
+        </a>
       </div>
       <button type="button" onClick={onClose}>
         <CloseIcon />
@@ -85,17 +83,16 @@ function ConversationFinishedToast({
     <div className="flex items-start gap-2">
       <SuccessIndicator status="success" />
       <div>
-        <Typography.H6>{t("MICROAGENT$SUCCESS_PR_READY")}</Typography.H6>
-        <Typography.Text>
-          <a
-            href={`/conversations/${conversationId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            {t("MICROAGENT$VIEW_CONVERSATION")}
-          </a>
-        </Typography.Text>
+        {t("MICROAGENT$SUCCESS_PR_READY")}
+        <br />
+        <a
+          href={`/conversations/${conversationId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          {t("MICROAGENT$VIEW_CONVERSATION")}
+        </a>
       </div>
       <button type="button" onClick={onClose}>
         <CloseIcon />
@@ -133,25 +130,33 @@ function ConversationErroredToast({
 }
 
 export const renderConversationCreatedToast = (conversationId: string) =>
-  toasterMessages.custom(
-    (props) => (
+  toast(
+    (t) => (
       <ConversationCreatedToast
         conversationId={conversationId}
-        onClose={props.onDismiss}
+        onClose={() => toast.dismiss(t.id)}
       />
     ),
-    { duration: 5_000, position: "top-right" },
+    {
+      ...TOAST_OPTIONS,
+      id: `status-${conversationId}`,
+      duration: 5000,
+    },
   );
 
 export const renderConversationFinishedToast = (conversationId: string) =>
-  toasterMessages.custom(
-    (props) => (
+  toast(
+    (t) => (
       <ConversationFinishedToast
         conversationId={conversationId}
-        onClose={props.onDismiss}
+        onClose={() => toast.dismiss(t.id)}
       />
     ),
-    { duration: 5_000, position: "top-right" },
+    {
+      ...TOAST_OPTIONS,
+      id: `status-${conversationId}`,
+      duration: 5000,
+    },
   );
 
 export const renderConversationErroredToast = (

--- a/frontend/src/components/features/feedback/feedback-form.tsx
+++ b/frontend/src/components/features/feedback/feedback-form.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { toasterMessages, Typography } from "@openhands/ui";
+import hotToast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import { Feedback } from "#/api/open-hands.types";
 import { useSubmitFeedback } from "#/hooks/mutation/use-submit-feedback";
 import { BrandButton } from "../settings/brand-button";
-import { displayInfoToast } from "#/utils/custom-toast-handlers";
 
 const FEEDBACK_VERSION = "1.0";
 const VIEWER_PAGE = "https://www.all-hands.dev/share";
@@ -19,7 +18,10 @@ export function FeedbackForm({ onClose, polarity }: FeedbackFormProps) {
   const { t } = useTranslation();
 
   const copiedToClipboardToast = () => {
-    displayInfoToast(t(I18nKey.FEEDBACK$PASSWORD_COPIED_MESSAGE));
+    hotToast(t(I18nKey.FEEDBACK$PASSWORD_COPIED_MESSAGE), {
+      icon: "📋",
+      position: "bottom-right",
+    });
   };
 
   const onPressToast = (password: string) => {
@@ -32,34 +34,27 @@ export function FeedbackForm({ onClose, polarity }: FeedbackFormProps) {
     link: string,
     password: string,
   ) => {
-    toasterMessages.custom(
-      () => (
-        <div className="flex flex-col gap-1 px-2">
-          <Typography.H5>{message}</Typography.H5>
-          <Typography.Text>
-            <a
-              data-testid="toast-share-url"
-              className="text-blue-500 underline"
-              onClick={() => onPressToast(password)}
-              href={link}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t(I18nKey.FEEDBACK$GO_TO_FEEDBACK)}
-            </a>
-          </Typography.Text>
-          <Typography.Text
-            onClick={() => onPressToast(password)}
-            className="cursor-pointer"
-          >
-            {t(I18nKey.FEEDBACK$PASSWORD)}: {password}{" "}
-            <span className="text-gray-500">
-              ({t(I18nKey.FEEDBACK$COPY_LABEL)})
-            </span>
-          </Typography.Text>
-        </div>
-      ),
-      { duration: 10_000 },
+    hotToast(
+      <div className="flex flex-col gap-1">
+        <span>{message}</span>
+        <a
+          data-testid="toast-share-url"
+          className="text-blue-500 underline"
+          onClick={() => onPressToast(password)}
+          href={link}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {t(I18nKey.FEEDBACK$GO_TO_FEEDBACK)}
+        </a>
+        <span onClick={() => onPressToast(password)} className="cursor-pointer">
+          {t(I18nKey.FEEDBACK$PASSWORD)}: {password}{" "}
+          <span className="text-gray-500">
+            ({t(I18nKey.FEEDBACK$COPY_LABEL)})
+          </span>
+        </span>
+      </div>,
+      { duration: 10000 },
     );
   };
 

--- a/frontend/src/components/shared/modals/security/invariant/invariant.tsx
+++ b/frontend/src/components/shared/modals/security/invariant/invariant.tsx
@@ -13,6 +13,7 @@ import {
 } from "#/state/security-analyzer-slice";
 import { useScrollToBottom } from "#/hooks/use-scroll-to-bottom";
 import { I18nKey } from "#/i18n/declaration";
+import toast from "#/utils/toast";
 import InvariantLogoIcon from "./assets/logo";
 import { getFormattedDateTime } from "#/utils/gget-formatted-datetime";
 import { downloadJSON } from "#/utils/download-json";
@@ -20,7 +21,6 @@ import InvariantService from "#/api/invariant-service";
 import { useGetPolicy } from "#/hooks/query/use-get-policy";
 import { useGetRiskSeverity } from "#/hooks/query/use-get-risk-severity";
 import { useGetTraces } from "#/hooks/query/use-get-traces";
-import { displayInfoToast } from "#/utils/custom-toast-handlers";
 
 type SectionType = "logs" | "policy" | "settings";
 
@@ -50,7 +50,7 @@ function SecurityInvariant() {
 
   const { refetch: exportTraces } = useGetTraces({
     onSuccess: (traces) => {
-      displayInfoToast(t(I18nKey.INVARIANT$TRACE_EXPORTED_MESSAGE));
+      toast.info(t(I18nKey.INVARIANT$TRACE_EXPORTED_MESSAGE));
 
       const filename = `openhands-trace-${getFormattedDateTime()}.json`;
       downloadJSON(traces, filename);
@@ -61,7 +61,7 @@ function SecurityInvariant() {
     mutationFn: (variables: { policy: string }) =>
       InvariantService.updatePolicy(variables.policy),
     onSuccess: () => {
-      displayInfoToast(t(I18nKey.INVARIANT$POLICY_UPDATED_MESSAGE));
+      toast.info(t(I18nKey.INVARIANT$POLICY_UPDATED_MESSAGE));
     },
   });
 
@@ -69,7 +69,7 @@ function SecurityInvariant() {
     mutationFn: (variables: { riskSeverity: number }) =>
       InvariantService.updateRiskSeverity(variables.riskSeverity),
     onSuccess: () => {
-      displayInfoToast(t(I18nKey.INVARIANT$SETTINGS_UPDATED_MESSAGE));
+      toast.info(t(I18nKey.INVARIANT$SETTINGS_UPDATED_MESSAGE));
     },
   });
 

--- a/frontend/src/root.tsx
+++ b/frontend/src/root.tsx
@@ -9,7 +9,7 @@ import {
 import "./tailwind.css";
 import "./index.css";
 import React from "react";
-import { ToastManager } from "@openhands/ui";
+import { Toaster } from "react-hot-toast";
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -21,11 +21,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <ToastManager>
-          {children}
-          <ScrollRestoration />
-          <Scripts />
-        </ToastManager>
+        {children}
+        <ScrollRestoration />
+        <Scripts />
+        <Toaster />
       </body>
     </html>
   );

--- a/frontend/src/utils/custom-toast-handlers.tsx
+++ b/frontend/src/utils/custom-toast-handlers.tsx
@@ -1,6 +1,5 @@
 import { CSSProperties } from "react";
-import { ToastOptions } from "react-hot-toast";
-import { toasterMessages } from "@openhands/ui";
+import toast, { ToastOptions } from "react-hot-toast";
 import { calculateToastDuration } from "./toast-duration";
 
 const TOAST_STYLE: CSSProperties = {
@@ -15,21 +14,12 @@ export const TOAST_OPTIONS: ToastOptions = {
   style: TOAST_STYLE,
 };
 
-export const displayErrorToast = (message: string) => {
-  const duration = calculateToastDuration(message, 5_000);
-  toasterMessages.error(message, { duration, position: "top-right" });
+export const displayErrorToast = (error: string) => {
+  const duration = calculateToastDuration(error, 4000);
+  toast.error(error, { ...TOAST_OPTIONS, duration });
 };
 
 export const displaySuccessToast = (message: string) => {
-  const duration = calculateToastDuration(message, 5_000);
-  toasterMessages.success(message, { duration, position: "top-right" });
-};
-
-export const displayWarningToast = (message: string) => {
-  const duration = calculateToastDuration(message, 4_000);
-  toasterMessages.warning(message, { duration, position: "top-right" });
-};
-export const displayInfoToast = (message: string) => {
-  const duration = calculateToastDuration(message, 4_000);
-  toasterMessages.info(message, { duration, position: "top-right" });
+  const duration = calculateToastDuration(message, 5000);
+  toast.success(message, { ...TOAST_OPTIONS, duration });
 };

--- a/frontend/src/utils/toast.tsx
+++ b/frontend/src/utils/toast.tsx
@@ -1,0 +1,62 @@
+import toast from "react-hot-toast";
+import { calculateToastDuration } from "./toast-duration";
+
+const idMap = new Map<string, string>();
+
+export default {
+  error: (id: string, msg: string) => {
+    if (idMap.has(id)) return; // prevent duplicate toast
+    const toastId = toast(msg, {
+      duration: 4000,
+      style: {
+        background: "#ef4444",
+        color: "#fff",
+      },
+      iconTheme: {
+        primary: "#ef4444",
+        secondary: "#fff",
+      },
+    });
+    idMap.set(id, toastId);
+  },
+  success: (id: string, msg: string, duration: number = 4000) => {
+    if (idMap.has(id)) return; // prevent duplicate toast
+    const toastId = toast.success(msg, {
+      duration,
+      style: {
+        background: "#333",
+        color: "#fff",
+      },
+      iconTheme: {
+        primary: "#333",
+        secondary: "#fff",
+      },
+    });
+    idMap.set(id, toastId);
+  },
+  settingsChanged: (msg: string) => {
+    toast(msg, {
+      position: "bottom-right",
+      className: "bg-tertiary",
+      duration: calculateToastDuration(msg, 5000),
+      icon: "⚙️",
+      style: {
+        background: "#333",
+        color: "#fff",
+      },
+    });
+  },
+
+  info: (msg: string) => {
+    toast(msg, {
+      position: "top-center",
+      className: "bg-tertiary",
+
+      style: {
+        background: "#333",
+        color: "#fff",
+        lineBreak: "anywhere",
+      },
+    });
+  },
+};


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The current implementation uses the design library toast, which introduces inconsistencies in font styling. To ensure visual consistency, we need to replace it with the existing non–design library toast component.

**Acceptance Criteria:**
- The non–design library toast component is used in place of the design library toast.
- Font styling remains consistent across the application.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR replaces design library toast.

We can refer to the image below for more information.

<img width="1440" height="743" alt="all-3299" src="https://github.com/user-attachments/assets/c750e0a4-996b-4a91-839c-6565652a2316" />

---
**Link of any specific issues this addresses:**
