### PR TITLE
fix(frontend): show account settings context menu when hovering over grip

### DIFF
--- a/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
+++ b/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
@@ -102,7 +102,7 @@ export function AccountSettingsContextMenu({
       testId="account-settings-context-menu"
       ref={ref}
       alignment="right"
-      className="mt-0 md:right-full md:left-full md:bottom-0 ml-0 z-10 w-fit"
+      className="mt-0 md:right-full md:left-full md:bottom-0 ml-0 z-10 w-fit z-[9999]"
     >
       {navItems.map(({ to, text, icon }) => (
         <Link key={to} to={to} className="text-decoration-none">


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
When the settings dropdown is open, it currently closes if the mouse moves over the area where the chat box gripper is activated.

**Acceptance Criteria:**
- The account settings context menu should remain visible and be displayed correctly when hovering over the grip.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR ensures that the account settings context menu is displayed when hovering over the grip.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/5bfe7701-847d-43b2-acb5-ff08548416c1

---
**Link of any specific issues this addresses:**
