### PR TITLE
fix(audio): use transcriptions endpoint and print usage info

### DIFF
--- a/openhands/runtime/plugins/agent_skills/file_reader/file_readers.py
+++ b/openhands/runtime/plugins/agent_skills/file_reader/file_readers.py
@@ -128,12 +128,12 @@ def parse_audio(file_path: str, model: str = 'whisper-1') -> None:
     """
     print(f'[Transcribing audio file from {file_path}]')
     try:
-        # TODO: record the COST of the API call
         with open(file_path, 'rb') as audio_file:
-            transcript = _get_openai_client().audio.translations.create(
+            transcript = _get_openai_client().audio.transcriptions.create(
                 model=model, file=audio_file
             )
         print(transcript.text)
+        print(f'Total usage tokens: {transcript.usage.total_tokens}')
 
     except Exception as e:
         print(f'Error transcribing audio file: {e}')


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
The audio parsing command now uses the transcription API instead of the translation endpoint, ensuring that audio is transcribed in its original language as expected. It also prints the total usage tokens returned by the API, giving users better visibility into resource consumption.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
This PR updates the `parse_audio` function to call `audio.transcriptions.create()` instead of `audio.translations.create()`. The previous implementation was translating audio rather than transcribing it, which caused confusion and unexpected results for same-language audio files.
Additionally, the function now prints `transcript.usage.total_tokens` to make API usage more transparent to developers and users. This change is backward-compatible and requires no additional configuration.

---
**Link of any specific issues this addresses:**
N/A