### PR TITLE
refactor(frontend): remove background color on home page while retaining it for boxes

### DIFF
--- a/frontend/src/components/common/react-select-styles.ts
+++ b/frontend/src/components/common/react-select-styles.ts
@@ -113,6 +113,13 @@ export const providerDropdownStyles: StylesConfig<SelectOption, false> = {
     "&:hover": {
       borderColor: "#727987",
     },
+    "& .provider-dropdown__placeholder": {
+      color: "#A3A3A3",
+      fontSize: "0.875rem",
+      fontWeight: "400",
+      lineHeight: "1.25rem",
+      paddingTop: "0.125rem",
+    },
     "& .provider-dropdown__single-value": {
       color: "#A3A3A3",
       fontSize: "0.75rem",

--- a/frontend/src/components/features/home/new-conversation.tsx
+++ b/frontend/src/components/features/home/new-conversation.tsx
@@ -23,7 +23,7 @@ export function NewConversation() {
     isPending || isSuccess || isCreatingConversationElsewhere;
 
   return (
-    <section className="w-full min-h-[286px] md:min-h-auto flex flex-col rounded-[12px] p-[20px] gap-[10px] border border-[#727987] relative">
+    <section className="w-full min-h-[286px] md:min-h-auto flex flex-col rounded-[12px] p-[20px] gap-[10px] border border-[#727987] bg-[#26282D] relative">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-[10px]">
           <PlusIcon width={17} height={14} />

--- a/frontend/src/components/features/home/repo-connector.tsx
+++ b/frontend/src/components/features/home/repo-connector.tsx
@@ -19,7 +19,7 @@ export function RepoConnector({ onRepoSelection }: RepoConnectorProps) {
   return (
     <section
       data-testid="repo-connector"
-      className="w-full flex flex-col gap-6 rounded-[12px] p-[20px] border border-[#727987]"
+      className="w-full flex flex-col gap-6 rounded-[12px] p-[20px] border border-[#727987] bg-[#26282D]"
     >
       {!providersAreSet && <ConnectToProviderMessage />}
       {providersAreSet && (

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -52,7 +52,7 @@ export function RepositorySelectionForm({
 
   // Auto-select provider if there's only one
   React.useEffect(() => {
-    if (providers.length === 1 && !selectedProvider) {
+    if (providers.length > 0 && !selectedProvider) {
       setSelectedProvider(providers[0]);
     }
   }, [providers, selectedProvider]);

--- a/frontend/src/routes/home.tsx
+++ b/frontend/src/routes/home.tsx
@@ -21,7 +21,7 @@ function HomeScreen() {
   return (
     <div
       data-testid="home-screen"
-      className="bg-[#26282D] h-full flex flex-col pt-[35px] overflow-y-auto rounded-xl px-[42px] pt-[42px]"
+      className="bg-transparent h-full flex flex-col pt-[35px] overflow-y-auto rounded-xl px-[42px] pt-[42px] custom-scrollbar-always"
     >
       <HomeHeader />
 

--- a/frontend/src/routes/root-layout.tsx
+++ b/frontend/src/routes/root-layout.tsx
@@ -27,6 +27,7 @@ import { useAuthCallback } from "#/hooks/use-auth-callback";
 import { LOCAL_STORAGE_KEYS } from "#/utils/local-storage";
 import { EmailVerificationGuard } from "#/components/features/guards/email-verification-guard";
 import { MaintenanceBanner } from "#/components/features/maintenance/maintenance-banner";
+import { cn } from "#/utils/utils";
 
 export function ErrorBoundary() {
   const error = useRouteError();
@@ -199,7 +200,10 @@ export default function MainApp() {
   return (
     <div
       data-testid="root-layout"
-      className="h-screen p-3 pl-0 lg:min-w-[1024px] flex flex-col md:flex-row bg-base"
+      className={cn(
+        "h-screen lg:min-w-[1024px] flex flex-col md:flex-row bg-base",
+        pathname === "/" ? "p-0" : "p-3 pl-0",
+      )}
     >
       <Sidebar />
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The background color applied to the home page should be removed. However, the background color must still be applied to individual boxes.

**Acceptance Criteria:**
- The home page background color is removed.
- Boxes continue to display their background color as intended.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR removes background color on home page while retaining it for boxes.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/796f2f69-afe0-4657-8ae5-a781bdf3d5b9

---
**Link of any specific issues this addresses:**
