### PR TITLE
feat(config): Add support for CONFIG_FILE env var to override config.toml path

### DIFF
--- a/docs/usage/configuration-options.mdx
+++ b/docs/usage/configuration-options.mdx
@@ -9,7 +9,7 @@ description: This page outlines all available configuration options for OpenHand
 </Note>
 
 <Note>
-   **Looking for Environment Variables?** All configuration options can also be set using environment variables. 
+   **Looking for Environment Variables?** All configuration options can also be set using environment variables.
    See the [Environment Variables Reference](./environment-variables) for a complete list with examples.
 </Note>
 
@@ -17,7 +17,8 @@ description: This page outlines all available configuration options for OpenHand
 
 When running OpenHands in CLI, headless, or development mode, you can use a project-specific `config.toml` file for configuration, which must be
 located in the same directory from which the command is run. Alternatively, you may use the `--config-file` option to
-specify a different path to the `config.toml` file.
+specify a different path to the `config.toml` file. When running the GUI server, you can set the `CONFIG_FILE`
+environment variable to override the default path that the backend uses when loading configuration.
 
 ## Core Configuration
 

--- a/docs/usage/environment-variables.mdx
+++ b/docs/usage/environment-variables.mdx
@@ -15,6 +15,12 @@ OpenHands follows a consistent naming pattern for environment variables:
 - **Sandbox settings**: Prefixed with `SANDBOX_` (e.g., `timeout` → `SANDBOX_TIMEOUT`)
 - **Security settings**: Prefixed with `SECURITY_` (e.g., `confirmation_mode` → `SECURITY_CONFIRMATION_MODE`)
 
+## Configuration File Selection
+
+| Environment Variable | Type | Default | Description |
+|---------------------|------|---------|-------------|
+| `CONFIG_FILE` | string | `config.toml` | Overrides the default TOML configuration file path used by the GUI server (and other entry points that do not specify `--config-file`). |
+
 ## Core Configuration Variables
 
 These variables correspond to the `[core]` section in `config.toml`:


### PR DESCRIPTION
### Summary  
This PR extends `load_openhands_config` so the config file path can be overridden.  

- Previously, in [openhands/server](https://github.com/All-Hands-AI/OpenHands/blob/de84af55862b489578c47409c29acc475d66cbe9/openhands/server/shared.py#L23), `load_openhands_config` always used the default `config.toml` in the working directory.  
- Now, if the `CONFIG_FILE` environment variable is set, it takes precedence (unless an explicit `--config-file` is passed).  
- On first run, the resolved configuration is logged in **debug mode only**, to help understand what’s being loaded.  

### Changes  
- Added `CONFIG_FILE` env var support in `openhands/core/config/utils.py`  
- Updated `docs/usage/environment-variables.mdx` to document the new option  
- Added debug-only logging of the effective config on first run  
- Preserves backward compatibility (default still `config.toml`)  

### Motivation  
This helps to:  
- Run OpenHands in different environments (e.g. dev, CI/CD, Kubernetes, on-prem)  
- Keep project-specific configs clean without relying only on env vars  
- Debug configuration more easily by logging the resolved config in debug mode  

### Thanks  
Really happy to use OpenHands — thanks for building such an amazing project and for the welcoming community 🙏
