### PR TITLE
fix(frontend): the suggested tasks change width when transitioning from the skeleton state to the data state

### DIFF
--- a/frontend/src/components/features/home/tasks/task-card.tsx
+++ b/frontend/src/components/features/home/tasks/task-card.tsx
@@ -79,7 +79,10 @@ export function TaskCard({ task }: TaskCardProps) {
           <span className="text-xs text-white leading-6 font-normal">
             {getTaskTypeMap(t)[task.task_type]}
           </span>
-          <span className="text-xs text-[#A3A3A3] leading-4 font-normal">
+          <span
+            className="text-xs text-[#A3A3A3] leading-4 font-normal max-w-50 truncate"
+            title={task.title}
+          >
             {task.title}
           </span>
         </div>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance crtieria:**
- Suggested tasks should remain the same width when loading and when data is present

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes the suggested tasks change width when transitioning from the skeleton state to the data state.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/90731fda-b8ab-49e7-b399-69e27c3139ca

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:eaa64ab-nikolaik   --name openhands-app-eaa64ab   docker.all-hands.dev/all-hands-ai/openhands:eaa64ab
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3374 openhands
```