### PR TITLE
fix(frontend): account settings menu fails to open for unauthenticated users

### DIFF
--- a/frontend/__tests__/components/features/home/task-suggestions.test.tsx
+++ b/frontend/__tests__/components/features/home/task-suggestions.test.tsx
@@ -33,7 +33,7 @@ vi.mock("#/hooks/query/use-is-authed", () => ({
 const renderTaskSuggestions = () => {
   const RouterStub = createRoutesStub([
     {
-      Component: () => <TaskSuggestions />,
+      Component: () => <TaskSuggestions providersAreSet={true} />,
       path: "/",
     },
     {

--- a/frontend/src/components/features/home/tasks/task-suggestions.tsx
+++ b/frontend/src/components/features/home/tasks/task-suggestions.tsx
@@ -9,12 +9,16 @@ import { GitRepository } from "#/types/git";
 
 interface TaskSuggestionsProps {
   filterFor?: GitRepository | null;
+  providersAreSet: boolean;
 }
 
-export function TaskSuggestions({ filterFor }: TaskSuggestionsProps) {
+export function TaskSuggestions({
+  filterFor,
+  providersAreSet,
+}: TaskSuggestionsProps) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { data: tasks, isLoading } = useSuggestedTasks();
+  const { data: tasks, isLoading } = useSuggestedTasks(providersAreSet);
 
   const suggestedTasks = filterFor
     ? tasks?.filter(

--- a/frontend/src/components/features/sidebar/user-actions.tsx
+++ b/frontend/src/components/features/sidebar/user-actions.tsx
@@ -3,6 +3,7 @@ import { UserAvatar } from "./user-avatar";
 import { AccountSettingsContextMenu } from "../context-menu/account-settings-context-menu";
 import { useShouldShowUserFeatures } from "#/hooks/use-should-show-user-features";
 import { cn } from "#/utils/utils";
+import { useConfig } from "#/hooks/query/use-config";
 
 interface UserActionsProps {
   onLogout: () => void;
@@ -13,6 +14,8 @@ interface UserActionsProps {
 export function UserActions({ onLogout, user, isLoading }: UserActionsProps) {
   const [accountContextMenuIsVisible, setAccountContextMenuIsVisible] =
     React.useState(false);
+
+  const { data: config } = useConfig();
 
   // Use the shared hook to determine if user actions should be shown
   const shouldShowUserActions = useShouldShowUserFeatures();
@@ -34,7 +37,9 @@ export function UserActions({ onLogout, user, isLoading }: UserActionsProps) {
   };
 
   // Show the menu based on the new logic
-  const showMenu = accountContextMenuIsVisible && shouldShowUserActions;
+  const showMenu =
+    accountContextMenuIsVisible &&
+    (shouldShowUserActions || config?.APP_MODE === "oss");
 
   return (
     <div
@@ -47,7 +52,7 @@ export function UserActions({ onLogout, user, isLoading }: UserActionsProps) {
         isLoading={isLoading}
       />
 
-      {shouldShowUserActions && (
+      {(shouldShowUserActions || config?.APP_MODE === "oss") && (
         <div
           className={cn(
             "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto",

--- a/frontend/src/hooks/query/use-suggested-tasks.ts
+++ b/frontend/src/hooks/query/use-suggested-tasks.ts
@@ -3,13 +3,13 @@ import { SuggestionsService } from "#/api/suggestions-service/suggestions-servic
 import { groupSuggestedTasks } from "#/utils/group-suggested-tasks";
 import { useIsAuthed } from "./use-is-authed";
 
-export const useSuggestedTasks = () => {
+export const useSuggestedTasks = (providersAreSet: boolean = false) => {
   const { data: userIsAuthenticated } = useIsAuthed();
 
   return useQuery({
     queryKey: ["tasks"],
     queryFn: SuggestionsService.getSuggestedTasks,
     select: groupSuggestedTasks,
-    enabled: !!userIsAuthenticated,
+    enabled: !!userIsAuthenticated && providersAreSet,
   });
 };

--- a/frontend/src/routes/home.tsx
+++ b/frontend/src/routes/home.tsx
@@ -6,6 +6,7 @@ import { TaskSuggestions } from "#/components/features/home/tasks/task-suggestio
 import { GitRepository } from "#/types/git";
 import { NewConversation } from "#/components/features/home/new-conversation";
 import { RecentConversations } from "#/components/features/home/recent-conversations/recent-conversations";
+import { useUserProviders } from "#/hooks/use-user-providers";
 
 <PrefetchPageLinks page="/conversations/:conversationId" />;
 
@@ -13,6 +14,10 @@ function HomeScreen() {
   const [selectedRepo, setSelectedRepo] = React.useState<GitRepository | null>(
     null,
   );
+
+  const { providers } = useUserProviders();
+
+  const providersAreSet = providers.length > 0;
 
   return (
     <div
@@ -37,7 +42,10 @@ function HomeScreen() {
           data-testid="home-screen-recent-conversations-section"
         >
           <RecentConversations />
-          <TaskSuggestions filterFor={selectedRepo} />
+          <TaskSuggestions
+            filterFor={selectedRepo}
+            providersAreSet={providersAreSet}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Issue:
Currently, the account settings menu does not open for unauthenticated users.

Acceptance Criteria:
- The account settings menu should be accessible and openable even when the user is not logged in.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes account settings menu fails to open for unauthenticated users.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/3ab899ed-10bb-481c-82ef-34afc927b98a

---
**Link of any specific issues this addresses:**
