### PR TITLE
fix(docs): add prominent CTA button to access OpenHands Cloud

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,3 +15,17 @@ they can modify code, run commands, browse the web, call APIs, and yes-even copy
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
 ></iframe>
+
+<div className="mt-8 flex justify-center">
+  <a
+    href="https://app.all-hands.dev?utm_source=docs&utm_medium=cta&utm_campaign=intro_page"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-3 px-7 py-3.5 text-md font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-gray-400 transition-colors duration-150 shadow-md hover:shadow-lg"
+  >
+    Launch OpenHands Cloud
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+    </svg>
+  </a>
+</div>


### PR DESCRIPTION
- [ ] This change is worth documenting at [https://docs.all-hands.dev/](https://docs.all-hands.dev/)
- [ ] Include this change in the Release Notes.

**End-user friendly description of the problem this fixes or functionality this introduces.**
This change adds a prominent, visually distinct CTA button on the main docs landing page that directly links to OpenHands Cloud, making it easier for users to launch the cloud version quickly.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

* Adds a new CTA button below the hero video on the main documentation page (`docs/index.mdx`).
* The button is styled to match the existing docs design system, with hover and shadow effects for visibility.
* The link includes UTM parameters for tracking click-throughs: `utm_source=docs&utm_medium=cta&utm_campaign=intro_page`.
* No other functionality or pages are modified.
<img width="885" height="796" alt="image" src="https://github.com/user-attachments/assets/ec28e7ba-6597-4cce-af32-9457672d9d7b" />

---
**Link of any specific issues this addresses:**
This PR addresses issue #11237 