### PR TITLE
Fix agent state carryover between conversations

### DIFF
--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -7,6 +7,8 @@ import { clearTerminal } from "#/state/command-slice";
 import { useEffectOnce } from "#/hooks/use-effect-once";
 import { clearJupyter } from "#/state/jupyter-slice";
 import { resetConversationState } from "#/state/conversation-slice";
+import { setCurrentAgentState } from "#/state/agent-slice";
+import { AgentState } from "#/types/agent-state";
 
 import { useBatchFeedback } from "#/hooks/query/use-batch-feedback";
 import { WsClientProvider } from "#/context/ws-client-provider";
@@ -62,12 +64,14 @@ function AppContent() {
     dispatch(clearTerminal());
     dispatch(clearJupyter());
     dispatch(resetConversationState());
+    dispatch(setCurrentAgentState(AgentState.LOADING));
   }, [conversationId]);
 
   useEffectOnce(() => {
     dispatch(clearTerminal());
     dispatch(clearJupyter());
     dispatch(resetConversationState());
+    dispatch(setCurrentAgentState(AgentState.LOADING));
   });
 
   return (


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Reset agent state to LOADING when switching conversations
- Prevents 'running' status from previous conversation showing while new conversation is connecting
- Added agent state reset in both useEffect hooks in conversation route
- Ensures clean state initialization for each conversation

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ea09ab2-nikolaik   --name openhands-app-ea09ab2   docker.all-hands.dev/all-hands-ai/openhands:ea09ab2
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@chat-input-state-state openhands
```