### PR TITLE
Fix ruff formatting in enterprise token_manager.py

### DIFF
--- a/enterprise/server/auth/token_manager.py
+++ b/enterprise/server/auth/token_manager.py
@@ -275,9 +275,7 @@ class TokenManager:
                 self._check_expiration_and_refresh
             )
             if not token_info:
-                logger.info(
-                    f'No tokens for user: {username}, identity provider: {idp}'
-                )
+                logger.info(f'No tokens for user: {username}, identity provider: {idp}')
                 raise ValueError(
                     f'No tokens for user: {username}, identity provider: {idp}'
                 )


### PR DESCRIPTION

The pre-commit hook ruff-format was failing because the logger.info statement was split across multiple lines, but ruff prefers it on a single line for better readability and consistency.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
The "Lint enterprise python" CI job was failing because `ruff-format` found a formatting inconsistency in `enterprise/server/auth/token_manager.py`. A `logger.info()` statement was split across multiple lines, but the formatter requires it to be on a single line for consistency with the project's code style standards.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Consolidate logger.info statement to single line as required by ruff-format
- This resolves the 'Lint enterprise python' CI job failure


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5ea6eb3-nikolaik   --name openhands-app-5ea6eb3   docker.all-hands.dev/all-hands-ai/openhands:5ea6eb3
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/enterprise-python-lint-formatting openhands
```