### PR TITLE
Add GitHub workflow for MDX format checking and fix parsing error

### DIFF
--- a/.github/workflows/mdx-lint.yml
+++ b/.github/workflows/mdx-lint.yml
@@ -1,0 +1,70 @@
+# Workflow that checks MDX format in docs/ folder
+name: MDX Lint
+
+# Run on pushes to main and on pull requests that modify docs/ files
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**/*.mdx'
+  pull_request:
+    paths:
+      - 'docs/**/*.mdx'
+
+# If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  mdx-lint:
+    name: Lint MDX files
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js 22
+        uses: useblacksmith/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Install MDX dependencies
+        run: |
+          npm install @mdx-js/mdx@3 glob@10
+
+      - name: Validate MDX files
+        run: |
+          node -e "
+          const {compile} = require('@mdx-js/mdx');
+          const fs = require('fs');
+          const path = require('path');
+          const glob = require('glob');
+
+          async function validateMDXFiles() {
+            const files = glob.sync('docs/**/*.mdx');
+            console.log('Found', files.length, 'MDX files to validate');
+
+            let hasErrors = false;
+
+            for (const file of files) {
+              try {
+                const content = fs.readFileSync(file, 'utf8');
+                await compile(content);
+                console.log('✅ MDX parsing successful for', file);
+              } catch (err) {
+                console.error('❌ MDX parsing failed for', file, ':', err.message);
+                hasErrors = true;
+              }
+            }
+
+            if (hasErrors) {
+              console.error('\\n❌ Some MDX files have parsing errors. Please fix them before merging.');
+              process.exit(1);
+            } else {
+              console.log('\\n✅ All MDX files are valid!');
+            }
+          }
+
+          validateMDXFiles();
+          "

--- a/docs/usage/architecture/runtime.mdx
+++ b/docs/usage/architecture/runtime.mdx
@@ -124,7 +124,7 @@ This tagging approach allows OpenHands to efficiently manage both development an
 OpenHands supports both bind mounts and Docker named volumes in SandboxConfig.volumes:
 
 - Bind mount: "/abs/host/path:/container/path[:mode]"
-- Named volume: "volume:<name>:/container/path[:mode]" or any non-absolute host spec treated as a named volume
+- Named volume: "volume:`<name>`:/container/path[:mode]" or any non-absolute host spec treated as a named volume
 
 Overlay mode (copy-on-write layer) is supported for bind mounts by appending ":overlay" to the mode (e.g., ":ro,overlay").
 To enable overlay COW, set SANDBOX_VOLUME_OVERLAYS to a writable host directory; per-container upper/work dirs are created under it. If SANDBOX_VOLUME_OVERLAYS is unset, overlay mounts are skipped.


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR adds automated MDX format validation to prevent documentation parsing errors and fixes an existing MDX syntax error in the runtime documentation.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR introduces two key improvements:

1. **Adds MDX Lint GitHub Workflow** (`.github/workflows/mdx-lint.yml`):
   - Automatically validates all MDX files in the `docs/` folder whenever they are modified
   - Runs on pushes to main and pull requests that affect `docs/**/*.mdx` files
   - Uses `@mdx-js/mdx` compiler to catch syntax errors before they reach production
   - Validates all 65 MDX files in the repository to ensure proper formatting
   - Uses Node.js 22 and blacksmith runners for consistency with other workflows

2. **Fixes MDX Parsing Error** in `docs/usage/architecture/runtime.mdx`:
   - Resolves parsing error: "Expected a closing tag for `<name>` (127:25-127:31) before the end of `paragraph`"
   - Wraps `<name>` with backticks to prevent MDX from interpreting it as an HTML tag
   - Changes `volume:<name>:` to `volume:`<name>`:` on line 127

**Design Decisions:**
- Uses inline Node.js script rather than separate files to keep the workflow self-contained
- Includes concurrency controls to cancel redundant runs and optimize CI resources
- Validates all MDX files (not just changed ones) to catch cross-file dependencies
- Uses glob pattern matching for comprehensive file discovery

---
**Link of any specific issues this addresses:**

Addresses the MDX parsing error mentioned in the user request:
```
parsing error ./openhands/usage/architecture/runtime.mdx:127:3 - Expected a closing tag for `<name>` (127:25-127:31) before the end of `paragraph`
```

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7368644b270a474299976a3d6808aa99)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0a92278-nikolaik   --name openhands-app-0a92278   docker.all-hands.dev/all-hands-ai/openhands:0a92278
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@add-mdx-lint-workflow openhands
```