### PR TITLE
chore - Make enterprise preview work when labeled after the fact

### DIFF
--- a/.github/workflows/enterprise-preview.yml
+++ b/.github/workflows/enterprise-preview.yml
@@ -1,0 +1,30 @@
+# Feature branch preview for enterprise code
+name: Enterprise Preview
+
+# Run on PRs labeled
+on:
+  pull_request:
+    types: [labeled]
+
+# Match ghcr-build.yml, but don't interrupt it.
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  # This must happen for the PR Docker workflow when the label is present,
+  # and also if it's added after the fact. Thus, it exists in both places.
+  enterprise-preview:
+    name: Enterprise preview
+    if: github.event.label.name == 'deploy'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs: [ghcr_build_enterprise]
+    steps:
+      # This should match the version in ghcr-build.yml
+      - name: Trigger remote job
+        run: |
+          curl --fail-with-body -sS -X POST \
+            -H "Authorization: Bearer ${{ secrets.PAT_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -d "{\"ref\": \"main\", \"inputs\": {\"openhandsPrNumber\": \"${{ github.event.pull_request.number }}\", \"deployEnvironment\": \"feature\", \"enterpriseImageTag\": \"pr-${{ github.event.pull_request.number }}\" }}" \
+            https://api.github.com/repos/All-Hands-AI/deploy/actions/workflows/deploy.yaml/dispatches

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -235,12 +235,11 @@ jobs:
 
   enterprise-preview:
     name: Enterprise preview
-    if: |
-      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'deploy') ||
-      (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy'))
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: [ghcr_build_enterprise]
     steps:
+      # This should match the version in enterprise-preview.yml
       - name: Trigger remote job
         run: |
           curl --fail-with-body -sS -X POST \


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The enterprise-preview job was added to `ghcr-build.yml` in #10770. It's intended when PR is created with `deploy` label or when the label is after the fact. The after-the-fact case did not work because the default `on: pull_request:` trigger does not included the `labeled` action. [GitHub Workflow Docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)

This workaround adds a new workflow with a small amount of duplication (probably not worth extracted). An alternative would be to add the `labeled` action to `ghcr-build.yml` but that would be more complicated because many conditionals would need to be added to prevent running all existing steps on every label

If we wanted to avoid the duplication we could use a [reusable workflow](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows).

---
**Link of any specific issues this addresses:**
