### PR TITLE
Missed a place for the group change

### DIFF
--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -54,7 +54,7 @@ else
       fi
     fi
   fi
-  usermod -aG app enduser
+  usermod -aG openhands enduser
   # get the user group of /var/run/docker.sock and set openhands to that group
   DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
   echo "Docker socket group id: $DOCKER_SOCKET_GID"


### PR DESCRIPTION
Recently changed the group name in the docker image to "openhands", but missed a reference in entrypoint.sh

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d4c78be-nikolaik   --name openhands-app-d4c78be   docker.all-hands.dev/all-hands-ai/openhands:d4c78be
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix-docker openhands
```