### PR TITLE
CLI(V1): Multiline inputs

### DIFF
--- a/openhands-cli/openhands_cli/pt_style.py
+++ b/openhands-cli/openhands_cli/pt_style.py
@@ -24,6 +24,7 @@ def get_cli_style() -> BaseStyle:
             "completion-menu.completion.current fuzzymatch.outside": "fg:#ffffff bg:#888888",
             "selected": COLOR_GOLD,
             "risk-high": "#FF0000 bold",  # Red bold for HIGH risk
+            "placeholder": "#888888 italic",
         }
     )
     return merge_styles([base, custom])

--- a/openhands-cli/openhands_cli/user_actions/utils.py
+++ b/openhands-cli/openhands_cli/user_actions/utils.py
@@ -155,7 +155,10 @@ def cli_text_input(
     return reason.strip()
 
 
-def get_session_prompter() -> PromptSession:
+def get_session_prompter(
+    input: Input | None = None,  # strictly for unit testing
+    output: Output | None = None,  # strictly for unit testing
+) -> PromptSession:
     bindings = KeyBindings()
 
     @bindings.add("\\", "enter")
@@ -176,6 +179,8 @@ def get_session_prompter() -> PromptSession:
         key_bindings=bindings,
         prompt_continuation=lambda width, line_number, is_soft_wrap: "...",
         multiline=True,
+        input=input,
+        output=output,
     )
 
     return session

