### PR TITLE
Remove parsedEvents from WebSocket provider and use useEventStore

### DIFF
--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -7,7 +7,7 @@ import { TrajectoryActions } from "../trajectory/trajectory-actions";
 import { createChatMessage } from "#/services/chat-service";
 import { InteractiveChatBox } from "./interactive-chat-box";
 import { AgentState } from "#/types/agent-state";
-import { isOpenHandsAction } from "#/types/core/guards";
+import { isOpenHandsAction, isActionOrObservation } from "#/types/core/guards";
 import { generateAgentStateChangeEvent } from "#/services/agent-state-service";
 import { FeedbackModal } from "../feedback/feedback-modal";
 import { useScrollToBottom } from "#/hooks/use-scroll-to-bottom";
@@ -24,6 +24,7 @@ import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { useErrorMessageStore } from "#/stores/error-message-store";
 import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
+import { useEventStore } from "#/stores/use-event-store";
 import { ErrorMessageBanner } from "./error-message-banner";
 import {
   hasUserEvent,
@@ -47,7 +48,8 @@ function getEntryPoint(
 export function ChatInterface() {
   const { setMessageToSend } = useConversationStore();
   const { errorMessage } = useErrorMessageStore();
-  const { send, isLoadingMessages, parsedEvents } = useWsClient();
+  const { send, isLoadingMessages } = useWsClient();
+  const storeEvents = useEventStore((state) => state.events);
   const { setOptimisticUserMessage, getOptimisticUserMessage } =
     useOptimisticUserMessageStore();
   const { t } = useTranslation();
@@ -74,18 +76,22 @@ export function ChatInterface() {
 
   const optimisticUserMessage = getOptimisticUserMessage();
 
-  const events = parsedEvents.filter(shouldRenderEvent);
+  const events = storeEvents
+    .filter(isActionOrObservation)
+    .filter(shouldRenderEvent);
 
   // Check if there are any substantive agent actions (not just system messages)
   const hasSubstantiveAgentActions = React.useMemo(
     () =>
-      parsedEvents.some(
-        (event) =>
-          isOpenHandsAction(event) &&
-          event.source === "agent" &&
-          event.action !== "system",
-      ),
-    [parsedEvents],
+      storeEvents
+        .filter(isActionOrObservation)
+        .some(
+          (event) =>
+            isOpenHandsAction(event) &&
+            event.source === "agent" &&
+            event.action !== "system",
+        ),
+    [storeEvents],
   );
 
   const handleSendMessage = async (

--- a/frontend/src/components/shared/buttons/confirmation-buttons.tsx
+++ b/frontend/src/components/shared/buttons/confirmation-buttons.tsx
@@ -5,11 +5,12 @@ import { AgentState } from "#/types/agent-state";
 import { generateAgentStateChangeEvent } from "#/services/agent-state-service";
 import { useWsClient } from "#/context/ws-client-provider";
 import { ActionTooltip } from "../action-tooltip";
-import { isOpenHandsAction } from "#/types/core/guards";
+import { isOpenHandsAction, isActionOrObservation } from "#/types/core/guards";
 import { ActionSecurityRisk } from "#/stores/security-analyzer-store";
 import { RiskAlert } from "#/components/shared/risk-alert";
 import WarningIcon from "#/icons/u-warning.svg?react";
 import { useEventMessageStore } from "#/stores/event-message-store";
+import { useEventStore } from "#/stores/use-event-store";
 
 export function ConfirmationButtons() {
   const submittedEventIds = useEventMessageStore(
@@ -21,10 +22,12 @@ export function ConfirmationButtons() {
 
   const { t } = useTranslation();
 
-  const { send, parsedEvents } = useWsClient();
+  const { send } = useWsClient();
+  const events = useEventStore((state) => state.events);
 
   // Find the most recent action awaiting confirmation
-  const awaitingAction = parsedEvents
+  const awaitingAction = events
+    .filter(isActionOrObservation)
     .slice()
     .reverse()
     .find((ev) => {

--- a/frontend/src/hooks/use-conversation-name-context-menu.ts
+++ b/frontend/src/hooks/use-conversation-name-context-menu.ts
@@ -2,10 +2,9 @@ import { useTranslation } from "react-i18next";
 import React from "react";
 import posthog from "posthog-js";
 import { useParams, useNavigate } from "react-router";
-import { useWsClient } from "#/context/ws-client-provider";
 import { transformVSCodeUrl } from "#/utils/vscode-url-helper";
 import useMetricsStore from "#/stores/metrics-store";
-import { isSystemMessage } from "#/types/core/guards";
+import { isSystemMessage, isActionOrObservation } from "#/types/core/guards";
 import { ConversationStatus } from "#/types/conversation-status";
 import ConversationService from "#/api/conversation-service/conversation-service.api";
 import { useDeleteConversation } from "./mutation/use-delete-conversation";
@@ -14,6 +13,7 @@ import { useGetTrajectory } from "./mutation/use-get-trajectory";
 import { downloadTrajectory } from "#/utils/download-trajectory";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import { I18nKey } from "#/i18n/declaration";
+import { useEventStore } from "#/stores/use-event-store";
 
 interface UseConversationNameContextMenuProps {
   conversationId?: string;
@@ -31,7 +31,7 @@ export function useConversationNameContextMenu({
   const { t } = useTranslation();
   const { conversationId: currentConversationId } = useParams();
   const navigate = useNavigate();
-  const { parsedEvents } = useWsClient();
+  const events = useEventStore((state) => state.events);
   const { mutate: deleteConversation } = useDeleteConversation();
   const { mutate: stopConversation } = useStopConversation();
   const { mutate: getTrajectory } = useGetTrajectory();
@@ -46,7 +46,9 @@ export function useConversationNameContextMenu({
   const [confirmStopModalVisible, setConfirmStopModalVisible] =
     React.useState(false);
 
-  const systemMessage = parsedEvents.find(isSystemMessage);
+  const systemMessage = events
+    .filter(isActionOrObservation)
+    .find(isSystemMessage);
 
   const handleDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();

--- a/frontend/src/stores/use-event-store.ts
+++ b/frontend/src/stores/use-event-store.ts
@@ -1,17 +1,19 @@
 import { create } from "zustand";
 import { OpenHandsEvent } from "#/types/v1/core";
 import { handleEventForUI } from "#/utils/handle-event-for-ui";
+import { OpenHandsParsedEvent } from "#/types/core";
 
 interface EventState {
-  events: OpenHandsEvent[];
-  uiEvents: OpenHandsEvent[];
-  addEvent: (event: OpenHandsEvent) => void;
+  events: OpenHandsParsedEvent[];
+  uiEvents: OpenHandsParsedEvent[];
+  addEvent: (event: OpenHandsParsedEvent) => void;
+  clearEvents: () => void;
 }
 
 export const useEventStore = create<EventState>()((set) => ({
   events: [],
   uiEvents: [],
-  addEvent: (event: OpenHandsEvent) =>
+  addEvent: (event: OpenHandsParsedEvent) =>
     set((state) => {
       const newEvents = [...state.events, event];
       const newUiEvents = handleEventForUI(event, state.uiEvents);
@@ -21,4 +23,9 @@ export const useEventStore = create<EventState>()((set) => ({
         uiEvents: newUiEvents,
       };
     }),
+  clearEvents: () =>
+    set(() => ({
+      events: [],
+      uiEvents: [],
+    })),
 }));

--- a/frontend/src/types/core/guards.ts
+++ b/frontend/src/types/core/guards.ts
@@ -105,3 +105,8 @@ export const isStatusUpdate = (event: unknown): event is StatusUpdate =>
   "status_update" in event &&
   "type" in event &&
   "id" in event;
+
+export const isActionOrObservation = (
+  event: OpenHandsParsedEvent,
+): event is OpenHandsAction | OpenHandsObservation =>
+  isOpenHandsAction(event) || isOpenHandsObservation(event);


### PR DESCRIPTION

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Remove parsedEvents from UseWsClient interface and context
- Update chat interface to use useEventStore with type guards
- Update confirmation buttons to filter events with isActionOrObservation
- Update conversation name context menu to filter events properly
- Add isActionOrObservation type guard to handle OpenHandsParsedEvent filtering
- Restore uiEvents functionality in event store with type casting
- All components now use centralized event store instead of duplicate parsedEvents


---
**Link of any specific issues this addresses:**
