### PR TITLE
refactor(frontend): hide three-dots icon while editing conversation title

### DIFF
--- a/frontend/src/components/features/conversation/conversation-name.tsx
+++ b/frontend/src/components/features/conversation/conversation-name.tsx
@@ -135,7 +135,7 @@ export function ConversationName() {
             onKeyUp={handleKeyUp}
             type="text"
             defaultValue={conversation.title}
-            className="text-white leading-5 bg-transparent border-none outline-none text-base font-normal w-fit max-w-fit"
+            className="text-white leading-5 bg-transparent border-none outline-none text-base font-normal w-fit max-w-fit field-sizing-content"
           />
         ) : (
           <div
@@ -148,33 +148,35 @@ export function ConversationName() {
           </div>
         )}
 
-        <div className="relative flex items-center">
-          <EllipsisButton fill="#B1B9D3" onClick={handleEllipsisClick} />
-          {contextMenuOpen && (
-            <ConversationNameContextMenu
-              onClose={() => setContextMenuOpen(false)}
-              onRename={handleRename}
-              onDelete={handleDelete}
-              onStop={shouldShowStop ? handleStop : undefined}
-              onDisplayCost={
-                shouldShowDisplayCost ? handleDisplayCost : undefined
-              }
-              onShowAgentTools={
-                shouldShowAgentTools ? handleShowAgentTools : undefined
-              }
-              onShowMicroagents={
-                shouldShowMicroagents ? handleShowMicroagents : undefined
-              }
-              onExportConversation={
-                shouldShowExport ? handleExportConversation : undefined
-              }
-              onDownloadViaVSCode={
-                shouldShowDownload ? handleDownloadViaVSCode : undefined
-              }
-              position="bottom"
-            />
-          )}
-        </div>
+        {titleMode !== "edit" && (
+          <div className="relative flex items-center">
+            <EllipsisButton fill="#B1B9D3" onClick={handleEllipsisClick} />
+            {contextMenuOpen && (
+              <ConversationNameContextMenu
+                onClose={() => setContextMenuOpen(false)}
+                onRename={handleRename}
+                onDelete={handleDelete}
+                onStop={shouldShowStop ? handleStop : undefined}
+                onDisplayCost={
+                  shouldShowDisplayCost ? handleDisplayCost : undefined
+                }
+                onShowAgentTools={
+                  shouldShowAgentTools ? handleShowAgentTools : undefined
+                }
+                onShowMicroagents={
+                  shouldShowMicroagents ? handleShowMicroagents : undefined
+                }
+                onExportConversation={
+                  shouldShowExport ? handleExportConversation : undefined
+                }
+                onDownloadViaVSCode={
+                  shouldShowDownload ? handleDownloadViaVSCode : undefined
+                }
+                position="bottom"
+              />
+            )}
+          </div>
+        )}
       </div>
 
       {/* Metrics Modal */}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Acceptance Criteria:
- On the conversation page, the three-dots icon should be hidden while the user is editing the conversation title.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR hides the three-dots icon on the conversation page while the user is editing the conversation title.

A demo of the behavior can be found in the video below.

https://github.com/user-attachments/assets/bd801372-e37c-4e01-84af-280e3960f31f

---
**Link of any specific issues this addresses:**
