### PR TITLE
Enable native tool calling for Anthropic Claude 3.5 Sonnet (dot-notation) models

### DIFF
--- a/openhands/llm/model_features.py
+++ b/openhands/llm/model_features.py
@@ -65,6 +65,7 @@ FUNCTION_CALLING_PATTERNS: list[str] = [
     'claude-3.7-sonnet*',
     'claude-sonnet-3-7-latest',
     'claude-3-5-sonnet*',
+    'claude-3.5-sonnet*',  # Accept dot-notation for Sonnet 3.5 as well
     'claude-3.5-haiku*',
     'claude-3-5-haiku*',
     'claude-sonnet-4*',


### PR DESCRIPTION
Problem
- Sonnet 3.5 models referenced with dot-notation (e.g., `claude-3.5-sonnet-...`) were not included in `FUNCTION_CALLING_PATTERNS`, so native tool calling defaulted to off.

Fix
- Add `'claude-3.5-sonnet*'` to `FUNCTION_CALLING_PATTERNS` in `openhands/llm/model_features.py` so that Sonnet 3.5 dot-notation models default to native tool calling, consistent with the existing dashed variant (`'claude-3-5-sonnet*'`).

Why
- Anthropic models appear in both dashed and dotted naming variants. Haiku entries already accounted for both; Sonnet 3.5 should match the same intent.

Risk
- Low. This only amends the default feature detection for the dotted variant to match the already-enabled dashed variant.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0d8acd682cc649cdb9581cea95a6e3cd)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a1b716b-nikolaik   --name openhands-app-a1b716b   docker.all-hands.dev/all-hands-ai/openhands:a1b716b
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/sonnet35-native-tools openhands
```