### PR TITLE
refactor(frontend): make user settings menu appear on hover (conversation UX improvements)

### DIFF
--- a/frontend/__tests__/components/context-menu/account-settings-context-menu.test.tsx
+++ b/frontend/__tests__/components/context-menu/account-settings-context-menu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, test, vi } from "vitest";
 import { AccountSettingsContextMenu } from "#/components/features/context-menu/account-settings-context-menu";
@@ -9,7 +9,6 @@ describe("AccountSettingsContextMenu", () => {
   const user = userEvent.setup();
   const onClickAccountSettingsMock = vi.fn();
   const onLogoutMock = vi.fn();
-  const onCloseMock = vi.fn();
 
   // Create a wrapper with MemoryRouter and renderWithProviders
   const renderWithRouter = (ui: React.ReactElement) => {
@@ -19,16 +18,10 @@ describe("AccountSettingsContextMenu", () => {
   afterEach(() => {
     onClickAccountSettingsMock.mockClear();
     onLogoutMock.mockClear();
-    onCloseMock.mockClear();
   });
 
   it("should always render the right options", () => {
-    renderWithRouter(
-      <AccountSettingsContextMenu
-        onLogout={onLogoutMock}
-        onClose={onCloseMock}
-      />,
-    );
+    renderWithRouter(<AccountSettingsContextMenu onLogout={onLogoutMock} />);
 
     expect(
       screen.getByTestId("account-settings-context-menu"),
@@ -37,12 +30,7 @@ describe("AccountSettingsContextMenu", () => {
   });
 
   it("should call onLogout when the logout option is clicked", async () => {
-    renderWithRouter(
-      <AccountSettingsContextMenu
-        onLogout={onLogoutMock}
-        onClose={onCloseMock}
-      />,
-    );
+    renderWithRouter(<AccountSettingsContextMenu onLogout={onLogoutMock} />);
 
     const logoutOption = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
     await user.click(logoutOption);
@@ -51,31 +39,11 @@ describe("AccountSettingsContextMenu", () => {
   });
 
   test("logout button is always enabled", async () => {
-    renderWithRouter(
-      <AccountSettingsContextMenu
-        onLogout={onLogoutMock}
-        onClose={onCloseMock}
-      />,
-    );
+    renderWithRouter(<AccountSettingsContextMenu onLogout={onLogoutMock} />);
 
     const logoutOption = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
     await user.click(logoutOption);
 
     expect(onLogoutMock).toHaveBeenCalledOnce();
-  });
-
-  it("should call onClose when clicking outside of the element", async () => {
-    renderWithRouter(
-      <AccountSettingsContextMenu
-        onLogout={onLogoutMock}
-        onClose={onCloseMock}
-      />,
-    );
-
-    const accountSettingsButton = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
-    await user.click(accountSettingsButton);
-    await user.click(document.body);
-
-    expect(onCloseMock).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/__tests__/components/landing-translations.test.tsx
+++ b/frontend/__tests__/components/landing-translations.test.tsx
@@ -5,7 +5,13 @@ import translations from "../../src/i18n/translation.json";
 import { UserAvatar } from "../../src/components/features/sidebar/user-avatar";
 
 vi.mock("@heroui/react", () => ({
-  Tooltip: ({ content, children }: { content: string; children: React.ReactNode }) => (
+  Tooltip: ({
+    content,
+    children,
+  }: {
+    content: string;
+    children: React.ReactNode;
+  }) => (
     <div>
       {children}
       <div>{content}</div>
@@ -13,15 +19,33 @@ vi.mock("@heroui/react", () => ({
   ),
 }));
 
-const supportedLanguages = ['en', 'ja', 'zh-CN', 'zh-TW', 'ko-KR', 'de', 'no', 'it', 'pt', 'es', 'ar', 'fr', 'tr'];
+const supportedLanguages = [
+  "en",
+  "ja",
+  "zh-CN",
+  "zh-TW",
+  "ko-KR",
+  "de",
+  "no",
+  "it",
+  "pt",
+  "es",
+  "ar",
+  "fr",
+  "tr",
+];
 
 // Helper function to check if a translation exists for all supported languages
 function checkTranslationExists(key: string) {
   const missingTranslations: string[] = [];
 
-  const translationEntry = (translations as Record<string, Record<string, string>>)[key];
+  const translationEntry = (
+    translations as Record<string, Record<string, string>>
+  )[key];
   if (!translationEntry) {
-    throw new Error(`Translation key "${key}" does not exist in translation.json`);
+    throw new Error(
+      `Translation key "${key}" does not exist in translation.json`,
+    );
   }
 
   for (const lang of supportedLanguages) {
@@ -53,7 +77,9 @@ function findDuplicateKeys(obj: Record<string, any>) {
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => {
-      const translationEntry = (translations as Record<string, Record<string, string>>)[key];
+      const translationEntry = (
+        translations as Record<string, Record<string, string>>
+      )[key];
       return translationEntry?.ja || key;
     },
   }),
@@ -66,7 +92,7 @@ describe("Landing page translations", () => {
       const { t } = useTranslation();
       return (
         <div>
-          <UserAvatar onClick={() => {}} />
+          <UserAvatar />
           <div data-testid="main-content">
             <h1>{t("LANDING$TITLE")}</h1>
             <button>{t("VSCODE$OPEN")}</button>
@@ -102,15 +128,12 @@ describe("Landing page translations", () => {
     // Check main content translations
     expect(screen.getByText("開発を始めましょう！")).toBeInTheDocument();
     expect(screen.getByText("VS Codeで開く")).toBeInTheDocument();
-    expect(screen.getByText("テストカバレッジを向上させる")).toBeInTheDocument();
+    expect(
+      screen.getByText("テストカバレッジを向上させる"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Dependabot PRを自動マージ")).toBeInTheDocument();
     expect(screen.getByText("READMEを改善")).toBeInTheDocument();
     expect(screen.getByText("依存関係を整理")).toBeInTheDocument();
-
-    // Check user avatar tooltip
-    const userAvatar = screen.getByTestId("user-avatar");
-    userAvatar.focus();
-    expect(screen.getByText("アカウント設定")).toBeInTheDocument();
 
     // Check tab labels
     const tabs = screen.getByTestId("tabs");
@@ -120,17 +143,18 @@ describe("Landing page translations", () => {
     expect(tabs).toHaveTextContent("コードエディタ");
 
     // Check workspace label and new project button
-    expect(screen.getByTestId("workspace-label")).toHaveTextContent("ワークスペース");
-    expect(screen.getByTestId("new-project")).toHaveTextContent("新規プロジェクト");
+    expect(screen.getByTestId("workspace-label")).toHaveTextContent(
+      "ワークスペース",
+    );
+    expect(screen.getByTestId("new-project")).toHaveTextContent(
+      "新規プロジェクト",
+    );
 
     // Check status messages
     const status = screen.getByTestId("status");
     expect(status).toHaveTextContent("クライアントの準備を待機中");
     expect(status).toHaveTextContent("接続済み");
     expect(status).toHaveTextContent("サーバーに接続済み");
-
-    // Check account settings menu
-    expect(screen.getByText("アカウント設定")).toBeInTheDocument();
 
     // Check time-related translations
     const time = screen.getByTestId("time");
@@ -159,12 +183,12 @@ describe("Landing page translations", () => {
       "STATUS$CONNECTED_TO_SERVER",
       "TIME$MINUTES_AGO",
       "TIME$HOURS_AGO",
-      "TIME$DAYS_AGO"
+      "TIME$DAYS_AGO",
     ];
 
     // Check all keys and collect missing translations
     const missingTranslationsMap = new Map<string, string[]>();
-    translationKeys.forEach(key => {
+    translationKeys.forEach((key) => {
       const missing = checkTranslationExists(key);
       if (missing.length > 0) {
         missingTranslationsMap.set(key, missing);
@@ -174,8 +198,11 @@ describe("Landing page translations", () => {
     // If any translations are missing, throw an error with all missing translations
     if (missingTranslationsMap.size > 0) {
       const errorMessage = Array.from(missingTranslationsMap.entries())
-        .map(([key, langs]) => `\n- "${key}" is missing translations for: ${langs.join(', ')}`)
-        .join('');
+        .map(
+          ([key, langs]) =>
+            `\n- "${key}" is missing translations for: ${langs.join(", ")}`,
+        )
+        .join("");
       throw new Error(`Missing translations:${errorMessage}`);
     }
   });
@@ -184,7 +211,9 @@ describe("Landing page translations", () => {
     const duplicates = findDuplicateKeys(translations);
 
     if (duplicates.length > 0) {
-      throw new Error(`Found duplicate translation keys: ${duplicates.join(', ')}`);
+      throw new Error(
+        `Found duplicate translation keys: ${duplicates.join(", ")}`,
+      );
     }
   });
 });

--- a/frontend/__tests__/components/user-avatar.test.tsx
+++ b/frontend/__tests__/components/user-avatar.test.tsx
@@ -1,40 +1,18 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { UserAvatar } from "#/components/features/sidebar/user-avatar";
 
 describe("UserAvatar", () => {
-  const onClickMock = vi.fn();
-
-  afterEach(() => {
-    onClickMock.mockClear();
-  });
-
   it("(default) should render the placeholder avatar when the user is logged out", () => {
-    render(<UserAvatar onClick={onClickMock} />);
+    render(<UserAvatar />);
     expect(screen.getByTestId("user-avatar")).toBeInTheDocument();
     expect(
       screen.getByLabelText("USER$AVATAR_PLACEHOLDER"),
     ).toBeInTheDocument();
   });
 
-  it("should call onClick when clicked", async () => {
-    const user = userEvent.setup();
-    render(<UserAvatar onClick={onClickMock} />);
-
-    const userAvatarContainer = screen.getByTestId("user-avatar");
-    await user.click(userAvatarContainer);
-
-    expect(onClickMock).toHaveBeenCalledOnce();
-  });
-
   it("should display the user's avatar when available", () => {
-    render(
-      <UserAvatar
-        onClick={onClickMock}
-        avatarUrl="https://example.com/avatar.png"
-      />,
-    );
+    render(<UserAvatar avatarUrl="https://example.com/avatar.png" />);
 
     expect(screen.getByAltText("AVATAR$ALT_TEXT")).toBeInTheDocument();
     expect(
@@ -43,24 +21,20 @@ describe("UserAvatar", () => {
   });
 
   it("should display a loading spinner instead of an avatar when isLoading is true", () => {
-    const { rerender } = render(<UserAvatar onClick={onClickMock} />);
+    const { rerender } = render(<UserAvatar />);
     expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
     expect(
       screen.getByLabelText("USER$AVATAR_PLACEHOLDER"),
     ).toBeInTheDocument();
 
-    rerender(<UserAvatar onClick={onClickMock} isLoading />);
+    rerender(<UserAvatar isLoading />);
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
     expect(
       screen.queryByLabelText("USER$AVATAR_PLACEHOLDER"),
     ).not.toBeInTheDocument();
 
     rerender(
-      <UserAvatar
-        onClick={onClickMock}
-        avatarUrl="https://example.com/avatar.png"
-        isLoading
-      />,
+      <UserAvatar avatarUrl="https://example.com/avatar.png" isLoading />,
     );
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
     expect(screen.queryByAltText("AVATAR$ALT_TEXT")).not.toBeInTheDocument();

--- a/frontend/__tests__/i18n/translations.test.tsx
+++ b/frontend/__tests__/i18n/translations.test.tsx
@@ -10,7 +10,7 @@ describe("Translations", () => {
     i18n.changeLanguage("en");
     renderWithProviders(
       <MemoryRouter>
-        <AccountSettingsContextMenu onLogout={() => {}} onClose={() => {}} />
+        <AccountSettingsContextMenu onLogout={() => {}} />
       </MemoryRouter>,
     );
     expect(
@@ -47,7 +47,6 @@ describe("Translations", () => {
 
       await i18n.changeLanguage("zh-CN");
       expect(i18n.language).toBe("zh-CN");
-
     } finally {
       // Restore the original language
       await i18n.changeLanguage(originalLanguage);

--- a/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
+++ b/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router";
 import { ContextMenu } from "#/ui/context-menu";
 import { ContextMenuListItem } from "./context-menu-list-item";
 import { ContextMenuSeparator } from "./context-menu-separator";
-import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { useConfig } from "#/hooks/query/use-config";
 import { I18nKey } from "#/i18n/declaration";
 import CreditCardIcon from "#/icons/credit-card.svg?react";
@@ -17,7 +16,6 @@ import UserIcon from "#/icons/user.svg?react";
 
 interface AccountSettingsContextMenuProps {
   onLogout: () => void;
-  onClose: () => void;
 }
 
 const SAAS_NAV_ITEMS = [
@@ -83,33 +81,22 @@ const OSS_NAV_ITEMS = [
 
 export function AccountSettingsContextMenu({
   onLogout,
-  onClose,
 }: AccountSettingsContextMenuProps) {
-  const ref = useClickOutsideElement<HTMLUListElement>(onClose);
   const { t } = useTranslation();
   const { data: config } = useConfig();
 
   const isSaas = config?.APP_MODE === "saas";
   const navItems = isSaas ? SAAS_NAV_ITEMS : OSS_NAV_ITEMS;
 
-  const handleNavigationClick = () => {
-    onClose();
-    // The Link component will handle the actual navigation
-  };
-
   return (
     <ContextMenu
       testId="account-settings-context-menu"
-      ref={ref}
       alignment="right"
-      className="md:right-full md:left-full md:mt-0 md:bottom-0 ml-2 z-10 w-fit"
+      className="mt-0 md:right-full md:left-full md:bottom-0 ml-0 z-10 w-fit"
     >
       {navItems.map(({ to, text, icon }) => (
         <Link key={to} to={to} className="text-decoration-none">
-          <ContextMenuListItem
-            onClick={() => handleNavigationClick()}
-            className="flex items-center gap-2 p-2 hover:bg-[#5C5D62] rounded h-[30px]"
-          >
+          <ContextMenuListItem className="flex items-center gap-2 p-2 hover:bg-[#5C5D62] rounded h-[30px]">
             {icon}
             <span className="text-white text-sm">{t(text)}</span>
           </ContextMenuListItem>

--- a/frontend/src/components/features/context-menu/context-menu-list-item.tsx
+++ b/frontend/src/components/features/context-menu/context-menu-list-item.tsx
@@ -2,7 +2,7 @@ import { cn } from "#/utils/utils";
 
 interface ContextMenuListItemProps {
   testId?: string;
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   isDisabled?: boolean;
   className?: string;
 }

--- a/frontend/src/components/features/sidebar/user-actions.tsx
+++ b/frontend/src/components/features/sidebar/user-actions.tsx
@@ -10,42 +10,24 @@ interface UserActionsProps {
 }
 
 export function UserActions({ onLogout, user, isLoading }: UserActionsProps) {
-  const [accountContextMenuIsVisible, setAccountContextMenuIsVisible] =
-    React.useState(false);
-
   // Use the shared hook to determine if user actions should be shown
   const shouldShowUserActions = useShouldShowUserFeatures();
 
-  const toggleAccountMenu = () => {
-    // Always toggle the menu, even if user is undefined
-    setAccountContextMenuIsVisible((prev) => !prev);
-  };
-
-  const closeAccountMenu = () => {
-    setAccountContextMenuIsVisible(false);
-  };
-
   const handleLogout = () => {
     onLogout();
-    closeAccountMenu();
   };
 
-  // Show the menu based on the new logic
-  const showMenu = accountContextMenuIsVisible && shouldShowUserActions;
-
   return (
-    <div data-testid="user-actions" className="w-8 h-8 relative cursor-pointer">
-      <UserAvatar
-        avatarUrl={user?.avatar_url}
-        onClick={toggleAccountMenu}
-        isLoading={isLoading}
-      />
+    <div
+      data-testid="user-actions"
+      className="w-8 h-8 relative cursor-pointer group"
+    >
+      <UserAvatar avatarUrl={user?.avatar_url} isLoading={isLoading} />
 
-      {showMenu && (
-        <AccountSettingsContextMenu
-          onLogout={handleLogout}
-          onClose={closeAccountMenu}
-        />
+      {shouldShowUserActions && (
+        <div className="opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto">
+          <AccountSettingsContextMenu onLogout={handleLogout} />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/features/sidebar/user-avatar.tsx
+++ b/frontend/src/components/features/sidebar/user-avatar.tsx
@@ -4,23 +4,19 @@ import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import ProfileIcon from "#/icons/profile.svg?react";
 import { cn } from "#/utils/utils";
 import { Avatar } from "./avatar";
-import { TooltipButton } from "#/components/shared/buttons/tooltip-button";
 
 interface UserAvatarProps {
-  onClick: () => void;
   avatarUrl?: string;
   isLoading?: boolean;
 }
 
-export function UserAvatar({ onClick, avatarUrl, isLoading }: UserAvatarProps) {
+export function UserAvatar({ avatarUrl, isLoading }: UserAvatarProps) {
   const { t } = useTranslation();
 
   return (
-    <TooltipButton
-      testId="user-avatar"
-      tooltip={t(I18nKey.USER$ACCOUNT_SETTINGS)}
-      ariaLabel={t(I18nKey.USER$ACCOUNT_SETTINGS)}
-      onClick={onClick}
+    <button
+      type="button"
+      data-testid="user-avatar"
       className={cn(
         "w-8 h-8 rounded-full flex items-center justify-center cursor-pointer",
         isLoading && "bg-transparent",
@@ -36,6 +32,6 @@ export function UserAvatar({ onClick, avatarUrl, isLoading }: UserAvatarProps) {
         />
       )}
       {isLoading && <LoadingSpinner size="small" />}
-    </TooltipButton>
+    </button>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance criteria:**
- We need to make user settings menu appear on hover, not click

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR makes user settings menu appear on hover.

We can refer to the video below for more information.

https://github.com/user-attachments/assets/84a831ea-35f1-4c46-86c9-96cd92854754

---
**Link of any specific issues this addresses:**
