### PR TITLE
fix - Tag enterprise with the same SHA as app image.

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -176,8 +176,10 @@ jobs:
     # Do not build enterprise in forks
     if: github.event.pull_request.head.repo.fork != true
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Set up Docker Buildx for better performance
       - name: Set up Docker Buildx


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This changes the enterprise docker build to checkout the PR commit rather than the merge commit, making it consistent with app and runtime images.

This affects what Dockerfile and enterprise code is used, and also the SHA tagged on the image. All of these we need to be consistent with app image now that they are in the same repo.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c7d352b-nikolaik   --name openhands-app-c7d352b   docker.all-hands.dev/all-hands-ai/openhands:c7d352b
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@ray/build-tag openhands
```