### PR TITLE
refactor(frontend): align chat message action buttons

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -58,7 +58,7 @@ export function ChatMessage({
         "rounded-xl relative w-fit max-w-full last:mb-4",
         "flex flex-col gap-2",
         type === "user" && " p-4 bg-tertiary self-end",
-        type === "agent" && "mt-6 max-w-full bg-transparent",
+        type === "agent" && "mt-6 w-full max-w-full bg-transparent",
       )}
     >
       <div
@@ -107,7 +107,7 @@ export function ChatMessage({
       </div>
 
       <div
-        className="text-sm"
+        className="text-sm w-fit"
         style={{
           whiteSpace: "normal",
           wordBreak: "break-word",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="731" height="243" alt="image" src="https://github.com/user-attachments/assets/3a38b873-fd0d-487c-beca-c80213a6ff18" />

These buttons should probably be aligned to the right side of the chat window rather than the text.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates CSS to make those buttons aligned to the right side of the chat window rather than the text.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/27f5ea75-8da0-4d1f-814c-a1915877d1e3

---
**Link of any specific issues this addresses:**

Resolves #11152 
