### PR TITLE
refactor(frontend): standardize font colors and sizes in empty state

### DIFF
--- a/frontend/src/components/features/browser/empty-browser-message.tsx
+++ b/frontend/src/components/features/browser/empty-browser-message.tsx
@@ -6,9 +6,12 @@ export function EmptyBrowserMessage() {
   const { t } = useTranslation();
 
   return (
-    <div className="flex flex-col items-center h-full justify-center">
-      <IoIosGlobe size={100} />
-      {t(I18nKey.BROWSER$NO_PAGE_LOADED)}
+    <div className="flex flex-col items-center justify-center w-full h-full p-10 gap-4">
+      <IoIosGlobe size={113} />
+      <span className="text-[#8D95A9] text-[19px] font-normal leading-5">
+        {" "}
+        {t(I18nKey.BROWSER$NO_PAGE_LOADED)}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

We need to standardize font colors and sizes in empty state

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR standardizes font colors and sizes in empty state.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c69e886-nikolaik   --name openhands-app-c69e886   docker.all-hands.dev/all-hands-ai/openhands:c69e886
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3471 openhands
```