### PR TITLE
refactor(frontend): remove arrow icons from ResizePanel (conversation UX improvements)

### DIFF
--- a/frontend/src/components/layout/resizable-panel.tsx
+++ b/frontend/src/components/layout/resizable-panel.tsx
@@ -1,12 +1,5 @@
 import React, { CSSProperties, JSX, useEffect, useRef, useState } from "react";
-import {
-  VscChevronDown,
-  VscChevronLeft,
-  VscChevronRight,
-  VscChevronUp,
-} from "react-icons/vsc";
 import { twMerge } from "tailwind-merge";
-import { IconButton } from "../shared/buttons/icon-button";
 
 export enum Orientation {
   HORIZONTAL = "horizontal",
@@ -42,7 +35,7 @@ export function ResizablePanel({
   const [dividerPosition, setDividerPosition] = useState<number | null>(null);
   const firstRef = useRef<HTMLDivElement>(null);
   const secondRef = useRef<HTMLDivElement>(null);
-  const [collapse, setCollapse] = useState<Collapse>(Collapse.SPLIT);
+  const [collapse] = useState<Collapse>(Collapse.SPLIT);
   const isHorizontal = orientation === Orientation.HORIZONTAL;
 
   useEffect(() => {
@@ -139,22 +132,6 @@ export function ResizablePanel({
     return style;
   };
 
-  const onCollapse = () => {
-    if (collapse === Collapse.SPLIT) {
-      setCollapse(Collapse.COLLAPSED);
-    } else {
-      setCollapse(Collapse.SPLIT);
-    }
-  };
-
-  const onExpand = () => {
-    if (collapse === Collapse.SPLIT) {
-      setCollapse(Collapse.FILLED);
-    } else {
-      setCollapse(Collapse.SPLIT);
-    }
-  };
-
   return (
     <div className={twMerge("flex", !isHorizontal && "flex-col", className)}>
       <div
@@ -167,18 +144,7 @@ export function ResizablePanel({
       <div
         className={`${isHorizontal ? "cursor-ew-resize w-3 flex-col" : "cursor-ns-resize h-3 flex-row"} shrink-0 flex justify-center items-center`}
         onMouseDown={collapse === Collapse.SPLIT ? onMouseDown : undefined}
-      >
-        <IconButton
-          icon={isHorizontal ? <VscChevronLeft /> : <VscChevronUp />}
-          ariaLabel="Collapse"
-          onClick={onCollapse}
-        />
-        <IconButton
-          icon={isHorizontal ? <VscChevronRight /> : <VscChevronDown />}
-          ariaLabel="Expand"
-          onClick={onExpand}
-        />
-      </div>
+      />
       <div
         ref={secondRef}
         className={twMerge(secondClassName, "transition-all ease-soft-spring")}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Currently, the drawer icon in the top-right corner of the screen allows users to show or hide the action panel. Because of this, the two arrow icons in the ResizePanel are no longer necessary.

**Acceptance Criteria:**
- Remove the two arrow icons from the ResizePanel.

We currently have this [PR](https://github.com/All-Hands-AI/OpenHands/pull/10402) in progress to refactor the code using the react-resizable library.

However, rather than waiting for that PR to be completed, we should first remove the arrow icons from the ResizePanel. This will help prevent user confusion while testing the new conversation UX improvements.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR removes the arrow icons from ResizePanel.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/3d2625f1-1920-4738-b55f-a168f94a0119

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:95f45e0-nikolaik   --name openhands-app-95f45e0   docker.all-hands.dev/all-hands-ai/openhands:95f45e0
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3306 openhands
```