### PR TITLE
Add 14px left padding to conversation title

### DIFF
--- a/frontend/src/components/features/conversation/conversation-name.tsx
+++ b/frontend/src/components/features/conversation/conversation-name.tsx
@@ -123,7 +123,7 @@ export function ConversationName() {
   return (
     <>
       <div
-        className="flex items-center gap-2 h-[22px] text-base font-normal text-left"
+        className="flex items-center gap-2 h-[22px] text-base font-normal text-left pl-[14px]"
         data-testid="conversation-name"
       >
         {titleMode === "edit" ? (


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Added pl-[14px] Tailwind class to conversation title container
- Improves visual spacing in the conversation screen header
- All tests pass and linting is clean

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6064d88-nikolaik   --name openhands-app-6064d88   docker.all-hands.dev/all-hands-ai/openhands:6064d88
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@left-padding openhands
```