### PR TITLE
feat: implement fade in/out animation for chat suggestions

### DIFF
--- a/frontend/src/components/features/chat/chat-suggestions.tsx
+++ b/frontend/src/components/features/chat/chat-suggestions.tsx
@@ -5,6 +5,7 @@ import { I18nKey } from "#/i18n/declaration";
 import BuildIt from "#/icons/build-it.svg?react";
 import { SUGGESTIONS } from "#/utils/suggestions";
 import { RootState } from "#/store";
+import { cn } from "#/utils/utils";
 
 interface ChatSuggestionsProps {
   onSuggestionsClick: (value: string) => void;
@@ -16,15 +17,13 @@ export function ChatSuggestions({ onSuggestionsClick }: ChatSuggestionsProps) {
     (state: RootState) => state.conversation.shouldHideSuggestions,
   );
 
-  // Don't render if suggestions should be hidden
-  if (shouldHideSuggestions) {
-    return null;
-  }
-
   return (
     <div
       data-testid="chat-suggestions"
-      className="flex flex-col h-full items-center justify-center"
+      className={cn(
+        "flex flex-col h-full items-center justify-center transition-opacity duration-300 ease-in-out",
+        shouldHideSuggestions ? "opacity-0 pointer-events-none" : "opacity-100",
+      )}
     >
       <div className="flex flex-col items-center p-4 rounded-xl w-full">
         <BuildIt width={86} height={103} />


### PR DESCRIPTION

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Replace immediate hide/show behavior with smooth opacity transition when user expands chat input. The zero state icon and suggestions now fade out over 300ms when input height exceeds threshold and fade back in when collapsed.

- Use CSS transition-opacity with 300ms duration and ease-in-out timing
- Add pointer-events-none when hidden to prevent interaction
- Use cn utility for cleaner className composition
- Maintain existing functionality while improving UX


https://github.com/user-attachments/assets/fea618af-50d5-483a-bffc-c5b23ffb7603


---
**Link of any specific issues this addresses:**
