### PR TITLE
Fix https://github.com/All-Hands-AI/OpenHands/issues/11046

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     environment:
       - SANDBOX_RUNTIME_CONTAINER_IMAGE=${SANDBOX_RUNTIME_CONTAINER_IMAGE:-docker.all-hands.dev/all-hands-ai/runtime:0.57-nikolaik}
       #- SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234} # enable this only if you want a specific non-root sandbox user but you will have to manually adjust permissions of ~/.openhands for this user
-      - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
+      - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE}
+      - SANDBOX_VOLUMES=${SANDBOX_VOLUMES}
     ports:
       - "3000:3000"
     extra_hosts:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes this issues:
- docker-compose.yml sets a default value when WORKSPACE_MOUNT_PATH is empty. It's currently not possible to leave it empty.
- Also, it's not possible to pass the new SANDBOX_VOLUMES env var.

This affects `make docker-run` and also when running `docker compose up` directly.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

It allows running docker-compose with empty `WORKSPACE_MOUNT_PATH` and also provde `SANDBOX_VOLUMES`.
