### PR TITLE
fix - Set claude sonnet output limit

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -502,11 +502,9 @@ class LLM(RetryMixin, DebugMixin):
 
         # Set max_output_tokens from model info if not explicitly set
         if self.config.max_output_tokens is None:
-            # Special case for Claude 3.7 Sonnet models
-            if any(
-                model in self.config.model
-                for model in ['claude-3-7-sonnet', 'claude-3.7-sonnet']
-            ):
+            # Special case for Claude Sonnet models
+            sonnet_models = ['claude-3-7-sonnet', 'claude-3.7-sonnet', 'claude-sonnet-4']
+            if any(model in self.config.model for model in sonnet_models):
                 self.config.max_output_tokens = 64000  # litellm set max to 128k, but that requires a header to be set
             # Try to get from model info
             elif self.model_info is not None:

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -503,7 +503,11 @@ class LLM(RetryMixin, DebugMixin):
         # Set max_output_tokens from model info if not explicitly set
         if self.config.max_output_tokens is None:
             # Special case for Claude Sonnet models
-            sonnet_models = ['claude-3-7-sonnet', 'claude-3.7-sonnet', 'claude-sonnet-4']
+            sonnet_models = [
+                'claude-3-7-sonnet',
+                'claude-3.7-sonnet',
+                'claude-sonnet-4',
+            ]
             if any(model in self.config.model for model in sonnet_models):
                 self.config.max_output_tokens = 64000  # litellm set max to 128k, but that requires a header to be set
             # Try to get from model info

--- a/tests/unit/llm/test_llm.py
+++ b/tests/unit/llm/test_llm.py
@@ -1053,11 +1053,17 @@ def test_claude_3_7_sonnet_max_output_tokens():
     assert llm.config.max_input_tokens is None
 
 
-def test_claude_sonnet_4_max_output_tokens():
+@patch('openhands.llm.llm.litellm.get_model_info')
+def test_claude_sonnet_4_max_output_tokens(mock_get_model_info):
     """Test that Claude Sonnet 4 models get the correct max_output_tokens and max_input_tokens values."""
+    mock_get_model_info.return_value = {
+        'max_input_tokens': 100000,
+        'max_output_tokens': 200000,
+    }
     # Create LLM instance with a Claude Sonnet 4 model
     config = LLMConfig(model='claude-sonnet-4-20250514', api_key='test_key')
     llm = LLM(config, service_id='test-service')
+    llm.init_model_info()
 
     # Verify max_output_tokens is set to the expected value
     assert llm.config.max_output_tokens == 64000

--- a/tests/unit/llm/test_llm.py
+++ b/tests/unit/llm/test_llm.py
@@ -1058,18 +1058,17 @@ def test_claude_sonnet_4_max_output_tokens(mock_get_model_info):
     """Test that Claude Sonnet 4 models get the correct max_output_tokens and max_input_tokens values."""
     mock_get_model_info.return_value = {
         'max_input_tokens': 100000,
-        'max_output_tokens': 200000,
+        'max_output_tokens': 100000,
     }
     # Create LLM instance with a Claude Sonnet 4 model
     config = LLMConfig(model='claude-sonnet-4-20250514', api_key='test_key')
     llm = LLM(config, service_id='test-service')
     llm.init_model_info()
 
-    # Verify max_output_tokens is set to the expected value
-    assert llm.config.max_output_tokens == 64000
-    # Verify max_input_tokens is set to the expected value
-    # For Claude models, we expect a specific value from litellm
-    assert llm.config.max_input_tokens == 200000
+    assert llm.config.max_output_tokens == 64000, 'output max should be decreased'
+    assert llm.config.max_input_tokens == 100000, (
+        'input max should be the litellm value'
+    )
 
 
 def test_sambanova_deepseek_model_max_output_tokens():


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Addressing #11090. Seems like we're getting an output token limit from LiteLLM that's too big for Claude Sonnet and they're API has started erroring in this case.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

https://github.com/All-Hands-AI/OpenHands/issues/11090

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:77ac63c-nikolaik   --name openhands-app-77ac63c   docker.all-hands.dev/all-hands-ai/openhands:77ac63c
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@ray/claude-4-max-tokens openhands
```