### PR TITLE
Fix runtime status polling condition and improve conversation state management

### DIFF
--- a/frontend/src/hooks/query/use-active-conversation.ts
+++ b/frontend/src/hooks/query/use-active-conversation.ts
@@ -8,10 +8,17 @@ const FIVE_MINUTES = 1000 * 60 * 5;
 export const useActiveConversation = () => {
   const { conversationId } = useConversationId();
   const userConversation = useUserConversation(conversationId, (query) => {
-    if (query.state.data?.status === "STARTING") {
+    const { data } = query.state;
+
+    // Poll frequently if conversation is starting OR runtime is not ready
+    if (
+      data?.status === "STARTING" ||
+      data?.runtime_status !== "STATUS$READY"
+    ) {
       return 3000; // 3 seconds
     }
-    return FIVE_MINUTES;
+
+    return FIVE_MINUTES; // 5 minutes
   });
 
   useEffect(() => {


### PR DESCRIPTION
- Simplify broken runtime status condition from contradictory logic to data?.runtime_status !== 'STATUS$READY'
- Add proper state cleanup when switching conversations to reset agent state, clear optimistic messages, and remove error messages
- Ensure typing indicators, button states, and disabled states are properly reset

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
This resolves an issue where the frontend would incorrectly poll the server every 5 minutes instead of every 3 seconds when the runtime was starting up or not ready, causing delayed UI updates and poor user experience during conversation initialization.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Fixes broken runtime status polling logic and improves conversation state management

Key changes:
- Runtime polling fix: `status !== "READY"` to properly poll every 3 seconds when runtime isn't ready
- State cleanup: Added proper reset of agent state, optimistic messages, and error messages when switching conversations to prevent UI artifacts from previous sessions

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4694511-nikolaik   --name openhands-app-4694511   docker.all-hands.dev/all-hands-ai/openhands:4694511
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@ALL-3517-fix-runtime-status-polling-condition openhands
```