### PR TITLE
feat: Expose session_id to sandbox/runtime container

### DIFF
--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -466,6 +466,7 @@ class DockerRuntime(ActionExecutionClient):
                 'VSCODE_PORT': str(self._vscode_port),
                 'APP_PORT_1': str(self._app_ports[0]),
                 'APP_PORT_2': str(self._app_ports[1]),
+                'OPENHANDS_SESSION_ID': str(self.sid),
                 'PIP_BREAK_SYSTEM_PACKAGES': '1',
             }
         )


### PR DESCRIPTION
This exposes the self.sid var to the runtime/sandbox container as the envvar `OPENHANDS_SESSION_ID` . 

This enables some tooling to be able to discern the notion of `what session am I` which, if combined with the exposure of the settings store to the sandbox environment allows for programatic evaluation of the session-scoped `metadata.json` file located in `settings/sessions/<OPENHANDS_SESSION_ID>/` as `settings/sessions/<OPENHANDS_SESSION_ID>/metadata.json`


(This is, admittedly, not as optimal as depositing the session's metadata.json to a file in /tmp on the sandbox host; however, it's  much easier to accomplish and since the)

IMO a slightly  better solution would be to deposit the `metadata.json`  in /tmp or something similar which would facilitate the setting of additional vars like `CODEHOST_ORGANIZATION` `CODEHOST_PROJECT_PATH` `CODEHOST_SELECTED_PROJECT` `CODEHOST_PROJECT_ACTIVE_BRANCH`

EvenMoarBetr:tm:  would be to, rather than exposing the metadata attributes to runtime/main in a way that
"conversation_id", "selected_repository","selected_branch", "git_provider"
could be added automagically as envvars without having to scrape the metadata artifact for the information, but this is simple enough and feels reasonably sane as a stepping stone.
Subsequently, and with a little voodoo / interaction with the user, this allows for the determination of  `PROJECT_DEFAULT_BRANCH` `PROJECT_WORKING_BRANCH` `PROJECT_TARGET_BRANCH`  (or something)... but that's not really relevant to this change.

- [ X ] This change is worth documenting at https://docs.all-hands.dev/
- [ X ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Exposes the CONVERSATION_ID/ SESSION_ID / SID openhands associates with a conversation to the runtime container. Facilitating sandbox-scoped tooling to discern more information about the work in flight. 

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This exposes the self.sid var to the runtime/sandbox container as the envvar `OPENHANDS_SESSION_ID` . 
This enables some tooling to be able to discern the notion of `what session am I` which, if combined with the exposure of the settings store to the sandbox environment allows for programatic evaluation of the session-scoped `metadata.json` file located in `settings/sessions/<OPENHANDS_SESSION_ID>/` as `settings/sessions/<OPENHANDS_SESSION_ID>/metadata.json`


---
**Link of any specific issues this addresses:**
