### PR TITLE
refactor(frontend): The PR hides repository actions when no repository is connected (conversation UX improvements)

### DIFF
--- a/frontend/src/components/features/chat/git-control-bar.tsx
+++ b/frontend/src/components/features/chat/git-control-bar.tsx
@@ -85,42 +85,46 @@ export function GitControlBar({
           />
         </GitControlBarTooltipWrapper>
 
-        <GitControlBarTooltipWrapper
-          tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
-          testId="git-control-bar-pull-button-tooltip"
-          shouldShowTooltip={!hasRepository}
-        >
-          <GitControlBarPullButton
-            onSuggestionsClick={onSuggestionsClick}
-            isEnabled={isButtonEnabled}
-          />
-        </GitControlBarTooltipWrapper>
+        {hasRepository ? (
+          <>
+            <GitControlBarTooltipWrapper
+              tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
+              testId="git-control-bar-pull-button-tooltip"
+              shouldShowTooltip={!hasRepository}
+            >
+              <GitControlBarPullButton
+                onSuggestionsClick={onSuggestionsClick}
+                isEnabled={isButtonEnabled}
+              />
+            </GitControlBarTooltipWrapper>
 
-        <GitControlBarTooltipWrapper
-          tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
-          testId="git-control-bar-push-button-tooltip"
-          shouldShowTooltip={!hasRepository}
-        >
-          <GitControlBarPushButton
-            onSuggestionsClick={onSuggestionsClick}
-            isEnabled={isButtonEnabled}
-            hasRepository={hasRepository}
-            currentGitProvider={gitProvider}
-          />
-        </GitControlBarTooltipWrapper>
+            <GitControlBarTooltipWrapper
+              tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
+              testId="git-control-bar-push-button-tooltip"
+              shouldShowTooltip={!hasRepository}
+            >
+              <GitControlBarPushButton
+                onSuggestionsClick={onSuggestionsClick}
+                isEnabled={isButtonEnabled}
+                hasRepository={hasRepository}
+                currentGitProvider={gitProvider}
+              />
+            </GitControlBarTooltipWrapper>
 
-        <GitControlBarTooltipWrapper
-          tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
-          testId="git-control-bar-pr-button-tooltip"
-          shouldShowTooltip={!hasRepository}
-        >
-          <GitControlBarPrButton
-            onSuggestionsClick={onSuggestionsClick}
-            isEnabled={isButtonEnabled}
-            hasRepository={hasRepository}
-            currentGitProvider={gitProvider}
-          />
-        </GitControlBarTooltipWrapper>
+            <GitControlBarTooltipWrapper
+              tooltipMessage={t(I18nKey.COMMON$GIT_TOOLS_DISABLED_CONTENT)}
+              testId="git-control-bar-pr-button-tooltip"
+              shouldShowTooltip={!hasRepository}
+            >
+              <GitControlBarPrButton
+                onSuggestionsClick={onSuggestionsClick}
+                isEnabled={isButtonEnabled}
+                hasRepository={hasRepository}
+                currentGitProvider={gitProvider}
+              />
+            </GitControlBarTooltipWrapper>
+          </>
+        ) : null}
       </div>
 
       {/* Right Arrow */}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When a conversation is not connected to a repository, the following action buttons should not be displayed: Push, Pull, and Create PR.

**Acceptance Criteria:**
- The Push, Pull, and Create PR buttons must be hidden whenever the conversation is not linked to a repository.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR hides repository actions when no repository is connected (conversation UX improvements)

We can refer to the image below for the output of the PR.

<img width="1436" height="743" alt="all-3316" src="https://github.com/user-attachments/assets/e85ec219-d87f-463d-a30c-e6820124ec1d" />

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:69ae098-nikolaik   --name openhands-app-69ae098   docker.all-hands.dev/all-hands-ai/openhands:69ae098
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3316 openhands
```