### PR TITLE
V1: Add --task and --file parameters to V1 CLI app (openhands-cli)

### DIFF
--- a/openhands-cli/openhands_cli/agent_chat.py
+++ b/openhands-cli/openhands_cli/agent_chat.py
@@ -5,6 +5,7 @@ Provides a conversation interface with an AI agent using OpenHands patterns.
 """
 
 import sys
+import os
 
 from openhands.sdk import (
     Message,
@@ -72,6 +73,12 @@ def run_cli_entry(resume_conversation_id: str | None = None) -> None:
     # Create conversation runner to handle state machine logic
     runner = ConversationRunner(conversation)
     session = get_session_prompter()
+
+    # If an initial task was injected via environment (from --task/--file), send it once.
+    initial_task = os.environ.pop("OPENHANDS_CLI_INITIAL_TASK", None)
+    if initial_task:
+        message = Message(role="user", content=[TextContent(text=initial_task)])
+        runner.process_message(message)
 
     # Main chat loop
     while True:

--- a/openhands-cli/openhands_cli/simple_main.py
+++ b/openhands-cli/openhands_cli/simple_main.py
@@ -17,6 +17,31 @@ from prompt_toolkit.formatted_text import HTML
 from openhands_cli.agent_chat import run_cli_entry
 
 
+def _build_initial_task_from_args(args: argparse.Namespace) -> str | None:
+    """Build initial task message from --file/--task arguments.
+
+    --file overrides --task if both are provided.
+    """
+    if getattr(args, "file", None):
+        try:
+            with open(args.file, "r", encoding="utf-8") as f:
+                file_content = f.read()
+            return (
+                f"The user has tagged a file '{args.file}'.\n"
+                "Please read and understand the following file content first:\n\n"
+                "```\n"
+                f"{file_content}\n"
+                "```\n\n"
+                "After reviewing the file, please ask the user what they would like to do with it."
+            )
+        except Exception as e:
+            # Fall back to a simple task if file cannot be read
+            return f"The user attempted to share file '{args.file}', but it could not be read: {e}"
+    if getattr(args, "task", None):
+        return args.task
+    return None
+
+
 def main() -> None:
     """Main entry point for the OpenHands CLI.
 
@@ -32,10 +57,26 @@ def main() -> None:
         type=str,
         help="Conversation ID to use for the session. If not provided, a random UUID will be generated."
     )
+    parser.add_argument(
+        "--task",
+        type=str,
+        default=None,
+        help="Initial task for the agent to perform. Ignored if --file is provided."
+    )
+    parser.add_argument(
+        "--file",
+        type=str,
+        default=None,
+        help="Path to a file containing the task or context. Overrides --task if both are provided."
+    )
 
     args = parser.parse_args()
 
     try:
+        # Build optional initial message from args
+        initial_task = _build_initial_task_from_args(args)
+        if initial_task is not None:
+            os.environ["OPENHANDS_CLI_INITIAL_TASK"] = initial_task
         # Start agent chat
         run_cli_entry(resume_conversation_id=args.resume)
 


### PR DESCRIPTION
OpenHands-GPT-5 here. This PR adds support for the VSCode extension-style CLI parameters to the V1 CLI app.

Summary
- Add --task and --file flags to openhands-cli (V1 CLI) entrypoint
- If --file is provided, read the file content and construct a contextual initial message
- If both --file and --task are provided, --file takes precedence
- Pass the initial message into the chat loop via an environment variable consumed at startup to send one initial user message automatically

Why
- On main, the VSCode extension invokes `openhands --task` and `openhands --file`. V1 CLI lacked these, causing divergence. This brings V1 CLI to parity for consistent integration.

Implementation details
- openhands-cli/openhands_cli/simple_main.py: add argparse options and construct the initial message; export via OPENHANDS_CLI_INITIAL_TASK if present
- openhands-cli/openhands_cli/agent_chat.py: consume OPENHANDS_CLI_INITIAL_TASK once before the main chat loop by sending a user message

Notes
- No change to run_cli_entry signature; existing tests that patch it remain valid
- Behavior mirrors the main CLI’s semantics for `--file` vs `--task`

Co-authored-by: openhands <openhands@all-hands.dev>


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2a541835b8e242838bc20ea1e2481629)