### PR TITLE
docs: suggest uv tool install as alternative to uvx

### DIFF
--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -52,6 +52,10 @@ Note that you'll still need `uv` installed for the default MCP servers to work p
 
 <Accordion title="Create shell aliases for easy access across environments">
 
+You have two options for setting up shell aliases:
+
+**Option 1: Using uvx (runs latest version each time)**
+
 Add the following to your shell configuration file (`.bashrc`, `.zshrc`, etc.):
 
 ```bash
@@ -59,6 +63,23 @@ Add the following to your shell configuration file (`.bashrc`, `.zshrc`, etc.):
 alias openhands="uvx --python 3.12 --from openhands-ai openhands"
 alias oh="uvx --python 3.12 --from openhands-ai openhands"
 ```
+
+**Option 2: Using uv tool install (persistent installation, recommended for stability)**
+
+First, install OpenHands as a tool:
+
+```bash
+uv tool install --python 3.12 openhands-ai
+```
+
+Then add these aliases to your shell configuration file:
+
+```bash
+# Add OpenHands aliases after uv tool install
+alias oh="openhands"
+```
+
+Note: With `uv tool install`, you control when to update by running `uv tool upgrade openhands-ai`.
 
 After adding these lines, reload your shell configuration with `source ~/.bashrc` or `source ~/.zshrc` (depending on your shell).
 

--- a/openhands/cli/main.py
+++ b/openhands/cli/main.py
@@ -517,6 +517,22 @@ def run_alias_setup_flow(config: OpenHandsConfig) -> None:
         )
     )
     print_formatted_text('')
+    print_formatted_text(
+        HTML(
+            '<grey>💡 Tip: For a persistent installation, you can also use:</grey>'
+        )
+    )
+    print_formatted_text(
+        HTML(
+            '<grey>   <b>uv tool install --python 3.12 openhands-ai</b></grey>'
+        )
+    )
+    print_formatted_text(
+        HTML(
+            '<grey>   This installs OpenHands globally and allows you to control updates.</grey>'
+        )
+    )
+    print_formatted_text('')
 
     # Use cli_confirm to get user choice
     choice = cli_confirm(


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---

This PR adds an alternative method for installing OpenHands using uv tool install. The CLI and documentation have been updated to show this option for a persistent installation, in addition to the existing uvx method. This provides another way to set up and use the tool.

**Link of any specific issues this addresses:**
#10754 