### PR TITLE
fix(frontend): jupyter tab missing border radius on scroll

### DIFF
--- a/frontend/src/components/features/jupyter/jupyter.tsx
+++ b/frontend/src/components/features/jupyter/jupyter.tsx
@@ -35,7 +35,7 @@ export function JupyterEditor({ maxWidth }: JupyterEditorProps) {
         <div className="flex-1 h-full flex flex-col" style={{ maxWidth }}>
           <div
             data-testid="jupyter-container"
-            className="flex-1 overflow-y-auto fast-smooth-scroll custom-scrollbar-always"
+            className="flex-1 overflow-y-auto fast-smooth-scroll custom-scrollbar-always rounded-xl"
             ref={jupyterRef}
             onScroll={(e) => onChatBodyScroll(e.currentTarget)}
           >


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The Jupyter tab currently does not display the border radius when scrolling.

We can refer to the image below for more information.

<img width="1435" height="738" alt="all-3456-issue" src="https://github.com/user-attachments/assets/12f696ee-6e81-4db7-8706-436436ce3dfe" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR resolves the issue where the Jupyter tab’s border radius was not applied during scrolling.

We can refer to the image below for the output of the PR.

<img width="1435" height="738" alt="all-3456-solution" src="https://github.com/user-attachments/assets/3765e3c1-1c1e-4556-9868-6c9ba57fcd90" />

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:76747d2-nikolaik   --name openhands-app-76747d2   docker.all-hands.dev/all-hands-ai/openhands:76747d2
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3456 openhands
```