### PR TITLE
refactor(frontend): enable message drafting during page load

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -198,6 +198,10 @@ export function CustomChatInput({
 
   // Send button click handler
   const handleSubmit = () => {
+    if (disabled) {
+      return;
+    }
+
     const message = chatInputRef.current?.innerText || "";
 
     if (message.trim()) {
@@ -218,6 +222,10 @@ export function CustomChatInput({
 
   // Resume agent button click handler
   const handleResumeAgent = () => {
+    if (disabled) {
+      return;
+    }
+
     const message = chatInputRef.current?.innerText || "continue";
 
     onSubmit(message.trim());
@@ -407,11 +415,8 @@ export function CustomChatInput({
                 <div className="basis-0 flex flex-col font-normal grow justify-center leading-[0] min-h-px min-w-px overflow-ellipsis overflow-hidden relative shrink-0 text-[#d0d9fa] text-[16px] text-left">
                   <div
                     ref={chatInputRef}
-                    className={cn(
-                      "chat-input bg-transparent text-white text-[16px] font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[400px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap",
-                      disabled && "cursor-not-allowed",
-                    )}
-                    contentEditable={!disabled}
+                    className="chat-input bg-transparent text-white text-[16px] font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[400px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap"
+                    contentEditable
                     data-placeholder={t("SUGGESTIONS$WHAT_TO_BUILD")}
                     data-testid="chat-input"
                     onInput={handleInput}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

On the conversation page, users should have the ability to draft messages while the page is still loading.

**Acceptance Criteria:**
- Users are able to type and edit messages during the loading state.
- Users are not permitted to send messages until the page has fully loaded.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR enables message drafting during page load.

We can refer to the video below for the output of the PR.

Uploading all-3488.mov…

---
**Link of any specific issues this addresses:**
