### PR TITLE
Remove git authentication requirement for secrets in SaaS mode

### DIFF
--- a/frontend/__tests__/routes/secrets-settings.test.tsx
+++ b/frontend/__tests__/routes/secrets-settings.test.tsx
@@ -86,28 +86,21 @@ describe("Content", () => {
     expect(screen.queryByTestId("connect-git-button")).not.toBeInTheDocument();
   });
 
-  it("should render a button to connect with git if they havent already in saas", async () => {
+  it("should render add secret button in saas mode", async () => {
     const getConfigSpy = vi.spyOn(OpenHands, "getConfig");
-    const getSettingsSpy = vi.spyOn(OpenHands, "getSettings");
     const getSecretsSpy = vi.spyOn(SecretsService, "getSecrets");
     // @ts-expect-error - only return the config we need
     getConfigSpy.mockResolvedValue({
       APP_MODE: "saas",
     });
-    getSettingsSpy.mockResolvedValue({
-      ...MOCK_DEFAULT_USER_SETTINGS,
-      provider_tokens_set: {},
-    });
 
     renderSecretsSettings();
 
-    // In SAAS mode, getSecrets is still called because the user is authenticated
+    // In SAAS mode, getSecrets is called and add secret button should be available
     await waitFor(() => expect(getSecretsSpy).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(screen.queryByTestId("add-secret-button")).not.toBeInTheDocument(),
-    );
-    const button = await screen.findByTestId("connect-git-button");
-    expect(button).toHaveAttribute("href", "/settings/integrations");
+    const button = await screen.findByTestId("add-secret-button");
+    expect(button).toBeInTheDocument();
+    expect(screen.queryByTestId("connect-git-button")).not.toBeInTheDocument();
   });
 
   it("should render an empty table when there are no existing secrets", async () => {

--- a/frontend/src/routes/secrets-settings.tsx
+++ b/frontend/src/routes/secrets-settings.tsx
@@ -1,6 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
 import React from "react";
-import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useGetSecrets } from "#/hooks/query/use-get-secrets";
 import { useDeleteSecret } from "#/hooks/mutation/use-delete-secret";
@@ -12,21 +11,14 @@ import {
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { ConfirmationModal } from "#/components/shared/modals/confirmation-modal";
 import { GetSecretsResponse } from "#/api/secrets-service.types";
-import { useUserProviders } from "#/hooks/use-user-providers";
 import { I18nKey } from "#/i18n/declaration";
-import { useConfig } from "#/hooks/query/use-config";
 
 function SecretsSettingsScreen() {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
 
-  const { data: config } = useConfig();
   const { data: secrets, isLoading: isLoadingSecrets } = useGetSecrets();
   const { mutate: deleteSecret } = useDeleteSecret();
-  const { providers } = useUserProviders();
-
-  const isSaas = config?.APP_MODE === "saas";
-  const hasProviderSet = providers.length > 0;
 
   const [view, setView] = React.useState<
     "list" | "add-secret-form" | "edit-secret-form"
@@ -69,8 +61,6 @@ function SecretsSettingsScreen() {
     setConfirmationModalIsVisible(false);
   };
 
-  const shouldRenderConnectToGitButton = isSaas && !hasProviderSet;
-
   return (
     <div
       data-testid="secrets-settings-screen"
@@ -84,20 +74,7 @@ function SecretsSettingsScreen() {
         </ul>
       )}
 
-      {shouldRenderConnectToGitButton && (
-        <Link
-          to="/settings/integrations"
-          data-testid="connect-git-button"
-          type="button"
-          className="self-start"
-        >
-          <BrandButton type="button" variant="secondary">
-            {t(I18nKey.SECRETS$CONNECT_GIT_PROVIDER)}
-          </BrandButton>
-        </Link>
-      )}
-
-      {!shouldRenderConnectToGitButton && view === "list" && (
+      {view === "list" && (
         <BrandButton
           testId="add-secret-button"
           type="button"


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
User had to be authed with a Git provider in order to use secrets in saas.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Remove unnecessary git provider authentication check for secrets management
- Users can now add/edit/delete secrets in SaaS mode without connecting git providers first

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2d82c33-nikolaik   --name openhands-app-2d82c33   docker.all-hands.dev/all-hands-ai/openhands:2d82c33
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@remove-saas-secret-requirement openhands
```