### PR TITLE
cli: dedupe TaskTrackingAction thoughts by using display_thought_if_new

### DIFF
--- a/openhands/cli/tui.py
+++ b/openhands/cli/tui.py
@@ -522,7 +522,7 @@ def display_task_tracking_action(event: TaskTrackingAction) -> None:
     """Display a TaskTracking action in the CLI."""
     # Display thought first if present
     if hasattr(event, 'thought') and event.thought:
-        display_message(event.thought)
+        display_thought_if_new(event.thought)
 
     # Format the command and task list for display
     display_text = f'Command: {event.command}'


### PR DESCRIPTION
Summary
- In the CLI TUI, display_task_tracking_action now calls display_thought_if_new instead of display_message when rendering the action's thought.

Rationale
- Align TaskTrackingAction thought rendering with other actions that already use display_thought_if_new.
- Prevent duplicate thought lines if the same thought is emitted multiple times in quick succession.
- Preserve agent styling/markdown handling via existing message rendering logic.

Change details
- openhands/cli/tui.py:
  - Replace display_message(event.thought) with display_thought_if_new(event.thought)

Potential behavior changes
- Thoughts attached to TaskTrackingAction will now be de-duplicated against the recent_thoughts buffer (size 5). If the exact same thought string repeats within the recent buffer, it will not be printed again.
- If previously you relied on repeated thought lines appearing for the same TaskTrackingAction, you will now see fewer duplicates in the CLI output.
- Styling consistency: when thoughts are shown, they continue to go through the same markdown/HTML sanitation and agent styling pathways as before, matching other action types.

Testing
- Ran backend pre-commit linters locally; no issues.
- The change is minimal and isolated to CLI output formatting.

Checklist
- [x] This change is worth documenting at https://docs.all-hands.dev/ (N/A — minor UX polish for CLI output)
- [x] Include this change in the Release Notes. If checked, you must provide an end-user friendly description below:

Release Notes blurb
- CLI: Reduce duplicate thought lines for task-tracking actions by deduplicating repeated thoughts within a short recent history window.


@raymyers can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1c5394710bfd4da294fb80fc062c4587)