### PR TITLE
feat(frontend): persist drawer open/close state on page refresh

### DIFF
--- a/frontend/src/state/conversation-slice.tsx
+++ b/frontend/src/state/conversation-slice.tsx
@@ -117,8 +117,6 @@ export const conversationSlice = createSlice({
     },
     // Reset conversation state (useful for cleanup)
     resetConversationState: (state) => {
-      state.selectedTab = "editor";
-      state.isRightPanelShown = true;
       state.shouldHideSuggestions = false;
     },
     setHasRightPanelToggled: (state, action) => {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Description:**

The drawer’s open/close state currently resets when the page is refreshed, which can disrupt the user experience. Implementing state persistence—potentially using localStorage—will ensure the drawer maintains its previous state across page reloads.

**Acceptance Criteria:**
- The drawer retains its open or closed state after a page refresh.
- State persistence is implemented in a reliable and maintainable way (e.g., using localStorage).

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR persists drawer open/close state on page refresh.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/911eb287-f9b5-4b68-bc40-278e7d5687f9

---
**Link of any specific issues this addresses:**
