### PR TITLE
feat(frontend): display “Open Repository” title on left-hand card in zero-state

### DIFF
--- a/frontend/src/components/features/home/connect-to-provider-message.tsx
+++ b/frontend/src/components/features/home/connect-to-provider-message.tsx
@@ -2,6 +2,8 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { useSettings } from "#/hooks/query/use-settings";
+import RepoForkedIcon from "#/icons/repo-forked.svg?react";
+import { I18nKey } from "#/i18n/declaration";
 
 export function ConnectToProviderMessage() {
   const { isLoading } = useSettings();
@@ -9,7 +11,15 @@ export function ConnectToProviderMessage() {
 
   return (
     <div className="flex flex-col gap-4 justify-between h-full">
-      <p>{t("HOME$CONNECT_PROVIDER_MESSAGE")}</p>
+      <div className="flex flex-col gap-2.5">
+        <div className="flex items-center gap-[10px]">
+          <RepoForkedIcon width={24} height={24} />
+          <span className="leading-5 font-bold text-base text-white">
+            {t(I18nKey.COMMON$OPEN_REPOSITORY)}
+          </span>
+        </div>
+        <p>{t("HOME$CONNECT_PROVIDER_MESSAGE")}</p>
+      </div>
       <Link
         data-testid="navigate-to-settings-button"
         to="/settings/integrations"


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Requirement:

The Open Repository title must remain visible on the left-hand card when the card is in its zero-state.

**Acceptance Criteria:**
- The left-hand card should consistently display the Open Repository title while in zero-state.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR displays “Open Repository” title on left-hand card in zero-state.

We can refer to the image below for the output of the PR.

<img width="1431" height="745" alt="all-3391" src="https://github.com/user-attachments/assets/074ac855-5c28-4c99-a3af-dfe14b60c5a1" />

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5ab5aa5-nikolaik   --name openhands-app-5ab5aa5   docker.all-hands.dev/all-hands-ai/openhands:5ab5aa5
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3391 openhands
```