### PR TITLE
refactor(frontend): spinner overlaps text when conversation list is loading (conversation UX improvements)

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -140,7 +140,7 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
           <p className="text-danger">{error.message}</p>
         </div>
       )}
-      {conversations?.length === 0 && (
+      {!isFetching && conversations?.length === 0 && (
         <div className="flex flex-col items-center justify-center h-full">
           <p className="text-neutral-400">
             {t(I18nKey.CONVERSATION$NO_CONVERSATIONS)}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="950" height="1264" alt="all-3315-issue" src="https://github.com/user-attachments/assets/d25b2ad1-6bf0-49d9-aca6-9041108cbcd4" />

Currently, when the conversation list is first loading, the spinner overlaps the text in the chat input area.

**Acceptance Criteria:**
- The message “No conversations found” is displayed only when there are no conversations in the list.
- The spinner is displayed only while the API call to retrieve the conversation list is in progress.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR handles spinner overlaps text when conversation list is loading (conversation UX improvements).

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/df389f13-518c-4ffd-a0a9-6a6b90ea54c8

---
**Link of any specific issues this addresses:**
