### PR TITLE
refactor(frontend): privacy preferences modal update

### DIFF
--- a/frontend/src/components/features/analytics/analytics-consent-form-modal.tsx
+++ b/frontend/src/components/features/analytics/analytics-consent-form-modal.tsx
@@ -1,6 +1,4 @@
 import { useTranslation } from "react-i18next";
-import { Checkbox } from "@openhands/ui";
-import { useState } from "react";
 import {
   BaseModalTitle,
   BaseModalDescription,
@@ -21,7 +19,6 @@ export function AnalyticsConsentFormModal({
 }: AnalyticsConsentFormModalProps) {
   const { t } = useTranslation();
   const { mutate: saveUserSettings } = useSaveSettings();
-  const [checked, setChecked] = useState(true);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -51,13 +48,11 @@ export function AnalyticsConsentFormModal({
           <BaseModalDescription>
             {t(I18nKey.ANALYTICS$DESCRIPTION)}
           </BaseModalDescription>
-          <Checkbox
-            checked={checked}
-            className="flex gap-2 items-center self-start"
-            name="analytics"
-            onChange={(e) => setChecked(e.target.checked)}
-            label={t(I18nKey.ANALYTICS$SEND_ANONYMOUS_DATA)}
-          />
+
+          <label className="flex gap-2 items-center self-start text-sm">
+            <input name="analytics" type="checkbox" defaultChecked />
+            {t(I18nKey.ANALYTICS$SEND_ANONYMOUS_DATA)}
+          </label>
 
           <BrandButton
             testId="confirm-preferences"


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="758" height="479" alt="all-3280-issue" src="https://github.com/user-attachments/assets/8bf66002-6a8c-41cd-8487-738014b63702" />

The modal is currently displaying the incorrect font. This needs to be corrected.

**Acceptance Criteria:**
- The modal must use the correct font and styling.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates the privacy preferences modal.

We can refer to the image below for the output of the PR.

<img width="1440" height="743" alt="all-3280" src="https://github.com/user-attachments/assets/86d11f26-25dc-4b7a-8a3a-ae41477e535e" />

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0213df7-nikolaik   --name openhands-app-0213df7   docker.all-hands.dev/all-hands-ai/openhands:0213df7
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3280 openhands
```