### PR TITLE
ALL-3400: Fix SaaS search bug by using installation organizations

### DIFF
--- a/openhands/integrations/bitbucket/service/repos.py
+++ b/openhands/integrations/bitbucket/service/repos.py
@@ -13,7 +13,13 @@ class BitBucketReposMixin(BitBucketMixinBase):
     """
 
     async def search_repositories(
-        self, query: str, per_page: int, sort: str, order: str, public: bool
+        self,
+        query: str,
+        per_page: int,
+        sort: str,
+        order: str,
+        public: bool,
+        app_mode: AppMode | None = None,
     ) -> list[Repository]:
         """Search for repositories."""
         repositories = []

--- a/openhands/integrations/gitlab/service/repos.py
+++ b/openhands/integrations/gitlab/service/repos.py
@@ -75,6 +75,7 @@ class GitLabReposMixin(GitLabMixinBase):
         sort: str = 'updated',
         order: str = 'desc',
         public: bool = False,
+        app_mode: AppMode | None = None,
     ) -> list[Repository]:
         if public:
             # When public=True, query is a GitLab URL that we need to parse

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -291,12 +291,13 @@ class ProviderHandler:
         per_page: int,
         sort: str,
         order: str,
+        app_mode: AppMode | None = None,
     ) -> list[Repository]:
         if selected_provider:
             service = self._get_service(selected_provider)
             public = self._is_repository_url(query, selected_provider)
             user_repos = await service.search_repositories(
-                query, per_page, sort, order, public
+                query, per_page, sort, order, public, app_mode
             )
             return self._deduplicate_repositories(user_repos)
 
@@ -306,7 +307,7 @@ class ProviderHandler:
                 service = self._get_service(provider)
                 public = self._is_repository_url(query, provider)
                 service_repos = await service.search_repositories(
-                    query, per_page, sort, order, public
+                    query, per_page, sort, order, public, app_mode
                 )
                 all_repos.extend(service_repos)
             except Exception as e:

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -458,7 +458,13 @@ class GitService(Protocol):
         ...
 
     async def search_repositories(
-        self, query: str, per_page: int, sort: str, order: str, public: bool
+        self,
+        query: str,
+        per_page: int,
+        sort: str,
+        order: str,
+        public: bool,
+        app_mode: AppMode | None = None,
     ) -> list[Repository]:
         """Search for public repositories"""
         ...

--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -148,7 +148,7 @@ async def search_repositories(
         )
         try:
             repos: list[Repository] = await client.search_repositories(
-                selected_provider, query, per_page, sort, order
+                selected_provider, query, per_page, sort, order, server_config.app_mode
             )
             return repos
 


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Searching 'agent-sdk' returned empty results in SaaS mode while 'All-Hands-AI/agent-sdk' worked.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Add `get_installation_organizations()` method to GitHub service to extract orgs from GitHub App installations
- Update `search_repositories()` to use installation orgs in SaaS mode vs user orgs in OSS mode
- Add comprehensive tests for both SaaS and OSS search modes

---
**Link of any specific issues this addresses:**
