### PR TITLE
Tag enterprise-server image with PR Head

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -213,6 +213,8 @@ jobs:
             latest=auto
             prefix=
             suffix=
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
       - name: Determine app image tag
         shell: bash
         run: |


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The action `docker/metadata-action` is tagging the enterprise-server image with sha that initiated the PR, but that's actually a merge commit - we build with the PR head commit and should tag with that one. Setting the env var DOCKER_METADATA_PR_HEAD_SHA, as documented here.

https://github.com/docker/metadata-action?tab=readme-ov-file#environment-variables


---
**Link of any specific issues this addresses:**
