### PR TITLE
Fix: Robust Sonnet 4.5 detection incl. Bedrock dotted vendor prefixes; avoid reasoning_effort for Sonnet 4.5

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -148,7 +148,10 @@ class LLM(RetryMixin, DebugMixin):
                 logger.debug(
                     f'Gemini model {self.config.model} with reasoning_effort {self.config.reasoning_effort} mapped to thinking {kwargs.get("thinking")}'
                 )
-            elif 'claude-sonnet-4-5' in self.config.model:
+            elif (
+                'claude-sonnet-4-5' in self.config.model
+                or 'claude-sonnet-4.5' in self.config.model
+            ):
                 kwargs.pop(
                     'reasoning_effort', None
                 )  # don't send reasoning_effort to Claude Sonnet 4.5


### PR DESCRIPTION
fix #11248

Summary
- Normalize Bedrock-style region.vendor prefixes (e.g., `us.anthropic.*`) so Sonnet 4.5 is recognized as a reasoning model
- Add pattern for dot variant (`claude-sonnet-4.5*`) in addition to dash variant
- Avoid sending `reasoning_effort` to Claude Sonnet 4.5 (both `-` and `.` variants)
- As a result, temperature/top_p are now correctly suppressed for Sonnet 4.5 reasoning models to prevent Bedrock 400 errors

Details
- openhands/llm/model_features.py
  - normalize_model_name: strips dotted prefixes up to the first known vendor (anthropic, meta, cohere, mistral, ai21, amazon); handles cases like `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0` -> `claude-sonnet-4-5-20250929-v1`
  - REASONING_EFFORT_PATTERNS: added `claude-sonnet-4.5*`
- openhands/llm/llm.py
  - For reasoning models: as before, pop `temperature` and `top_p`
  - Special-case extended to also drop `reasoning_effort` for `claude-sonnet-4.5`

Verification
- Verified that normalization maps Bedrock model IDs to canonical basenames used by matching
- Verified that Sonnet 4.5 (dash or dot variants) triggers reasoning behavior and does not receive `reasoning_effort`

No dependency changes.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/367caf2d7f944e42b6ba7c200765481b)