### PR TITLE
Add refetchInterval to useActiveHost hook for automatic host status updates

### DIFF
--- a/frontend/__tests__/hooks/query/use-active-host.test.tsx
+++ b/frontend/__tests__/hooks/query/use-active-host.test.tsx
@@ -1,0 +1,122 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+    useQueries: vi.fn(),
+  };
+});
+
+// Mock the dependencies
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useConversationId: () => ({ conversationId: "test-conversation-id" }),
+}));
+
+vi.mock("#/hooks/use-runtime-is-ready", () => ({
+  useRuntimeIsReady: () => true,
+}));
+
+vi.mock("#/api/open-hands", () => ({
+  default: {
+    getWebHosts: vi.fn().mockResolvedValue(["http://localhost:3000", "http://localhost:3001"]),
+  },
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: "OK" }),
+    create: vi.fn(() => ({
+      get: vi.fn(),
+      interceptors: {
+        response: {
+          use: vi.fn(),
+        },
+      },
+    })),
+  },
+}));
+
+describe("useActiveHost", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(async () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    
+    // Mock useQuery to return hosts data
+    const { useQuery, useQueries } = await import("@tanstack/react-query");
+    vi.mocked(useQuery).mockReturnValue({
+      data: { hosts: ["http://localhost:3000", "http://localhost:3001"] },
+      isLoading: false,
+      error: null,
+    } as any);
+    
+    // Mock useQueries to return empty array of results
+    vi.mocked(useQueries).mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  it("should configure refetchInterval for host availability queries", async () => {
+    // Import the hook after mocks are set up
+    const { useActiveHost } = await import("#/hooks/query/use-active-host");
+    const { useQueries } = await import("@tanstack/react-query");
+    
+    renderHook(() => useActiveHost(), { wrapper });
+
+    // Check that useQueries was called
+    expect(useQueries).toHaveBeenCalled();
+    
+    // Get the queries configuration passed to useQueries
+    const queriesConfig = vi.mocked(useQueries).mock.calls[0][0];
+    
+    
+    // Verify that the queries configuration includes refetchInterval
+    expect(queriesConfig).toEqual({
+      queries: expect.arrayContaining([
+        expect.objectContaining({
+          refetchInterval: 3000,
+        }),
+      ]),
+    });
+  });
+
+  it("should fail if refetchInterval is not configured", async () => {
+    // Import the hook after mocks are set up
+    const { useActiveHost } = await import("#/hooks/query/use-active-host");
+    const { useQueries } = await import("@tanstack/react-query");
+    
+    renderHook(() => useActiveHost(), { wrapper });
+
+    // Check that useQueries was called
+    expect(useQueries).toHaveBeenCalled();
+    
+    // Get the queries configuration passed to useQueries
+    const queriesConfig = vi.mocked(useQueries).mock.calls[0][0];
+    
+    // This test will fail if refetchInterval is commented out in the hook
+    // because the queries won't have the refetchInterval property
+    const hasRefetchInterval = (queriesConfig as any).queries.some((query: any) => 
+      query.refetchInterval === 3000
+    );
+    
+    expect(hasRefetchInterval).toBe(true);
+  });
+});

--- a/frontend/src/hooks/query/use-active-host.ts
+++ b/frontend/src/hooks/query/use-active-host.ts
@@ -34,7 +34,7 @@ export const useActiveHost = () => {
           return "";
         }
       },
-      // refetchInterval: 3000,
+      refetchInterval: 3000,
       meta: {
         disableToast: true,
       },


### PR DESCRIPTION
## Summary

This PR enables automatic host availability detection in the `useActiveHost` hook by uncommenting the `refetchInterval` configuration and adding comprehensive tests to ensure the functionality works correctly.

## Changes

### 🔧 Hook Enhancement
- **Uncommented `refetchInterval: 3000`** in `useActiveHost` hook to enable periodic host availability checks every 3 seconds
- This allows the frontend to automatically detect when hosts become available or unavailable without requiring manual refresh

### 🧪 Test Coverage
- **Added comprehensive test suite** for `useActiveHost` hook in `frontend/__tests__/hooks/query/use-active-host.test.tsx`
- **Test verifies refetchInterval configuration** is properly passed to TanStack Query's `useQueries`
- **Test would fail if refetchInterval is commented out**, ensuring the functionality is maintained
- Uses proper mocking of TanStack Query hooks (`useQuery` and `useQueries`) to test configuration

## Technical Details

The `useActiveHost` hook:
1. Fetches the list of available hosts using `useQuery`
2. Creates individual queries for each host using `useQueries` to check availability
3. With `refetchInterval: 3000`, each host is checked every 3 seconds automatically
4. Updates the active host when availability changes

## Testing

- ✅ All tests pass with the refetchInterval enabled
- ✅ Tests would fail if refetchInterval was commented out (verified during development)
- ✅ Frontend linting and type checking passes
- ✅ Backend pre-commit hooks pass

## Impact

This change improves the user experience by:
- **Automatically detecting host status changes** without manual intervention
- **Providing real-time updates** when hosts become available or unavailable
- **Maintaining responsive UI** that reflects current host availability

## Related

- Addresses issue ALL-3409
- No breaking changes
- Backward compatible

@amanape can click here to [continue refining the PR](https://app.all-hands.dev/conversations/75d1fde869664ede8547c7329e026a6a)