### PR TITLE
Add verbose output to ruff pre-commit hooks

### DIFF
--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: ruff
         entry: ruff check --config dev_config/python/ruff.toml
         types_or: [python, pyi, jupyter]
-        args: [--fix, --unsafe-fixes]
+        args: [--fix, --unsafe-fixes, --verbose]
         exclude: ^(third_party/|enterprise/)
       # Run the formatter.
       - id: ruff-format

--- a/enterprise/dev_config/python/.pre-commit-config.yaml
+++ b/enterprise/dev_config/python/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: ruff
         entry: ruff check --config enterprise/dev_config/python/ruff.toml
         types_or: [python, pyi, jupyter]
-        args: [--fix]
+        args: [--fix, --verbose]
         files: ^enterprise/
       # Run the formatter.
       - id: ruff-format


### PR DESCRIPTION
## Summary

This PR adds the `--verbose` flag to ruff linter configuration in pre-commit hooks to provide more detailed output when linting errors are found.

## Changes

- **Main pre-commit config** (`dev_config/python/.pre-commit-config.yaml`): Added `--verbose` flag to ruff arguments
- **Enterprise pre-commit config** (`enterprise/dev_config/python/.pre-commit-config.yaml`): Added `--verbose` flag to ruff arguments

## Benefits

When ruff finds linting errors, the verbose output will now include:

1. **Debug timestamps** showing the execution process
2. **Configuration file resolution** details  
3. **File processing timing** information
4. **Detailed error context** with line numbers and code snippets
5. **Summary statistics** showing how many errors were found, fixed, and remaining

## Impact

This change will make the "Lint python" GitHub Action much more informative when ruff encounters errors, making it easier to:

- Debug linting issues in CI
- Understand which files are being processed
- See exactly what errors were found and where
- Track performance of the linting process

## Testing

Tested locally by creating a file with ruff errors and confirming that verbose output is displayed with detailed debug information and error context.

The changes are backward compatible and will only show additional verbose information when ruff actually finds errors to report.

@chuckbutkus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/00c175aa88c34166b4618da72f305234)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1d8d598-nikolaik   --name openhands-app-1d8d598   docker.all-hands.dev/all-hands-ai/openhands:1d8d598
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@add-ruff-verbose-output openhands
```