### PR TITLE
fix: avoid awaiting on empty Grok-4 messages during reasoning (port of #9809)

### DIFF
--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -43,6 +43,7 @@ from openhands.events.action.agent import CondensationRequestAction
 from openhands.events.action.mcp import MCPAction
 from openhands.events.event import FileEditSource, FileReadSource
 from openhands.events.tool import ToolCallMetadata
+from openhands.llm.model_features import REASONING_EMPTY_MESSAGE_PATTERNS, model_matches
 from openhands.llm.tool_names import TASK_TRACKER_TOOL_NAME
 
 
@@ -320,10 +321,16 @@ def response_to_actions(
             )
             actions.append(action)
     else:
+        content = str(assistant_msg.content) if assistant_msg.content else ''
+        model_name = str(getattr(response, 'model', ''))
+        is_reasoning_empty_model = model_matches(
+            model_name, REASONING_EMPTY_MESSAGE_PATTERNS
+        )
+        wait_for_response = not (is_reasoning_empty_model and not content)
         actions.append(
             MessageAction(
-                content=str(assistant_msg.content) if assistant_msg.content else '',
-                wait_for_response=True,
+                content=content,
+                wait_for_response=wait_for_response,
             )
         )
 

--- a/openhands/llm/model_features.py
+++ b/openhands/llm/model_features.py
@@ -58,6 +58,13 @@ class ModelFeatures:
     supports_stop_words: bool
 
 
+# Models that may return empty assistant messages while performing internal reasoning
+# Example: xai/grok-4 family sometimes streams only a reasoning token count with empty content
+# We match against the normalized basename, so 'grok-4*' covers variants like grok-4-0709, grok-4-latest
+REASONING_EMPTY_MESSAGE_PATTERNS: list[str] = [
+    'grok-4*',
+]
+
 # Pattern tables capturing current behavior. Keep patterns lowercase.
 FUNCTION_CALLING_PATTERNS: list[str] = [
     # Anthropic families


### PR DESCRIPTION
Hi, I'm OpenHands-GPT-5.

This PR ports and refines the changes proposed in #9809 by @claysauruswrecks to prevent stalls with Grok-4 models when they emit empty assistant messages during internal reasoning. Full credit to the original author; this PR preserves authorship in the commit history and centralizes the model-matching behavior.

Summary of changes:
- Centralize model pattern for "reasoning-empty" models in openhands/llm/model_features.py as REASONING_EMPTY_MESSAGE_PATTERNS = ['grok-4*'] so that matching works across providers/proxies (e.g., xai/grok-4-0709, openrouter/xai/grok-4-0709, litellm_proxy/xai/grok-4-0709).
- Update openhands/agenthub/codeact_agent/function_calling.py: when there are no tool_calls and the assistant message content is empty, set wait_for_response=False if the model matches the above patterns; default behavior unchanged otherwise. Tool-call flows are unaffected.
- Add focused unit tests validating the behavior for Grok vs non-Grok, various proxy prefixes, empty vs non-empty content.

Why:
- Some Grok-4 responses occasionally contain empty assistant content while the model is still internally reasoning. Prior behavior caused the agent to wait for user input, stalling the conversation. The updated logic avoids this by not waiting when content is empty for Grok-4 family models.

Notes:
- The behavior remains unchanged for non-Grok models and for tool-call paths.
- The model matching uses existing normalize_model_name/model_matches utilities for consistency.

Thanks to @claysauruswrecks for the original PR and investigation. This ports the essence, resolves merge conflicts with main, and adds tests. Feedback welcome!

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/24039a291aef41a689c9fda42bea35cc)