### PR TITLE
Fix the loop issue caused by exceeding the length limit

### DIFF
--- a/openhands/core/exceptions.py
+++ b/openhands/core/exceptions.py
@@ -233,3 +233,16 @@ class MicroagentValidationError(MicroagentError):
 
     def __init__(self, message: str = 'Microagent validation failed') -> None:
         super().__init__(message)
+
+
+# ============================================
+# Memory Exceptions
+# ============================================
+
+
+class CondenserValidationException(RuntimeError):
+    def __init__(
+        self,
+        message: str = 'The conversation history only contains content that needs to be retained and cannot be further considered.',
+    ) -> None:
+        super().__init__(message)

--- a/openhands/memory/condenser/impl/conversation_window_condenser.py
+++ b/openhands/memory/condenser/impl/conversation_window_condenser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from openhands.core.config.condenser_config import ConversationWindowCondenserConfig
+from openhands.core.exceptions import CondenserValidationException
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action.agent import (
     CondensationAction,
@@ -11,9 +12,6 @@ from openhands.events.event import EventSource
 from openhands.events.observation import Observation
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.memory.condenser.condenser import Condensation, RollingCondenser, View
-from openhands.core.exceptions import (
-    CondenserValidationException,
-)
 
 class ConversationWindowCondenser(RollingCondenser):
     def __init__(self) -> None:

--- a/openhands/memory/condenser/impl/conversation_window_condenser.py
+++ b/openhands/memory/condenser/impl/conversation_window_condenser.py
@@ -11,7 +11,9 @@ from openhands.events.event import EventSource
 from openhands.events.observation import Observation
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.memory.condenser.condenser import Condensation, RollingCondenser, View
-
+from openhands.core.exceptions import (
+    CondenserValidationException,
+)
 
 class ConversationWindowCondenser(RollingCondenser):
     def __init__(self) -> None:
@@ -170,6 +172,8 @@ class ConversationWindowCondenser(RollingCondenser):
                 action = CondensationAction(forgotten_event_ids=forgotten_event_ids)
         else:
             action = CondensationAction(forgotten_event_ids=[])
+            if self.should_condense(view):
+                raise CondenserValidationException()
 
         return Condensation(action=action)
 

--- a/openhands/memory/condenser/impl/conversation_window_condenser.py
+++ b/openhands/memory/condenser/impl/conversation_window_condenser.py
@@ -13,6 +13,7 @@ from openhands.events.observation import Observation
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.memory.condenser.condenser import Condensation, RollingCondenser, View
 
+
 class ConversationWindowCondenser(RollingCondenser):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
When the events that need to be retained have exceeded the model limits, a dead loop may occur at this point.
<img width="713" height="220" alt="image" src="https://github.com/user-attachments/assets/3d445c60-ad61-4d71-beeb-d55a3bfa6827" />
