### PR TITLE
Remove missing user message check for REMOTE_API_KEY

### DIFF
--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -226,19 +226,6 @@ async def new_conversation(
     if auth_type == AuthType.BEARER:
         conversation_trigger = ConversationTrigger.REMOTE_API_KEY
 
-    if (
-        conversation_trigger == ConversationTrigger.REMOTE_API_KEY
-        and not initial_user_msg
-    ):
-        return JSONResponse(
-            content={
-                'status': 'error',
-                'message': 'Missing initial user message',
-                'msg_id': 'CONFIGURATION$MISSING_USER_MESSAGE',
-            },
-            status_code=status.HTTP_400_BAD_REQUEST,
-        )
-
     try:
         if repository:
             provider_handler = ProviderHandler(provider_tokens)


### PR DESCRIPTION
Removed check for missing initial user message when using REMOTE_API_KEY.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7cc8cae-nikolaik   --name openhands-app-7cc8cae   docker.all-hands.dev/all-hands-ai/openhands:7cc8cae
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@rbren-patch-5 openhands
```