### PR TITLE
fix(frontend): incorrect active state behavior in chat actions

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-nav.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-nav.tsx
@@ -27,7 +27,7 @@ export function ConversationTabNav({
           : "hover:text-white hover:bg-[#0D0F11]",
         isActive
           ? "focus-within:text-white focus-within:bg-tertiary"
-          : "focus-within:text-white focus-within:bg-[#0D0F11]",
+          : "focus-within:text-[#9299AA] focus-within:bg-[#0D0F11]",
       )}
     >
       <Icon className={cn("w-5 h-5 text-inherit")} />


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The active state behavior of the chat actions is currently incorrect. When the user clicks on the active tab to close the action panel, the icon remains white instead of reverting to its default state.

Please refer to the video below for additional details.

https://github.com/user-attachments/assets/931106df-a495-4ba8-8662-12edcf45a104

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes the issue - the icon state should be updated to inactive in this scenario.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/70ae5126-eb57-4d77-a58c-b8dc00cdae46

---
**Link of any specific issues this addresses:**

Resolves #11279