### PR TITLE
style(frontend): add margin spacing between chat messages and input

### DIFF
--- a/frontend/src/components/features/chat/components/chat-input-container.tsx
+++ b/frontend/src/components/features/chat/components/chat-input-container.tsx
@@ -52,8 +52,9 @@ export function ChatInputContainer({
 }: ChatInputContainerProps) {
   return (
     <div
+      // added mt-6 for better spacing between last message and chat box
       ref={chatContainerRef}
-      className="bg-[#25272D] box-border content-stretch flex flex-col items-start justify-center p-4 pt-3 relative rounded-[15px] w-full"
+      className="bg-[#25272D]   box-border content-stretch flex flex-col items-start justify-center p-4 pt-3 mt-6 relative rounded-[15px] w-full"
       onDragOver={(e) => onDragOver(e, disabled)}
       onDragLeave={(e) => onDragLeave(e, disabled)}
       onDrop={(e) => onDrop(e, disabled)}


### PR DESCRIPTION
Fixed insufficient spacing between the last message and chat input by adding **mt-6** .
This improves the ui and adds better readability.
<img width="3024" height="1964" alt="Screenshot 2025-09-21 at 12 40 23 AM" src="https://github.com/user-attachments/assets/877c78fc-98aa-4a59-b27b-4c0d2668a5de" />