--- a/openhands-cli/openhands_cli/user_actions/utils.py
+++ b/openhands-cli/openhands_cli/user_actions/utils.py
@@ -176,11 +176,6 @@ def get_session_prompter(
     def _keyboard_interrupt(event: KeyPressEvent):
         event.app.exit(exception=KeyboardInterrupt())
 
-    placeholder_style = Style.from_dict({
-        "placeholder": "#888888 italic",
-    })
-    combined_style = merge_styles([DEFAULT_STYLE, placeholder_style])
-
 
     session = PromptSession(
         completer=CommandCompleter(),
@@ -189,7 +184,7 @@ def get_session_prompter(
         multiline=True,
         input=input,
         output=output,
-        style=combined_style,
+        style=DEFAULT_STYLE,
         placeholder=HTML(
             "<placeholder>"
             "Type your message… (tip: press <b>\\</b> + <b>Enter</b> to insert a newline)"

--- a/openhands-cli/openhands_cli/user_actions/utils.py
+++ b/openhands-cli/openhands_cli/user_actions/utils.py
@@ -172,7 +172,7 @@ def get_session_prompter(
 
     @bindings.add("c-c")
     def _keyboard_interrupt(event: KeyPressEvent):
-        event.app.exit(exception=KeyboardInterrupt)
+        event.app.exit(exception=KeyboardInterrupt())
 
     session = PromptSession(
         completer=CommandCompleter(),

--- a/openhands-cli/openhands_cli/user_actions/utils.py
+++ b/openhands-cli/openhands_cli/user_actions/utils.py
@@ -157,18 +157,25 @@ def cli_text_input(
 
 def get_session_prompter() -> PromptSession:
     bindings = KeyBindings()
-    # Create prompt session with command completer
+
+    @bindings.add("\\", "enter")
+    def _(event: KeyPressEvent) -> None:
+        # Typing '\' + Enter forces a newline regardless
+        event.current_buffer.insert_text("\n")
+
     @bindings.add("enter")
     def _handle_enter(event: KeyPressEvent):
         event.app.exit(result=event.current_buffer.text)
 
     @bindings.add("c-c")
     def _keyboard_interrupt(event: KeyPressEvent):
-        event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
+        event.app.exit(exception=KeyboardInterrupt)
 
     session = PromptSession(
         completer=CommandCompleter(),
-        key_bindings=bindings
+        key_bindings=bindings,
+        prompt_continuation=lambda width, line_number, is_soft_wrap: "...",
+        multiline=True,
     )
 
     return session

--- a/openhands-cli/openhands_cli/user_actions/utils.py
+++ b/openhands-cli/openhands_cli/user_actions/utils.py
@@ -1,5 +1,5 @@
 from openhands_cli.tui.tui import CommandCompleter
-from prompt_toolkit import PromptSession
+from prompt_toolkit import HTML, PromptSession
 from prompt_toolkit.application import Application
 from prompt_toolkit.completion import Completer
 from prompt_toolkit.input.base import Input
@@ -12,6 +12,8 @@ from prompt_toolkit.layout.layout import Layout
 from prompt_toolkit.output.base import Output
 from prompt_toolkit.shortcuts import prompt
 from prompt_toolkit.validation import Validator, ValidationError
+from prompt_toolkit.styles import Style
+from prompt_toolkit.styles import merge_styles
 
 
 from openhands_cli.tui import DEFAULT_STYLE
@@ -174,6 +176,12 @@ def get_session_prompter(
     def _keyboard_interrupt(event: KeyPressEvent):
         event.app.exit(exception=KeyboardInterrupt())
 
+    placeholder_style = Style.from_dict({
+        "placeholder": "#888888 italic",
+    })
+    combined_style = merge_styles([DEFAULT_STYLE, placeholder_style])
+
+
     session = PromptSession(
         completer=CommandCompleter(),
         key_bindings=bindings,
@@ -181,6 +189,13 @@ def get_session_prompter(
         multiline=True,
         input=input,
         output=output,
+        style=combined_style,
+        placeholder=HTML(
+            "<placeholder>"
+            "Type your message… (tip: press <b>\\</b> + <b>Enter</b> to insert a newline)"
+            "</placeholder>"
+        ),
+
     )
 
     return session

--- a/openhands-cli/tests/test_session_prompter.py
+++ b/openhands-cli/tests/test_session_prompter.py
@@ -1,191 +1,102 @@
-#!/usr/bin/env python3
-"""
-Tests for get_session_prompter functionality in OpenHands CLI.
-"""
-
 import time
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import patch
+from typing import Optional, Type
 
 import pytest
+from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.output.defaults import DummyOutput
-from prompt_toolkit.formatted_text import HTML
 
 from openhands_cli.user_actions.utils import get_session_prompter
 from tests.utils import _send_keys
 
 
-class TestSessionPrompter:
-    """Test suite for get_session_prompter functionality."""
+def _run_prompt_and_type(
+    prompt_text: str,
+    keys: str,
+    *,
+    expect_exception: Optional[Type[BaseException]] = None,
+    timeout: float = 2.0,
+    settle: float = 0.05,
+) -> str | None:
+    """
+    Helper to:
+      1) create a pipe + session,
+      2) start session.prompt in a background thread,
+      3) send keys, and
+      4) return the result or raise the expected exception.
 
-    def test_get_session_prompter_basic_input(self) -> None:
-        """Test that get_session_prompter handles basic single-line input."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
+    Returns:
+      - The prompt result (str) if no exception expected.
+      - None if an exception is expected and raised.
+    """
+    with create_pipe_input() as pipe:
+        session = get_session_prompter(input=pipe, output=DummyOutput())
+        with ThreadPoolExecutor(max_workers=1) as ex:
+            fut = ex.submit(session.prompt, HTML(prompt_text))
+            # Allow the prompt loop to start consuming input
+            time.sleep(settle)
+            _send_keys(pipe, keys)
+            if expect_exception:
+                with pytest.raises(expect_exception):
+                    fut.result(timeout=timeout)
+                return None
+            return fut.result(timeout=timeout)
 
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send basic text and enter
-                _send_keys(pipe, "hello world\r")
-                
-                result = future.result(timeout=2.0)
-                assert result == "hello world"
 
-    def test_get_session_prompter_multiline_with_backslash_enter(self) -> None:
-        """Test that get_session_prompter handles multiline input with backslash+enter."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
+@pytest.mark.parametrize(
+    "desc,keys,expected",
+    [
+        ("basic single line", "hello world\r", "hello world"),
+        ("empty input", "\r", ""),
+        ("single multiline via backslash-enter", "line 1\\\rline 2\r", "line 1\nline 2"),
+        (
+            "multiple multiline segments",
+            "first line\\\rsecond line\\\rthird line\r",
+            "first line\nsecond line\nthird line",
+        ),
+        (
+            "backslash-only newline then text",
+            "\\\rafter newline\r",
+            "\nafter newline",
+        ),
+        (
+            "mixed content (code-like)",
+            "def function():\\\r    return 'hello'\\\r    # end of function\r",
+            "def function():\n    return 'hello'\n    # end of function",
+        ),
+        (
+            "whitespace preservation (including blank line)",
+            "  indented line\\\r\\\r    more indented\r",
+            "  indented line\n\n    more indented",
+        ),
+        (
+            "special characters",
+            "echo 'hello world'\\\rgrep -n \"pattern\" file.txt\r",
+            "echo 'hello world'\ngrep -n \"pattern\" file.txt",
+        ),
+    ],
+)
+def test_get_session_prompter_scenarios(desc, keys, expected):
+    """Covers most behaviors via parametrization to reduce duplication."""
+    result = _run_prompt_and_type("<gold>> </gold>", keys)
+    assert result == expected
 
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send text with backslash+enter for newline, then more text, then enter
-                _send_keys(pipe, "line 1\\\r")  # backslash + enter
-                time.sleep(0.1)  # Give time for the newline to be processed
-                _send_keys(pipe, "line 2\r")  # final enter to submit
-                
-                result = future.result(timeout=2.0)
-                assert result == "line 1\nline 2"
 
-    def test_get_session_prompter_multiple_multiline_segments(self) -> None:
-        """Test that get_session_prompter handles multiple multiline segments."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
+def test_get_session_prompter_keyboard_interrupt():
+    """Focused test for Ctrl+C behavior."""
+    _run_prompt_and_type("<gold>> </gold>", "\x03", expect_exception=KeyboardInterrupt)
 
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send multiple lines with backslash+enter
-                _send_keys(pipe, "first line\\\r")  # backslash + enter
-                time.sleep(0.1)
-                _send_keys(pipe, "second line\\\r")  # backslash + enter
-                time.sleep(0.1)
-                _send_keys(pipe, "third line\r")  # final enter to submit
-                
-                result = future.result(timeout=2.0)
-                assert result == "first line\nsecond line\nthird line"
 
-    def test_get_session_prompter_empty_input(self) -> None:
-        """Test that get_session_prompter handles empty input."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
+def test_get_session_prompter_default_parameters():
+    """Lightweight sanity check for default construction."""
+    session = get_session_prompter()
+    assert session is not None
+    assert session.multiline is True
+    assert session.key_bindings is not None
+    assert session.completer is not None
 
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send just enter
-                _send_keys(pipe, "\r")
-                
-                result = future.result(timeout=2.0)
-                assert result == ""
-
-    def test_get_session_prompter_backslash_only_then_text(self) -> None:
-        """Test that get_session_prompter handles backslash+enter followed by text."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
-
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send backslash+enter first, then text
-                _send_keys(pipe, "\\\r")  # backslash + enter for newline
-                time.sleep(0.1)
-                _send_keys(pipe, "after newline\r")  # text + enter to submit
-                
-                result = future.result(timeout=2.0)
-                assert result == "\nafter newline"
-
-    def test_get_session_prompter_keyboard_interrupt(self) -> None:
-        """Test that get_session_prompter handles Ctrl+C (KeyboardInterrupt)."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
-
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send Ctrl+C
-                _send_keys(pipe, "\x03")  # Ctrl+C
-                
-                with pytest.raises(KeyboardInterrupt):
-                    future.result(timeout=2.0)
-
-    def test_get_session_prompter_mixed_content_with_multiline(self) -> None:
-        """Test that get_session_prompter handles mixed content with multiline."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
-
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send complex multiline input
-                _send_keys(pipe, "def function():\\\r")  # backslash + enter
-                time.sleep(0.1)
-                _send_keys(pipe, "    return 'hello'\\\r")  # backslash + enter
-                time.sleep(0.1)
-                _send_keys(pipe, "    # end of function\r")  # final enter to submit
-                
-                result = future.result(timeout=2.0)
-                expected = "def function():\n    return 'hello'\n    # end of function"
-                assert result == expected
-
-    def test_get_session_prompter_whitespace_preservation(self) -> None:
-        """Test that get_session_prompter preserves whitespace in multiline input."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
-
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send input with various whitespace
-                _send_keys(pipe, "  indented line\\\r")  # backslash + enter
-                time.sleep(0.1)
-                _send_keys(pipe, "\\\r")  # empty line with backslash + enter
-                time.sleep(0.1)
-                _send_keys(pipe, "    more indented\r")  # final enter to submit
-                
-                result = future.result(timeout=2.0)
-                assert result == "  indented line\n\n    more indented"
-
-    def test_get_session_prompter_special_characters(self) -> None:
-        """Test that get_session_prompter handles special characters in multiline input."""
-        with create_pipe_input() as pipe:
-            output = DummyOutput()
-            session = get_session_prompter(input=pipe, output=output)
-
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
-                
-                # Send input with special characters
-                _send_keys(pipe, "echo 'hello world'\\\r")  # backslash + enter
-                time.sleep(0.1)
-                _send_keys(pipe, "grep -n \"pattern\" file.txt\r")  # final enter to submit
-                
-                result = future.result(timeout=2.0)
-                assert result == "echo 'hello world'\ngrep -n \"pattern\" file.txt"
-
-    def test_get_session_prompter_default_parameters(self) -> None:
-        """Test that get_session_prompter works with default parameters (no input/output)."""
-        # This test just ensures the function can be called without parameters
-        # and returns a PromptSession object
-        session = get_session_prompter()
-        
-        # Verify it's a PromptSession with the expected configuration
-        assert session is not None
-        assert session.multiline is True
-        assert session.key_bindings is not None
-        assert session.completer is not None
-        
-        # Verify the prompt continuation function
-        continuation = session.prompt_continuation
-        assert continuation is not None
-        assert continuation(80, 1, False) == "..."
+    # Prompt continuation should be callable and return the expected string
+    cont = session.prompt_continuation
+    assert callable(cont)
+    assert cont(80, 1, False) == "..."

--- a/openhands-cli/tests/test_session_prompter.py
+++ b/openhands-cli/tests/test_session_prompter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Tests for get_session_prompter functionality in OpenHands CLI.
+"""
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.output.defaults import DummyOutput
+from prompt_toolkit.formatted_text import HTML
+
+from openhands_cli.user_actions.utils import get_session_prompter
+from tests.utils import _send_keys
+
+
+class TestSessionPrompter:
+    """Test suite for get_session_prompter functionality."""
+
+    def test_get_session_prompter_basic_input(self) -> None:
+        """Test that get_session_prompter handles basic single-line input."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send basic text and enter
+                _send_keys(pipe, "hello world\r")
+                
+                result = future.result(timeout=2.0)
+                assert result == "hello world"
+
+    def test_get_session_prompter_multiline_with_backslash_enter(self) -> None:
+        """Test that get_session_prompter handles multiline input with backslash+enter."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send text with backslash+enter for newline, then more text, then enter
+                _send_keys(pipe, "line 1\\\r")  # backslash + enter
+                time.sleep(0.1)  # Give time for the newline to be processed
+                _send_keys(pipe, "line 2\r")  # final enter to submit
+                
+                result = future.result(timeout=2.0)
+                assert result == "line 1\nline 2"
+
+    def test_get_session_prompter_multiple_multiline_segments(self) -> None:
+        """Test that get_session_prompter handles multiple multiline segments."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send multiple lines with backslash+enter
+                _send_keys(pipe, "first line\\\r")  # backslash + enter
+                time.sleep(0.1)
+                _send_keys(pipe, "second line\\\r")  # backslash + enter
+                time.sleep(0.1)
+                _send_keys(pipe, "third line\r")  # final enter to submit
+                
+                result = future.result(timeout=2.0)
+                assert result == "first line\nsecond line\nthird line"
+
+    def test_get_session_prompter_empty_input(self) -> None:
+        """Test that get_session_prompter handles empty input."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send just enter
+                _send_keys(pipe, "\r")
+                
+                result = future.result(timeout=2.0)
+                assert result == ""
+
+    def test_get_session_prompter_backslash_only_then_text(self) -> None:
+        """Test that get_session_prompter handles backslash+enter followed by text."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send backslash+enter first, then text
+                _send_keys(pipe, "\\\r")  # backslash + enter for newline
+                time.sleep(0.1)
+                _send_keys(pipe, "after newline\r")  # text + enter to submit
+                
+                result = future.result(timeout=2.0)
+                assert result == "\nafter newline"
+
+    def test_get_session_prompter_keyboard_interrupt(self) -> None:
+        """Test that get_session_prompter handles Ctrl+C (KeyboardInterrupt)."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send Ctrl+C
+                _send_keys(pipe, "\x03")  # Ctrl+C
+                
+                with pytest.raises(KeyboardInterrupt):
+                    future.result(timeout=2.0)
+
+    def test_get_session_prompter_mixed_content_with_multiline(self) -> None:
+        """Test that get_session_prompter handles mixed content with multiline."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send complex multiline input
+                _send_keys(pipe, "def function():\\\r")  # backslash + enter
+                time.sleep(0.1)
+                _send_keys(pipe, "    return 'hello'\\\r")  # backslash + enter
+                time.sleep(0.1)
+                _send_keys(pipe, "    # end of function\r")  # final enter to submit
+                
+                result = future.result(timeout=2.0)
+                expected = "def function():\n    return 'hello'\n    # end of function"
+                assert result == expected
+
+    def test_get_session_prompter_whitespace_preservation(self) -> None:
+        """Test that get_session_prompter preserves whitespace in multiline input."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send input with various whitespace
+                _send_keys(pipe, "  indented line\\\r")  # backslash + enter
+                time.sleep(0.1)
+                _send_keys(pipe, "\\\r")  # empty line with backslash + enter
+                time.sleep(0.1)
+                _send_keys(pipe, "    more indented\r")  # final enter to submit
+                
+                result = future.result(timeout=2.0)
+                assert result == "  indented line\n\n    more indented"
+
+    def test_get_session_prompter_special_characters(self) -> None:
+        """Test that get_session_prompter handles special characters in multiline input."""
+        with create_pipe_input() as pipe:
+            output = DummyOutput()
+            session = get_session_prompter(input=pipe, output=output)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(session.prompt, HTML("<gold>> </gold>"))
+                
+                # Send input with special characters
+                _send_keys(pipe, "echo 'hello world'\\\r")  # backslash + enter
+                time.sleep(0.1)
+                _send_keys(pipe, "grep -n \"pattern\" file.txt\r")  # final enter to submit
+                
+                result = future.result(timeout=2.0)
+                assert result == "echo 'hello world'\ngrep -n \"pattern\" file.txt"
+
+    def test_get_session_prompter_default_parameters(self) -> None:
+        """Test that get_session_prompter works with default parameters (no input/output)."""
+        # This test just ensures the function can be called without parameters
+        # and returns a PromptSession object
+        session = get_session_prompter()
+        
+        # Verify it's a PromptSession with the expected configuration
+        assert session is not None
+        assert session.multiline is True
+        assert session.key_bindings is not None
+        assert session.completer is not None
+        
+        # Verify the prompt continuation function
+        continuation = session.prompt_continuation
+        assert continuation is not None
+        assert continuation(80, 1, False) == "..."


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR allows users to perform multiline inputs via typing `\` + `enter`.

When pasting multi line inputs, its should wrap as expected as well.



---
**Link of any specific issues this addresses:**

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:aa92938-nikolaik   --name openhands-app-aa92938   docker.all-hands.dev/all-hands-ai/openhands:aa92938
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@v1-cli-multiline-input openhands
```