### PR TITLE
refactor(frontend): adjust font weight of “continue” button in terms and services acceptance modal

### DIFF
--- a/frontend/src/routes/accept-tos.tsx
+++ b/frontend/src/routes/accept-tos.tsx
@@ -78,7 +78,7 @@ export default function AcceptTOS() {
           type="button"
           variant="primary"
           onClick={handleAcceptTOS}
-          className="w-full"
+          className="w-full font-semibold"
         >
           {isSubmitting ? t(I18nKey.HOME$LOADING) : t(I18nKey.TOS$CONTINUE)}
         </BrandButton>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

We need to adjust font weight of “continue” button in terms and services acceptance modal.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR adjusts font weight of “continue” button in terms and services acceptance modal.

We can refer to the image below for the output of the PR.

<img width="1435" height="738" alt="all-3468" src="https://github.com/user-attachments/assets/c4146417-8fe2-49e3-a770-97159a49b9e6" />

---
**Link of any specific issues this addresses:**
