### PR TITLE
style: Change repo and branch buttons to outlined style

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -382,7 +382,7 @@ export function CustomChatInput({
         {/* Chat Input Component */}
         <div
           ref={chatContainerRef}
-          className="bg-[#25272D] box-border content-stretch flex flex-col items-start justify-center p-4 pt-3 relative rounded-[15px] w-full"
+          className="bg-[#1E1E1E] box-border content-stretch flex flex-col items-start justify-center p-4 pt-3 relative rounded-[15px] w-full"
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}

--- a/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
@@ -33,8 +33,8 @@ export function GitControlBarBranchButton({
       className={cn(
         "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit max-w-none flex-shrink-0 max-w-[108px] truncate relative",
         hasBranch
-          ? "bg-[#25272D] hover:bg-[#454545] cursor-pointer"
-          : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed min-w-[108px]",
+          ? "border border-[#525252] bg-transparent hover:border-[#454545] cursor-pointer"
+          : "border border-[rgba(71,74,84,0.50)] bg-transparent cursor-not-allowed min-w-[108px]",
       )}
     >
       <div className="flex flex-row gap-2 items-center justify-start">

--- a/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
@@ -35,8 +35,8 @@ export function GitControlBarRepoButton({
       className={cn(
         "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit flex-shrink-0 max-w-[170px] truncate relative",
         hasRepository
-          ? "bg-[#25272D] hover:bg-[#454545] cursor-pointer"
-          : "bg-[rgba(71,74,84,0.50)] cursor-not-allowed min-w-[170px]",
+          ? "border border-[#525252] bg-transparent hover:border-[#454545] cursor-pointer"
+          : "border border-[rgba(71,74,84,0.50)] bg-transparent cursor-not-allowed min-w-[170px]",
       )}
     >
       <div className="flex flex-row gap-2 items-center justify-start">


### PR DESCRIPTION

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Updated git-control-bar-repo-button.tsx to use outlined styling instead of filled background
- Updated git-control-bar-branch-button.tsx to use outlined styling instead of filled background
- Changed from bg-[#25272D] to border border-[#525252] bg-transparent for active state
- Changed hover effect from hover:bg-[#454545] to hover:border-[#454545]
- Updated disabled state to use border styling as well
- Reverted unintended changes to chat input container styling


---
**Link of any specific issues this addresses:**
