### PR TITLE
fix(frontend): insufficient spacing between last message and chat input

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -55,7 +55,7 @@ export function ChatMessage({
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       className={cn(
-        "rounded-xl relative w-fit max-w-full",
+        "rounded-xl relative w-fit max-w-full last:mb-4",
         "flex flex-col gap-2",
         type === "user" && " p-4 bg-tertiary self-end",
         type === "agent" && "mt-6 max-w-full bg-transparent",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="2774" height="1808" alt="Image" src="https://github.com/user-attachments/assets/fe387a5f-2dca-4d25-96f6-16da5a65a84c" />

As shown in the image above, the gap between the last message and the chat input should be increased.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates CSS to increase the gap between the last message and the chat input.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/757148d5-fc6c-4651-8f9d-c1a5a971277d

---
**Link of any specific issues this addresses:**

Resolves #11040 

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9e8d349-nikolaik   --name openhands-app-9e8d349   docker.all-hands.dev/all-hands-ai/openhands:9e8d349
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3659 openhands
```