### PR TITLE
Fix runtime init

### DIFF
--- a/openhands/runtime/utils/runtime_init.py
+++ b/openhands/runtime/utils/runtime_init.py
@@ -54,6 +54,7 @@ def init_user_and_working_directory(
         # Check if the username already exists
         logger.debug(f'Attempting to create user `{username}` with UID {user_id}.')
         existing_user_id = -1
+        setup_user = True
         try:
             result = subprocess.run(
                 f'id -u {username}', shell=True, check=True, capture_output=True
@@ -69,8 +70,7 @@ def init_user_and_working_directory(
                 logger.warning(
                     f'User `{username}` already exists with UID {existing_user_id}. Skipping user setup.'
                 )
-                return existing_user_id
-            return None
+            setup_user = False
         except subprocess.CalledProcessError as e:
             # Returncode 1 indicates, that the user does not exist yet
             if e.returncode == 1:
@@ -83,26 +83,29 @@ def init_user_and_working_directory(
                 )
                 raise
 
-        # Add sudoer
-        sudoer_line = r"echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"
-        output = subprocess.run(sudoer_line, shell=True, capture_output=True)
-        if output.returncode != 0:
-            raise RuntimeError(f'Failed to add sudoer: {output.stderr.decode()}')
-        logger.debug(f'Added sudoer successfully. Output: [{output.stdout.decode()}]')
-
-        command = (
-            f'useradd -rm -d /home/{username} -s /bin/bash '
-            f'-g root -G sudo -u {user_id} {username}'
-        )
-        output = subprocess.run(command, shell=True, capture_output=True)
-        if output.returncode == 0:
+        if setup_user:
+            # Add sudoer
+            sudoer_line = r"echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"
+            output = subprocess.run(sudoer_line, shell=True, capture_output=True)
+            if output.returncode != 0:
+                raise RuntimeError(f'Failed to add sudoer: {output.stderr.decode()}')
             logger.debug(
-                f'Added user `{username}` successfully with UID {user_id}. Output: [{output.stdout.decode()}]'
+                f'Added sudoer successfully. Output: [{output.stdout.decode()}]'
             )
-        else:
-            raise RuntimeError(
-                f'Failed to create user `{username}` with UID {user_id}. Output: [{output.stderr.decode()}]'
+
+            command = (
+                f'useradd -rm -d /home/{username} -s /bin/bash '
+                f'-g root -G sudo -u {user_id} {username}'
             )
+            output = subprocess.run(command, shell=True, capture_output=True)
+            if output.returncode == 0:
+                logger.debug(
+                    f'Added user `{username}` successfully with UID {user_id}. Output: [{output.stdout.decode()}]'
+                )
+            else:
+                raise RuntimeError(
+                    f'Failed to create user `{username}` with UID {user_id}. Output: [{output.stderr.decode()}]'
+                )
 
     # First create the working directory, independent of the user
     logger.debug(f'Client working directory: {initial_cwd}')


### PR DESCRIPTION
Fix a bug introduced when fixing the setup to use a non-root user in the runtimes.

I had moved the user creation before the workspace directory creation as we wanted to set ownership of the workspace directory to the created user.  However, I did not correctly handle the case where the user already exists as it was skipping the workspace directory creation.

This fixes that error.