### PR TITLE
fix(frontend): org level microagents not appearing (microagent management)

### DIFF
--- a/frontend/__tests__/components/features/microagent-management/microagent-management.test.tsx
+++ b/frontend/__tests__/components/features/microagent-management/microagent-management.test.tsx
@@ -157,7 +157,51 @@ describe("MicroagentManagement", () => {
       owner_type: "organization",
       pushed_at: "2021-10-06T12:00:00Z",
     },
+    {
+      id: "7",
+      full_name: "user/gitlab-repo/openhands-config",
+      git_provider: "gitlab",
+      is_public: true,
+      owner_type: "user",
+      pushed_at: "2021-10-07T12:00:00Z",
+    },
+    {
+      id: "8",
+      full_name: "org/gitlab-org-repo/openhands-config",
+      git_provider: "gitlab",
+      is_public: true,
+      owner_type: "organization",
+      pushed_at: "2021-10-08T12:00:00Z",
+    },
   ];
+
+  // Helper function to filter repositories with OpenHands suffixes
+  const getRepositoriesWithOpenHandsSuffix = (
+    repositories: GitRepository[],
+  ) => {
+    return repositories.filter(
+      (repo) =>
+        repo.full_name.endsWith("/.openhands") ||
+        repo.full_name.endsWith("/openhands-config"),
+    );
+  };
+
+  // Helper functions for mocking search repositories
+  const mockSearchRepositoriesWithData = (data: GitRepository[]) => {
+    mockUseSearchRepositories.mockReturnValue({
+      data,
+      isLoading: false,
+      isError: false,
+    });
+  };
+
+  const mockSearchRepositoriesEmpty = () => {
+    mockUseSearchRepositories.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+  };
 
   const mockMicroagents: RepositoryMicroagent[] = [
     {
@@ -265,11 +309,11 @@ describe("MicroagentManagement", () => {
       isError: false,
     });
 
-    mockUseSearchRepositories.mockReturnValue({
-      data: [],
-      isLoading: false,
-      isError: false,
-    });
+    // Mock the search repositories hook to return repositories with OpenHands suffixes
+    const mockSearchResults =
+      getRepositoriesWithOpenHandsSuffix(mockRepositories);
+
+    mockSearchRepositoriesWithData(mockSearchResults);
 
     // Setup default mock for retrieveUserGitRepositories
     vi.spyOn(GitService, "retrieveUserGitRepositories").mockResolvedValue({
@@ -594,6 +638,9 @@ describe("MicroagentManagement", () => {
       onLoadMore: vi.fn(),
     });
 
+    // Mock empty search results
+    mockSearchRepositoriesEmpty();
+
     renderMicroagentManagement();
 
     // Wait for repositories to be loaded
@@ -782,6 +829,10 @@ describe("MicroagentManagement", () => {
 
     it("should handle empty search results", async () => {
       const user = userEvent.setup();
+
+      // Mock empty search results for this test
+      mockSearchRepositoriesEmpty();
+
       renderMicroagentManagement();
 
       // Wait for repositories to be loaded

--- a/frontend/src/components/features/microagent-management/microagent-management-sidebar.tsx
+++ b/frontend/src/components/features/microagent-management/microagent-management-sidebar.tsx
@@ -9,7 +9,12 @@ import { GitProviderDropdown } from "#/components/features/home/git-provider-dro
 import { useMicroagentManagementStore } from "#/state/microagent-management-store";
 import { GitRepository } from "#/types/git";
 import { Provider } from "#/types/settings";
-import { cn } from "#/utils/utils";
+import {
+  cn,
+  shouldIncludeRepository,
+  getOpenHandsQuery,
+  hasOpenHandsSuffix,
+} from "#/utils/utils";
 import { sanitizeQuery } from "#/utils/sanitize-query";
 import { I18nKey } from "#/i18n/declaration";
 import { useDebounce } from "#/hooks/use-debounce";
@@ -55,6 +60,16 @@ export function MicroagentManagementSidebar({
   const { data: searchResults, isLoading: isSearchLoading } =
     useSearchRepositories(debouncedSearchQuery, selectedProvider, false, 500); // Increase page size to 500 to to retrieve all search results. This should be optimized in the future.
 
+  const {
+    data: userAndOrgLevelRepositorySearchResults,
+    isLoading: isUserAndOrgLevelRepositoryLoading,
+  } = useSearchRepositories(
+    getOpenHandsQuery(selectedProvider),
+    selectedProvider,
+    false,
+    500,
+  );
+
   // Auto-select provider if there's only one
   useEffect(() => {
     if (providers.length > 0 && !selectedProvider) {
@@ -93,43 +108,61 @@ export function MicroagentManagementSidebar({
     });
   }, [repositories, debouncedSearchQuery, searchResults]);
 
+  // Process personal and organization repositories from search results
   useEffect(() => {
-    if (!filteredRepositories?.length) {
+    if (!userAndOrgLevelRepositorySearchResults?.length) {
       setPersonalRepositories([]);
       setOrganizationRepositories([]);
-      setRepositories([]);
       return;
     }
 
     const personalRepos: GitRepository[] = [];
     const organizationRepos: GitRepository[] = [];
+
+    // Process personal repositories with exact match filtering
+    if (userAndOrgLevelRepositorySearchResults?.length) {
+      userAndOrgLevelRepositorySearchResults.forEach((repo: GitRepository) => {
+        if (
+          hasOpenHandsSuffix(repo, selectedProvider) &&
+          shouldIncludeRepository(repo, debouncedSearchQuery)
+        ) {
+          if (repo.owner_type === "user") {
+            personalRepos.push(repo);
+          } else if (repo.owner_type === "organization") {
+            organizationRepos.push(repo);
+          }
+        }
+      });
+    }
+
+    setPersonalRepositories(personalRepos);
+    setOrganizationRepositories(organizationRepos);
+  }, [
+    userAndOrgLevelRepositorySearchResults,
+    selectedProvider,
+    debouncedSearchQuery,
+    setPersonalRepositories,
+    setOrganizationRepositories,
+  ]);
+
+  // Process other repositories (non-OpenHands repositories) from filteredRepositories
+  useEffect(() => {
+    if (!filteredRepositories?.length) {
+      setRepositories([]);
+      return;
+    }
+
     const otherRepos: GitRepository[] = [];
 
     filteredRepositories.forEach((repo: GitRepository) => {
-      const hasOpenHandsSuffix =
-        selectedProvider === "gitlab"
-          ? repo.full_name.endsWith("/openhands-config")
-          : repo.full_name.endsWith("/.openhands");
-
-      if (repo.owner_type === "user" && hasOpenHandsSuffix) {
-        personalRepos.push(repo);
-      } else if (repo.owner_type === "organization" && hasOpenHandsSuffix) {
-        organizationRepos.push(repo);
-      } else {
+      // Only include repositories that don't have the OpenHands suffix
+      if (!hasOpenHandsSuffix(repo, selectedProvider)) {
         otherRepos.push(repo);
       }
     });
 
-    setPersonalRepositories(personalRepos);
-    setOrganizationRepositories(organizationRepos);
     setRepositories(otherRepos);
-  }, [
-    filteredRepositories,
-    selectedProvider,
-    setPersonalRepositories,
-    setOrganizationRepositories,
-    setRepositories,
-  ]);
+  }, [filteredRepositories, selectedProvider, setRepositories]);
 
   // Handle scroll to bottom for pagination
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
@@ -199,7 +232,7 @@ export function MicroagentManagementSidebar({
         </div>
       </div>
 
-      {isLoading ? (
+      {isLoading || isUserAndOrgLevelRepositoryLoading ? (
         <div className="flex flex-col items-center justify-center gap-4 flex-1">
           <Spinner size="sm" />
           <span className="text-sm text-white">

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -3,6 +3,8 @@ import { twMerge } from "tailwind-merge";
 import { Provider } from "#/types/settings";
 import { SuggestedTaskGroup } from "#/utils/types";
 import { ConversationStatus } from "#/types/conversation-status";
+import { GitRepository } from "#/types/git";
+import { sanitizeQuery } from "#/utils/sanitize-query";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -508,4 +510,51 @@ export const getStatusClassName = (status: string) => {
     return "bg-yellow-800 text-yellow-200";
   }
   return "bg-gray-700 text-gray-300";
+};
+
+/**
+ * Helper function to apply client-side filtering based on search query
+ * @param repo The Git repository to check
+ * @param searchQuery The search query string
+ * @returns True if the repository should be included based on the search query
+ */
+export const shouldIncludeRepository = (
+  repo: GitRepository,
+  searchQuery: string,
+): boolean => {
+  if (!searchQuery.trim()) {
+    return true;
+  }
+
+  const sanitizedQuery = sanitizeQuery(searchQuery);
+  const sanitizedRepoName = sanitizeQuery(repo.full_name);
+  return sanitizedRepoName.includes(sanitizedQuery);
+};
+
+/**
+ * Get the OpenHands query string based on the provider
+ * @param provider The git provider
+ * @returns The query string for searching OpenHands repositories
+ */
+export const getOpenHandsQuery = (provider: Provider | null): string => {
+  if (provider === "gitlab") {
+    return "openhands-config";
+  }
+  return ".openhands";
+};
+
+/**
+ * Check if a repository has the OpenHands suffix based on the provider
+ * @param repo The Git repository to check
+ * @param provider The git provider
+ * @returns True if the repository has the OpenHands suffix
+ */
+export const hasOpenHandsSuffix = (
+  repo: GitRepository,
+  provider: Provider | null,
+): boolean => {
+  if (provider === "gitlab") {
+    return repo.full_name.endsWith("/openhands-config");
+  }
+  return repo.full_name.endsWith("/.openhands");
 };


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Organization-level microagents are not appearing in the Microagent Management UI. For users who are part of the All-Hands-AI GitHub org:
- Navigate to the Microagent Management UI
- Click Organizations tab
- Notice that the All-Hands-AI/.openhands repo is not loading

**Expected result:**
- Users can review microagents within the .openhands repo and create new ones

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes the issue - org level microagents not appearing (microagent management).

We can refer to the image below for more information.

<img width="1440" height="738" alt="all-3718" src="https://github.com/user-attachments/assets/d5565a5f-0af3-48f9-b54a-436c7d12ad16" />

---
**Link of any specific issues this addresses:**

Resolves #11087 

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5d46256-nikolaik   --name openhands-app-5d46256   docker.all-hands.dev/all-hands-ai/openhands:5d46256
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3718 openhands
```