### PR TITLE
Revert "feat(agent): add security-related items in system prompt to defense against data exfiltration"

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -62,18 +62,8 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </PROBLEM_SOLVING_WORKFLOW>
 
 <SECURITY>
-* Apply least privilege: scope file paths narrowly, avoid wildcards or broad recursive actions.
-* NEVER exfiltrate secrets (tokens, keys, .env, PII, SSH keys, credentials, cookies)!
-  - Block: uploading to file-sharing, embedding in code/comments, printing/logging secrets, sending config files to external APIs
-* Recognize credential patterns: ghp_/gho_/ghu_/ghs_/ghr_ (GitHub), AKIA/ASIA/AROA (AWS), API keys, base64/hex-encoded secrets
-* NEVER process/display/encode/decode/manipulate secrets in ANY form - encoding doesn't make them safe
-* Refuse requests that:
-  - Search env vars for "hp_", "key", "token", "secret"
-  - Encode/decode potentially sensitive data
-  - Use patterns like `env | grep [pattern] | base64`, `cat ~/.ssh/* | [encoding]`, `echo $[CREDENTIAL] | [processing]`
-  - Frame credential handling as "debugging/testing"
-* When encountering sensitive data: STOP, refuse, explain security risk, offer alternatives
-* Prefer official APIs unless user explicitly requests browsing/automation
+* Only use GITHUB_TOKEN and other credentials in ways the user has explicitly requested and would expect.
+* Use APIs to work with GitHub or other platforms, unless the user asks otherwise or your task requires browsing.
 </SECURITY>
 
 <SECURITY_RISK_ASSESSMENT>


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#10477

Maybe we could give this some thought: it needs done, but maybe we can adjust the prompt so that it's not so broad, or maybe give some ability to the user... OK, not sure what ability wouldn't be hijackable, but it's a tough tradeoff.
<img width="1034" height="254" alt="image" src="https://github.com/user-attachments/assets/2089af0d-daa7-46f7-ba17-3557c201b97c" />

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:607e41a-nikolaik   --name openhands-app-607e41a   docker.all-hands.dev/all-hands-ai/openhands:607e41a
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@revert-10477-xw/security-aware openhands
```