### PR TITLE
fix(frontend): suppressing event display in the absence of user messages

### DIFF
--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -25,7 +25,10 @@ import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { useOptimisticUserMessage } from "#/hooks/use-optimistic-user-message";
 import { useWSErrorMessage } from "#/hooks/use-ws-error-message";
 import { ErrorMessageBanner } from "./error-message-banner";
-import { shouldRenderEvent } from "./event-content-helpers/should-render-event";
+import {
+  hasUserEvent,
+  shouldRenderEvent,
+} from "./event-content-helpers/should-render-event";
 import { useUploadFiles } from "#/hooks/mutation/use-upload-files";
 import { useConfig } from "#/hooks/query/use-config";
 import { validateFiles } from "#/utils/file-validation";
@@ -168,14 +171,14 @@ export function ChatInterface() {
     onChatBodyScroll,
   };
 
+  const userEventsExist = hasUserEvent(events);
+
   return (
     <ScrollProvider value={scrollProviderValue}>
       <div className="h-full flex flex-col justify-between pr-0 md:pr-4 relative">
         {!hasSubstantiveAgentActions &&
           !optimisticUserMessage &&
-          !events.some(
-            (event) => isOpenHandsAction(event) && event.source === "user",
-          ) && (
+          !userEventsExist && (
             <ChatSuggestions
               onSuggestionsClick={(message) =>
                 dispatch(setMessageToSend(message))
@@ -195,7 +198,7 @@ export function ChatInterface() {
             </div>
           )}
 
-          {!isLoadingMessages && (
+          {!isLoadingMessages && userEventsExist && (
             <Messages
               messages={events}
               isAwaitingUserConfirmation={

--- a/frontend/src/components/features/chat/event-content-helpers/should-render-event.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/should-render-event.ts
@@ -45,3 +45,8 @@ export const shouldRenderEvent = (
 
   return true;
 };
+
+export const hasUserEvent = (
+  events: (OpenHandsAction | OpenHandsObservation)[],
+) =>
+  events.some((event) => isOpenHandsAction(event) && event.source === "user");


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="1440" height="746" alt="all-3550-issue" src="https://github.com/user-attachments/assets/1e59af9f-15d1-4015-8e05-42a3ba475387" />

Based on the reference image, events should not be displayed when there are no corresponding user messages.

**Acceptance Criteria:**
- Events must not be shown if no user messages are present.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This pull request disables event display when no user messages are present.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/9a714691-d78d-45e4-bbe3-c5c123bf97ed

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7a70ae5-nikolaik   --name openhands-app-7a70ae5   docker.all-hands.dev/all-hands-ai/openhands:7a70ae5
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3550 openhands
```