### PR TITLE
fix(openhands/runtime/base.py): adjust org-repo logic

### DIFF
--- a/docs/usage/prompting/microagents-org.mdx
+++ b/docs/usage/prompting/microagents-org.mdx
@@ -1,35 +1,107 @@
 ---
 title: Organization and User Microagents
-description: Organizations and users can define microagents that apply to all repositories belonging to the organization or user.
+description: An OpenHands configuration repository allows you to define microagents that apply to all adjacent or descendent-pathed repositories.
 ---
 
 ## Usage
 
-These microagents can be [any type of microagent](./microagents-overview#microagent-types) and will be loaded
-accordingly. However, they are applied to all repositories belonging to the organization or user.
+Organization microagents may be any type of microagent. (see [Microagent Types](./microagents-overview#microagent-types))
+The primary difference is that in an Organization-or-User "OpenHands Config" repo, the repo itself conveys the `.openhands` scope construct.
+Thus, in an OpenHands Config repo, OpenHands will look for Microagents in  `microagents/`.
+In a Project repository, OpenHands will look in `.openhands/microagents/`.
+apply to **all repositories** belonging to the organization or user.
 
-Add a `.openhands` repository under the organization or user and create a `microagents` directory and place the
-microagents in that directory.
+To consume microagents from an OpenHands configuration repository, the repo must contain a `microagents/` directory, as this is where OpenHands will search for microagent definitions.
 
-For GitLab organizations, use `openhands-config` as the repository name instead of `.openhands`, since GitLab doesn't support repository names starting with non-alphanumeric characters.
+### Configuration Repository Naming Conventions
+
+- In **GitHub** and **Bitbucket**, OpenHands will look for a repository named `.openhands` within the top-level scope of an organization (or user) account.
+- Since [**GitLab** disallows repository names that begin with non‑alphanumeric characters](https://gitlab.com/gitlab-org/gitlab-foss/-/issues/12721). OpenHands will instead search for a repository named `openhands-config` for GitLab repos.
+
+### TLDR
+
+#### BitBucket,  GitHub, Gitea
+
+- Create a repository with the name  `.openhands` within the organization or user's namespace relevant to the projects OpenHands will be working with.
+
+#### GitLab
+
+- Create a repository with the name `openhands-config` within the organization or user's namespace relevant to the projects OpenHands will be working with.
+
+#### then...
+
+- Within your new Configuration repository, create a `microagents` directory
+- Place your microagent assets in the `microagents` folder.
+ instead of `.openhands`, since GitLab doesn't support repository names starting with non‑alphanumeric characters.
+
+## Functionality
+
+### Loading Logic in OpenHands
+When OpenHands starts a session for a selected repository, Microagents are discovered via the following steps:
+
+1. **Identify Organization Path** – The full repository path (e.g., `github.com/acme/api`) is split into its hierarchical components (`acme`, `api`).
+2. **Generate Candidate Org Paths** – Starting from the deepest group, OpenHands builds candidate paths in descending order:
+   - `acme/api`
+   - `acme`
+3. **Check for Org Repository** – For each candidate, OpenHands checks if an organization‑level repository exists (`<candidate>/.openhands` on GitHub or `<candidate>/openhands-config` on GitLab).
+4. **Clone / Use Local Copy** – If the repo exists locally (already cloned) it is used; otherwise OpenHands clones the remote repo.
+5. **Load Microagents** – Once a repository with a `microagents/` directory is found, all microagents inside are loaded. The first successful candidate stops further searching.
+
+This approach ensures that **nested groups** (e.g., `org/subgroup/project`) can provide their own microagents, and the deepest level takes precedence over higher‑level org repositories.
+
+### Priority Handling
+
+If both a top‑level organization repo and a sub‑group repo contain microagents, OpenHands loads only the microagents from the **deepest** (most specific) repository found first in the descending search order. This allows sub‑groups to override or augment top‑level guidelines without duplication.
 
 ## Example
 
-General microagent file example for organization `Great-Co` located inside the `.openhands` repository:
-`microagents/org-microagent.md`:
-```
-* Use type hints and error boundaries; validate inputs at system boundaries and fail with meaningful error messages.
-* Document interfaces and public APIs; use implementation comments only for non-obvious logic.
-* Follow the same naming convention for variables, classes, constants, etc. already used in each repository.
-```
+### Setting Up an Organization‑Level Microagents Repository (GitHub)
 
-For GitLab organizations, the same microagent would be located inside the `openhands-config` repository.
+1. **Create the Org Repo**
+   ```bash
+   # On GitHub under organization "Great-Co"
+   git init --bare .openhands
+   ```
 
-## User Microagents When Running Openhands on Your Own
+2. **Add a `microagents` Directory**
+   ```bash
+   mkdir -p .openhands/microagents
+   ```
+
+3. **Create a Microagent File** (`.openhands/microagents/org-microagent.md`)
+   ```md
+   * Use type hints and error boundaries; validate inputs at system boundaries and fail with meaningful error messages.
+   * Document interfaces and public APIs; use implementation comments only for non‑obvious logic.
+   * Follow the same naming convention for variables, classes, constants, etc. already used in each repository.
+   ```
+
+### Setting Up an Organization‑Level Microagents Repository (GitLab)
+
+1. **Create the Org Repo**
+   ```bash
+   # On GitLab under organization "Great-Co"
+   git init --bare openhands-config
+   ```
+
+2. **Add a `microagents` Directory**
+   ```bash
+   mkdir -p openhands-config/microagents
+   ```
+
+3. **Create the Same Microagent File** (`openhands-config/microagents/org-microagent.md`) with the same content as above.
+
+These steps ensure that OpenHands will discover and load the microagents for any repository belonging to `Great-Co`.
+
+## User Microagents When Running OpenHands on Your Own
 
 <Note>
-  This works with CLI, headless and development modes. It does not work out of the box when running OpenHands using the docker command.
+  This works with CLI, headless and development modes. It does not work out of the box when running OpenHands using the Docker command.
 </Note>
 
-When running OpenHands on your own, you can place microagents in the `~/.openhands/microagents` folder on your local
-system and OpenHands will always load it for all your conversations.
+When you run OpenHands locally (e.g., via the CLI or in a development environment), you can place microagents in your home directory:
+
+```bash
+mkdir -p ~/.openhands/microagents
+```
+
+Any Markdown files placed inside `~/.openhands/microagents` are automatically loaded for **all** conversations, providing user‑wide guidance.

--- a/tests/unit/runtime/test_runtime_gitlab_microagents.py
+++ b/tests/unit/runtime/test_runtime_gitlab_microagents.py
@@ -8,13 +8,14 @@ import pytest
 
 from openhands.core.config import OpenHandsConfig, SandboxConfig
 from openhands.events import EventStream
-from openhands.integrations.service_types import ProviderType, Repository
+from openhands.integrations.service_types import ProviderType, Repository, AuthenticationError
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.microagent.microagent import (
     RepoMicroagent,
 )
 from openhands.runtime.base import Runtime
 from openhands.storage import get_file_store
+from types import MappingProxyType
 
 
 class MockRuntime(Runtime):
@@ -39,10 +40,9 @@ class MockRuntime(Runtime):
             config=config,
             event_stream=event_stream,
             llm_registry=llm_registry,
-            sid='test',
-            git_provider_tokens={},
+            sid='test'
         )
-
+        self.git_provider_tokens=MappingProxyType({})
         self._workspace_root = workspace_root
         self._logs = []
 
@@ -57,13 +57,16 @@ class MockRuntime(Runtime):
 
     def run_action(self, action):
         """Mock run_action method."""
-        # For testing, we'll simulate successful cloning
+        # For testing, we construct a CmdOutputObservation with the required command argument.
         from openhands.events.observation import CmdOutputObservation
 
-        return CmdOutputObservation(content='', exit_code=0)
+        # The `action` passed in is a CmdRunAction; its command attribute holds the shell command string.
+        # Use that as the `command` parameter for CmdOutputObservation.
+        return CmdOutputObservation(content='', command=action.command, exit_code=0)
 
     def read(self, action):
         """Mock read method."""
+        # For simplicity, always return an error indicating the file is missing.
         from openhands.events.observation import ErrorObservation
 
         return ErrorObservation('File not found')
@@ -134,7 +137,13 @@ class MockRuntime(Runtime):
         pass
 
     def list_files(self, path=None):
-        return []
+        # Return a list of all files under the given directory (as strings)
+        from pathlib import Path
+        target_path = Path(path) if path else self._workspace_root
+        if not target_path.is_dir():
+            return []
+        # Collect all file paths recursively
+        return [str(p) for p in target_path.rglob('*')]
 
     def get_mcp_config(self, extra_stdio_servers=None):
         from openhands.core.config.mcp_config import MCPConfig
@@ -198,6 +207,51 @@ def test_is_gitlab_repository_github(temp_workspace):
             assert result is False
 
 
+def test_get_microagents_from_org_or_user_github_success(temp_workspace):
+    """Test loading org‑level microagents for a GitHub repository when the org repo exists."""
+    runtime = MockRuntime(temp_workspace)
+
+    # Create an org‑level repository directory with a .git folder and microagents
+    org_repo_dir = temp_workspace / 'org_openhands_owner'
+    (org_repo_dir / '.git').mkdir(parents=True, exist_ok=True)
+    create_test_microagents(org_repo_dir, config_dir_name='.')
+
+    # Mock verify_repo_provider to return a Repository indicating the org repo exists
+    mock_org_repo = Repository(
+        id='1',
+        full_name='owner/.openhands',
+        git_provider=ProviderType.GITHUB,
+        is_public=True,
+    )
+    async def mock_verify(*args, **kwargs):
+        return mock_org_repo
+
+    with patch.object(runtime.provider_handler, 'verify_repo_provider', mock_verify):
+        # Invoke the org‑level microagent loading
+        loaded_microagents = runtime.get_microagents_from_org_or_user('github.com/owner/repo')
+        assert len(loaded_microagents) > 0
+        # The test microagent created by create_test_microagents has name 'mock_test'
+        names = [m.name for m in loaded_microagents]
+        assert any(name == 'mock_test' for name in names)
+
+
+def test_get_microagents_from_org_or_user_auth_error_continuation(temp_workspace):
+    """Test that an AuthenticationError while checking org‑level repo does not abort loading and returns empty list."""
+    runtime = MockRuntime(temp_workspace)
+
+    # Mock verify_repo_provider to raise AuthenticationError
+    async def mock_verify(*args, **kwargs):
+        raise AuthenticationError('auth failed')
+
+    with patch.object(runtime.provider_handler, 'verify_repo_provider', mock_verify):
+        loaded_microagents = runtime.get_microagents_from_org_or_user('github.com/owner/repo')
+        assert loaded_microagents == []
+
+        # Verify that a warning was logged about the AuthenticationError
+        warnings = [msg for level, msg in runtime._logs if level == 'warning']
+        assert any('AuthenticationError' in msg for msg in warnings)
+
+
 def test_is_gitlab_repository_gitlab(temp_workspace):
     """Test that GitLab repositories are correctly identified."""
     runtime = MockRuntime(temp_workspace)
@@ -254,22 +308,28 @@ def test_get_microagents_from_org_or_user_gitlab_success_with_config(temp_worksp
     """Test that GitLab repositories use openhands-config and succeed."""
     runtime = MockRuntime(temp_workspace)
 
-    # Create a mock org directory with microagents
-    org_dir = temp_workspace / 'org_openhands_owner'
-    create_test_microagents(org_dir, '.')  # Create microagents directly in org_dir
-
+    # No local org directory is created; we rely on cloning from remote
     # Mock the provider detection to return GitLab
     with patch.object(runtime, '_is_gitlab_repository', return_value=True):
         # Mock successful cloning for openhands-config
         with patch('openhands.runtime.base.call_async_from_sync') as mock_async:
-            mock_async.return_value = 'https://gitlab.com/owner/openhands-config.git'
+            # Simulate two async calls: one for verification, one for fetching the URL
+            mock_async.side_effect = [
+                Repository(
+                    id='1',
+                    full_name='owner/.openhands-config',
+                    git_provider=ProviderType.GITLAB,
+                    is_public=True,
+                ),
+                'https://gitlab.com/owner/openhands-config.git'
+            ]
 
             result = runtime.get_microagents_from_org_or_user('gitlab.com/owner/repo')
 
-            # Should succeed with openhands-config
+            # Should succeed with openhands-config (no local microagents)
             assert len(result) >= 0  # May be empty if no microagents found
-            # Should only try once for openhands-config
-            assert mock_async.call_count == 1
+            # Expect two async calls: verification and URL retrieval
+            assert mock_async.call_count == 2
 
 
 def test_get_microagents_from_org_or_user_gitlab_failure(temp_workspace):
@@ -333,3 +393,111 @@ def test_get_microagents_from_selected_repo_github_only_openhands(temp_workspace
 
             # Should only check .openhands directory, not openhands-config
             assert isinstance(result, list)
+
+
+def test_org_microagent_fallback_subgroup_has_microagents_top_level_missing(temp_workspace):
+    """When the top‑level org repo has microagents but a sub‑group org repo also exists,
+    the sub‑group should be selected for loading microagents (priority to deeper level)."""
+    runtime = MockRuntime(temp_workspace)
+
+    # Top‑level org repo with microagents
+    top_org_dir = temp_workspace / 'org_openhands_top'
+    (top_org_dir / '.git').mkdir(parents=True, exist_ok=True)
+    create_test_microagents(top_org_dir, '')
+
+    # Sub‑group org repo with its own microagents
+    sub_org_dir = temp_workspace / 'org_openhands_top' / 'sub1'
+    (sub_org_dir / '.git').mkdir(parents=True, exist_ok=True)
+    create_test_microagents(sub_org_dir, '')
+
+    # Mock verify_repo_provider to simulate remote checks:
+    async def mock_verify(repo):
+        # Simulate that the deepest org repo does NOT exist, forcing selection of sub‑group
+        if repo == "top/sub1/sub2/openhands-config":
+            raise Exception('not found')
+        elif repo in [
+            "top/sub1/openhands-config",
+            "top/openhands-config",
+        ]:
+            return Repository(
+                id='1',
+                full_name=repo,
+                git_provider=ProviderType.GITLAB,
+                is_public=True,
+            )
+        raise Exception('unexpected')
+
+    with patch.object(runtime.provider_handler, 'verify_repo_provider', mock_verify), \
+         patch.object(runtime, '_is_gitlab_repository', return_value=True):
+        # Use default run_action (success) from MockRuntime
+        loaded = runtime.get_microagents_from_org_or_user(
+            "gitlab.com/top/sub1/sub2/repo"
+        )
+        # Should load microagents from the sub‑group org repo (deeper level)
+        assert any(isinstance(m, RepoMicroagent) for m in loaded)
+        names = [m.name for m in loaded]
+        # Expect microagents from sub‑group (named 'mock_test' as created)
+        assert any('mock_test' in n for n in names)
+
+
+
+def test_org_microagent_fallback_subgroup_missing_top_level_has(temp_workspace):
+    """When the sub‑group org repo is missing remotely but a local directory exists with microagents,
++    fallback to that local sub‑group directory (since it has microagents)."""
+    runtime = MockRuntime(temp_workspace)
+
+    # Top‑level org repo with microagents
+    top_org_dir = temp_workspace / 'org_openhands_top'
+    (top_org_dir / '.git').mkdir(parents=True, exist_ok=True)
+    create_test_microagents(top_org_dir, '')
+
+    # Local sub‑group directory exists with microagents (no remote)
+    sub_org_dir = temp_workspace / 'org_openhands_top' / 'sub1'
+    (sub_org_dir / '.git').mkdir(parents=True, exist_ok=True)
+    create_test_microagents(sub_org_dir, '')
+
+    async def mock_verify(repo):
+        # Remote checks: only top‑level repo is found; sub‑group remote missing
+        if repo == "top/sub1/sub2/openhands-config":
+            raise Exception('not found')
+        elif repo == "top/sub1/openhands-config":
+            raise Exception('not found')  # remote missing
+        elif repo == "top/openhands-config":
+            return Repository(
+                id='1',
+                full_name='top/.openhands-config',
+                git_provider=ProviderType.GITLAB,
+                is_public=True,
+            )
+        else:
+            raise Exception('unexpected')
+
+    with patch.object(runtime.provider_handler, 'verify_repo_provider', mock_verify), \
+         patch.object(runtime, '_is_gitlab_repository', return_value=True):
+        loaded = runtime.get_microagents_from_org_or_user(
+            "gitlab.com/top/sub1/sub2/repo"
+        )
+        # Should load microagents from the top‑level org repo (since sub‑group has none)
+        assert any(isinstance(m, RepoMicroagent) for m in loaded)
+        # Verify that the source path includes the top‑level directory but not sub‑group
+        assert any('org_openhands_top' in m.source and 'sub1' not in m.source for m in loaded)
+        # (Removed: sub‑group source path check is not applicable when fallback to top‑level repo)
+        names = [m.name for m in loaded]
+        # Expect microagents from top‑level (named 'mock_test')
+        assert any('mock_test' in n for n in names)
+
+
+
+def test_org_microagent_fallback_missing_all_candidates(temp_workspace):
+    """If none of the candidate org repos exist or have microagents,
+    get_microagents_from_org_or_user should return an empty list."""
+    runtime = MockRuntime(temp_workspace)
+
+    async def mock_verify(repo):
+        raise Exception('not found')  # all candidates fail
+
+    with patch.object(runtime.provider_handler, 'verify_repo_provider', mock_verify):
+        loaded = runtime.get_microagents_from_org_or_user(
+            "gitlab.com/top/sub1/sub2/repo"
+        )
+        assert loaded == []


### PR DESCRIPTION
adjust org-repo detection logic to better handle sub-groups which may or may not have their own openhands-config repos

- added tests to cover the fall through logic. 
- updated documentation to be a little clearer about how microagents are detected and used.

- [ X ] This change is worth documenting at https://docs.all-hands.dev/
      
- [ x ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**Enhance the robustness of org-repository microagent handling**


---

**Summary**:  This change ensures that when working on/in a project that is nested in the upstream code host, OpenHands will iteratively search the codehost URI hierarchy looking for an org-config repository. 

- for each directory path in the hierarchy, openhands will:
   - look in the codehost for an org-config repo
   - look in the workspace for a local directory following the expected naming convention of `org_openhands_groupname`
    - if a local directory is found
      - try to update it from git upstream.
        - if pull fails, warn, but leave as is. likely intentional.
    - inspect local copy of repo (freshly downloaded or not) for a `microagents` directory. 
    - if found, and has microagents, stop iterating. 
   
