### PR TITLE
fix(frontend): Fixed prompt box resizing behavior (fixes #11025)

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -140,6 +140,7 @@ export function CustomChatInput({
     handleGripMouseDown,
     handleGripTouchStart,
     increaseHeightForEmptyContent,
+    resetManualResize,
   } = useAutoResize(chatInputRef, {
     minHeight: 20,
     maxHeight: 400,
@@ -223,7 +224,8 @@ export function CustomChatInput({
         fileInputRef.current.value = "";
       }
 
-      // Reset height and show suggestions again
+      // Allow shrink for next input and reset height
+      resetManualResize();
       smartResize();
     }
   };
@@ -242,7 +244,8 @@ export function CustomChatInput({
       fileInputRef.current.value = "";
     }
 
-    // Reset height and show suggestions again
+    // Allow shrink for next input and reset height
+    resetManualResize();
     smartResize();
   };
 

--- a/frontend/src/hooks/use-drag-resize.ts
+++ b/frontend/src/hooks/use-drag-resize.ts
@@ -9,6 +9,7 @@ interface UseDragResizeOptions {
   onGripDragStart?: () => void;
   onGripDragEnd?: () => void;
   onHeightChange?: (height: number) => void;
+  onReachedMinHeight?: () => void; // new: notify when user drags to min height
 }
 
 export const useDragResize = ({
@@ -18,6 +19,7 @@ export const useDragResize = ({
   onGripDragStart,
   onGripDragEnd,
   onHeightChange,
+  onReachedMinHeight,
 }: UseDragResizeOptions) => {
   const getClientY = (event: MouseEvent | TouchEvent): number => {
     if ("touches" in event && event.touches.length > 0) {
@@ -55,6 +57,11 @@ export const useDragResize = ({
       // Call the height change callback if provided
       if (onHeightChange) {
         onHeightChange(newHeight);
+      }
+
+      // If the user dragged down to minHeight, notify so manual mode can be cleared
+      if (onReachedMinHeight && newHeight === minHeight) {
+        onReachedMinHeight();
       }
     };
     return handleDragMove;


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The chat input prompt box now properly shrinks back to its normal size when you delete text from multiline prompts. Previously, once the input grew to accommodate multiple lines, it would stay permanently enlarged even after deleting all the text, requiring a browser refresh to return to normal size.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes the chat input autosize behavior by implementing manual resize tracking to distinguish between user-intended sizing and automatic content-based sizing. The solution preserves the existing UX where manually resized input boxes maintain their size while typing (allowing users to create a larger workspace for complex prompts), but enables automatic shrinking when content is deleted.

Key changes:

- Added _hasUserResizedRef_ to track when users manually drag-resize the input
- Modified _smartResize()_ logic to only shrink when not in manual mode or when at minimum height
- Clear manual mode when user drags down to minHeight, re-enabling full autosize behavior
- Reset manual mode after send/resume to ensure fresh autosize behavior for new prompts 

The design intentionally preserves manual resize persistence during editing - when users manually enlarge the input, it stays that size while they type, as this appears to be the intended behavior for users working on longer, more complex prompts. The input only shrinks automatically when content is deleted if the user hasn't manually resized it above the minimum height.

---
**Link of any specific issues this addresses:**
Fixes #11025 