### PR TITLE
fix: align chat input bottom padding with right panel

### DIFF
--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -214,7 +214,7 @@ export function ChatInterface() {
             )}
         </div>
 
-        <div className="flex flex-col gap-[6px] px-4 pb-4">
+        <div className="flex flex-col gap-[6px] px-4">
           <div className="flex justify-between relative">
             {events.length > 0 && (
               <TrajectoryActions


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Remove pb-4 from chat input container to match the bottom spacing of the action panel/canvas on the right side. Both panels now have consistent 12px bottom spacing from the main layout gap-3.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:69b90f5-nikolaik   --name openhands-app-69b90f5   docker.all-hands.dev/all-hands-ai/openhands:69b90f5
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@git-controls-padding openhands
```