### PR TITLE
fix(frontend): duplicate LLM navigation items in settings sidebar

### DIFF
--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -2,14 +2,12 @@ import { useMemo } from "react";
 import { Outlet, redirect, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useConfig } from "#/hooks/query/use-config";
-import { I18nKey } from "#/i18n/declaration";
 import { Route } from "./+types/settings";
 import OptionService from "#/api/option-service/option-service.api";
 import { queryClient } from "#/query-client-config";
 import { GetConfigResponse } from "#/api/option-service/option.types";
 import { useSubscriptionAccess } from "#/hooks/query/use-subscription-access";
 import { SAAS_NAV_ITEMS, OSS_NAV_ITEMS } from "#/constants/settings-nav";
-import CircuitIcon from "#/icons/u-circuit.svg?react";
 import { Typography } from "#/ui/typography";
 import { SettingsLayout } from "#/components/features/settings/settings-layout";
 
@@ -52,13 +50,6 @@ function SettingsScreen() {
   const navItems = useMemo(() => {
     const items = [];
     if (isSaas) {
-      if (subscriptionAccess) {
-        items.push({
-          icon: <CircuitIcon width={22} height={22} />,
-          to: "/settings",
-          text: "SETTINGS$NAV_LLM" as I18nKey,
-        });
-      }
       items.push(...SAAS_NAV_ITEMS);
     } else {
       items.push(...OSS_NAV_ITEMS);


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="289" height="738" alt="issue" src="https://github.com/user-attachments/assets/228d7bc9-93c0-42ab-9305-57eed7ccd37e" />

**Description**
- As shown in the image above, the Settings sidebar currently displays duplicate LLM navigation items.

**Acceptance Criteria**
- The Settings sidebar should display each LLM navigation item only once.
- No duplicate entries should appear.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes duplicated LLM navigation items in settings sidebar.

---
**Link of any specific issues this addresses:**
