### PR TITLE
Fix alignment issue with suggested tasks on home screen

### DIFF
--- a/frontend/src/components/features/home/tasks/task-suggestions.tsx
+++ b/frontend/src/components/features/home/tasks/task-suggestions.tsx
@@ -49,19 +49,19 @@ export function TaskSuggestions({ filterFor }: TaskSuggestionsProps) {
           !hasSuggestedTasks && "mb-[14px]",
         )}
       >
-        <h3 className="text-xs leading-4 text-white font-semibold py-[14px] pl-4">
+        <h3 className="text-xs leading-4 text-white font-semibold py-[14px] pl-[14px]">
           {t(I18nKey.TASKS$SUGGESTED_TASKS)}
         </h3>
       </div>
 
       <div className="flex flex-col">
         {isLoading && (
-          <div className="pl-4">
+          <div className="px-[14px]">
             <TaskSuggestionsSkeleton />
           </div>
         )}
         {!hasSuggestedTasks && !isLoading && (
-          <span className="text-xs leading-4 text-white font-medium pl-4">
+          <span className="text-xs leading-4 text-white font-medium px-[14px]">
             {t(I18nKey.TASKS$NO_TASKS_AVAILABLE)}
           </span>
         )}
@@ -86,7 +86,7 @@ export function TaskSuggestions({ filterFor }: TaskSuggestionsProps) {
       </div>
 
       {!isLoading && hasMoreTasks && (
-        <div className="flex justify-start mt-6 mb-8 ml-4">
+        <div className="flex justify-start mt-6 mb-8 ml-[14px]">
           <button
             type="button"
             onClick={handleToggle}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Changed skeleton loading padding from pl-4 (16px) to px-[14px] to match actual content
- Updated 'no tasks available' message padding to px-[14px] for consistency
- Fixed 'view more/less' button margin from ml-4 to ml-[14px]
- Updated header padding from pl-4 to pl-[14px]
- All elements now consistently use 14px left padding/margin to prevent alignment shift when data loads

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
