### PR TITLE
Fix SaaS callback URLs and pro pill positioning

### DIFF
--- a/enterprise/server/routes/billing.py
+++ b/enterprise/server/routes/billing.py
@@ -417,7 +417,7 @@ async def success_callback(session_id: str, request: Request):
             session.commit()
 
     return RedirectResponse(
-        f'{request.base_url}settings?checkout=success', status_code=302
+        f'{request.base_url}settings/billing?checkout=success', status_code=302
     )
 
 
@@ -444,6 +444,17 @@ async def cancel_callback(session_id: str, request: Request):
             session.merge(billing_session)
             session.commit()
 
+            # Redirect credit purchases to billing screen, subscriptions to LLM settings
+            if billing_session.billing_session_type == BillingSessionType.DIRECT_PAYMENT.value:
+                return RedirectResponse(
+                    f'{request.base_url}settings/billing?checkout=cancel', status_code=302
+                )
+            else:
+                return RedirectResponse(
+                    f'{request.base_url}settings?checkout=cancel', status_code=302
+                )
+
+    # If no billing session found, default to LLM settings (subscription flow)
     return RedirectResponse(
         f'{request.base_url}settings?checkout=cancel', status_code=302
     )

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -91,9 +91,7 @@ function SettingsScreen() {
             }
           >
             <span className="text-[#F9FBFE] text-sm">{t(text)}</span>
-            {isSaas && to === "/settings" && (
-              <ProPill className="absolute top-0 -right-7" />
-            )}
+            {isSaas && to === "/settings" && <ProPill className="ml-2" />}
           </NavLink>
         ))}
       </nav>


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Backend changes:
- Fix credit purchase callback URLs to redirect to billing screen (/settings/billing) instead of LLM settings (/settings)
- Improved cancel callback logic to differentiate between credit and subscription purchases
- Credit purchase cancellations now redirect to billing screen with appropriate toast
- Subscription purchase cancellations redirect to LLM settings with appropriate toast

Frontend changes:
- Move pro pill from absolute top-right position to inline next to LLM text

---
**Link of any specific issues this addresses:**
