### PR TITLE
refactor(frontend): align "no repo" icons between conversation panel and recent conversations

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card/no-repository.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/no-repository.tsx
@@ -1,13 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
-import RepoIcon from "#/icons/repo.svg?react";
+import RepoForkedIcon from "#/icons/repo-forked.svg?react";
 
 export function NoRepository() {
   const { t } = useTranslation();
 
   return (
     <div className="flex items-center gap-1 text-xs text-[#A3A3A3]">
-      <RepoIcon width={14} height={14} className="text-[#A3A3A3]" />
+      <RepoForkedIcon width={14} height={14} className="text-[#A3A3A3]" />
       <span>{t(I18nKey.COMMON$NO_REPOSITORY)}</span>
     </div>
   );


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance criteria:**
- We need to align "no repo" icons between conversation panel and recent conversations.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR aligns "no repo" icons between conversation panel and recent conversations.

We can refer to the image below for the output of the PR.

<img width="1431" height="745" alt="all-3422" src="https://github.com/user-attachments/assets/c8d3732a-ab04-4099-897f-9bcb053d6f52" />

---
**Link of any specific issues this addresses:**
