### PR TITLE
Add support for passing list of `Message` into LLM `completion`

### DIFF
--- a/openhands/agenthub/browsing_agent/browsing_agent.py
+++ b/openhands/agenthub/browsing_agent/browsing_agent.py
@@ -217,7 +217,7 @@ class BrowsingAgent(Agent):
         messages.append(Message(role='user', content=[TextContent(text=prompt)]))
 
         response = self.llm.completion(
-            messages=self.llm.format_messages_for_llm(messages),
+            messages=messages,
             stop=[')```', ')\n```'],
         )
         return self.response_parser.parse(response)

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -204,7 +204,7 @@ class CodeActAgent(Agent):
         initial_user_message = self._get_initial_user_message(state.history)
         messages = self._get_messages(condensed_history, initial_user_message)
         params: dict = {
-            'messages': self.llm.format_messages_for_llm(messages),
+            'messages': messages,
         }
         params['tools'] = check_tools(self.tools, self.llm.config)
         params['extra_body'] = {

--- a/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
+++ b/openhands/agenthub/visualbrowsing_agent/visualbrowsing_agent.py
@@ -301,10 +301,8 @@ You are an agent trying to solve a web task based on the content of the page and
         messages.append(Message(role='system', content=[TextContent(text=system_msg)]))
         messages.append(Message(role='user', content=human_prompt))
 
-        flat_messages = self.llm.format_messages_for_llm(messages)
-
         response = self.llm.completion(
-            messages=flat_messages,
+            messages=messages,
             temperature=0.0,
             stop=[')```', ')\n```'],
         )

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -242,6 +242,8 @@ class LLM(RetryMixin, DebugMixin):
             else:
                 messages = cast(list[dict[str, Any]], messages_list)
 
+            kwargs['messages'] = messages
+
             # handle conversion of to non-function calling messages if needed
             original_fncall_messages = copy.deepcopy(messages)
             mock_fncall_tools = None

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -3,7 +3,7 @@ import os
 import time
 import warnings
 from functools import partial
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import httpx
 
@@ -209,7 +209,9 @@ class LLM(RetryMixin, DebugMixin):
             """Wrapper for the litellm completion function. Logs the input and output of the completion function."""
             from openhands.io import json
 
-            messages_kwarg: list[dict[str, Any]] | dict[str, Any] = []
+            messages_kwarg: (
+                dict[str, Any] | Message | list[dict[str, Any]] | list[Message]
+            ) = []
             mock_function_calling = not self.is_function_calling_active()
 
             # some callers might send the model and messages directly
@@ -228,9 +230,17 @@ class LLM(RetryMixin, DebugMixin):
                 messages_kwarg = kwargs['messages']
 
             # ensure we work with a list of messages
-            messages: list[dict[str, Any]] = (
+            messages_list = (
                 messages_kwarg if isinstance(messages_kwarg, list) else [messages_kwarg]
             )
+            # Format Message objects to dict format if needed
+            messages: list[dict] = []
+            if messages_list and isinstance(messages_list[0], Message):
+                messages = self.format_messages_for_llm(
+                    cast(list[Message], messages_list)
+                )
+            else:
+                messages = cast(list[dict[str, Any]], messages_list)
 
             # handle conversion of to non-function calling messages if needed
             original_fncall_messages = copy.deepcopy(messages)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds support for passing list of Message into LLM.completion, which makes it easy for accessing the list of Message in the completion to make routing decision, if we want to make Router inherit LLM.

In the previous PR #10650 I forgot to override the existing `messages` of kwargs with the formatted one:

```py
            messages: list[dict] = []
            if messages_list and isinstance(messages_list[0], Message):
                messages = self.format_messages_for_llm(
                    cast(list[Message], messages_list)
                )
            else:
                messages = cast(list[dict[str, Any]], messages_list)

            kwargs['messages'] = messages
```

I tested this locally it works normally now.

---
**Link of any specific issues this addresses:**
