### PR TITLE
CLI(V1): restore terminal state

### DIFF
--- a/openhands-cli/openhands_cli/agent_chat.py
+++ b/openhands-cli/openhands_cli/agent_chat.py
@@ -153,7 +153,7 @@ def run_cli_entry() -> None:
             exit_confirmation = exit_session_confirmation()
             if exit_confirmation == UserConfirmation.ACCEPT:
                 print_formatted_text(HTML("\n<yellow>Goodbye! 👋</yellow>"))
-            break
+                break
 
 
     # Clean up terminal state

--- a/openhands-cli/openhands_cli/agent_chat.py
+++ b/openhands-cli/openhands_cli/agent_chat.py
@@ -5,14 +5,15 @@ Provides a conversation interface with an AI agent using OpenHands patterns.
 """
 
 import logging
+import sys
 import uuid
 
 from openhands.sdk import (
     Message,
     TextContent,
-    AgentContext,
 )
 from openhands.sdk.conversation.state import AgentExecutionStatus
+from openhands_cli.user_actions.utils import get_session_prompter
 from prompt_toolkit import PromptSession, print_formatted_text
 from prompt_toolkit.formatted_text import HTML
 
@@ -20,14 +21,25 @@ from openhands_cli.runner import ConversationRunner
 from openhands_cli.setup import setup_conversation, MissingAgentSpec
 from openhands_cli.tui.settings.settings_screen import SettingsScreen
 from openhands_cli.tui.tui import (
-    CommandCompleter,
     display_help,
     display_welcome,
 )
 from openhands_cli.user_actions import UserConfirmation, exit_session_confirmation
-from openhands_cli.locations import WORK_DIR
+
 
 logger = logging.getLogger(__name__)
+
+def _restore_tty() -> None:
+    """
+    Ensure terminal modes are reset in case prompt_toolkit cleanup didn't run.
+    - Turn off application cursor keys (DECCKM): ESC[?1l
+    - Turn off bracketed paste: ESC[?2004l
+    """
+    try:
+        sys.stdout.write("\x1b[?1l\x1b[?2004l")
+        sys.stdout.flush()
+    except Exception:
+        pass
 
 
 def run_cli_entry() -> None:
@@ -53,11 +65,9 @@ def run_cli_entry() -> None:
 
     display_welcome(session_id)
 
-    # Create prompt session with command completer
-    session = PromptSession(completer=CommandCompleter())
-
     # Create conversation runner to handle state machine logic
     runner = ConversationRunner(conversation)
+    session = get_session_prompter()
 
     # Main chat loop
     while True:
@@ -143,4 +153,9 @@ def run_cli_entry() -> None:
             exit_confirmation = exit_session_confirmation()
             if exit_confirmation == UserConfirmation.ACCEPT:
                 print_formatted_text(HTML("\n<yellow>Goodbye! 👋</yellow>"))
-                break
+            break
+
+
+    # Clean up terminal state
+    _restore_tty()
+

--- a/openhands-cli/openhands_cli/user_actions/utils.py
+++ b/openhands-cli/openhands_cli/user_actions/utils.py
@@ -1,3 +1,5 @@
+from openhands_cli.tui.tui import CommandCompleter
+from prompt_toolkit import PromptSession
 from prompt_toolkit.application import Application
 from prompt_toolkit.completion import Completer
 from prompt_toolkit.input.base import Input
@@ -146,3 +148,23 @@ def cli_text_input(
         )
     )
     return reason.strip()
+
+
+
+def get_session_prompter() -> PromptSession:
+    bindings = KeyBindings()
+    # Create prompt session with command completer
+    @bindings.add("enter")
+    def _handle_enter(event: KeyPressEvent):
+        event.app.exit(result=event.current_buffer.text)
+
+    @bindings.add("c-c")
+    def _keyboard_interrupt(event: KeyPressEvent):
+        event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
+
+    session = PromptSession(
+        completer=CommandCompleter(),
+        key_bindings=bindings
+    )
+
+    return session

--- a/openhands-cli/openhands_cli/user_actions/utils.py
+++ b/openhands-cli/openhands_cli/user_actions/utils.py
@@ -130,12 +130,16 @@ def cli_text_input(
 
         @kb.add('c-c')
         def _(event: KeyPressEvent) -> None:
-            raise KeyboardInterrupt()
+            event.app.exit(exception=KeyboardInterrupt())
 
         @kb.add('c-p')
         def _(event: KeyPressEvent) -> None:
-            raise KeyboardInterrupt()
+            event.app.exit(exception=KeyboardInterrupt())
 
+
+    @kb.add("enter")
+    def _handle_enter(event: KeyPressEvent):
+        event.app.exit(result=event.current_buffer.text)
 
     reason = str(
         prompt(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

#### Steps to reproduce
1. run `make run`
2. type `/exit` 
3. select `Yes, proceed`
4. press any arrow keys on the keyboard, they will display raw escape sequences for arrow keys (^[[A, ^[[B, ^[[C, ^[[D)


#### Fix
This PR 

1. standardizes the user of app exit so prompt toolkit can clean up prompt applications properly
2. even after implementing part 1 we still see arrow keys not being restored. for this reason we add `restore_tty` as a workaround to turn off application cursor keys and bracketed paste if they were left on


#### Followup 

We should open an issue upstream with prompt toolkit to fix the improper cleanup

---
**Link of any specific issues this addresses:**
