### PR TITLE
Filter all warnings in CLI when DEBUG is disabled

### DIFF
--- a/openhands-cli/openhands_cli/simple_main.py
+++ b/openhands-cli/openhands_cli/simple_main.py
@@ -7,10 +7,12 @@ This is a simplified version that demonstrates the TUI functionality.
 import argparse
 import logging
 import os
+import warnings
 
 debug_env = os.getenv('DEBUG', 'false').lower()
 if debug_env != '1' and debug_env != 'true':
     logging.disable(logging.WARNING)
+    warnings.filterwarnings('ignore')
 
 from prompt_toolkit import print_formatted_text
 from prompt_toolkit.formatted_text import HTML


### PR DESCRIPTION
## Summary
This PR adds warnings filtering to the OpenHands CLI to suppress all warnings when DEBUG mode is not enabled.

## Changes
- Added `warnings.filterwarnings('ignore')` in `simple_main.py` to filter all warnings when DEBUG is not set
- Similar behavior to the existing `logging.disable(logging.WARNING)` call
- Ensures cleaner output in production mode while allowing full visibility during debugging

## Testing
- Warnings are suppressed when DEBUG environment variable is not set or is set to false
- Warnings are still shown when DEBUG=1 or DEBUG=true

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:70eadc4-nikolaik   --name openhands-app-70eadc4   docker.all-hands.dev/all-hands-ai/openhands:70eadc4
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@xw/cli-filter-warnings#subdirectory=openhands-cli openhands
```