### PR TITLE
refactor(frontend): hovering three-dots to show the context menu (conversation panel)

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card.tsx
@@ -179,7 +179,7 @@ export function ConversationCard({
           </div>
 
           {hasContextMenu && (
-            <div>
+            <div className="group">
               <button
                 data-testid="ellipsis-button"
                 type="button"
@@ -192,36 +192,41 @@ export function ConversationCard({
               >
                 <EllipsisIcon />
               </button>
-              <div className="relative">
-                {contextMenuOpen && (
-                  <ConversationCardContextMenu
-                    onClose={() => onContextMenuToggle?.(false)}
-                    onDelete={onDelete && handleDelete}
-                    onStop={
-                      conversationStatus !== "STOPPED"
-                        ? onStop && handleStop
-                        : undefined
-                    }
-                    onEdit={onChangeTitle && handleEdit}
-                    onDownloadViaVSCode={
-                      conversationId && showOptions
-                        ? handleDownloadViaVSCode
-                        : undefined
-                    }
-                    onDisplayCost={showOptions ? handleDisplayCost : undefined}
-                    onShowAgentTools={
-                      showOptions && systemMessage
-                        ? handleShowAgentTools
-                        : undefined
-                    }
-                    onShowMicroagents={
-                      showOptions && conversationId
-                        ? handleShowMicroagents
-                        : undefined
-                    }
-                    position="bottom"
-                  />
+              <div
+                className={cn(
+                  // Show on hover (desktop) or when explicitly opened (click/touch)
+                  "relative opacity-0 invisible group-hover:opacity-100 group-hover:visible",
+                  // Override hover styles when explicitly opened via click
+                  contextMenuOpen && "opacity-100 visible",
                 )}
+              >
+                <ConversationCardContextMenu
+                  onClose={() => onContextMenuToggle?.(false)}
+                  onDelete={onDelete && handleDelete}
+                  onStop={
+                    conversationStatus !== "STOPPED"
+                      ? onStop && handleStop
+                      : undefined
+                  }
+                  onEdit={onChangeTitle && handleEdit}
+                  onDownloadViaVSCode={
+                    conversationId && showOptions
+                      ? handleDownloadViaVSCode
+                      : undefined
+                  }
+                  onDisplayCost={showOptions ? handleDisplayCost : undefined}
+                  onShowAgentTools={
+                    showOptions && systemMessage
+                      ? handleShowAgentTools
+                      : undefined
+                  }
+                  onShowMicroagents={
+                    showOptions && conversationId
+                      ? handleShowMicroagents
+                      : undefined
+                  }
+                  position="bottom"
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance Criteria:**
- When hovering over the three-dots icon in the conversation panel, the context menu should be displayed.
- The context menu should also be accessible via a click action on the three-dots icon.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR enables the display of the context menu in the conversation panel when the user either hovers over or clicks the three-dots icon.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/ca6b31c8-33df-4a1b-a8f9-3034acdfa86f

---
**Link of any specific issues this addresses:**
