### PR TITLE
fix(frontend): the horizontal scrollbar is not displayed for the markdown content

### DIFF
--- a/frontend/src/components/features/chat/chat-message.tsx
+++ b/frontend/src/components/features/chat/chat-message.tsx
@@ -107,7 +107,7 @@ export function ChatMessage({
       </div>
 
       <div
-        className="text-sm w-fit"
+        className="text-sm"
         style={{
           whiteSpace: "normal",
           wordBreak: "break-word",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

https://github.com/user-attachments/assets/c90f07db-a416-44a6-ac27-b3091c23617d

As shown in the video above, the horizontal scrollbar does not appear for long markdown content.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes the horizontal scrollbar is not displayed for the markdown content.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/8e33b523-0a7e-4dba-8e14-7865387eceed

---
**Link of any specific issues this addresses:**

Resolves #11199

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ecc6187-nikolaik   --name openhands-app-ecc6187   docker.all-hands.dev/all-hands-ai/openhands:ecc6187
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3806 openhands
```