### PR TITLE
refactor(frontend): increase z-index of account settings context menu

### DIFF
--- a/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
+++ b/frontend/src/components/features/context-menu/account-settings-context-menu.tsx
@@ -102,7 +102,7 @@ export function AccountSettingsContextMenu({
       testId="account-settings-context-menu"
       ref={ref}
       alignment="right"
-      className="mt-0 md:right-full md:left-full md:bottom-0 ml-0 z-10 w-fit"
+      className="mt-0 md:right-full md:left-full md:bottom-0 ml-0 z-10 w-fit z-[9999]"
     >
       {navItems.map(({ to, text, icon }) => (
         <Link key={to} to={to} className="text-decoration-none">


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Issue:
When a user hovers over the settings while the conversations list is open, the settings dropdown is hidden behind the list. The dropdown should instead appear above it, which requires a z-index adjustment.

**Acceptance Criteria:**
- The settings dropdown should always appear above the conversations list when hovered.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR increases z-index of account settings context menu.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/4e0ed2da-d7f4-4676-a092-ec3e47e5eb9b

---
**Link of any specific issues this addresses:**
