### PR TITLE
refactor(frontend): add padding to the changes tab

### DIFF
--- a/frontend/src/routes/changes-tab.tsx
+++ b/frontend/src/routes/changes-tab.tsx
@@ -67,7 +67,7 @@ function GitChanges() {
   ]);
 
   return (
-    <main className="h-full overflow-y-scroll px-4 py-3 pr-1.5 gap-3 flex flex-col items-center custom-scrollbar-always">
+    <main className="h-full overflow-y-scroll p-4 pr-1.5 gap-3 flex flex-col items-center custom-scrollbar-always">
       {!isSuccess || !gitChanges.length ? (
         <div className="relative flex h-full w-full items-center">
           <div className="absolute inset-x-0 top-1/2 -translate-y-1/2">


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

We need to add padding to the changes tab

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR adds padding to the changes tab

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:83b6d99-nikolaik   --name openhands-app-83b6d99   docker.all-hands.dev/all-hands-ai/openhands:83b6d99
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3473 openhands
```