### PR TITLE
feat(logging): JSON log config for Uvicorn when LOG_JSON=1

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -4,7 +4,6 @@ import asyncio
 import copy
 import os
 import time
-import traceback
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
@@ -285,19 +284,28 @@ class AgentController:
             )
         self._closed = True
 
-    def log(self, level: str, message: str, extra: dict | None = None) -> None:
+    def log(
+        self,
+        level: str,
+        message: str,
+        extra: dict | None = None,
+        exc_info: bool = False,
+    ) -> None:
         """Logs a message to the agent controller's logger.
 
         Args:
             level (str): The logging level to use (e.g., 'info', 'debug', 'error').
             message (str): The message to log.
             extra (dict | None, optional): Additional fields to log. Includes session_id by default.
+            exc_info (bool, optional): Whether to include exception info. Defaults to False.
         """
         message = f'[Agent Controller {self.id}] {message}'
         if extra is None:
             extra = {}
         extra_merged = {'session_id': self.id, **extra}
-        getattr(logger, level)(message, extra=extra_merged, stacklevel=2)
+        getattr(logger, level)(
+            message, extra=extra_merged, exc_info=exc_info, stacklevel=2
+        )
 
     async def _react_to_exception(
         self,
@@ -364,8 +372,8 @@ class AgentController:
         except Exception as e:
             self.log(
                 'error',
-                f'Error while running the agent (session ID: {self.id}): {e}. '
-                f'Traceback: {traceback.format_exc()}',
+                f'Error while running the agent (session ID: {self.id}): {e}',
+                exc_info=True,
             )
             reported = RuntimeError(
                 f'There was an unexpected error while running the agent: {e.__class__.__name__}. You can refresh the page or ask the agent to try again.'

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -514,3 +514,74 @@ class OpenHandsLoggerAdapter(logging.LoggerAdapter):
         else:
             kwargs['extra'] = self.extra
         return msg, kwargs
+
+
+def get_uvicorn_json_log_config() -> dict:
+    """Returns a uvicorn log config dict for JSON structured logging.
+
+    This configuration ensures Uvicorn's error and access logs are emitted
+    as single-line JSON when LOG_JSON=1, avoiding multi-line plain-text
+    tracebacks in log aggregators like Datadog.
+
+    Returns:
+        A dict suitable for passing to uvicorn.run(..., log_config=...).
+    """
+    return {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            # Uvicorn mutates 'default' and 'access' to set use_colors;
+            # keep them present using Uvicorn formatters
+            'default': {
+                '()': 'uvicorn.logging.DefaultFormatter',
+                'fmt': '%(levelprefix)s %(message)s',
+                'use_colors': None,
+            },
+            'access': {
+                '()': 'uvicorn.logging.AccessFormatter',
+                'fmt': '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+                'use_colors': None,
+            },
+            # Actual JSON formatters used by handlers below
+            'json': {
+                '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+                'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(exc_info)s',
+            },
+            'json_access': {
+                '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+                'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(client_addr)s %(request_line)s %(status_code)s',
+            },
+        },
+        'handlers': {
+            'default': {
+                'class': 'logging.StreamHandler',
+                'level': 'INFO',
+                'formatter': 'json',
+                'stream': 'ext://sys.stdout',
+            },
+            'access': {
+                'class': 'logging.StreamHandler',
+                'level': 'INFO',
+                'formatter': 'json_access',
+                'stream': 'ext://sys.stdout',
+            },
+        },
+        'loggers': {
+            'uvicorn': {
+                'handlers': ['default'],
+                'level': 'INFO',
+                'propagate': False,
+            },
+            'uvicorn.error': {
+                'handlers': ['default'],
+                'level': 'INFO',
+                'propagate': False,
+            },
+            'uvicorn.access': {
+                'handlers': ['access'],
+                'level': 'INFO',
+                'propagate': False,
+            },
+        },
+        'root': {'level': 'INFO', 'handlers': ['default']},
+    }

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -357,11 +357,7 @@ def log_uncaught_exceptions(
     """
     # Route uncaught exceptions through our logger with proper exc_info
     # Avoid manual formatting which creates multi-line plain-text log entries
-    try:
-        openhands_logger.error('Uncaught exception', exc_info=(ex_cls, ex, tb))
-    except Exception:
-        # Fallback to root logger if our logger isn't initialized yet
-        logging.error('Uncaught exception', exc_info=(ex_cls, ex, tb))
+    openhands_logger.error('Uncaught exception', exc_info=(ex_cls, ex, tb))
 
 
 sys.excepthook = log_uncaught_exceptions

--- a/openhands/core/logger.py
+++ b/openhands/core/logger.py
@@ -345,7 +345,7 @@ logging.basicConfig(level=logging.ERROR)
 def log_uncaught_exceptions(
     ex_cls: type[BaseException], ex: BaseException, tb: TracebackType | None
 ) -> Any:
-    """Logs uncaught exceptions along with the traceback.
+    """Logs uncaught exceptions in structured form when JSON logging is enabled.
 
     Args:
         ex_cls: The type of the exception.
@@ -355,9 +355,13 @@ def log_uncaught_exceptions(
     Returns:
         None
     """
-    if tb:  # Add check since tb can be None
-        logging.error(''.join(traceback.format_tb(tb)))
-    logging.error('{0}: {1}'.format(ex_cls, ex))
+    # Route uncaught exceptions through our logger with proper exc_info
+    # Avoid manual formatting which creates multi-line plain-text log entries
+    try:
+        openhands_logger.error('Uncaught exception', exc_info=(ex_cls, ex, tb))
+    except Exception:
+        # Fallback to root logger if our logger isn't initialized yet
+        logging.error('Uncaught exception', exc_info=(ex_cls, ex, tb))
 
 
 sys.excepthook = log_uncaught_exceptions

--- a/openhands/events/observation/commands.py
+++ b/openhands/events/observation/commands.py
@@ -1,6 +1,5 @@
 import json
 import re
-import traceback
 from dataclasses import dataclass, field
 from typing import Any, Self
 
@@ -65,8 +64,8 @@ class CmdOutputMetadata(BaseModel):
                 matches.append(match)
             except json.JSONDecodeError:
                 logger.warning(
-                    f'Failed to parse PS1 metadata: {match.group(1)}. Skipping.'
-                    + traceback.format_exc()
+                    f'Failed to parse PS1 metadata: {match.group(1)}. Skipping.',
+                    exc_info=True,
                 )
                 continue  # Skip if not valid JSON
         return matches

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -1079,6 +1079,18 @@ if __name__ == '__main__':
             'version': 1,
             'disable_existing_loggers': False,
             'formatters': {
+                # Uvicorn mutates 'default' and 'access' to set use_colors; keep them present using Uvicorn formatters
+                'default': {
+                    '()': 'uvicorn.logging.DefaultFormatter',
+                    'fmt': '%(levelprefix)s %(message)s',
+                    'use_colors': None,
+                },
+                'access': {
+                    '()': 'uvicorn.logging.AccessFormatter',
+                    'fmt': '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+                    'use_colors': None,
+                },
+                # Actual JSON formatters used by handlers below
                 'json': {
                     '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
                     'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(exc_info)s',

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -35,6 +35,7 @@ from uvicorn import run
 
 from openhands.core.config.mcp_config import MCPStdioServerConfig
 from openhands.core.exceptions import BrowserUnavailableException
+from openhands.core.logger import get_uvicorn_json_log_config
 from openhands.core.logger import openhands_logger as logger
 from openhands.events.action import (
     Action,
@@ -240,7 +241,7 @@ class ActionExecutor:
             self.browser = BrowserEnv(self.browsergym_eval_env)
             logger.debug('Browser initialized asynchronously')
         except Exception as e:
-            logger.error(f'Failed to initialize browser: {e}', exc_info=True)
+            logger.exception(f'Failed to initialize browser: {e}')
             self.browser = None
 
     async def _ensure_browser_ready(self):
@@ -392,7 +393,7 @@ class ActionExecutor:
             obs = await call_sync_from_async(bash_session.execute, action)
             return obs
         except Exception as e:
-            logger.error(f'Error running command: {e}', exc_info=True)
+            logger.exception(f'Error running command: {e}')
             return ErrorObservation(str(e))
 
     async def run_ipython(self, action: IPythonRunCellAction) -> Observation:
@@ -767,14 +768,14 @@ if __name__ == '__main__':
 
     @app.exception_handler(StarletteHTTPException)
     async def http_exception_handler(request: Request, exc: StarletteHTTPException):
-        logger.error(f'HTTP exception occurred: {exc.detail}', exc_info=True)
+        logger.exception(f'HTTP exception occurred: {exc.detail}')
         return JSONResponse(status_code=exc.status_code, content={'detail': exc.detail})
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(
         request: Request, exc: RequestValidationError
     ):
-        logger.error(f'Validation error occurred: {exc}', exc_info=True)
+        logger.exception(f'Validation error occurred: {exc}')
         return JSONResponse(
             status_code=422,
             content={
@@ -821,9 +822,7 @@ if __name__ == '__main__':
             observation = await client.run_action(action)
             return event_to_dict(observation)
         except Exception as e:
-            logger.error(
-                f'Error while running /execute_action: {str(e)}', exc_info=True
-            )
+            logger.exception(f'Error while running /execute_action: {str(e)}')
             raise HTTPException(
                 status_code=500,
                 detail=f'Internal server error: {str(e)}',
@@ -1068,69 +1067,12 @@ if __name__ == '__main__':
             return JSONResponse(content=sorted_entries)
 
         except Exception as e:
-            logger.error(f'Error listing files: {e}', exc_info=True)
+            logger.exception(f'Error listing files: {e}')
             return JSONResponse(content=[])
 
     logger.debug(f'Starting action execution API on port {args.port}')
     # When LOG_JSON=1, provide a JSON log config to Uvicorn so error/access logs are structured
     log_config = None
     if os.getenv('LOG_JSON', '0') in ('1', 'true', 'True'):
-        log_config = {
-            'version': 1,
-            'disable_existing_loggers': False,
-            'formatters': {
-                # Uvicorn mutates 'default' and 'access' to set use_colors; keep them present using Uvicorn formatters
-                'default': {
-                    '()': 'uvicorn.logging.DefaultFormatter',
-                    'fmt': '%(levelprefix)s %(message)s',
-                    'use_colors': None,
-                },
-                'access': {
-                    '()': 'uvicorn.logging.AccessFormatter',
-                    'fmt': '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
-                    'use_colors': None,
-                },
-                # Actual JSON formatters used by handlers below
-                'json': {
-                    '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-                    'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(exc_info)s',
-                },
-                'json_access': {
-                    '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-                    'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(client_addr)s %(request_line)s %(status_code)s',
-                },
-            },
-            'handlers': {
-                'default': {
-                    'class': 'logging.StreamHandler',
-                    'level': 'INFO',
-                    'formatter': 'json',
-                    'stream': 'ext://sys.stdout',
-                },
-                'access': {
-                    'class': 'logging.StreamHandler',
-                    'level': 'INFO',
-                    'formatter': 'json_access',
-                    'stream': 'ext://sys.stdout',
-                },
-            },
-            'loggers': {
-                'uvicorn': {
-                    'handlers': ['default'],
-                    'level': 'INFO',
-                    'propagate': False,
-                },
-                'uvicorn.error': {
-                    'handlers': ['default'],
-                    'level': 'INFO',
-                    'propagate': False,
-                },
-                'uvicorn.access': {
-                    'handlers': ['access'],
-                    'level': 'INFO',
-                    'propagate': False,
-                },
-            },
-            'root': {'level': 'INFO', 'handlers': ['default']},
-        }
+        log_config = get_uvicorn_json_log_config()
     run(app, host='0.0.0.0', port=args.port, log_config=log_config, use_colors=False)

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -821,7 +821,9 @@ if __name__ == '__main__':
             observation = await client.run_action(action)
             return event_to_dict(observation)
         except Exception as e:
-            logger.error(f'Error while running /execute_action: {str(e)}', exc_info=True)
+            logger.error(
+                f'Error while running /execute_action: {str(e)}', exc_info=True
+            )
             raise HTTPException(
                 status_code=500,
                 detail=f'Internal server error: {str(e)}',
@@ -1101,9 +1103,21 @@ if __name__ == '__main__':
                 },
             },
             'loggers': {
-                'uvicorn': {'handlers': ['default'], 'level': 'INFO', 'propagate': False},
-                'uvicorn.error': {'handlers': ['default'], 'level': 'INFO', 'propagate': False},
-                'uvicorn.access': {'handlers': ['access'], 'level': 'INFO', 'propagate': False},
+                'uvicorn': {
+                    'handlers': ['default'],
+                    'level': 'INFO',
+                    'propagate': False,
+                },
+                'uvicorn.error': {
+                    'handlers': ['default'],
+                    'level': 'INFO',
+                    'propagate': False,
+                },
+                'uvicorn.access': {
+                    'handlers': ['access'],
+                    'level': 'INFO',
+                    'propagate': False,
+                },
             },
             'root': {'level': 'INFO', 'handlers': ['default']},
         }

--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -1,7 +1,6 @@
 import os
 import re
 import time
-import traceback
 import uuid
 from enum import Enum
 from typing import Any
@@ -46,8 +45,8 @@ def split_bash_commands(commands: str) -> list[str]:
         logger.debug(
             f'Failed to parse bash commands\n'
             f'[input]: {commands}\n'
-            f'[warning]: {traceback.format_exc()}\n'
-            f'The original command will be returned as is.'
+            f'The original command will be returned as is.',
+            exc_info=True,
         )
         # If parsing fails, return the original commands
         return [commands]
@@ -165,8 +164,8 @@ def escape_bash_special_chars(command: str) -> str:
         logger.debug(
             f'Failed to parse bash commands for special characters escape\n'
             f'[input]: {command}\n'
-            f'[warning]: {traceback.format_exc()}\n'
-            f'The original command will be returned as is.'
+            f'The original command will be returned as is.',
+            exc_info=True,
         )
         return command
 

--- a/openhands/runtime/utils/windows_bash.py
+++ b/openhands/runtime/utils/windows_bash.py
@@ -6,7 +6,6 @@ way to manage PowerShell processes compared to using temporary script files.
 
 import os
 import time
-import traceback
 from pathlib import Path
 from threading import RLock
 
@@ -155,8 +154,9 @@ class WindowsPowershellSession:
             self._initialized = True  # Set to True only on successful initialization
             logger.info(f'PowerShell runspace created. Initial CWD set to: {self._cwd}')
         except Exception as e:
-            logger.error(f'Failed to create or open PowerShell runspace: {e}')
-            logger.error(traceback.format_exc())
+            logger.error(
+                f'Failed to create or open PowerShell runspace: {e}', exc_info=True
+            )
             self.close()  # Ensure cleanup if init fails partially
             raise RuntimeError(f'Failed to initialize PowerShell runspace: {e}')
 
@@ -177,8 +177,7 @@ class WindowsPowershellSession:
                 # Optional: Confirm CWD even on success for robustness
                 # self._confirm_cwd()
         except Exception as e:
-            logger.error(f'Exception setting initial CWD: {e}')
-            logger.error(traceback.format_exc())
+            logger.error(f'Exception setting initial CWD: {e}', exc_info=True)
             # Attempt to confirm CWD even if setting threw an exception
             self._confirm_cwd()
         finally:
@@ -945,8 +944,10 @@ class WindowsPowershellSession:
                 )
 
         except Exception as parse_ex:
-            logger.error(f'Exception during PowerShell command parsing: {parse_ex}')
-            logger.error(traceback.format_exc())
+            logger.error(
+                f'Exception during PowerShell command parsing: {parse_ex}',
+                exc_info=True,
+            )
             return ErrorObservation(
                 content=f'ERROR: An exception occurred while parsing the command: {parse_ex}'
             )
@@ -1119,9 +1120,9 @@ class WindowsPowershellSession:
                             self.active_job = None
                 except AttributeError as e:
                     logger.error(
-                        f'Get-Job returned an object without expected properties on BaseObject: {e}'
+                        f'Get-Job returned an object without expected properties on BaseObject: {e}',
+                        exc_info=True,
                     )
-                    logger.error(traceback.format_exc())
                     all_errors.append('Get-Job did not return a valid Job object.')
                     job_start_failed = True
 
@@ -1131,8 +1132,9 @@ class WindowsPowershellSession:
                 job_start_failed = True
 
         except Exception as start_ex:
-            logger.error(f'Exception during job start/retrieval: {start_ex}')
-            logger.error(traceback.format_exc())
+            logger.error(
+                f'Exception during job start/retrieval: {start_ex}', exc_info=True
+            )
             all_errors.append(f'[Job Start/Get Exception: {start_ex}]')
             job_start_failed = True
         finally:
@@ -1403,8 +1405,9 @@ class WindowsPowershellSession:
                 self.runspace.Dispose()
                 logger.info('PowerShell runspace closed and disposed.')
             except Exception as e:
-                logger.error(f'Error closing/disposing PowerShell runspace: {e}')
-                logger.error(traceback.format_exc())
+                logger.error(
+                    f'Error closing/disposing PowerShell runspace: {e}', exc_info=True
+                )
 
         self.runspace = None
         self._initialized = False

--- a/openhands/runtime/utils/windows_bash.py
+++ b/openhands/runtime/utils/windows_bash.py
@@ -154,9 +154,7 @@ class WindowsPowershellSession:
             self._initialized = True  # Set to True only on successful initialization
             logger.info(f'PowerShell runspace created. Initial CWD set to: {self._cwd}')
         except Exception as e:
-            logger.error(
-                f'Failed to create or open PowerShell runspace: {e}', exc_info=True
-            )
+            logger.exception(f'Failed to create or open PowerShell runspace: {e}')
             self.close()  # Ensure cleanup if init fails partially
             raise RuntimeError(f'Failed to initialize PowerShell runspace: {e}')
 
@@ -177,7 +175,7 @@ class WindowsPowershellSession:
                 # Optional: Confirm CWD even on success for robustness
                 # self._confirm_cwd()
         except Exception as e:
-            logger.error(f'Exception setting initial CWD: {e}', exc_info=True)
+            logger.exception(f'Exception setting initial CWD: {e}')
             # Attempt to confirm CWD even if setting threw an exception
             self._confirm_cwd()
         finally:
@@ -944,10 +942,7 @@ class WindowsPowershellSession:
                 )
 
         except Exception as parse_ex:
-            logger.error(
-                f'Exception during PowerShell command parsing: {parse_ex}',
-                exc_info=True,
-            )
+            logger.exception(f'Exception during PowerShell command parsing: {parse_ex}')
             return ErrorObservation(
                 content=f'ERROR: An exception occurred while parsing the command: {parse_ex}'
             )
@@ -1119,9 +1114,8 @@ class WindowsPowershellSession:
                         with self._job_lock:
                             self.active_job = None
                 except AttributeError as e:
-                    logger.error(
-                        f'Get-Job returned an object without expected properties on BaseObject: {e}',
-                        exc_info=True,
+                    logger.exception(
+                        f'Get-Job returned an object without expected properties on BaseObject: {e}'
                     )
                     all_errors.append('Get-Job did not return a valid Job object.')
                     job_start_failed = True
@@ -1132,9 +1126,7 @@ class WindowsPowershellSession:
                 job_start_failed = True
 
         except Exception as start_ex:
-            logger.error(
-                f'Exception during job start/retrieval: {start_ex}', exc_info=True
-            )
+            logger.exception(f'Exception during job start/retrieval: {start_ex}')
             all_errors.append(f'[Job Start/Get Exception: {start_ex}]')
             job_start_failed = True
         finally:
@@ -1405,9 +1397,7 @@ class WindowsPowershellSession:
                 self.runspace.Dispose()
                 logger.info('PowerShell runspace closed and disposed.')
             except Exception as e:
-                logger.error(
-                    f'Error closing/disposing PowerShell runspace: {e}', exc_info=True
-                )
+                logger.exception(f'Error closing/disposing PowerShell runspace: {e}')
 
         self.runspace = None
         self._initialized = False

--- a/openhands/server/__main__.py
+++ b/openhands/server/__main__.py
@@ -3,6 +3,8 @@ import warnings
 
 import uvicorn
 
+from openhands.core.logger import get_uvicorn_json_log_config
+
 
 def main():
     # Suppress SyntaxWarnings from pydub.utils about invalid escape sequences
@@ -11,64 +13,7 @@ def main():
     # When LOG_JSON=1, configure Uvicorn to emit JSON logs for error/access
     log_config = None
     if os.getenv('LOG_JSON', '0') in ('1', 'true', 'True'):
-        log_config = {
-            'version': 1,
-            'disable_existing_loggers': False,
-            'formatters': {
-                # Uvicorn mutates 'default' and 'access' to set use_colors; keep them present using Uvicorn formatters
-                'default': {
-                    '()': 'uvicorn.logging.DefaultFormatter',
-                    'fmt': '%(levelprefix)s %(message)s',
-                    'use_colors': None,
-                },
-                'access': {
-                    '()': 'uvicorn.logging.AccessFormatter',
-                    'fmt': '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
-                    'use_colors': None,
-                },
-                # Actual JSON formatters used by handlers below
-                'json': {
-                    '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-                    'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(exc_info)s',
-                },
-                'json_access': {
-                    '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-                    'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(client_addr)s %(request_line)s %(status_code)s',
-                },
-            },
-            'handlers': {
-                'default': {
-                    'class': 'logging.StreamHandler',
-                    'level': 'INFO',
-                    'formatter': 'json',
-                    'stream': 'ext://sys.stdout',
-                },
-                'access': {
-                    'class': 'logging.StreamHandler',
-                    'level': 'INFO',
-                    'formatter': 'json_access',
-                    'stream': 'ext://sys.stdout',
-                },
-            },
-            'loggers': {
-                'uvicorn': {
-                    'handlers': ['default'],
-                    'level': 'INFO',
-                    'propagate': False,
-                },
-                'uvicorn.error': {
-                    'handlers': ['default'],
-                    'level': 'INFO',
-                    'propagate': False,
-                },
-                'uvicorn.access': {
-                    'handlers': ['access'],
-                    'level': 'INFO',
-                    'propagate': False,
-                },
-            },
-            'root': {'level': 'INFO', 'handlers': ['default']},
-        }
+        log_config = get_uvicorn_json_log_config()
 
     uvicorn.run(
         'openhands.server.listen:app',

--- a/openhands/server/__main__.py
+++ b/openhands/server/__main__.py
@@ -8,11 +8,52 @@ def main():
     # Suppress SyntaxWarnings from pydub.utils about invalid escape sequences
     warnings.filterwarnings('ignore', category=SyntaxWarning, module=r'pydub\.utils')
 
+    # When LOG_JSON=1, configure Uvicorn to emit JSON logs for error/access
+    log_config = None
+    if os.getenv('LOG_JSON', '0') in ('1', 'true', 'True'):
+        log_config = {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'json': {
+                    '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+                    # Keep format minimal; our JsonFormatter adds timestamp automatically when configured in core.logger
+                    'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(exc_info)s',
+                },
+                'json_access': {
+                    '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+                    'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(client_addr)s %(request_line)s %(status_code)s',
+                },
+            },
+            'handlers': {
+                'default': {
+                    'class': 'logging.StreamHandler',
+                    'level': 'INFO',
+                    'formatter': 'json',
+                    'stream': 'ext://sys.stdout',
+                },
+                'access': {
+                    'class': 'logging.StreamHandler',
+                    'level': 'INFO',
+                    'formatter': 'json_access',
+                    'stream': 'ext://sys.stdout',
+                },
+            },
+            'loggers': {
+                'uvicorn': {'handlers': ['default'], 'level': 'INFO', 'propagate': False},
+                'uvicorn.error': {'handlers': ['default'], 'level': 'INFO', 'propagate': False},
+                'uvicorn.access': {'handlers': ['access'], 'level': 'INFO', 'propagate': False},
+            },
+            'root': {'level': 'INFO', 'handlers': ['default']},
+        }
+
     uvicorn.run(
         'openhands.server.listen:app',
         host='0.0.0.0',
         port=int(os.environ.get('port') or '3000'),
         log_level='debug' if os.environ.get('DEBUG') else 'info',
+        log_config=log_config,
+        use_colors=False,
     )
 
 

--- a/openhands/server/__main__.py
+++ b/openhands/server/__main__.py
@@ -40,9 +40,21 @@ def main():
                 },
             },
             'loggers': {
-                'uvicorn': {'handlers': ['default'], 'level': 'INFO', 'propagate': False},
-                'uvicorn.error': {'handlers': ['default'], 'level': 'INFO', 'propagate': False},
-                'uvicorn.access': {'handlers': ['access'], 'level': 'INFO', 'propagate': False},
+                'uvicorn': {
+                    'handlers': ['default'],
+                    'level': 'INFO',
+                    'propagate': False,
+                },
+                'uvicorn.error': {
+                    'handlers': ['default'],
+                    'level': 'INFO',
+                    'propagate': False,
+                },
+                'uvicorn.access': {
+                    'handlers': ['access'],
+                    'level': 'INFO',
+                    'propagate': False,
+                },
             },
             'root': {'level': 'INFO', 'handlers': ['default']},
         }

--- a/openhands/server/__main__.py
+++ b/openhands/server/__main__.py
@@ -15,9 +15,20 @@ def main():
             'version': 1,
             'disable_existing_loggers': False,
             'formatters': {
+                # Uvicorn mutates 'default' and 'access' to set use_colors; keep them present using Uvicorn formatters
+                'default': {
+                    '()': 'uvicorn.logging.DefaultFormatter',
+                    'fmt': '%(levelprefix)s %(message)s',
+                    'use_colors': None,
+                },
+                'access': {
+                    '()': 'uvicorn.logging.AccessFormatter',
+                    'fmt': '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+                    'use_colors': None,
+                },
+                # Actual JSON formatters used by handlers below
                 'json': {
                     '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-                    # Keep format minimal; our JsonFormatter adds timestamp automatically when configured in core.logger
                     'fmt': '%(message)s %(levelname)s %(name)s %(asctime)s %(exc_info)s',
                 },
                 'json_access': {
@@ -65,7 +76,8 @@ def main():
         port=int(os.environ.get('port') or '3000'),
         log_level='debug' if os.environ.get('DEBUG') else 'info',
         log_config=log_config,
-        use_colors=False,
+        # If LOG_JSON enabled, force colors off; otherwise let uvicorn default
+        use_colors=False if log_config else None,
     )
 
 


### PR DESCRIPTION
[From OpenHands]
Summary
- Ensure Uvicorn emits single-line JSON logs when LOG_JSON=1 to avoid multi-line/plain-text tracebacks in Datadog
- Applies to both OpenHands server entrypoint and action execution server

Changes
- openhands/server/__main__.py: supply dictConfig to uvicorn.run() when LOG_JSON is enabled (json formatters for uvicorn.error and uvicorn.access). Disable colors to avoid ANSI
- openhands/runtime/action_execution_server.py: same dictConfig for runtime Action Execution Server. Disable colors
- openhands/core/logger.py: route sys.excepthook through our logger using exc_info so uncaught exceptions are JSON-formatted

Why
- Datadog production logs show multi-line tracebacks and plain-text Uvicorn access lines. Our own logger already uses JSON, but Uvicorn loggers were not. By configuring Uvicorn loggers explicitly, all logs are JSON and arrive as a single event per error/traceback.

  [From @neubig]
  I have confirmed that this works locally

With `LOG_JSON` set:
```
{"message": "Could not load conversation metadata: f6c33e57-648d-4a-98f675d6db166e0", "level": "WARNING", "timestamp": "2025-10-07T11:36:02.112861+00:00"}
{"message": "Could not load conversation metadata: 4ed95844-5ea9-46-d05f14a289a05b9", "level": "WARNING", "timestamp": "2025-10-07T11:36:02.113073+00:00"}
{"message": "Could not load conversation metadata: 969fd99f-c2bd-49-7d2a53576bf5b6a", "level": "WARNING", "timestamp": "2025-10-07T11:36:02.113334+00:00"}
```

With `LOG_JSON` unset:
```
07:40:25 - openhands:WARNING: file_conversation_store.py:90 - Could not load conversation metadata: 7f918920-900e-4e-442dfa8f46ff214
07:40:25 - openhands:WARNING: file_conversation_store.py:90 - Could not load conversation metadata: 59b0b417-04ec-46-07d3ae31bd0f4d0
07:40:25 - openhands:WARNING: file_conversation_store.py:90 - Could not load conversation metadata: 5224b960-f96c-49-fd566da9b2b36a4
```

Co-authored-by: openhands <openhands@all-hands.dev>

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/85d01aa6651b4e62b27133b9848ef689)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5170908-nikolaik   --name openhands-app-5170908   docker.all-hands.dev/all-hands-ai/openhands:5170908
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@feat/json-uvicorn-logging#subdirectory=openhands-cli openhands
```