### PR TITLE
refactor(frontend): restrict message sending when runtime is stopped

### DIFF
--- a/frontend/src/components/features/chat/interactive-chat-box.tsx
+++ b/frontend/src/components/features/chat/interactive-chat-box.tsx
@@ -147,9 +147,13 @@ export function InteractiveChatBox({
     handleSubmit(suggestion);
   };
 
+  const isRuntimeStopped =
+    conversation?.status === "STOPPED" && !conversation.runtime_status;
+
   const isDisabled =
     curAgentState === AgentState.LOADING ||
-    curAgentState === AgentState.AWAITING_USER_CONFIRMATION;
+    curAgentState === AgentState.AWAITING_USER_CONFIRMATION ||
+    isRuntimeStopped;
 
   return (
     <div data-testid="interactive-chat-box">


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

On the conversation page, message sending should be disabled whenever the runtime is stopped.

**Acceptance Criteria:**
- Users are prevented from sending messages while the runtime is stopped.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR restricts message sending when runtime is stopped

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:32ff027-nikolaik   --name openhands-app-32ff027   docker.all-hands.dev/all-hands-ai/openhands:32ff027
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3489 openhands
```