### PR TITLE
fix(frontend): double loading spinner after selecting a repo

### DIFF
--- a/frontend/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
+++ b/frontend/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
@@ -21,6 +21,7 @@ import { DropdownMenu } from "./dropdown-menu";
 export interface GitRepoDropdownProps {
   provider: Provider;
   value?: string | null;
+  repositoryName?: string | null;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -30,6 +31,7 @@ export interface GitRepoDropdownProps {
 export function GitRepoDropdown({
   provider,
   value,
+  repositoryName,
   placeholder = "Search repositories...",
   className,
   disabled = false,
@@ -75,6 +77,7 @@ export function GitRepoDropdown({
     urlSearchResults,
     inputValue,
     value,
+    repositoryName,
   );
 
   // Filter repositories based on input value

--- a/frontend/src/components/features/home/git-repo-dropdown/use-repository-data.tsx
+++ b/frontend/src/components/features/home/git-repo-dropdown/use-repository-data.tsx
@@ -11,6 +11,7 @@ export function useRepositoryData(
   urlSearchResults: GitRepository[],
   inputValue: string,
   value?: string | null,
+  repositoryName?: string | null,
 ) {
   // Fetch user repositories with pagination
   const {
@@ -25,9 +26,18 @@ export function useRepositoryData(
     enabled: !disabled,
   });
 
+  // Determine if we should skip search (when input matches selected repository)
+  const shouldSkipSearch = useMemo(
+    () => inputValue === repositoryName,
+    [repositoryName, inputValue],
+  );
+
   // Search repositories when user types
   const { data: searchData, isLoading: isSearchLoading } =
-    useSearchRepositories(processedSearchInput, provider);
+    useSearchRepositories(
+      shouldSkipSearch ? "" : processedSearchInput,
+      provider,
+    );
 
   // Combine all repositories from paginated data
   const allRepositories = useMemo(

--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -106,6 +106,7 @@ export function RepositorySelectionForm({
       <GitRepoDropdown
         provider={selectedProvider || providers[0]}
         value={selectedRepository?.id || null}
+        repositoryName={selectedRepository?.full_name || null}
         placeholder="user/repo"
         disabled={!selectedProvider}
         onChange={handleRepoSelection}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Issue: On the home page, after selecting a repo, two loading spinners appear. However, only the branch dropdown should display a spinner.

**Acceptance Criteria:**
- The repo dropdown should not display a loading spinner after a repo is selected.
- Only the branch dropdown should display a loading spinner.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes this issue - after selecting a repo, two loading spinners appear.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/90658125-9d90-465e-a08c-b36f175bde6e

---
**Link of any specific issues this addresses:**
